### PR TITLE
Moved Militia and Police units to proper side templates

### DIFF
--- a/A3-Antistasi/Templates/InvadersVanillaAltis.sqf
+++ b/A3-Antistasi/Templates/InvadersVanillaAltis.sqf
@@ -45,7 +45,7 @@ vehCSATPlane = "O_Plane_CAS_02_dynamicLoadout_F";
 vehCSATPlaneAA = "O_Plane_Fighter_02_F";
 vehCSATTransportPlanes = ["O_T_VTOL_02_infantry_F"]; //VTOL isn't available without APEX nor there is a replacement, i'd leave it there regardles it's Altis
 vehCSATPatrolHeli = "O_Heli_Light_02_unarmed_F";
-vehCSATTransportHelis = ["O_Heli_Transport_04_bench_F",vehCSATPatrolHeli]; 
+vehCSATTransportHelis = ["O_Heli_Transport_04_bench_F",vehCSATPatrolHeli];
 vehCSATAttackHelis = ["O_Heli_Attack_02_dynamicLoadout_F","O_Heli_Attack_02_F"];
 vehCSATAir = vehCSATTransportHelis + vehCSATAttackHelis + [vehCSATPlane,vehCSATPlaneAA] + vehCSATTransportPlanes;
 vehCSATUAV = "O_UAV_02_F";
@@ -53,7 +53,6 @@ vehCSATUAVSmall = "O_UAV_01_F";
 vehCSATMRLS = "O_MBT_02_arty_F";
 vehCSATMRLSMags = "32Rnd_155mm_Mo_shells"; // I HOPE THEY ARE THE SAME!
 vehCSATNormal = vehCSATLight + vehCSATTrucks + [vehCSATAmmoTruck, "O_Truck_03_fuel_F", "O_Truck_03_medical_F", "O_Truck_03_repair_F"];
-
 
 vehCSATBike = "O_Quadbike_01_F";
 
