### PR TITLE
Remove Problematic Petros ACE Interactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ A3-Antistasi/mission.sqm
 A3-Antistasi/roadsDB*.sqf
 A3-Antistasi/PIC.jpg
 A3-Antistasi/ak.jpg
+
+#Ignore packaged missions
+PreparedMissions/

--- a/A3-Antistasi/changelog_2_2.txt
+++ b/A3-Antistasi/changelog_2_2.txt
@@ -71,6 +71,8 @@ CHANGELOG 2.2
   - Fixed arsenal being called before it could init
   - Fixed Petros not respawning. Well, at least in theory.
   - Fixed statics at base sneaking away. We got you, sneaky bastards.
+  - Fixed the player being able to take Petros as a prisoner.
+  - Fixed the player being able to join Petros' group.
 
 =================  Code  =========================
 

--- a/A3-Antistasi/functions/Base/fn_initPetros.sqf
+++ b/A3-Antistasi/functions/Base/fn_initPetros.sqf
@@ -91,4 +91,8 @@ petros addMPEventHandler ["mpkilled",
 	};
 }];
 [] spawn {sleep 120; petros allowDamage true;};
+//Disable ACE Interactions
+[typeOf petros, 0,["ACE_ApplyHandcuffs"]] call ace_interact_menu_fnc_removeActionFromClass;
+[typeOf petros, 0,["ACE_MainActions", "ACE_JoinGroup"]] call ace_interact_menu_fnc_removeActionFromClass;
+
 diag_log format ["%1: [Antistasi] | INFO | initPetros Completed.",servertime];

--- a/A3-Antistasi/functions/Base/fn_initPetros.sqf
+++ b/A3-Antistasi/functions/Base/fn_initPetros.sqf
@@ -92,7 +92,8 @@ petros addMPEventHandler ["mpkilled",
 }];
 [] spawn {sleep 120; petros allowDamage true;};
 //Disable ACE Interactions
-[typeOf petros, 0,["ACE_ApplyHandcuffs"]] call ace_interact_menu_fnc_removeActionFromClass;
-[typeOf petros, 0,["ACE_MainActions", "ACE_JoinGroup"]] call ace_interact_menu_fnc_removeActionFromClass;
-
+if (hasACE) then {
+    [typeOf petros, 0,["ACE_ApplyHandcuffs"]] call ace_interact_menu_fnc_removeActionFromClass;
+    [typeOf petros, 0,["ACE_MainActions", "ACE_JoinGroup"]] call ace_interact_menu_fnc_removeActionFromClass;
+};
 diag_log format ["%1: [Antistasi] | INFO | initPetros Completed.",servertime];


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Enhancement

### What have you changed and why?
Removed the player's ability to take Petros prisoner and join his group which could both be exploited.

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the Mission in Singleplayer?
2. [x] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes (Please provide further detail below.)

********************************************************
There could be other problematic ACE interactions but the only ones I could think of were taking him prisoner and joining his group