### PR TITLE
Fix for acre2 radios not being recognized as a units radio

### DIFF
--- a/A3-Antistasi/Ammunition/getRadio.sqf
+++ b/A3-Antistasi/Ammunition/getRadio.sqf
@@ -14,7 +14,7 @@ params ["_unit"];
  
 private _items = assignedItems _unit; 
 
-private _radioPosition = _items findIf {_x == "ItemRadio" || {_x find "tf_" > -1} || {_x find "acre_" > -1}}; 
+private _radioPosition = _items findIf {_x == "ItemRadio" || {_x find "tf_" > -1} || {_x find "ACRE_" > -1} || {_x find "Acre" > -1}}; 
  
 if (_radioPosition > -1) then {
 	_items select _radioPosition;


### PR DESCRIPTION
`{_x find "Acre" > -1}` allows for finding the acre ItemRadio replacement ("ItemRadioAcreFlagged"),
`{_x find "ACRE_" > -1}` allows for finding the acre radio classes if acre is not flagging the unit correctly ("ACRE_PRC343")

Fixes #324