### PR TITLE
Add JNL cargo hardpoints for Zil131 covered and open trucks

### DIFF
--- a/A3-Antistasi/JeroenArsenal/JNL/fn_logistics_init.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNL/fn_logistics_init.sqf
@@ -132,6 +132,12 @@ jnl_vehicleHardpoints = [
     	[1,		[0,-1.78506,-0.19277],	[6,7,8,9,11,10]]
     ]],
 
+	//RHS Zil131 plain (eg. rhsgref_cdf_zil131) and open (eg. rhsgref_cdf_zil131_open)
+	["rhsafrf\addons\rhs_zil131\rhs_zil131", [
+		[1, [0,-0.1,-0.45], [10,11,2,3,4,5]],
+		[1, [0,-1.8,-0.45], [6,7,8,9]]			// only 10 seats
+	]],
+
     //USAF Truck seats covered
     ["\rhsusf\addons\rhsusf_fmtv\M1078A1P2",[
     [1,[-0.0065918,0.0195313,-0.48801],[12,3,13,4,5,2]],

--- a/A3-Antistasi/JeroenArsenal/JNL/fn_logistics_init.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNL/fn_logistics_init.sqf
@@ -110,8 +110,8 @@ jnl_vehicleHardpoints = [
     //RHS Gaz-66 truck  "rhs_gaz66_vdv"
     ["\rhsafrf\addons\rhs_gaz66\rhs_gaz66.p3d", [
     	[0,		[0,-0.88974,-0.610707],		[]], //Weapon node
-    	[1,		[0,-0.135376,-0.610707],	[]], //Cargo node
-    	[1,		[0,-1.73634,-0.610707],		[]]
+    	[1,		[0,-0.135376,-0.610707],	[12,3,13,4,5,2]], //Cargo node
+    	[1,		[0,-1.73634,-0.610707],		[6,7,8,9,11,10]]
     ]],
 
     //RHS truck "rhsgref_nat_ural_open"


### PR DESCRIPTION
Enables loading cargo crates into the Zil131 trucks. Tested with rhsgref_cdf_zil131 as used in the occupant CDF templates, but should also work for open versions, VDV and others, as they all use the same base model. Seat mappings were tested.