### PR TITLE
Auto rearm fix

### DIFF
--- a/A3-Antistasi/Templates/3CB_Reb_CNM_Temp.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_CNM_Temp.sqf
@@ -93,7 +93,6 @@ APERSMineMag = "rhs_mine_pmn2_mag";
 //Starting Unlocks
 initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L107A1","UK3CB_Enfield","UK3CB_Enfield_rail","rhs_weap_rpg75"];
 initialRebelEquipment append ["UK3CB_Enfield","UK3CB_Enfield_rail"];
-initialWeapons append ["UK3CB_Enfield","UK3CB_Enfield_rail"];
 initialRebelEquipment append ["rhs_weap_rpg75"];
 initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enfield_mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK3CB_TKC_C_B_Sidor_MED","UK3CB_CW_SOV_O_LATE_B_Sidor_RIF","UK3CB_CW_SOV_O_EARLY_B_Sidor_RIF"];

--- a/A3-Antistasi/Templates/3CB_Reb_CNM_Trop.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_CNM_Trop.sqf
@@ -93,7 +93,6 @@ APERSMineMag = "rhs_mine_pmn2_mag";
 //Starting Unlocks
 initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L107A1","UK3CB_Enfield","UK3CB_Enfield_rail","rhs_weap_rpg75"];
 initialRebelEquipment append ["UK3CB_Enfield","UK3CB_Enfield_rail"];
-initialWeapons append ["UK3CB_Enfield","UK3CB_Enfield_rail"];
 initialRebelEquipment append ["rhs_weap_rpg75"];
 initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enfield_mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK3CB_TKC_C_B_Sidor_MED","UK3CB_CW_SOV_O_LATE_B_Sidor_RIF","UK3CB_CW_SOV_O_EARLY_B_Sidor_RIF"];

--- a/A3-Antistasi/Templates/3CB_Reb_TPGM_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_TPGM_Arid.sqf
@@ -93,7 +93,6 @@ APERSMineMag = "rhs_mine_pmn2_mag";
 //Starting Unlocks
 initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L107A1","UK3CB_Enfield","UK3CB_Enfield_rail","rhs_weap_rpg75"];
 initialRebelEquipment append ["UK3CB_Enfield","UK3CB_Enfield_rail"];
-initialWeapons append ["UK3CB_Enfield","UK3CB_Enfield_rail"];
 initialRebelEquipment append ["rhs_weap_rpg75"];
 initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enfield_mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK3CB_TKC_C_B_Sidor_MED","UK3CB_CW_SOV_O_LATE_B_Sidor_RIF","UK3CB_CW_SOV_O_EARLY_B_Sidor_RIF"];

--- a/A3-Antistasi/Templates/3CB_Reb_TTF_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_TTF_Arid.sqf
@@ -97,7 +97,6 @@ APERSMineMag = "rhs_mine_pmn2_mag";
 //Starting Unlocks
 initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L107A1","UK3CB_Enfield","UK3CB_Enfield_rail","rhs_weap_rpg75"];
 initialRebelEquipment append ["UK3CB_Enfield","UK3CB_Enfield_rail"];
-initialWeapons append ["UK3CB_Enfield","UK3CB_Enfield_rail"];
 initialRebelEquipment append ["rhs_weap_rpg75"];
 initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enfield_mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK3CB_TKC_C_B_Sidor_MED","UK3CB_CW_SOV_O_LATE_B_Sidor_RIF","UK3CB_CW_SOV_O_EARLY_B_Sidor_RIF"];

--- a/A3-Antistasi/Templates/IFA_Reb_POL_Arct.sqf
+++ b/A3-Antistasi/Templates/IFA_Reb_POL_Arct.sqf
@@ -93,7 +93,6 @@ APERSMineMag = "LIB_shumine_42_MINE_mag";
 //Starting Unlocks
 initialRebelEquipment append ["LIB_PTRD","LIB_M38","LIB_Webley_Mk6","LIB_Webley_Flare"];
 initialRebelEquipment append ["LIB_M38"];
-initialWeapons append ["LIB_M38"];
 initialRebelEquipment append ["LIB_1Rnd_145x114","LIB_5Rnd_762x54","LIB_6Rnd_455","LIB_1Rnd_flare_red","LIB_1Rnd_flare_green","LIB_1Rnd_flare_white","LIB_1Rnd_flare_yellow","LIB_US_TNT_4pound_mag","LIB_Shg24","LIB_Shg24x7","LIB_No77"];
 initialRebelEquipment append ["B_LIB_SOV_RA_Gasbag"];
 initialRebelEquipment append ["V_LIB_WP_OfficerVest","V_LIB_WP_SniperBela","V_LIB_WP_Kar98Vest","V_LIB_SOV_RA_Belt"];

--- a/A3-Antistasi/Templates/IFA_Reb_POL_Arid.sqf
+++ b/A3-Antistasi/Templates/IFA_Reb_POL_Arid.sqf
@@ -93,7 +93,6 @@ APERSMineMag = "LIB_shumine_42_MINE_mag";
 //Starting Unlocks
 initialRebelEquipment append ["LIB_PTRD","LIB_M38","LIB_Webley_Mk6","LIB_Webley_Flare"];
 initialRebelEquipment append ["LIB_M38"];
-initialWeapons append ["LIB_M38"];
 initialRebelEquipment append ["LIB_1Rnd_145x114","LIB_5Rnd_762x54","LIB_6Rnd_455","LIB_1Rnd_flare_red","LIB_1Rnd_flare_green","LIB_1Rnd_flare_white","LIB_1Rnd_flare_yellow","LIB_US_TNT_4pound_mag","LIB_Shg24","LIB_Shg24x7","LIB_No77"];
 initialRebelEquipment append ["B_LIB_SOV_RA_Gasbag"];
 initialRebelEquipment append ["V_LIB_WP_OfficerVest","V_LIB_WP_SniperBela","V_LIB_WP_Kar98Vest","V_LIB_SOV_RA_Belt"];

--- a/A3-Antistasi/Templates/IFA_Reb_POL_Temp.sqf
+++ b/A3-Antistasi/Templates/IFA_Reb_POL_Temp.sqf
@@ -93,7 +93,6 @@ APERSMineMag = "LIB_shumine_42_MINE_mag";
 //Starting Unlocks
 initialRebelEquipment append ["LIB_PTRD","LIB_M38","LIB_Webley_Mk6","LIB_Webley_Flare"];
 initialRebelEquipment append ["LIB_M38"];
-initialWeapons append ["LIB_M38"];
 initialRebelEquipment append ["LIB_1Rnd_145x114","LIB_5Rnd_762x54","LIB_6Rnd_455","LIB_1Rnd_flare_red","LIB_1Rnd_flare_green","LIB_1Rnd_flare_white","LIB_1Rnd_flare_yellow","LIB_US_TNT_4pound_mag","LIB_Shg24","LIB_Shg24x7","LIB_No77"];
 initialRebelEquipment append ["B_LIB_SOV_RA_Gasbag"];
 initialRebelEquipment append ["V_LIB_WP_OfficerVest","V_LIB_WP_SniperBela","V_LIB_WP_Kar98Vest","V_LIB_SOV_RA_Belt"];

--- a/A3-Antistasi/Templates/RHS_Reb_CDF_Arid.sqf
+++ b/A3-Antistasi/Templates/RHS_Reb_CDF_Arid.sqf
@@ -93,7 +93,6 @@ APERSMineMag = "rhsusf_mine_m7a2_mag";
 //Starting Unlocks
 initialRebelEquipment append ["rhsusf_weap_m1911a1","rhs_weap_tt33","rhs_weap_Izh18","rhs_weap_m1garand_sa43","rhs_weap_m72a7"];
 initialRebelEquipment append ["rhs_weap_Izh18","rhs_weap_m1garand_sa43"];