@@ -83,3 +82,17 @@ ammunitionCSAT append ["30Rnd_65x39_caseless_green","10Rnd_762x54_Mag","150Rnd_7
 flagCSATmrk = "flag_CSAT";
 nameInvaders = "CSAT";
 if (isServer) then {"CSAT_carrier" setMarkerText "CSAT Carrier"};
+//Militia Units for Rebels Vs Invaders
+if (gameMode == 4) then
+	{
+	FIARifleman = "O_soldierU_F";
+	FIAMarksman = "O_soldierU_M_F";
+	vehFIAArmedCar = "O_MRAP_02_hmg_F";
+	vehFIATruck = "O_Truck_02_transport_F";
+	vehFIACar = "O_MRAP_02_F";
+	groupsFIASmall = [["O_SoldierU_GL_F",FIARifleman],[FIAMarksman,FIARifleman],["O_soldierU_M_F","O_SoldierU_GL_F"]];//["IRG_InfSentry","IRG_ReconSentry","IRG_SniperTeam_M"];///
+	groupsFIAMid = [["O_SoldierU_SL_F","O_SoldierU_GL_F","O_soldierU_AR_F",FIAMarksman],["O_SoldierU_SL_F","O_SoldierU_GL_F","O_soldierU_AR_F","O_soldierU_LAT_F"],["O_SoldierU_SL_F","O_SoldierU_GL_F","O_soldierU_AR_F","O_engineer_U_F"]];
+	FIASquad = ["O_SoldierU_SL_F","O_soldierU_AR_F","O_SoldierU_GL_F",FIARifleman,FIARifleman,FIAMarksman,"O_soldierU_LAT_F","O_soldierU_medic_F"];//"IRG_InfSquad";///
+	groupsFIASquad = [FIASquad,["O_SoldierU_SL_F","O_soldierU_AR_F","O_SoldierU_GL_F",FIARifleman,"O_soldierU_A_F","O_soldierU_exp_F","O_soldierU_LAT_F","O_soldierU_medic_F"]];
+	factionFIA = "";
+	};

--- a/A3-Antistasi/Templates/OccupantsVanillaAltis.sqf
+++ b/A3-Antistasi/Templates/OccupantsVanillaAltis.sqf
@@ -89,3 +89,30 @@ flagNATOmrk = "flag_NATO";
 
 nameOccupants = "NATO";
 if (isServer) then {"NATO_carrier" setMarkerText "NATO Carrier"};
+	
+//Militia Units
+if (gameMode != 4) then {
+	if (hasFFAA) then
+		{
+		call compile preProcessFileLineNumbers "Templates\OccupantsFFAA.sqf"
+		}
+	else
+		{
+		FIARifleman = "B_Soldier_lite_F";
+		FIAMarksman = "B_soldier_M_F";
+		vehFIAArmedCar = "B_LSV_01_armed_F";
+		vehFIATruck = "B_Truck_01_transport_F";
+		vehFIACar = "B_LSV_01_unarmed_F";
+		groupsFIASmall = [["B_Soldier_GL_F",FIARifleman],[FIAMarksman,FIARifleman],["B_Sharpshooter_F","B_soldier_M_F"]];//["IRG_InfSentry","IRG_ReconSentry","IRG_SniperTeam_M"];///
+		groupsFIAMid = [["B_Soldier_TL_F","B_Soldier_GL_F","B_soldier_AR_F","B_soldier_M_F"],["B_Soldier_TL_F","B_Soldier_GL_F","B_soldier_AR_F","B_soldier_LAT2_F"],["B_Soldier_TL_F","B_soldier_AR_F","B_soldier_AAA_F","B_soldier_AA_F"]];
+		FIASquad = ["B_Soldier_TL_F","B_soldier_AR_F","B_Soldier_GL_F","B_Soldier_lite_F","B_Soldier_lite_F","B_soldier_M_F","B_soldier_LAT2_F","B_medic_F"];//"IRG_InfSquad";///
+		groupsFIASquad = [FIASquad,["B_Soldier_TL_F","B_support_AMG_F","B_Soldier_GL_F","B_Soldier_lite_F","B_support_MG_F","B_soldier_M_F","B_soldier_LAT2_F","B_medic_F"]];
+		factionFIA = "";
+		};
+	};
+//Police Units
+vehPoliceCar = "B_GEN_OFFROAD_01_gen_F";
+policeOfficer = "B_GEN_Commander_F";
+policeGrunt = "B_GEN_Soldier_F";
+groupsNATOGen = [policeOfficer,policeGrunt];
+factionGEN = "BLU_GEN_F";

--- a/A3-Antistasi/Templates/teamPlayerVanillaAltis.sqf
+++ b/A3-Antistasi/Templates/teamPlayerVanillaAltis.sqf
@@ -50,47 +50,7 @@ lampsSDK = ["acc_flashlight"];
 ATMineMag = "ATMine_Range_Mag";
 APERSMineMag = "APERSMine_Range_Mag";
 
-if (hasFFAA) then
-	{
-	call compile preProcessFileLineNumbers "Templates\OccupantsFFAA.sqf"
-	}
-else
-	{
-	if (gameMode != 4) then
-		{
-		FIARifleman = "B_Soldier_lite_F";
-		FIAMarksman = "B_soldier_M_F";
-		vehFIAArmedCar = "B_LSV_01_armed_F";
-		vehFIATruck = "B_Truck_01_transport_F";
-		vehFIACar = "B_LSV_01_unarmed_F";
-		groupsFIASmall = [["B_Soldier_GL_F",FIARifleman],[FIAMarksman,FIARifleman],["B_Sharpshooter_F","B_soldier_M_F"]];//["IRG_InfSentry","IRG_ReconSentry","IRG_SniperTeam_M"];///
-		groupsFIAMid = [["B_Soldier_TL_F","B_Soldier_GL_F","B_soldier_AR_F","B_soldier_M_F"],["B_Soldier_TL_F","B_Soldier_GL_F","B_soldier_AR_F","B_soldier_LAT2_F"],["B_Soldier_TL_F","B_soldier_AR_F","B_soldier_AAA_F","B_soldier_AA_F"]];
-		FIASquad = ["B_Soldier_TL_F","B_soldier_AR_F","B_Soldier_GL_F","B_Soldier_lite_F","B_Soldier_lite_F","B_soldier_M_F","B_soldier_LAT2_F","B_medic_F"];//"IRG_InfSquad";///
-		groupsFIASquad = [FIASquad,["B_Soldier_TL_F","B_support_AMG_F","B_Soldier_GL_F","B_Soldier_lite_F","B_support_MG_F","B_soldier_M_F","B_soldier_LAT2_F","B_medic_F"]];
-		factionFIA = "";
-		}
-	else
-		{
-		FIARifleman = "O_soldierU_F";
-		FIAMarksman = "O_soldierU_M_F";
-		vehFIAArmedCar = "O_MRAP_02_hmg_F";
-		vehFIATruck = "O_Truck_02_transport_F";
-		vehFIACar = "O_MRAP_02_F";
-		groupsFIASmall = [["O_SoldierU_GL_F",FIARifleman],[FIAMarksman,FIARifleman],["O_soldierU_M_F","O_SoldierU_GL_F"]];//["IRG_InfSentry","IRG_ReconSentry","IRG_SniperTeam_M"];///
-		groupsFIAMid = [["O_SoldierU_SL_F","O_SoldierU_GL_F","O_soldierU_AR_F",FIAMarksman],["O_SoldierU_SL_F","O_SoldierU_GL_F","O_soldierU_AR_F","O_soldierU_LAT_F"],["O_SoldierU_SL_F","O_SoldierU_GL_F","O_soldierU_AR_F","O_engineer_U_F"]];
-		FIASquad = ["O_SoldierU_SL_F","O_soldierU_AR_F","O_SoldierU_GL_F",FIARifleman,FIARifleman,FIAMarksman,"O_soldierU_LAT_F","O_soldierU_medic_F"];//"IRG_InfSquad";///
-		groupsFIASquad = [FIASquad,["O_SoldierU_SL_F","O_soldierU_AR_F","O_SoldierU_GL_F",FIARifleman,"O_soldierU_A_F","O_soldierU_exp_F","O_soldierU_LAT_F","O_soldierU_medic_F"]];
-		factionFIA = "";
-		};
-	};
-
-vehPoliceCar = "B_GEN_OFFROAD_01_gen_F";
-policeOfficer = "B_GEN_Commander_F";
-policeGrunt = "B_GEN_Soldier_F";
-groupsNATOGen = [policeOfficer,policeGrunt];
 nameTeamPlayer = if (worldName == "Tanoa") then {"SDK"} else {"FIA"};
-
-factionGEN = "BLU_GEN_F";
 
 //Player spawn loadout
 teamPlayerDefaultLoadout = [[],[],[],["U_BG_Guerilla1_1", []],[],[],"","",[],["ItemMap","","","","",""]];
@@ -110,6 +70,3 @@ if !(isMultiplayer) then
 	unlockedAT = ["launch_MRAWS_olive_rail_F"];
 	unlockedMagazines pushBack "MRAWS_HEAT_F";
   };
-//TFAR Unlocks
-if (hasTFAR) then {unlockedItems = unlockedItems + ["tf_microdagr","tf_anprc154"]};
-if (startLR) then {unlockedBackpacks = unlockedBackpacks + ["tf_anprc155"]};

--- a/A3-Antistasi/Templates/teamPlayerVanillaAltis.sqf
+++ b/A3-Antistasi/Templates/teamPlayerVanillaAltis.sqf
@@ -70,3 +70,6 @@ if !(isMultiplayer) then
 	unlockedAT = ["launch_MRAWS_olive_rail_F"];
 	unlockedMagazines pushBack "MRAWS_HEAT_F";
   };
+//TFAR Unlocks
+if (hasTFAR) then {unlockedItems = unlockedItems + ["tf_microdagr","tf_anprc154"]};
+if (startLR) then {unlockedBackpacks = unlockedBackpacks + ["tf_anprc155"]};


### PR DESCRIPTION
Resolves #18 
Moved militia units and police units to occupant template, and the gamemode check for reb vs invaders occupants and their militia to invader template.

Others will follow.