-initialWeapons append ["rhs_weap_Izh18","rhs_weap_m1garand_sa43"];
 initialRebelEquipment append ["rhs_weap_m72a7"];
 initialRebelEquipment append ["rhsusf_mag_7x45acp_MHP","rhs_mag_762x25_8","rhsgref_1Rnd_00Buck","rhsgref_1Rnd_Slug","rhsgref_8Rnd_762x63_M2B_M1rifle","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["B_FieldPack_oli","B_FieldPack_blk","B_FieldPack_ocamo","B_FieldPack_oucamo","B_FieldPack_cbr"];

--- a/A3-Antistasi/Templates/RHS_Reb_CDF_Wdl.sqf
+++ b/A3-Antistasi/Templates/RHS_Reb_CDF_Wdl.sqf
@@ -93,7 +93,6 @@ APERSMineMag = "rhsusf_mine_m7a2_mag";
 //Starting Unlocks
 initialRebelEquipment append ["rhsusf_weap_m1911a1","rhs_weap_tt33","rhs_weap_Izh18","rhs_weap_m1garand_sa43","rhs_weap_m72a7"];
 initialRebelEquipment append ["rhs_weap_Izh18","rhs_weap_m1garand_sa43"];
-initialWeapons append ["rhs_weap_Izh18","rhs_weap_m1garand_sa43"];
 initialRebelEquipment append ["rhs_weap_m72a7"];
 initialRebelEquipment append ["rhsusf_mag_7x45acp_MHP","rhs_mag_762x25_8","rhsgref_1Rnd_00Buck","rhsgref_1Rnd_Slug","rhsgref_8Rnd_762x63_M2B_M1rifle","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["B_FieldPack_oli","B_FieldPack_blk","B_FieldPack_ocamo","B_FieldPack_oucamo","B_FieldPack_cbr"];

--- a/A3-Antistasi/Templates/RHS_Reb_NAPA_Arid.sqf
+++ b/A3-Antistasi/Templates/RHS_Reb_NAPA_Arid.sqf
@@ -93,7 +93,6 @@ APERSMineMag = "rhs_mine_ozm72_b_mag";
 //Starting Unlocks
 initialRebelEquipment append ["rhs_weap_type94_new","rhs_weap_tt33","rhs_weap_Izh18","rhs_weap_kar98k","rhs_weap_panzerfaust60"];
 initialRebelEquipment append ["rhs_weap_Izh18","rhs_weap_kar98k"];
-initialWeapons append ["rhs_weap_Izh18","rhs_weap_kar98k"];
 initialRebelEquipment append ["rhs_weap_panzerfaust60"];
 initialRebelEquipment append ["rhs_mag_6x8mm_mhp","rhs_mag_762x25_8","rhsgref_1Rnd_00Buck","rhsgref_1Rnd_Slug","rhsgref_5Rnd_792x57_kar98k","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["B_FieldPack_oli","B_FieldPack_blk","B_FieldPack_ocamo","B_FieldPack_oucamo","B_FieldPack_cbr"];

--- a/A3-Antistasi/Templates/RHS_Reb_NAPA_Wdl.sqf
+++ b/A3-Antistasi/Templates/RHS_Reb_NAPA_Wdl.sqf
@@ -93,7 +93,6 @@ APERSMineMag = "rhs_mine_ozm72_b_mag";
 //Starting Unlocks
 initialRebelEquipment append ["rhs_weap_type94_new","rhs_weap_tt33","rhs_weap_Izh18","rhs_weap_kar98k","rhs_weap_panzerfaust60"];
 initialRebelEquipment append ["rhs_weap_Izh18","rhs_weap_m1garand_sa43"];
-initialWeapons append ["rhs_weap_Izh18","rhs_weap_m1garand_sa43"];
 initialRebelEquipment append ["rhs_weap_panzerfaust60"];
 initialRebelEquipment append ["rhs_mag_6x8mm_mhp","rhs_mag_762x25_8","rhsgref_1Rnd_00Buck","rhsgref_1Rnd_Slug","rhsgref_5Rnd_792x57_kar98k","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["B_FieldPack_oli","B_FieldPack_blk","B_FieldPack_ocamo","B_FieldPack_oucamo","B_FieldPack_cbr"];

--- a/A3-Antistasi/Templates/Vanilla_Reb_FIA_Altis.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_FIA_Altis.sqf
@@ -96,7 +96,6 @@ APERSMineMag = "APERSMine_Range_Mag";
 //Starting Unlocks
 initialRebelEquipment append ["hgun_Pistol_heavy_02_F","hgun_P07_F","SMG_01_F","SMG_02_F"];
 initialRebelEquipment append ["SMG_01_F","SMG_02_F"];
-initialWeapons append ["SMG_01_F","SMG_02_F"];
 initialRebelEquipment append ["6Rnd_45ACP_Cylinder","16Rnd_9x21_Mag","30Rnd_45ACP_Mag_SMG_01","30Rnd_9x21_Mag_SMG_02","MiniGrenade","SmokeShell","IEDLandBig_Remote_Mag","IEDUrbanBig_Remote_Mag","IEDLandSmall_Remote_Mag","IEDUrbanSmall_Remote_Mag"];
 initialRebelEquipment append ["B_FieldPack_oli","B_FieldPack_blk","B_FieldPack_ocamo","B_FieldPack_oucamo","B_FieldPack_cbr","B_FieldPack_khk"];
 initialRebelEquipment append ["V_Chestrig_blk","V_Chestrig_rgr","V_Chestrig_khk","V_Chestrig_oli","V_BandollierB_blk","V_BandollierB_cbr","V_BandollierB_rgr","V_BandollierB_khk","V_BandollierB_oli","V_Rangemaster_belt"];

--- a/A3-Antistasi/Templates/Vanilla_Reb_FIA_B_Altis.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_FIA_B_Altis.sqf
@@ -93,7 +93,6 @@ APERSMineMag = "APERSMine_Range_Mag";
 //Starting Unlocks
 initialRebelEquipment append ["hgun_Pistol_heavy_02_F","hgun_ACPC2_F","hgun_PDW2000_F","SMG_01_F"];
 initialRebelEquipment append ["SMG_01_F","hgun_PDW2000_F"];
-initialWeapons append ["SMG_01_F","hgun_PDW2000_F"];
 initialRebelEquipment append ["6Rnd_45ACP_Cylinder","9Rnd_45_Mag","30Rnd_9x21_Mag","30Rnd_9x21_Mag_SMG_02","MiniGrenade","SmokeShell","IEDLandBig_Remote_Mag","IEDUrbanBig_Remote_Mag","IEDLandSmall_Remote_Mag","IEDUrbanSmall_Remote_Mag"];
 initialRebelEquipment append ["B_FieldPack_oli","B_FieldPack_blk","B_FieldPack_ocamo","B_FieldPack_oucamo","B_FieldPack_cbr","B_FieldPack_khk"];
 initialRebelEquipment append ["V_Chestrig_blk","V_Chestrig_rgr","V_Chestrig_khk","V_Chestrig_oli","V_BandollierB_blk","V_BandollierB_cbr","V_BandollierB_rgr","V_BandollierB_khk","V_BandollierB_oli","V_Rangemaster_belt"];

--- a/A3-Antistasi/Templates/Vanilla_Reb_FIA_Enoch.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_FIA_Enoch.sqf
@@ -95,7 +95,6 @@ APERSMineMag = "APERSMine_Range_Mag";
 //Starting Unlocks
 initialRebelEquipment append ["hgun_Pistol_heavy_02_F","hgun_Pistol_heavy_01_green_F","sgun_HunterShotgun_01_F","SMG_02_F"];
 initialRebelEquipment append ["SMG_02_F"];
-initialWeapons append ["sgun_HunterShotgun_01_F","SMG_02_F"];
 initialRebelEquipment append ["6Rnd_45ACP_Cylinder","9Rnd_45ACP_Mag","2Rnd_12Guage_Pellets","2Rnd_12Guage_Slug","30Rnd_9x21_Mag_SMG_02","MiniGrenade","SmokeShell","IEDLandBig_Remote_Mag","IEDUrbanBig_Remote_Mag","IEDLandSmall_Remote_Mag","IEDUrbanSmall_Remote_Mag"];
 initialRebelEquipment append ["B_FieldPack_blk","B_FieldPack_oucamo","B_FieldPack_cbr","B_FieldPack_oli","B_FieldPack_green_F","B_FieldPack_taiga_F"];
 initialRebelEquipment append ["V_Chestrig_blk","V_Chestrig_rgr","V_Chestrig_khk","V_Chestrig_oli","V_BandollierB_blk","V_SmershVest_01_F","V_BandollierB_rgr","V_SmershVest_01_radio_F","V_BandollierB_oli","V_Rangemaster_belt"];

--- a/A3-Antistasi/Templates/Vanilla_Reb_SDK_Tanoa.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_SDK_Tanoa.sqf
@@ -95,7 +95,6 @@ APERSMineMag = "APERSMine_Range_Mag";
 //Starting Unlocks
 initialRebelEquipment append ["hgun_Pistol_01_F","hgun_P07_khk_F","SMG_05_F","hgun_PDW2000_F"];
 initialRebelEquipment append ["SMG_05_F","hgun_PDW2000_F"];
-initialWeapons append ["SMG_05_F","hgun_PDW2000_F"];
 initialRebelEquipment append ["10Rnd_9x21_Mag","16Rnd_9x21_Mag","30Rnd_9x21_Mag_SMG_02","MiniGrenade","SmokeShell","IEDLandBig_Remote_Mag","IEDUrbanBig_Remote_Mag","IEDLandSmall_Remote_Mag","IEDUrbanSmall_Remote_Mag"];
 initialRebelEquipment append ["B_FieldPack_blk","B_FieldPack_oucamo","B_FieldPack_cbr","B_FieldPack_oli","B_FieldPack_ghex_F"];
 initialRebelEquipment append ["V_Chestrig_blk","V_Chestrig_rgr","V_Chestrig_khk","V_Chestrig_oli","V_BandollierB_blk","V_BandollierB_ghex","V_BandollierB_rgr","V_BandollierB_oli","V_Rangemaster_belt","V_TacChestrig_cbr_F","V_TacChestrig_oli_F","V_TacChestrig_grn_F"];

--- a/A3-Antistasi/functions/AI/fn_autoRearm.sqf
+++ b/A3-Antistasi/functions/AI/fn_autoRearm.sqf
@@ -275,7 +275,7 @@ if (hmd _unit == "") then {
 	if ((_foundItem) && (_unit getVariable "rearming")) then {
 		_unit stop false;
 		_selectedContainer setVariable ["busy",true];
-		_hmd = hmd _selectedContainer;
+		private _hmd = hmd _selectedContainer;
 		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking NV Googles"};
 		_timeOut = time + 60;
@@ -305,7 +305,7 @@ if (!(headgear _unit in allArmoredHeadgear)) then {
 	if ((_foundItem) && (_unit getVariable "rearming")) then {
 		_unit stop false;
 		_selectedContainer setVariable ["busy",true];
-		_helmet = headgear _selectedContainer;
+		private _helmet = headgear _selectedContainer;
 		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking a Helmet"};
 		_timeOut = time + 60;
@@ -321,8 +321,8 @@ if (!(headgear _unit in allArmoredHeadgear)) then {
 };
 
 _foundItem = false;
-_minFA = if ([_unit] call A3A_fnc_isMedic) then {10} else {1};
-if ({_x == "FirstAidKit"} count (items _unit) < _minFA) then {
+private _targetFAKs = if ([_unit] call A3A_fnc_isMedic) then {10} else {1};
+if ({_x == "FirstAidKit"} count (items _unit) < _targetFAKs) then {
 	_needsRearm = true;
 	_foundItem = false;
 	_deadBodies = allDead select {(_x distance _unit < _maxDistance) && (!(_x getVariable ["busy",false]))};
@@ -342,7 +342,7 @@ if ({_x == "FirstAidKit"} count (items _unit) < _minFA) then {
 		sleep 1;
 		waitUntil {!([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
 		if (_unit distance _selectedContainer < 3) then {
-			while {{_x == "FirstAidKit"} count (items _unit) < _minFA} do {
+			while {{_x == "FirstAidKit"} count (items _unit) < _targetFAKs} do {
 				_unit action ["rearm",_selectedContainer];
 				_unit addItem "FirstAidKit";
 				_selectedContainer removeItem "FirstAidKit";

--- a/A3-Antistasi/functions/AI/fn_autoRearm.sqf
+++ b/A3-Antistasi/functions/AI/fn_autoRearm.sqf
@@ -27,12 +27,14 @@ private _deadBodies = [];
 private _selectedBody = objNull;
 private _targetMagazines = 4;
 private _primaryMagazines = [];
+private _bodyEquipment = [];
+private _selectedEquipment = objNull;
 
 _nearbyContainers = nearestObjects [_unit, ["ReammoBox_F","LandVehicle","WeaponHolderSimulated","GroundWeaponHolder","WeaponHolder"], _maxDistance];
 if (boxX in _nearbyContainers) then {_nearbyContainers = _nearbyContainers - [boxX]};
 
 
-if ((_primaryWeapon in initialRebelEquipment) || (_primaryWeapon == "")) then {
+if ((_primaryWeapon in initialRebelEquipment) || (_primaryWeapon isEqualTo "")) then {
 	_needsRearm = true;
 	if (count _nearbyContainers > 0) then {
 		{
@@ -374,10 +376,10 @@ if ((_foundItem) && (_unit getVariable "rearming")) then {
 		_unit addVest (vest _selectedContainer);
 		{_unit addItemToVest _x} forEach _itemsUnit;
 		_unit action ["rearm",_selectedContainer];
-		_things = nearestObjects [_selectedContainer, ["WeaponHolderSimulated", "GroundWeaponHolder", "WeaponHolder"], 5];
-		if (count _things > 0) then {
-			_thingX = _things select 0;
-			{_thingX addItemCargoGlobal [_x,1]} forEach (vestItems _selectedContainer);
+		_bodyEquipment = nearestObjects [_selectedContainer, ["WeaponHolderSimulated", "GroundWeaponHolder", "WeaponHolder"], 5];
+		if (count _bodyEquipment > 0) then {
+			_selectedEquipment = _bodyEquipment select 0;
+			{_selectedEquipment addItemCargoGlobal [_x,1]} forEach (vestItems _selectedContainer);
 		};
 		removeVest _selectedContainer;
 	};
@@ -406,10 +408,10 @@ if (backpack _unit == "") then {
 		if (_unit distance _selectedContainer < 3) then {
 			_unit addBackPackGlobal ((backpack _selectedContainer) call A3A_fnc_basicBackpack);
 			_unit action ["rearm",_selectedContainer];
-			_things = nearestObjects [_selectedContainer, ["WeaponHolderSimulated", "GroundWeaponHolder", "WeaponHolder"], 5];
-			if (count _things > 0) then {
-				_thingX = _things select 0;
-				{_thingX addItemCargoGlobal [_x,1]} forEach (backpackItems _selectedContainer);
+			_bodyEquipment = nearestObjects [_selectedContainer, ["WeaponHolderSimulated", "GroundWeaponHolder", "WeaponHolder"], 5];
+			if (count _bodyEquipment > 0) then {
+				_selectedEquipment = _bodyEquipment select 0;
+				{_selectedEquipment addItemCargoGlobal [_x,1]} forEach (backpackItems _selectedContainer);
 			};
 			removeBackpackGlobal _selectedContainer;
 		};

--- a/A3-Antistasi/functions/AI/fn_autoRearm.sqf
+++ b/A3-Antistasi/functions/AI/fn_autoRearm.sqf
@@ -1,492 +1,413 @@
-private ["_unit","_Pweapon","_Sweapon","_countX","_magazines","_hasBox","_distanceX","_objectsX","_target","_victim","_check","_timeOut","_weaponX","_weaponsX","_rearming","_basePossible","_hmd","_helmet","_truckX","_autoLoot","_itemsUnit"];
-
-_unit = _this select 0;
-
+private _unit = _this select 0;
 if (isPlayer _unit) exitWith {};
 if !([_unit] call A3A_fnc_canFight) exitWith {};
-_inPlayerGroup = (isPlayer (leader _unit));
-//_helping = _unit getVariable "helping";
+
+private _inPlayerGroup = (isPlayer (leader _unit));
 if (_unit getVariable ["helping",false]) exitWith {if (_inPlayerGroup) then {_unit groupChat "I cannot rearm right now. I'm healing a comrade"}};
-_rearming = _unit getVariable ["rearming",false];
+
+private _rearming = _unit getVariable ["rearming",false];
 if (_rearming) exitWith {if (_inPlayerGroup) then {_unit groupChat "I am currently rearming. Cancelling."; _unit setVariable ["rearming",false]}};
 if (vehicle _unit != _unit) exitWith {};
 _unit setVariable ["rearming",true];
 
-_Pweapon = primaryWeapon _unit;
-_Sweapon = secondaryWeapon _unit;
+private _primaryWeapon = primaryWeapon _unit;
+private _secondaryWeapon = secondaryWeapon _unit;
+private _nearbyContainers = [];
+private _foundWeapon = false;
+private _weaponX = objNull;
+private _potentialWeapon = objNull;
+private _baseWeapon = objNull;
+private _potentialContainer = objNull;
+private _selectedContainer = objNull;
+private _containerWeapons = [];
+private _maxDistance = 51;
+private _needsRearm = false;
+private _timeOut = 0;
+private _deadBodies = [];
+private _selectedBody = objNull;
+private _targetMagazines = 4;
+private _primaryMagazines = [];
 
-_objectsX = [];
-_hasBox = false;
-_weaponX = "";
-_weaponsX = [];
-_distanceX = 51;
-_objectsX = nearestObjects [_unit, ["ReammoBox_F","LandVehicle","WeaponHolderSimulated", "GroundWeaponHolder", "WeaponHolder"], 50];
-if (boxX in _objectsX) then {_objectsX = _objectsX - [boxX]};
+_nearbyContainers = nearestObjects [_unit, ["ReammoBox_F","LandVehicle","WeaponHolderSimulated","GroundWeaponHolder","WeaponHolder"], _maxDistance];
+if (boxX in _nearbyContainers) then {_nearbyContainers = _nearbyContainers - [boxX]};
 
-_needsRearm = false;
 
-if ((_Pweapon in initialWeapons) or (_Pweapon == "")) then
-	{
+if ((_primaryWeapon in initialRebelEquipment) or (_primaryWeapon == "")) then {
 	_needsRearm = true;
-	if (count _objectsX > 0) then
+	if (count _nearbyContainers > 0) then {
 		{
-		{
-		_objectX = _x;
-		if (_unit distance _objectX < _distanceX) then
-			{
-			if ((count weaponCargo _objectX > 0) and !(_objectX getVariable ["busy",false])) then
-				{
-				_weaponsX = weaponCargo _objectX;
-				for "_i" from 0 to (count _weaponsX - 1) do
-					{
-					_potential = _weaponsX select _i;
-					_basePossible = [_potential] call BIS_fnc_baseWeapon;
-					if ((not(_basePossible in ["hgun_PDW2000_F","hgun_Pistol_01_F","hgun_ACPC2_F","arifle_AKM_F","arifle_AKS_F","SMG_05_F","LMG_03_F"])) and ((_basePossible in allRifles) or (_basePossible in allSniperRifles) or (_basePossible in allMachineGuns))) then
-						{
-						_target = _objectX;
-						_hasBox = true;
-						_distanceX = _unit distance _objectX;
-						_weaponX = _potential;
+			_potentialContainer = _x;
+			if (_unit distance _potentialContainer < _maxDistance) then {
+				if ((count weaponCargo _potentialContainer > 0) and !(_potentialContainer getVariable ["busy",false])) then {
+					_containerWeapons = weaponCargo _potentialContainer;
+					for "_i" from 0 to (count _containerWeapons - 1) do {
+						_potentialWeapon = _containerWeapons select _i;
+						_baseWeapon = [_potentialWeapon] call BIS_fnc_baseWeapon;
+						if (!(_baseWeapon in ["hgun_PDW2000_F","hgun_Pistol_01_F","hgun_ACPC2_F"]) && ((_baseWeapon in allRifles) || (_baseWeapon in allSniperRifles) || (_baseWeapon in allMachineGuns) || (_baseWeapon in allSMGs) || (_baseWeapon in allShotguns))) then {
+							_selectedContainer = _potentialContainer;
+							_foundWeapon = true;
+							_weaponX = _potentialWeapon;
+							};
 						};
 					};
 				};
-			};
-		} forEach _objectsX;
-		};
-	if ((_hasBox) and (_unit getVariable "rearming")) then
-		{
+		} forEach _nearbyContainers;
+	};
+	if ((_foundWeapon) and (_unit getVariable "rearming")) then {
 		_unit stop false;
-		if ((!alive _target) or (not(_target isKindOf "ReammoBox_F"))) then {_target setVariable ["busy",true]};
-		_unit doMove (getPosATL _target);
+		if ((!alive _selectedContainer) or (not(_selectedContainer isKindOf "ReammoBox_F"))) then {_selectedContainer setVariable ["busy",true]};
+		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking a better weapon"};
 		_timeOut = time + 60;
-		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _target) or (_unit distance _target < 3) or (_timeOut < time) or (unitReady _unit)};
-		if ((unitReady _unit) and ([_unit] call A3A_fnc_canFight) and (_unit distance _target > 3) and (_target isKindOf "ReammoBox_F") and (!isNull _target)) then {_unit setPos position _target};
-		if (_unit distance _target < 3) then
-			{
-			_unit action ["TakeWeapon",_target,_weaponX];
+		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _selectedContainer) or (_unit distance _selectedContainer < 3) or (_timeOut < time) or (unitReady _unit)};
+		if ((unitReady _unit) and ([_unit] call A3A_fnc_canFight) and (_unit distance _selectedContainer > 3) and (_selectedContainer isKindOf "ReammoBox_F") and (!isNull _selectedContainer)) then {_unit setPos position _selectedContainer};
+		if (_unit distance _selectedContainer < 3) then {
+			_unit action ["TakeWeapon",_selectedContainer,_weaponX];
 			sleep 5;
-			if (primaryWeapon _unit == _weaponX) then
-				{
+			if (primaryWeapon _unit == _weaponX) then {
 				if (_inPlayerGroup) then {_unit groupChat "I have a better weapon now"};
-				if (_target isKindOf "ReammoBox_F") then {_unit action ["rearm",_target]};
-				};
+				if (_selectedContainer isKindOf "ReammoBox_F") then {_unit action ["rearm",_selectedContainer]};
 			};
-		_target setVariable ["busy",false];
 		};
-	_distanceX = 51;
-	_Pweapon = primaryWeapon _unit;
+		_selectedContainer setVariable ["busy",false];
+	};
+	_primaryWeapon = primaryWeapon _unit;
 	sleep 3;
-	};
-_hasBox = false;
-_countX = 4;
-if (_Pweapon in allMachineGuns) then {_countX = 2};
-_magazines = getArray (configFile / "CfgWeapons" / _Pweapon / "magazines");
-if ({_x in _magazines} count (magazines _unit) < _countX) then
-	{
+};
+
+_foundWeapon = false;
+_targetMagazines = 4;
+if (_primaryWeapon in allMachineGuns) then {_targetMagazines = 2};
+_primaryMagazines = getArray (configFile / "CfgWeapons" / _primaryWeapon / "magazines");
+if ({_x in _primaryMagazines} count (magazines _unit) < _targetMagazines) then {
 	_needsRearm = true;
-	_hasBox = false;
-	if (count _objectsX > 0) then
+	_foundWeapon = false;
+	if (count _nearbyContainers > 0) then {
 		{
-		{
-		_objectX = _x;
-		if (({_x in _magazines} count magazineCargo _objectX) > 0) then
-			{
-			if (_unit distance _objectX < _distanceX) then
-				{
-				_target = _objectX;
-				_hasBox = true;
-				_distanceX = _unit distance _objectX;
+			_potentialContainer = _x;
+			if (({_x in _primaryMagazines} count magazineCargo _potentialContainer) > 0) then {
+				if (_unit distance _potentialContainer < _maxDistance) then {
+					_selectedContainer = _potentialContainer;
+					_foundWeapon = true;
 				};
 			};
-		} forEach _objectsX;
-		};
-	_victims = allDead select {(_x distance _unit < 51) and (!(_x getVariable ["busy",false]))};
-	{
-	_victim = _x;
-	if (({_x in _magazines} count (magazines _victim) > 0) and (_unit distance _victim < _distanceX)) then
-		{
-		_target = _victim;
-		_hasBox = true;
-		_distanceX = _victim distance _unit;
-		};
-	} forEach _victims;
+		} forEach _nearbyContainers;
 	};
-if ((_hasBox) and (_unit getVariable "rearming")) then
+	_deadBodies = allDead select {(_x distance _unit < _maxDistance) and (!(_x getVariable ["busy",false]))};
 	{
+		_selectedBody = _x;
+		if (({_x in _primaryMagazines} count (magazines _selectedBody) > 0) and (_unit distance _selectedBody < _maxDistance)) then {
+			_selectedContainer = _selectedBody;
+			_foundWeapon = true;
+		};
+	} forEach _deadBodies;
+};
+
+if ((_foundWeapon) and (_unit getVariable "rearming")) then {
 	_unit stop false;
-	if ((!alive _target) or (not(_target isKindOf "ReammoBox_F"))) then {_target setVariable ["busy",true]};
-	_unit doMove (getPosATL _target);
+	if ((!alive _selectedContainer) or (not(_selectedContainer isKindOf "ReammoBox_F"))) then {_selectedContainer setVariable ["busy",true]};
+	_unit doMove (getPosATL _selectedContainer);
 	if (_inPlayerGroup) then {_unit groupChat "Rearming"};
 	_timeOut = time + 60;
-	waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _target) or (_unit distance _target < 3) or (_timeOut < time) or (unitReady _unit)};
-	if ((unitReady _unit) and ([_unit] call A3A_fnc_canFight) and (_unit distance _target > 3) and (_target isKindOf "ReammoBox_F") and (!isNull _target)) then {_unit setPos position _target};
-	if (_unit distance _target < 3) then
-		{
-		_unit action ["rearm",_target];
-		if ({_x in _magazines} count (magazines _unit) >= _countX) then
-			{
+	waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _selectedContainer) or (_unit distance _selectedContainer < 3) or (_timeOut < time) or (unitReady _unit)};
+	if ((unitReady _unit) and ([_unit] call A3A_fnc_canFight) and (_unit distance _selectedContainer > 3) and (_selectedContainer isKindOf "ReammoBox_F") and (!isNull _selectedContainer)) then {_unit setPos position _selectedContainer};
+	if (_unit distance _selectedContainer < 3) then {
+		_unit action ["rearm",_selectedContainer];
+		if ({_x in _primaryMagazines} count (magazines _unit) >= _targetMagazines) then {
 			if (_inPlayerGroup) then {_unit groupChat "Rearmed"};
-			}
-		else
-			{
+		} else {
 			if (_inPlayerGroup) then {_unit groupChat "Partially Rearmed"};
-			};
 		};
-	_target setVariable ["busy",false];
-	}
-else
-	{
-	if (_inPlayerGroup) then {_unit groupChat "No source to rearm my primary weapon"};
 	};
-_hasBox = false;
-if ((_Sweapon == "") and (loadAbs _unit < 340)) then
-	{
-	if (count _objectsX > 0) then
+	_selectedContainer setVariable ["busy",false];
+} else {
+	if (_inPlayerGroup) then {_unit groupChat "No source to rearm my primary weapon"};
+};
+
+_foundWeapon = false;
+if ((_secondaryWeapon == "") and (loadAbs _unit < 340)) then {
+	if (count _nearbyContainers > 0) then {
 		{
-		{
-		_objectX = _x;
-		if (_unit distance _objectX < _distanceX) then
-			{
-			if ((count weaponCargo _objectX > 0) and !(_objectX getVariable ["busy",false])) then
-				{
-				_weaponsX = weaponCargo _objectX;
-				for "_i" from 0 to (count _weaponsX - 1) do
-					{
-					_potential = _weaponsX select _i;
-					if ((_potential in allMissileLaunchers) or (_potential in allRocketLaunchers)) then
-						{
-						_target = _objectX;
-						_hasBox = true;
-						_distanceX = _unit distance _objectX;
-						_weaponX = _potential;
+			_potentialContainer = _x;
+			if (_unit distance _potentialContainer < _maxDistance) then {
+				if ((count weaponCargo _potentialContainer > 0) and !(_potentialContainer getVariable ["busy",false])) then {
+					_containerWeapons = weaponCargo _potentialContainer;
+					for "_i" from 0 to (count _containerWeapons - 1) do {
+						_potentialWeapon = _containerWeapons select _i;
+						if ((_potentialWeapon in allMissileLaunchers) or (_potentialWeapon in allRocketLaunchers)) then {
+							_selectedContainer = _potentialContainer;
+							_foundWeapon = true;
+							_weaponX = _potentialWeapon;
 						};
 					};
 				};
 			};
-		} forEach _objectsX;
-		};
-	if ((_hasBox) and (_unit getVariable "rearming")) then
-		{
+		} forEach _nearbyContainers;
+	};
+	if ((_foundWeapon) and (_unit getVariable "rearming")) then {
 		_unit stop false;
-		if ((!alive _target) or (not(_target isKindOf "ReammoBox_F"))) then {_target setVariable ["busy",true]};
-		_unit doMove (getPosATL _target);
+		if ((!alive _selectedContainer) or (not(_selectedContainer isKindOf "ReammoBox_F"))) then {_selectedContainer setVariable ["busy",true]};
+		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking a secondary weapon"};
 		_timeOut = time + 60;
-		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _target) or (_unit distance _target < 3) or (_timeOut < time) or (unitReady _unit)};
-		if ((unitReady _unit) and ([_unit] call A3A_fnc_canFight) and (_unit distance _target > 3) and (_target isKindOf "ReammoBox_F") and (!isNull _target)) then {_unit setPos position _target};
-		if (_unit distance _target < 3) then
-			{
-			_unit action ["TakeWeapon",_target,_weaponX];
+		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _selectedContainer) or (_unit distance _selectedContainer < 3) or (_timeOut < time) or (unitReady _unit)};
+		if ((unitReady _unit) and ([_unit] call A3A_fnc_canFight) and (_unit distance _selectedContainer > 3) and (_selectedContainer isKindOf "ReammoBox_F") and (!isNull _selectedContainer)) then {_unit setPos position _selectedContainer};
+		if (_unit distance _selectedContainer < 3) then {
+			_unit action ["TakeWeapon",_selectedContainer,_weaponX];
 			sleep 3;
-			if (secondaryWeapon _unit == _weaponX) then
-				{
+			if (secondaryWeapon _unit == _weaponX) then {
 				if (_inPlayerGroup) then {_unit groupChat "I have a secondary weapon now"};
-				if (_target isKindOf "ReammoBox_F") then {sleep 3;_unit action ["rearm",_target]};
-				};
+				if (_selectedContainer isKindOf "ReammoBox_F") then {sleep 3;_unit action ["rearm",_selectedContainer]};
 			};
-		_target setVariable ["busy",false];
 		};
-	_Sweapon = secondaryWeapon _unit;
-	_distanceX = 51;
-	sleep 3;
+		_selectedContainer setVariable ["busy",false];
 	};
-_hasBox = false;
-if (_Sweapon != "") then
-	{
-	_magazines = getArray (configFile / "CfgWeapons" / _Sweapon / "magazines");
-	if ({_x in _magazines} count (magazines _unit) < 2) then
-		{
+	_secondaryWeapon = secondaryWeapon _unit;
+	sleep 3;
+};
+
+_foundWeapon = false;
+if (_secondaryWeapon != "") then {
+	_primaryMagazines = getArray (configFile / "CfgWeapons" / _secondaryWeapon / "magazines");
+	if ({_x in _primaryMagazines} count (magazines _unit) < 2) then {
 		_needsRearm = true;
-		_hasBox = false;
-		_distanceX = 50;
-		if (count _objectsX > 0) then
+		_foundWeapon = false;
+		if (count _nearbyContainers > 0) then {
 			{
-			{
-			_objectX = _x;
-			if ({_x in _magazines} count magazineCargo _objectX > 0) then
-				{
-				if (_unit distance _objectX < _distanceX) then
-					{
-					_target = _objectX;
-					_hasBox = true;
-					_distanceX = _unit distance _objectX;
+				_potentialContainer = _x;
+				if ({_x in _primaryMagazines} count magazineCargo _potentialContainer > 0) then {
+					if (_unit distance _potentialContainer < _maxDistance) then {
+						_selectedContainer = _potentialContainer;
+						_foundWeapon = true;
 					};
 				};
-			} forEach _objectsX;
-			};
-		_victims = allDead select {(_x distance _unit < 51) and (!(_x getVariable ["busy",false]))};
-		{
-		_victim = _x;
-		if (({_x in _magazines} count (magazines _victim) > 0) and (_unit distance _victim < _distanceX)) then
-			{
-			_target = _victim;
-			_hasBox = true;
-			_distanceX = _victim distance _unit;
-			};
-		} forEach _victims;
+			} forEach _nearbyContainers;
 		};
-	if ((_hasBox) and (_unit getVariable "rearming")) then
+		_deadBodies = allDead select {(_x distance _unit < _maxDistance) and (!(_x getVariable ["busy",false]))};
 		{
+			_selectedBody = _x;
+			if (({_x in _primaryMagazines} count (magazines _selectedBody) > 0) and (_unit distance _selectedBody < _maxDistance)) then {
+				_selectedContainer = _selectedBody;
+				_foundWeapon = true;
+			};
+		} forEach _deadBodies;
+	};
+	if ((_foundWeapon) and (_unit getVariable "rearming")) then {
 		_unit stop false;
-		if (!alive _target) then {_target setVariable ["busy",true]};
-		_unit doMove (position _target);
+		if (!alive _selectedContainer) then {_selectedContainer setVariable ["busy",true]};
+		_unit doMove (position _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Rearming"};
 		_timeOut = time + 60;
-		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _target) or (_unit distance _target < 3) or (_timeOut < time) or (unitReady _unit)};
-		if ((unitReady _unit) and ([_unit] call A3A_fnc_canFight) and (_unit distance _target > 3) and (_target isKindOf "ReammoBox_F") and (!isNull _target)) then {_unit setPos position _target};
-		if (_unit distance _target < 3) then
-			{
-			if ((backpack _unit == "") and (backPack _target != "")) then
-				{
-				_unit addBackPackGlobal ((backpack _target) call A3A_fnc_basicBackpack);
-				_unit action ["rearm",_target];
+		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _selectedContainer) or (_unit distance _selectedContainer < 3) or (_timeOut < time) or (unitReady _unit)};
+		if ((unitReady _unit) and ([_unit] call A3A_fnc_canFight) and (_unit distance _selectedContainer > 3) and (_selectedContainer isKindOf "ReammoBox_F") and (!isNull _selectedContainer)) then {_unit setPos position _selectedContainer};
+		if (_unit distance _selectedContainer < 3) then {
+			if ((backpack _unit == "") and (backPack _selectedContainer != "")) then {
+				_unit addBackPackGlobal ((backpack _selectedContainer) call A3A_fnc_basicBackpack);
+				_unit action ["rearm",_selectedContainer];
 				sleep 3;
-				{_unit addItemToBackpack _x} forEach (backpackItems _target);
-				removeBackpackGlobal _target;
-				}
-			else
-				{
-				_unit action ["rearm",_target];
-				};
-
-			if ({_x in _magazines} count (magazines _unit) >= 2) then
-				{
-				if (_inPlayerGroup) then {_unit groupChat "Rearmed"};
-				}
-			else
-				{
-				if (_inPlayerGroup) then {_unit groupChat "Partially Rearmed"};
-				};
+				{_unit addItemToBackpack _x} forEach (backpackItems _selectedContainer);
+				removeBackpackGlobal _selectedContainer;
+			} else {
+				_unit action ["rearm",_selectedContainer];
 			};
-		_target setVariable ["busy",false];
-		}
-	else
-		{
+
+			if ({_x in _primaryMagazines} count (magazines _unit) >= 2) then {
+				if (_inPlayerGroup) then {_unit groupChat "Rearmed"};
+			} else {
+				if (_inPlayerGroup) then {_unit groupChat "Partially Rearmed"};
+			};
+		};
+		_selectedContainer setVariable ["busy",false];
+	} else {
 		if (_inPlayerGroup) then {_unit groupChat "No source to rearm my secondary weapon"};
-		};
-	sleep 3;
 	};
-_hasBox = false;
-if (!haveRadio && {_unit call A3A_fnc_getRadio == ""}) then
-	{
+	sleep 3;
+};
+
+_foundWeapon = false;
+if (!haveRadio && {_unit call A3A_fnc_getRadio == ""}) then {
 	_needsRearm = true;
-	_hasBox = false;
-	_distanceX = 50;
-	_victims = allDead select {(_x distance _unit < 51) and (!(_x getVariable ["busy",false]))};
+	_foundWeapon = false;
+	_deadBodies = allDead select {(_x distance _unit < _maxDistance) and (!(_x getVariable ["busy",false]))};
 	{
-	_victim = _x;
-	if ((_victim call A3A_fnc_getRadio != "") and (_unit distance _victim < _distanceX)) then
-		{
-		_target = _victim;
-		_hasBox = true;
-		_distanceX = _victim distance _unit;
+		_selectedBody = _x;
+		if ((_selectedBody call A3A_fnc_getRadio != "") and (_unit distance _selectedBody < _maxDistance)) then {
+			_selectedContainer = _selectedBody;
+			_foundWeapon = true;
 		};
-	} forEach _victims;
-	if ((_hasBox) and (_unit getVariable "rearming")) then
-		{
+	} forEach _deadBodies;
+	if ((_foundWeapon) and (_unit getVariable "rearming")) then {
 		_unit stop false;
-		_target setVariable ["busy",true];
-		_unit doMove (getPosATL _target);
+		_selectedContainer setVariable ["busy",true];
+		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking a Radio"};
 		_timeOut = time + 60;
-		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _target) or (_unit distance _target < 3) or (_timeOut < time) or (unitReady _unit)};
-		if (_unit distance _target < 3) then
-			{
-			_unit action ["rearm",_target];
-			private _radio = _target call A3A_fnc_getRadio;
+		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _selectedContainer) or (_unit distance _selectedContainer < 3) or (_timeOut < time) or (unitReady _unit)};
+		if (_unit distance _selectedContainer < 3) then {
+			_unit action ["rearm",_selectedContainer];
+			private _radio = _selectedContainer call A3A_fnc_getRadio;
 			_unit linkItem _radio;
-			_target unlinkItem _radio;
-			};
-		_target setVariable ["busy",false];
+			_selectedContainer unlinkItem _radio;
 		};
+		_selectedContainer setVariable ["busy",false];
 	};
-_hasBox = false;
-if (hmd _unit == "") then
-	{
-	_needsRearm = true;
-	_hasBox = false;
-	_distanceX = 50;
-	_victims = allDead select {(_x distance _unit < 51) and (!(_x getVariable ["busy",false]))};
-	{
-	_victim = _x;
-	if ((hmd _victim != "") and (_unit distance _victim < _distanceX)) then
-		{
-		_target = _victim;
-		_hasBox = true;
-		_distanceX = _victim distance _unit;
-		};
-	} forEach _victims;
+};
 
-	if ((_hasBox) and (_unit getVariable "rearming")) then
-		{
+_foundWeapon = false;
+if (hmd _unit == "") then {
+	_needsRearm = true;
+	_foundWeapon = false;
+	_deadBodies = allDead select {(_x distance _unit < _maxDistance) and (!(_x getVariable ["busy",false]))};
+	{
+		_selectedBody = _x;
+		if ((hmd _selectedBody != "") and (_unit distance _selectedBody < _maxDistance)) then {
+			_selectedContainer = _selectedBody;
+			_foundWeapon = true;
+		};
+	} forEach _deadBodies;
+	if ((_foundWeapon) and (_unit getVariable "rearming")) then {
 		_unit stop false;
-		_target setVariable ["busy",true];
-		_hmd = hmd _target;
-		_unit doMove (getPosATL _target);
+		_selectedContainer setVariable ["busy",true];
+		_hmd = hmd _selectedContainer;
+		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking NV Googles"};
 		_timeOut = time + 60;
-		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _target) or (_unit distance _target < 3) or (_timeOut < time) or (unitReady _unit)};
-		if (_unit distance _target < 3) then
-			{
-			_unit action ["rearm",_target];
+		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _selectedContainer) or (_unit distance _selectedContainer < 3) or (_timeOut < time) or (unitReady _unit)};
+		if (_unit distance _selectedContainer < 3) then {
+			_unit action ["rearm",_selectedContainer];
 			_unit linkItem _hmd;
-			_target unlinkItem _hmd;
-			};
-		_target setVariable ["busy",false];
+			_selectedContainer unlinkItem _hmd;
 		};
+		_selectedContainer setVariable ["busy",false];
 	};
-_hasBox = false;
-if (not(headgear _unit in allArmoredHeadgear)) then
-	{
+};
+
+_foundWeapon = false;
+if (not(headgear _unit in allArmoredHeadgear)) then {
 	_needsRearm = true;
-	_hasBox = false;
-	_distanceX = 50;
-	_victims = allDead select {(_x distance _unit < 51) and (!(_x getVariable ["busy",false]))};
+	_foundWeapon = false;
+	_deadBodies = allDead select {(_x distance _unit < _maxDistance) and (!(_x getVariable ["busy",false]))};
 	{
-	_victim = _x;
-	if (((headgear _victim) in allArmoredHeadgear) and (_unit distance _victim < _distanceX)) then
-		{
-		_target = _victim;
-		_hasBox = true;
-		_distanceX = _victim distance _unit;
+		_selectedBody = _x;
+		if (((headgear _selectedBody) in allArmoredHeadgear) and (_unit distance _selectedBody < _maxDistance)) then {
+			_selectedContainer = _selectedBody;
+			_foundWeapon = true;
 		};
-	} forEach _victims;
-	if ((_hasBox) and (_unit getVariable "rearming")) then
-		{
+	} forEach _deadBodies;
+	if ((_foundWeapon) and (_unit getVariable "rearming")) then {
 		_unit stop false;
-		_target setVariable ["busy",true];
-		_helmet = headgear _target;
-		_unit doMove (getPosATL _target);
+		_selectedContainer setVariable ["busy",true];
+		_helmet = headgear _selectedContainer;
+		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking a Helmet"};
 		_timeOut = time + 60;
-		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _target) or (_unit distance _target < 3) or (_timeOut < time) or (unitReady _unit)};
-		if (_unit distance _target < 3) then
-			{
-			_unit action ["rearm",_target];
+		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _selectedContainer) or (_unit distance _selectedContainer < 3) or (_timeOut < time) or (unitReady _unit)};
+		if (_unit distance _selectedContainer < 3) then {
+			_unit action ["rearm",_selectedContainer];
 			_unit addHeadgear _helmet;
-			removeHeadgear _target;
-			};
-		_target setVariable ["busy",false];
+			removeHeadgear _selectedContainer;
 		};
+		_selectedContainer setVariable ["busy",false];
 	};
-_hasBox = false;
-_minFA = if ([_unit] call A3A_fnc_isMedic) then {10} else {1};
+};
 
-if ({_x == "FirstAidKit"} count (items _unit) < _minFA) then
-	{
+_foundWeapon = false;
+_minFA = if ([_unit] call A3A_fnc_isMedic) then {10} else {1};
+if ({_x == "FirstAidKit"} count (items _unit) < _minFA) then {
 	_needsRearm = true;
-	_hasBox = false;
-	_distanceX = 50;
-	_victims = allDead select {(_x distance _unit < 51) and (!(_x getVariable ["busy",false]))};
+	_foundWeapon = false;
+	_deadBodies = allDead select {(_x distance _unit < _maxDistance) and (!(_x getVariable ["busy",false]))};
 	{
-	_victim = _x;
-	if (("FirstAidKit" in items _victim) and (_unit distance _victim < _distanceX)) then
-		{
-		_target = _victim;
-		_hasBox = true;
-		_distanceX = _victim distance _unit;
+		_selectedBody = _x;
+		if (("FirstAidKit" in items _selectedBody) and (_unit distance _selectedBody < _maxDistance)) then {
+			_selectedContainer = _selectedBody;
+			_foundWeapon = true;
 		};
-	} forEach _victims;
-	if ((_hasBox) and (_unit getVariable "rearming")) then
-		{
+	} forEach _deadBodies;
+	if ((_foundWeapon) and (_unit getVariable "rearming")) then {
 		_unit stop false;
-		_target setVariable ["busy",true];
-		_unit doMove (getPosATL _target);
+		_selectedContainer setVariable ["busy",true];
+		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking a First Aid Kit"};
 		_timeOut = time + 60;
-		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _target) or (_unit distance _target < 3) or (_timeOut < time) or (unitReady _unit)};
-		if (_unit distance _target < 3) then
-			{
-			while {{_x == "FirstAidKit"} count (items _unit) < _minFA} do
-				{
-				_unit action ["rearm",_target];
+		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _selectedContainer) or (_unit distance _selectedContainer < 3) or (_timeOut < time) or (unitReady _unit)};
+		if (_unit distance _selectedContainer < 3) then {
+			while {{_x == "FirstAidKit"} count (items _unit) < _minFA} do {
+				_unit action ["rearm",_selectedContainer];
 				_unit addItem "FirstAidKit";
-				_target removeItem "FirstAidKit";
-				if ("FirstAidKit" in items _victim) then {sleep 3};
-				};
+				_selectedContainer removeItem "FirstAidKit";
+				if ("FirstAidKit" in items _selectedBody) then {sleep 3};
 			};
-		_target setVariable ["busy",false];
 		};
+		_selectedContainer setVariable ["busy",false];
 	};
-_hasBox = false;
+};
+
+_foundWeapon = false;
 _numberX = getNumber (configfile >> "CfgWeapons" >> vest cursortarget >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Chest" >> "armor");
-_distanceX = 50;
-_victims = allDead select {(_x distance _unit < 51) and (!(_x getVariable ["busy",false]))};
+_deadBodies = allDead select {(_x distance _unit < _maxDistance) and (!(_x getVariable ["busy",false]))};
 {
-_victim = _x;
-if ((getNumber (configfile >> "CfgWeapons" >> vest _victim >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Chest" >> "armor") > _numberX) and (_unit distance _victim < _distanceX)) then
-	{
-	_target = _victim;
-	_hasBox = true;
-	_distanceX = _victim distance _unit;
+	_selectedBody = _x;
+	if ((getNumber (configfile >> "CfgWeapons" >> vest _selectedBody >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Chest" >> "armor") > _numberX) and (_unit distance _selectedBody < _maxDistance)) then {
+		_selectedContainer = _selectedBody;
+		_foundWeapon = true;
 	};
-} forEach _victims;
-if ((_hasBox) and (_unit getVariable "rearming")) then
-	{
+} forEach _deadBodies;
+if ((_foundWeapon) and (_unit getVariable "rearming")) then {
 	_unit stop false;
-	_target setVariable ["busy",true];
-	_unit doMove (getPosATL _target);
+	_selectedContainer setVariable ["busy",true];
+	_unit doMove (getPosATL _selectedContainer);
 	if (_inPlayerGroup) then {_unit groupChat "Picking a a better vest"};
 	_timeOut = time + 60;
-	waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _target) or (_unit distance _target < 3) or (_timeOut < time) or (unitReady _unit)};
-	if (_unit distance _target < 3) then
-		{
+	waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _selectedContainer) or (_unit distance _selectedContainer < 3) or (_timeOut < time) or (unitReady _unit)};
+	if (_unit distance _selectedContainer < 3) then {
 		_itemsUnit = vestItems _unit;
-		_unit addVest (vest _target);
+		_unit addVest (vest _selectedContainer);
 		{_unit addItemToVest _x} forEach _itemsUnit;
-		_unit action ["rearm",_target];
-		//{_unit addItemCargoGlobal [_x,1]} forEach ((backpackItems _target) + (backpackMagazines _target));
-		_things = nearestObjects [_target, ["WeaponHolderSimulated", "GroundWeaponHolder", "WeaponHolder"], 5];
-		if (count _things > 0) then
-			{
+		_unit action ["rearm",_selectedContainer];
+		//{_unit addItemCargoGlobal [_x,1]} forEach ((backpackItems _selectedContainer) + (backpackMagazines _selectedContainer));
+		_things = nearestObjects [_selectedContainer, ["WeaponHolderSimulated", "GroundWeaponHolder", "WeaponHolder"], 5];
+		if (count _things > 0) then {
 			_thingX = _things select 0;
-			{_thingX addItemCargoGlobal [_x,1]} forEach (vestItems _target);
-			};
-		removeVest _target;
+			{_thingX addItemCargoGlobal [_x,1]} forEach (vestItems _selectedContainer);
 		};
-	_target setVariable ["busy",false];
+		removeVest _selectedContainer;
 	};
+	_selectedContainer setVariable ["busy",false];
+};
 
-if (backpack _unit == "") then
-	{
+if (backpack _unit == "") then {
 	_needsRearm = true;
-	_hasBox = false;
-	_distanceX = 50;
-	_victims = allDead select {(_x distance _unit < 51) and (!(_x getVariable ["busy",false]))};
+	_foundWeapon = false;
+	_deadBodies = allDead select {(_x distance _unit < _maxDistance) and (!(_x getVariable ["busy",false]))};
 	{
-	_victim = _x;
-	if ((backpack _victim != "") and (_unit distance _victim < _distanceX)) then
-		{
-		_target = _victim;
-		_hasBox = true;
-		_distanceX = _victim distance _unit;
+		_selectedBody = _x;
+		if ((backpack _selectedBody != "") and (_unit distance _selectedBody < _maxDistance)) then {
+			_selectedContainer = _selectedBody;
+			_foundWeapon = true;
 		};
-	} forEach _victims;
-	if ((_hasBox) and (_unit getVariable "rearming")) then
-		{
+	} forEach _deadBodies;
+	if ((_foundWeapon) and (_unit getVariable "rearming")) then {
 		_unit stop false;
-		_target setVariable ["busy",true];
-		_unit doMove (getPosATL _target);
+		_selectedContainer setVariable ["busy",true];
+		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking a Backpack"};
 		_timeOut = time + 60;
-		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _target) or (_unit distance _target < 3) or (_timeOut < time) or (unitReady _unit)};
-		if (_unit distance _target < 3) then
-			{
-			_unit addBackPackGlobal ((backpack _target) call A3A_fnc_basicBackpack);
-			_unit action ["rearm",_target];
-			//{_unit addItemCargoGlobal [_x,1]} forEach ((backpackItems _target) + (backpackMagazines _target));
-			_things = nearestObjects [_target, ["WeaponHolderSimulated", "GroundWeaponHolder", "WeaponHolder"], 5];
-			if (count _things > 0) then
-				{
+		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _selectedContainer) or (_unit distance _selectedContainer < 3) or (_timeOut < time) or (unitReady _unit)};
+		if (_unit distance _selectedContainer < 3) then {
+			_unit addBackPackGlobal ((backpack _selectedContainer) call A3A_fnc_basicBackpack);
+			_unit action ["rearm",_selectedContainer];
+			_things = nearestObjects [_selectedContainer, ["WeaponHolderSimulated", "GroundWeaponHolder", "WeaponHolder"], 5];
+			if (count _things > 0) then {
 				_thingX = _things select 0;
-				{_thingX addItemCargoGlobal [_x,1]} forEach (backpackItems _target);
-				};
-			removeBackpackGlobal _target;
+				{_thingX addItemCargoGlobal [_x,1]} forEach (backpackItems _selectedContainer);
 			};
-		_target setVariable ["busy",false];
+			removeBackpackGlobal _selectedContainer;
 		};
+		_selectedContainer setVariable ["busy",false];
 	};
+};
+
 _unit doFollow (leader _unit);
 if (!_needsRearm) then {if (_inPlayerGroup) then {_unit groupChat "No need to rearm"}} else {if (_inPlayerGroup) then {_unit groupChat "Rearming Done"}};
 _unit setVariable ["rearming",false];

--- a/A3-Antistasi/functions/AI/fn_autoRearm.sqf
+++ b/A3-Antistasi/functions/AI/fn_autoRearm.sqf
@@ -13,8 +13,8 @@ _unit setVariable ["rearming",true];
 private _primaryWeapon = primaryWeapon _unit;
 private _secondaryWeapon = secondaryWeapon _unit;
 private _nearbyContainers = [];
-private _foundWeapon = false;
-private _weaponX = objNull;
+private _foundItem = false;
+private _selectedWeapon = objNull;
 private _potentialWeapon = objNull;
 private _baseWeapon = objNull;
 private _potentialContainer = objNull;
@@ -32,39 +32,40 @@ _nearbyContainers = nearestObjects [_unit, ["ReammoBox_F","LandVehicle","WeaponH
 if (boxX in _nearbyContainers) then {_nearbyContainers = _nearbyContainers - [boxX]};
 
 
-if ((_primaryWeapon in initialRebelEquipment) or (_primaryWeapon == "")) then {
+if ((_primaryWeapon in initialRebelEquipment) || (_primaryWeapon == "")) then {
 	_needsRearm = true;
 	if (count _nearbyContainers > 0) then {
 		{
 			_potentialContainer = _x;
 			if (_unit distance _potentialContainer < _maxDistance) then {
-				if ((count weaponCargo _potentialContainer > 0) and !(_potentialContainer getVariable ["busy",false])) then {
+				if ((count weaponCargo _potentialContainer > 0) && !(_potentialContainer getVariable ["busy",false])) then {
 					_containerWeapons = weaponCargo _potentialContainer;
 					for "_i" from 0 to (count _containerWeapons - 1) do {
 						_potentialWeapon = _containerWeapons select _i;
 						_baseWeapon = [_potentialWeapon] call BIS_fnc_baseWeapon;
 						if (!(_baseWeapon in ["hgun_PDW2000_F","hgun_Pistol_01_F","hgun_ACPC2_F"]) && ((_baseWeapon in allRifles) || (_baseWeapon in allSniperRifles) || (_baseWeapon in allMachineGuns) || (_baseWeapon in allSMGs) || (_baseWeapon in allShotguns))) then {
 							_selectedContainer = _potentialContainer;
-							_foundWeapon = true;
-							_weaponX = _potentialWeapon;
+							_foundItem = true;
+							_selectedWeapon = _potentialWeapon;
 							};
 						};
 					};
 				};
 		} forEach _nearbyContainers;
 	};
-	if ((_foundWeapon) and (_unit getVariable "rearming")) then {
+	if ((_foundItem) && (_unit getVariable "rearming")) then {
 		_unit stop false;
-		if ((!alive _selectedContainer) or (not(_selectedContainer isKindOf "ReammoBox_F"))) then {_selectedContainer setVariable ["busy",true]};
+		if (!((alive _selectedContainer) || (_selectedContainer isKindOf "ReammoBox_F"))) then {_selectedContainer setVariable ["busy",true]};
 		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking a better weapon"};
 		_timeOut = time + 60;
-		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _selectedContainer) or (_unit distance _selectedContainer < 3) or (_timeOut < time) or (unitReady _unit)};
-		if ((unitReady _unit) and ([_unit] call A3A_fnc_canFight) and (_unit distance _selectedContainer > 3) and (_selectedContainer isKindOf "ReammoBox_F") and (!isNull _selectedContainer)) then {_unit setPos position _selectedContainer};
+		sleep 1;
+		waitUntil {!([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
+		if ((unitReady _unit) && ([_unit] call A3A_fnc_canFight) && (_unit distance _selectedContainer > 3) && (_selectedContainer isKindOf "ReammoBox_F") && (!isNull _selectedContainer)) then {_unit setPos position _selectedContainer};
 		if (_unit distance _selectedContainer < 3) then {
-			_unit action ["TakeWeapon",_selectedContainer,_weaponX];
+			_unit action ["TakeWeapon",_selectedContainer,_selectedWeapon];
 			sleep 5;
-			if (primaryWeapon _unit == _weaponX) then {
+			if (primaryWeapon _unit isEqualTo _selectedWeapon) then {
 				if (_inPlayerGroup) then {_unit groupChat "I have a better weapon now"};
 				if (_selectedContainer isKindOf "ReammoBox_F") then {_unit action ["rearm",_selectedContainer]};
 			};
@@ -75,42 +76,43 @@ if ((_primaryWeapon in initialRebelEquipment) or (_primaryWeapon == "")) then {
 	sleep 3;
 };
 
-_foundWeapon = false;
+_foundItem = false;
 _targetMagazines = 4;
 if (_primaryWeapon in allMachineGuns) then {_targetMagazines = 2};
 _primaryMagazines = getArray (configFile / "CfgWeapons" / _primaryWeapon / "magazines");
 if ({_x in _primaryMagazines} count (magazines _unit) < _targetMagazines) then {
 	_needsRearm = true;
-	_foundWeapon = false;
+	_foundItem = false;
 	if (count _nearbyContainers > 0) then {
 		{
 			_potentialContainer = _x;
 			if (({_x in _primaryMagazines} count magazineCargo _potentialContainer) > 0) then {
 				if (_unit distance _potentialContainer < _maxDistance) then {
 					_selectedContainer = _potentialContainer;
-					_foundWeapon = true;
+					_foundItem = true;
 				};
 			};
 		} forEach _nearbyContainers;
 	};
-	_deadBodies = allDead select {(_x distance _unit < _maxDistance) and (!(_x getVariable ["busy",false]))};
+	_deadBodies = allDead select {(_x distance _unit < _maxDistance) && (!(_x getVariable ["busy",false]))};
 	{
 		_selectedBody = _x;
-		if (({_x in _primaryMagazines} count (magazines _selectedBody) > 0) and (_unit distance _selectedBody < _maxDistance)) then {
+		if (({_x in _primaryMagazines} count (magazines _selectedBody) > 0) && (_unit distance _selectedBody < _maxDistance)) then {
 			_selectedContainer = _selectedBody;
-			_foundWeapon = true;
+			_foundItem = true;
 		};
 	} forEach _deadBodies;
 };
 
-if ((_foundWeapon) and (_unit getVariable "rearming")) then {
+if ((_foundItem) && (_unit getVariable "rearming")) then {
 	_unit stop false;
-	if ((!alive _selectedContainer) or (not(_selectedContainer isKindOf "ReammoBox_F"))) then {_selectedContainer setVariable ["busy",true]};
+	if (!((alive _selectedContainer) || (_selectedContainer isKindOf "ReammoBox_F"))) then {_selectedContainer setVariable ["busy",true]};
 	_unit doMove (getPosATL _selectedContainer);
 	if (_inPlayerGroup) then {_unit groupChat "Rearming"};
 	_timeOut = time + 60;
-	waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _selectedContainer) or (_unit distance _selectedContainer < 3) or (_timeOut < time) or (unitReady _unit)};
-	if ((unitReady _unit) and ([_unit] call A3A_fnc_canFight) and (_unit distance _selectedContainer > 3) and (_selectedContainer isKindOf "ReammoBox_F") and (!isNull _selectedContainer)) then {_unit setPos position _selectedContainer};
+	sleep 1;
+	waitUntil {!([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
+	if ((unitReady _unit) && ([_unit] call A3A_fnc_canFight) && (_unit distance _selectedContainer > 3) && (_selectedContainer isKindOf "ReammoBox_F") && (!isNull _selectedContainer)) then {_unit setPos position _selectedContainer};
 	if (_unit distance _selectedContainer < 3) then {
 		_unit action ["rearm",_selectedContainer];
 		if ({_x in _primaryMagazines} count (magazines _unit) >= _targetMagazines) then {
@@ -124,38 +126,39 @@ if ((_foundWeapon) and (_unit getVariable "rearming")) then {
 	if (_inPlayerGroup) then {_unit groupChat "No source to rearm my primary weapon"};
 };
 
-_foundWeapon = false;
-if ((_secondaryWeapon == "") and (loadAbs _unit < 340)) then {
+_foundItem = false;
+if ((_secondaryWeapon == "") && (loadAbs _unit < 340)) then {
 	if (count _nearbyContainers > 0) then {
 		{
 			_potentialContainer = _x;
 			if (_unit distance _potentialContainer < _maxDistance) then {
-				if ((count weaponCargo _potentialContainer > 0) and !(_potentialContainer getVariable ["busy",false])) then {
+				if ((count weaponCargo _potentialContainer > 0) && !(_potentialContainer getVariable ["busy",false])) then {
 					_containerWeapons = weaponCargo _potentialContainer;
 					for "_i" from 0 to (count _containerWeapons - 1) do {
 						_potentialWeapon = _containerWeapons select _i;
-						if ((_potentialWeapon in allMissileLaunchers) or (_potentialWeapon in allRocketLaunchers)) then {
+						if ((_potentialWeapon in allMissileLaunchers) || (_potentialWeapon in allRocketLaunchers)) then {
 							_selectedContainer = _potentialContainer;
-							_foundWeapon = true;
-							_weaponX = _potentialWeapon;
+							_foundItem = true;
+							_selectedWeapon = _potentialWeapon;
 						};
 					};
 				};
 			};
 		} forEach _nearbyContainers;
 	};
-	if ((_foundWeapon) and (_unit getVariable "rearming")) then {
+	if ((_foundItem) && (_unit getVariable "rearming")) then {
 		_unit stop false;
-		if ((!alive _selectedContainer) or (not(_selectedContainer isKindOf "ReammoBox_F"))) then {_selectedContainer setVariable ["busy",true]};
+		if ((!alive _selectedContainer) || (!(_selectedContainer isKindOf "ReammoBox_F"))) then {_selectedContainer setVariable ["busy",true]};
 		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking a secondary weapon"};
 		_timeOut = time + 60;
-		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _selectedContainer) or (_unit distance _selectedContainer < 3) or (_timeOut < time) or (unitReady _unit)};
-		if ((unitReady _unit) and ([_unit] call A3A_fnc_canFight) and (_unit distance _selectedContainer > 3) and (_selectedContainer isKindOf "ReammoBox_F") and (!isNull _selectedContainer)) then {_unit setPos position _selectedContainer};
+		sleep 1;
+		waitUntil {!([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
+		if ((unitReady _unit) && ([_unit] call A3A_fnc_canFight) && (_unit distance _selectedContainer > 3) && (_selectedContainer isKindOf "ReammoBox_F") && (!isNull _selectedContainer)) then {_unit setPos position _selectedContainer};
 		if (_unit distance _selectedContainer < 3) then {
-			_unit action ["TakeWeapon",_selectedContainer,_weaponX];
+			_unit action ["TakeWeapon",_selectedContainer,_selectedWeapon];
 			sleep 3;
-			if (secondaryWeapon _unit == _weaponX) then {
+			if (secondaryWeapon _unit == _selectedWeapon) then {
 				if (_inPlayerGroup) then {_unit groupChat "I have a secondary weapon now"};
 				if (_selectedContainer isKindOf "ReammoBox_F") then {sleep 3;_unit action ["rearm",_selectedContainer]};
 			};
@@ -166,42 +169,43 @@ if ((_secondaryWeapon == "") and (loadAbs _unit < 340)) then {
 	sleep 3;
 };
 
-_foundWeapon = false;
+_foundItem = false;
 if (_secondaryWeapon != "") then {
 	_primaryMagazines = getArray (configFile / "CfgWeapons" / _secondaryWeapon / "magazines");
 	if ({_x in _primaryMagazines} count (magazines _unit) < 2) then {
 		_needsRearm = true;
-		_foundWeapon = false;
+		_foundItem = false;
 		if (count _nearbyContainers > 0) then {
 			{
 				_potentialContainer = _x;
 				if ({_x in _primaryMagazines} count magazineCargo _potentialContainer > 0) then {
 					if (_unit distance _potentialContainer < _maxDistance) then {
 						_selectedContainer = _potentialContainer;
-						_foundWeapon = true;
+						_foundItem = true;
 					};
 				};
 			} forEach _nearbyContainers;
 		};
-		_deadBodies = allDead select {(_x distance _unit < _maxDistance) and (!(_x getVariable ["busy",false]))};
+		_deadBodies = allDead select {(_x distance _unit < _maxDistance) && (!(_x getVariable ["busy",false]))};
 		{
 			_selectedBody = _x;
-			if (({_x in _primaryMagazines} count (magazines _selectedBody) > 0) and (_unit distance _selectedBody < _maxDistance)) then {
+			if (({_x in _primaryMagazines} count (magazines _selectedBody) > 0) && (_unit distance _selectedBody < _maxDistance)) then {
 				_selectedContainer = _selectedBody;
-				_foundWeapon = true;
+				_foundItem = true;
 			};
 		} forEach _deadBodies;
 	};
-	if ((_foundWeapon) and (_unit getVariable "rearming")) then {
+	if ((_foundItem) && (_unit getVariable "rearming")) then {
 		_unit stop false;
 		if (!alive _selectedContainer) then {_selectedContainer setVariable ["busy",true]};
 		_unit doMove (position _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Rearming"};
 		_timeOut = time + 60;
-		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _selectedContainer) or (_unit distance _selectedContainer < 3) or (_timeOut < time) or (unitReady _unit)};
-		if ((unitReady _unit) and ([_unit] call A3A_fnc_canFight) and (_unit distance _selectedContainer > 3) and (_selectedContainer isKindOf "ReammoBox_F") and (!isNull _selectedContainer)) then {_unit setPos position _selectedContainer};
+		sleep 1;
+		waitUntil {!([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
+		if ((unitReady _unit) && ([_unit] call A3A_fnc_canFight) && (_unit distance _selectedContainer > 3) && (_selectedContainer isKindOf "ReammoBox_F") && (!isNull _selectedContainer)) then {_unit setPos position _selectedContainer};
 		if (_unit distance _selectedContainer < 3) then {
-			if ((backpack _unit == "") and (backPack _selectedContainer != "")) then {
+			if ((backpack _unit == "") && (backPack _selectedContainer != "")) then {
 				_unit addBackPackGlobal ((backpack _selectedContainer) call A3A_fnc_basicBackpack);
 				_unit action ["rearm",_selectedContainer];
 				sleep 3;
@@ -224,25 +228,26 @@ if (_secondaryWeapon != "") then {
 	sleep 3;
 };
 
-_foundWeapon = false;
+_foundItem = false;
 if (!haveRadio && {_unit call A3A_fnc_getRadio == ""}) then {
 	_needsRearm = true;
-	_foundWeapon = false;
-	_deadBodies = allDead select {(_x distance _unit < _maxDistance) and (!(_x getVariable ["busy",false]))};
+	_foundItem = false;
+	_deadBodies = allDead select {(_x distance _unit < _maxDistance) && (!(_x getVariable ["busy",false]))};
 	{
 		_selectedBody = _x;
-		if ((_selectedBody call A3A_fnc_getRadio != "") and (_unit distance _selectedBody < _maxDistance)) then {
+		if ((_selectedBody call A3A_fnc_getRadio != "") && (_unit distance _selectedBody < _maxDistance)) then {
 			_selectedContainer = _selectedBody;
-			_foundWeapon = true;
+			_foundItem = true;
 		};
 	} forEach _deadBodies;
-	if ((_foundWeapon) and (_unit getVariable "rearming")) then {
+	if ((_foundItem) && (_unit getVariable "rearming")) then {
 		_unit stop false;
 		_selectedContainer setVariable ["busy",true];
 		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking a Radio"};
 		_timeOut = time + 60;
-		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _selectedContainer) or (_unit distance _selectedContainer < 3) or (_timeOut < time) or (unitReady _unit)};
+		sleep 1;
+		waitUntil {!([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
 		if (_unit distance _selectedContainer < 3) then {
 			_unit action ["rearm",_selectedContainer];
 			private _radio = _selectedContainer call A3A_fnc_getRadio;
@@ -253,26 +258,27 @@ if (!haveRadio && {_unit call A3A_fnc_getRadio == ""}) then {
 	};
 };
 
-_foundWeapon = false;
+_foundItem = false;
 if (hmd _unit == "") then {
 	_needsRearm = true;
-	_foundWeapon = false;
-	_deadBodies = allDead select {(_x distance _unit < _maxDistance) and (!(_x getVariable ["busy",false]))};
+	_foundItem = false;
+	_deadBodies = allDead select {(_x distance _unit < _maxDistance) && (!(_x getVariable ["busy",false]))};
 	{
 		_selectedBody = _x;
-		if ((hmd _selectedBody != "") and (_unit distance _selectedBody < _maxDistance)) then {
+		if ((hmd _selectedBody != "") && (_unit distance _selectedBody < _maxDistance)) then {
 			_selectedContainer = _selectedBody;
-			_foundWeapon = true;
+			_foundItem = true;
 		};
 	} forEach _deadBodies;
-	if ((_foundWeapon) and (_unit getVariable "rearming")) then {
+	if ((_foundItem) && (_unit getVariable "rearming")) then {
 		_unit stop false;
 		_selectedContainer setVariable ["busy",true];
 		_hmd = hmd _selectedContainer;
 		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking NV Googles"};
 		_timeOut = time + 60;
-		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _selectedContainer) or (_unit distance _selectedContainer < 3) or (_timeOut < time) or (unitReady _unit)};
+		sleep 1;
+		waitUntil {!([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
 		if (_unit distance _selectedContainer < 3) then {
 			_unit action ["rearm",_selectedContainer];
 			_unit linkItem _hmd;
@@ -282,26 +288,27 @@ if (hmd _unit == "") then {
 	};
 };
 
-_foundWeapon = false;
-if (not(headgear _unit in allArmoredHeadgear)) then {
+_foundItem = false;
+if (!(headgear _unit in allArmoredHeadgear)) then {
 	_needsRearm = true;
-	_foundWeapon = false;
-	_deadBodies = allDead select {(_x distance _unit < _maxDistance) and (!(_x getVariable ["busy",false]))};
+	_foundItem = false;
+	_deadBodies = allDead select {(_x distance _unit < _maxDistance) && (!(_x getVariable ["busy",false]))};
 	{
 		_selectedBody = _x;
-		if (((headgear _selectedBody) in allArmoredHeadgear) and (_unit distance _selectedBody < _maxDistance)) then {
+		if (((headgear _selectedBody) in allArmoredHeadgear) && (_unit distance _selectedBody < _maxDistance)) then {
 			_selectedContainer = _selectedBody;
-			_foundWeapon = true;
+			_foundItem = true;
 		};
 	} forEach _deadBodies;
-	if ((_foundWeapon) and (_unit getVariable "rearming")) then {
+	if ((_foundItem) && (_unit getVariable "rearming")) then {
 		_unit stop false;
 		_selectedContainer setVariable ["busy",true];
 		_helmet = headgear _selectedContainer;
 		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking a Helmet"};
 		_timeOut = time + 60;
-		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _selectedContainer) or (_unit distance _selectedContainer < 3) or (_timeOut < time) or (unitReady _unit)};
+		sleep 1;
+		waitUntil {!([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
 		if (_unit distance _selectedContainer < 3) then {
 			_unit action ["rearm",_selectedContainer];
 			_unit addHeadgear _helmet;
@@ -311,26 +318,27 @@ if (not(headgear _unit in allArmoredHeadgear)) then {
 	};
 };
 
-_foundWeapon = false;
+_foundItem = false;
 _minFA = if ([_unit] call A3A_fnc_isMedic) then {10} else {1};
 if ({_x == "FirstAidKit"} count (items _unit) < _minFA) then {
 	_needsRearm = true;
-	_foundWeapon = false;
-	_deadBodies = allDead select {(_x distance _unit < _maxDistance) and (!(_x getVariable ["busy",false]))};
+	_foundItem = false;
+	_deadBodies = allDead select {(_x distance _unit < _maxDistance) && (!(_x getVariable ["busy",false]))};
 	{
 		_selectedBody = _x;
-		if (("FirstAidKit" in items _selectedBody) and (_unit distance _selectedBody < _maxDistance)) then {
+		if (("FirstAidKit" in items _selectedBody) && (_unit distance _selectedBody < _maxDistance)) then {
 			_selectedContainer = _selectedBody;
-			_foundWeapon = true;
+			_foundItem = true;
 		};
 	} forEach _deadBodies;
-	if ((_foundWeapon) and (_unit getVariable "rearming")) then {
+	if ((_foundItem) && (_unit getVariable "rearming")) then {
 		_unit stop false;
 		_selectedContainer setVariable ["busy",true];
 		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking a First Aid Kit"};
 		_timeOut = time + 60;
-		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _selectedContainer) or (_unit distance _selectedContainer < 3) or (_timeOut < time) or (unitReady _unit)};
+		sleep 1;
+		waitUntil {!([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
 		if (_unit distance _selectedContainer < 3) then {
 			while {{_x == "FirstAidKit"} count (items _unit) < _minFA} do {
 				_unit action ["rearm",_selectedContainer];
@@ -343,29 +351,29 @@ if ({_x == "FirstAidKit"} count (items _unit) < _minFA) then {
 	};
 };
 
-_foundWeapon = false;
+_foundItem = false;
 _numberX = getNumber (configfile >> "CfgWeapons" >> vest cursortarget >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Chest" >> "armor");
-_deadBodies = allDead select {(_x distance _unit < _maxDistance) and (!(_x getVariable ["busy",false]))};
+_deadBodies = allDead select {(_x distance _unit < _maxDistance) && (!(_x getVariable ["busy",false]))};
 {
 	_selectedBody = _x;
-	if ((getNumber (configfile >> "CfgWeapons" >> vest _selectedBody >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Chest" >> "armor") > _numberX) and (_unit distance _selectedBody < _maxDistance)) then {
+	if ((getNumber (configfile >> "CfgWeapons" >> vest _selectedBody >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Chest" >> "armor") > _numberX) && (_unit distance _selectedBody < _maxDistance)) then {
 		_selectedContainer = _selectedBody;
-		_foundWeapon = true;
+		_foundItem = true;
 	};
 } forEach _deadBodies;
-if ((_foundWeapon) and (_unit getVariable "rearming")) then {
+if ((_foundItem) && (_unit getVariable "rearming")) then {
 	_unit stop false;
 	_selectedContainer setVariable ["busy",true];
 	_unit doMove (getPosATL _selectedContainer);
 	if (_inPlayerGroup) then {_unit groupChat "Picking a a better vest"};
 	_timeOut = time + 60;
-	waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _selectedContainer) or (_unit distance _selectedContainer < 3) or (_timeOut < time) or (unitReady _unit)};
+	sleep 1;
+	waitUntil {!([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
 	if (_unit distance _selectedContainer < 3) then {
 		_itemsUnit = vestItems _unit;
 		_unit addVest (vest _selectedContainer);
 		{_unit addItemToVest _x} forEach _itemsUnit;
 		_unit action ["rearm",_selectedContainer];
-		//{_unit addItemCargoGlobal [_x,1]} forEach ((backpackItems _selectedContainer) + (backpackMagazines _selectedContainer));
 		_things = nearestObjects [_selectedContainer, ["WeaponHolderSimulated", "GroundWeaponHolder", "WeaponHolder"], 5];
 		if (count _things > 0) then {
 			_thingX = _things select 0;
@@ -378,22 +386,23 @@ if ((_foundWeapon) and (_unit getVariable "rearming")) then {
 
 if (backpack _unit == "") then {
 	_needsRearm = true;
-	_foundWeapon = false;
-	_deadBodies = allDead select {(_x distance _unit < _maxDistance) and (!(_x getVariable ["busy",false]))};
+	_foundItem = false;
+	_deadBodies = allDead select {(_x distance _unit < _maxDistance) && (!(_x getVariable ["busy",false]))};
 	{
 		_selectedBody = _x;
-		if ((backpack _selectedBody != "") and (_unit distance _selectedBody < _maxDistance)) then {
+		if ((backpack _selectedBody != "") && (_unit distance _selectedBody < _maxDistance)) then {
 			_selectedContainer = _selectedBody;
-			_foundWeapon = true;
+			_foundItem = true;
 		};
 	} forEach _deadBodies;
-	if ((_foundWeapon) and (_unit getVariable "rearming")) then {
+	if ((_foundItem) && (_unit getVariable "rearming")) then {
 		_unit stop false;
 		_selectedContainer setVariable ["busy",true];
 		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking a Backpack"};
 		_timeOut = time + 60;
-		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) or (isNull _selectedContainer) or (_unit distance _selectedContainer < 3) or (_timeOut < time) or (unitReady _unit)};
+		sleep 1;
+		waitUntil {!([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
 		if (_unit distance _selectedContainer < 3) then {
 			_unit addBackPackGlobal ((backpack _selectedContainer) call A3A_fnc_basicBackpack);
 			_unit action ["rearm",_selectedContainer];

--- a/A3-Antistasi/initVar.sqf
+++ b/A3-Antistasi/initVar.sqf
@@ -53,7 +53,7 @@ if (isServer) then {
 diag_log format ["%1: [Antistasi] | INFO | initVar | Declaring Empty Arrays",servertime];
 
 weaponCategories = ["Rifles", "Handguns", "MachineGuns", "MissileLaunchers", "Mortars", "RocketLaunchers", "Shotguns", "SMGs", "SniperRifles"];
-itemCategories = ["Bipods", "MuzzleAttachments", "PointerAttachments", "Optics", "Binoculars", "Compasses", "FirstAidKits", "GPS", "LaserDesignators", 
+itemCategories = ["Bipods", "MuzzleAttachments", "PointerAttachments", "Optics", "Binoculars", "Compasses", "FirstAidKits", "GPS", "LaserDesignators",
 	"Maps", "Medikits", "MineDetectors", "NVGs", "Radios", "Toolkits", "UAVTerminals", "Watches", "Glasses", "Headgear", "Vests", "Uniforms", "Backpacks"];
 				  
 magazineCategories = ["MagArtillery", "MagBullet", "MagFlare", "Grenades", "MagLaser", "MagMissile", "MagRocket", "MagShell", "MagShotgun", "MagSmokeShell"];
@@ -71,7 +71,7 @@ aggregateCategories = ["Weapons", "Items", "Magazines", "Explosives"];
 //These are here because it's non-trivial to identify items in them. They might be a very specific subset of items, or the logic that identifies them might not be perfect.
 //It's recommended that these categories be used with caution.
 specialCategories = ["AA", "AT", "GrenadeLaunchers", "LightAttachments", "LaserAttachments", "Chemlights", "SmokeGrenades", "LaunchedSmokeGrenades", "LaunchedFlares", "HandFlares", "IRGrenades","LaserBatteries",
-	"RebelUniforms", "CivilianUniforms", "BackpacksEmpty", "BackpacksTool", "BackpacksStatic", "BackpacksDevice", "CivilianVests", "ArmoredVests", "ArmoredHeadgear", "CivilianHeadgear", 
+	"RebelUniforms", "CivilianUniforms", "BackpacksEmpty", "BackpacksTool", "BackpacksStatic", "BackpacksDevice", "CivilianVests", "ArmoredVests", "ArmoredHeadgear", "CivilianHeadgear",
 	"CivilianGlasses"];
 
 
@@ -88,8 +88,6 @@ allCategories = allCategoriesExceptSpecial + specialCategories;
 	missionNamespace setVariable ["unlocked" + _x, []];
 } forEach allCategoriesExceptSpecial + ["AA", "AT", "GrenadeLaunchers"]; //TODO: Implement all of the special categories.
 
-//Used for AI-Rearm (poor implementation)
-initialWeapons = [];
 //Used for initial unlocks.
 initialRebelEquipment = [];
 
@@ -687,6 +685,7 @@ publicVariable "unlockedGrenadeLaunchers";
 publicVariable "unlockedSniperRifles";
 publicVariable "unlockedAT";
 publicVariable "unlockedAA";
+publicVariable "initialRebelEquipment";
 
 publicVariable "allRifles";
 publicVariable "allHandguns";
@@ -700,7 +699,6 @@ publicVariable "allSniperRifles";
 publicVariable "allCivilianUniforms";
 publicVariable "allRebelUniforms";
 publicVariable "allArmoredHeadgear";
-publicVariable "initialWeapons";
 publicVariable "allSmokeGrenades";
 
 publicVariable "teamPlayer";


### PR DESCRIPTION
resolves #347 

**Changes**
- removed 'initialWeapons' array from all templates and initVar
- replaced 'initialWeapons' check with 'intialRebelEquipment'
- converted all `and/or/not` to `&&/||/!`
- cleaned up bracketing format
- unified whitespace
- replaced use of 'private' array for use as keyword
- removed unnecessary re-define of _maxDistance within each loop
- expanded weapons search to include new stored types

**Variables Changed**
- _Pweapon to _primaryWeapon
- _Sweapon to _secondaryWeapon
- _hasBox to _foundItem
- _distanceX to _maxDistance
- _objectsX to _nearbyContainers
- _objectX to _potentialContainer
- _target to _selectedContainer
- _potential to _potentialWeapon
- _weaponsX to _containerWeapons
- _weaponX to _selectedWeapon
- _basePossible to _baseWeapon
- _magazines to _primaryMagazines
- _countX to _targetMagazines
- _victims to _deadBodies
- _victim to _selectedBody
- _things to _bodyEquipment
- _thingX to _selectedEquipment
- _minFA to _targetFAKs