### PR TITLE
Rolls back recent changes to loadouts

### DIFF
--- a/A3-Antistasi/Templates/Loadouts/rhs_afrf_AT2.sqf
+++ b/A3-Antistasi/Templates/Loadouts/rhs_afrf_AT2.sqf
@@ -10,11 +10,11 @@
 	],
 
 	[//Launcher
-		"rhs_weap_igla",									//Weapon
+		"rhs_weap_rpg7",									//Weapon
 		"",													//Muzzle
 		"",													//Rail
 		"",								//Sight
-		["rhs_mag_9k38_rocket",1],							//Primary Magazine
+		["rhs_rpg7_PG7VL_mag",1],							//Primary Magazine
 		[],													//Secondary Magazine
 		""													//Bipod
 	],
@@ -50,7 +50,8 @@
 	[//Backpack
 		"rhs_rpg_empty",						//Backpack
 		[//Inventory
-			["rhs_mag_9k38_rocket",3,1]
+			["rhs_rpg7_PG7VL_mag",2,1],
+			["rhs_rpg7_type69_airburst_mag",2,1]
 		]
 		+ _aceClacker
 	],

--- a/A3-Antistasi/Templates/Loadouts/rhs_afrf_machineGunner.sqf
+++ b/A3-Antistasi/Templates/Loadouts/rhs_afrf_machineGunner.sqf
@@ -1,79 +1,36 @@
-[//Loadout
-	[//Primary Weapon
-		"rhs_weap_pkp",								//Weapon
-		"",													//Muzzle
-		"",													//Rail										
-		["rhs_acc_pkas"],                                //Sight
-		["rhs_100Rnd_762x54mmR_7N13",100],					//Primary Magazine
-		[],													//Secondary Magazine
-		""													//Bipod
-	],
-
-	[//Launcher
-		"",													//Weapon
-		"",													//Muzzle
-		"",													//Rail
-		"",													//Sight
-		[],													//Primary Magazine
-		[],													//Secondary Magazine
-		""													//Bipod
-	],
-
-	[//Secondary Weapon
-		"rhs_weap_pb_6p9",								//Weapon
-		"rhs_acc_6p9_suppressor",													//Muzzle
-		"",													//Rail
-		"",													//Sight
-		["rhs_mag_9x18_8_57n181S",8],						//Primary Magazine
-		[],													//Secondary Magazine
-		""													//Bipod
-	],
-
-	[//Uniform
-		"rhs_uniform_vdv_flora",								//Uniform
-		[] + _basicMedicalSupplies + _basicMiscItems
-	],
-
-	[//Vest
-		"rhs_6b23_6sh116_flora",						//Vest
-		[//Inventory
-			["rhs_1PN138",1],
-			["rhs_mag_9x18_8_57n181S",2,8],
-			["rhs_100Rnd_762x54mmR_7N13",1,100],
-			["rhs_mag_rgn",1,1],
-			["rhs_mag_rdg2_white",1,1],
-			["rhs_mag_rgo",1,1]
-		]
-		+ _aceFlashlight
-	],
-
-	[//Backpack
-		"rhs_sidor",						//Backpack
-		[//Inventory
-			["rhs_100Rnd_762x54mmR_7N13",2,100]
-		]
-		+ _aceClacker
-	],
-
-		"rhs_altyn_novisor_ess",				//Headgear 										
-		["rhs_balaclava"],                                     //Facewear
-
-	[//Binocular
-		"Binocular",										//Binocular
+[
+	[
+		"rhs_weap_pkp",
 		"",
 		"",
 		"",
-		[],
+		["rhs_100Rnd_762x54mmR_green",100],
 		[],
 		""
 	],
-
-	[//Item
-		"ItemMap",											//Map
-		"ItemGPS",													//Terminal
-		["tf_fadak_1"] call _fnc_tfarRadio,				//Radio
-		"ItemCompass",										//Compass
-		_tfarMicroDAGRNoArray,										//Watch
-		""													//Goggles
+	[],
+	[],
+	[
+		"rhs_uniform_gorka_r_g",
+		[] + _basicMedicalSupplies + _basicMiscItems
+	],
+	[
+		"rhs_6b23_6sh116_od",
+		[
+			["rhs_100Rnd_762x54mmR_green",1,100]]],
+	[
+		"rhs_sidor",
+		[
+			["rhs_100Rnd_762x54mmR_7BZ3",2,100]]],
+	"rhs_altyn_novisor_bala",
+	"",
+	[],
+	[
+		"ItemMap",
+		"",
+		["tf_fadak_1"] call _fnc_tfarRadio,
+		"ItemCompass",
+		"ItemWatch",
+		"rhs_1PN138"
 	]
 ];

--- a/A3-Antistasi/Templates/Loadouts/rhs_afrf_marksman.sqf
+++ b/A3-Antistasi/Templates/Loadouts/rhs_afrf_marksman.sqf
@@ -1,76 +1,38 @@
-[//Loadout
-	[//Primary Weapon
-		"rhs_weap_svds_npz",								//Weapon
-		"rhs_acc_tgpv",													//Muzzle
-		"",								//Rail
-		"rhs_acc_dh520x56",								//Sight
-		["rhs_10Rnd_762x54mmR_7N1",10],				//Primary Magazine
-		[],													//Secondary Magazine
-		""								//Bipod
-	],
-
-	[//Launcher
-		"",													//Weapon
-		"",													//Muzzle
-		"",													//Rail
-		"",													//Sight
-		[],													//Primary Magazine
-		[],													//Secondary Magazine
-		""													//Bipod
-	],
-
-	[//Secondary Weapon
-		"rhs_weap_pb_6p9",								//Weapon
-		"rhs_acc_6p9_suppressor",													//Muzzle
-		"",													//Rail
-		"",													//Sight
-		["rhs_mag_9x18_8_57n181S",8],						//Primary Magazine
-		[],													//Secondary Magazine
-		""													//Bipod
-	],
-
-	[//Uniform
-		"rhs_uniform_vdv_flora",								//Uniform
-		[] + _basicMedicalSupplies + _basicMiscItems
-	],
-
-	[//Vest
-		"rhs_6b23_digi_sniper",							//Vest
-		[//Inventory
-			["rhs_1PN138",1],
-			["rhs_mag_rgo",2,1],
-			["rhs_mag_rdg2_white",1,1],
-			["rhs_mag_rgn",1,1],
-			["rhs_10Rnd_762x54mmR_7N1",6,10],
-			["rhs_mag_9x18_8_57n181S",2,8]
-		]
-		+ _aceFlashlight
-		+ _aceKestrel
-		+ _aceRangecard
-	],
-
-	[//Backpack
-	],
-
-		"rhs_altyn_novisor_ess",				//Headgear
-		["rhs_balaclava"],   //Facewear
-											
-	[//Binocular
-		"rhs_pdu4",							//Binocular
+[
+	[
+		"rhs_weap_vss",
 		"",
 		"",
-		"",
-		[],
+		"rhs_acc_pso1m21",
+		["rhs_10rnd_9x39mm_SP6",10],
 		[],
 		""
 	],
-
-	[//Item
-		"ItemMap",											//Map
-		"ItemGPS",													//Terminal
-		["tf_fadak_1"] call _fnc_tfarRadio,				//Radio
-		"ItemCompass",										//Compass
-		_tfarMicroDAGRNoArray,										//Watch
-		""													//Goggles
+	[],
+	[],
+	[
+		"rhs_uniform_gorka_r_g",
+		[] + _basicMedicalSupplies + _basicMiscItems
+		],
+	[
+		"rhs_6b23_6sh116_od",
+		[
+			["rhs_1PN138",1],
+			["rhs_mag_rgo",1,1],
+			["rhs_mag_rgn",1,1],
+			["rhs_mag_rdg2_white",1,1],
+			["rhs_20rnd_9x39mm_SP6",2,20],
+			["rhs_10rnd_9x39mm_SP6",3,10]]],
+	[],
+	"rhs_beanie_green",
+	"",
+	[],
+	[
+		"ItemMap",
+		"",
+		["tf_fadak_1"] call _fnc_tfarRadio,
+		"ItemCompass",
+		"ItemWatch",
+		""
 	]
 ];

--- a/A3-Antistasi/Templates/Loadouts/rhs_afrf_medic.sqf
+++ b/A3-Antistasi/Templates/Loadouts/rhs_afrf_medic.sqf
@@ -1,77 +1,40 @@
-[//Loadout
-	[//Primary Weapon												
-		["rhs_weap_ak74m_gp25"],                              //Weapon
-		"rhs_acc_tgpa",													//Muzzle
-		"",								//Rail											
-		["rhs_acc_pkas"],                 //Sight
-		["rhs_30Rnd_545x39_7N10_plum_AL",30],			//Primary Magazine
-		["rhs_GRD40_white",1],													//Secondary Magazine
-		""													//Bipod
-	],
-
-	[//Launcher
-		"",													//Weapon
-		"",													//Muzzle
-		"",													//Rail
-		"",													//Sight
-		[],													//Primary Magazine
-		[],													//Secondary Magazine
-		""													//Bipod
-	],
-
-	[//Secondary Weapon
-		"rhs_weap_pb_6p9",								//Weapon
-		"rhs_acc_6p9_suppressor",													//Muzzle
-		"",													//Rail
-		"",													//Sight
-		["rhs_mag_9x18_8_57n181S",8],						//Primary Magazine
-		[],													//Secondary Magazine
-		""													//Bipod
-	],
-
-	[//Uniform
-		"rhs_uniform_vdv_flora",								//Uniform
-		[] + _basicMedicalSupplies + _basicMiscItems
-	],
-
-	[//Vest
-		"rhs_6b23_digi_medic",
-		[//Inventory
-		        ["rhs_1PN138",1],
-			["rhs_mag_rgo",2,1],
-			["rhs_mag_rdg2_white",1,1],
-			["rhs_mag_rgn",1,1],
-			["rhs_30Rnd_545x39_7N10_plum_AL",4,30],
-			["rhs_mag_9x18_8_57n181S",2,8]
-		]
-		+ _aceFlashlight
-	],
-
-		[//Backpack
-		"rhs_sidor",						//Backpack
-		[] + _medicSupplies
-	],
-
-		"rhs_altyn_novisor_ess",				//Headgear
-		SelectRandom 										//Facewear
-		["rhs_balaclava"],
-
-	[//Binocular
-		"Binocular",										//Binocular
+[
+	[
+		"rhs_weap_ak105",
+		"rhs_acc_pgs64",
+		"rhs_acc_perst1ik",
 		"",
-		"",
-		"",
-		[],
+		["rhs_30Rnd_545x39_7N22_AK",30],
 		[],
 		""
 	],
-
-	[//Item
-		"ItemMap",											//Map
-		"ItemGPS",													//Terminal
-		["tf_fadak_1"] call _fnc_tfarRadio,				//Radio
-		"ItemCompass",										//Compass
-		_tfarMicroDAGRNoArray,										//Watch
-		""													//Goggles
+	[],
+	[],
+	[
+		"rhs_uniform_gorka_r_g",
+		[] + _basicMedicalSupplies + _basicMiscItems
+	],
+	[
+		"rhs_6b23_6sh116_od",
+		[
+			["rhs_1PN138",1],
+			["rhs_30Rnd_545x39_7N22_AK",4,30],
+			["rhs_mag_rgo",1,1],
+			["rhs_mag_rgn",1,1],
+			["rhs_mag_rdg2_white",2,1]]],
+	[
+		"rhs_medic_bag",
+		[] + _medicSupplies
+	],
+	"rhs_altyn_novisor_ess_bala",
+	"",
+	[],
+	[
+		"ItemMap",
+		"",
+		["tf_fadak_1"] call _fnc_tfarRadio,
+		"ItemCompass",
+		"ItemWatch",
+		""
 	]
 ];

--- a/A3-Antistasi/Templates/Loadouts/rhs_afrf_teamLeader.sqf
+++ b/A3-Antistasi/Templates/Loadouts/rhs_afrf_teamLeader.sqf
@@ -1,60 +1,15 @@
-[//Loadout
-	[//Primary Weapon
-		"rhs_weap_ak103_2",								//Weapon
-		"rhs_acc_pbs1",													//Muzzle
-		"rhs_acc_perst1ik",								//Rail
-		"rhs_acc_pkas",								//Sight
-		["rhs_30Rnd_762x39mm_polymer",30],				//Primary Magazine
-		[],													//Secondary Magazine
-		""								//Bipod
+[
+	[
+		"rhs_weap_ak74m_gp25",
+		"rhs_acc_dtk",
+		"",
+		"rhs_acc_ekp8_02",
+		["rhs_30Rnd_545x39_7N22_AK",30],
+		["rhs_VOG25",1],
+		""
 	],
-
-	[//Launcher
-		"",													//Weapon
-		"",													//Muzzle
-		"",													//Rail
-		"",													//Sight
-		[],													//Primary Magazine
-		[],													//Secondary Magazine
-		""													//Bipod
-	],
-
-	[//Secondary Weapon
-		"rhs_weap_pb_6p9",								//Weapon
-		"rhs_acc_6p9_suppressor",													//Muzzle
-		"",													//Rail
-		"",													//Sight
-		["rhs_mag_9x18_8_57n181S",8],						//Primary Magazine
-		[],													//Secondary Magazine
-		""													//Bipod
-	],
-
-	[//Uniform
-		"rhs_uniform_vdv_flora",								//Uniform
-		[] + _basicMedicalSupplies + _basicMiscItems
-	],
-
-	[//Vest
-		"rhs_6b23_digi_vydra_3,",							//Vest
-		[//Inventory
-			["rhs_1PN138",1],
-			["rhs_mag_rgo",2,1],
-			["rhs_mag_rdg2_white",1,1],
-			["rhs_mag_rgn",1,1],
-			["rhs_30Rnd_762x39mm_polymer",4,30],
-			["rhs_mag_9x18_8_57n181S",2,8]
-		]
-		+ _aceFlashlight
-	],
-
-	[//Backpack
-	],
-
-		"rhs_altyn_novisor_ess",				//Headgear
-		["rhs_balaclava"],   //Facewear
-											
-	[//Binocular
-		"Binocular",							//Binocular
+	[
+		"rhs_weap_rpg26",
 		"",
 		"",
 		"",
@@ -62,13 +17,40 @@
 		[],
 		""
 	],
-
-	[//Item
-		"ItemMap",											//Map
-		"ItemGPS",													//Terminal
-		["tf_fadak_1"] call _fnc_tfarRadio,				//Radio
-		"ItemCompass",										//Compass
-		_tfarMicroDAGRNoArray,										//Watch
-		""													//Goggles
+	[],
+	[
+		"rhs_uniform_gorka_r_g",
+		[] + _basicMedicalSupplies + _basicMiscItems
+	],
+	[
+		"rhs_6b23_6sh116_vog_od",
+		[
+			["rhs_1PN138",1],
+			["rhs_mag_rgo",1,1],
+			["rhs_mag_rgn",1,1],
+			["rhs_mag_rdg2_white",1,1],
+			["rhs_VOG25",6,1],
+			["rhs_30Rnd_545x39_7N22_AK",4,30],
+			["rhs_VG40TB",4,1],
+			["rhs_VG40MD_White",2,1]]],
+	[],
+	"rhs_altyn_bala",
+	"",
+	[
+		"Binocular",
+		"",
+		"",
+		"",
+		[],
+		[],
+		""
+	],
+	[
+		"ItemMap",
+		"",
+		["tf_fadak_1"] call _fnc_tfarRadio,
+		"ItemCompass",
+		"ItemWatch",
+		""
 	]
 ];

--- a/A3-Antistasi/Templates/Loadouts/rhs_usaf_grenadier.sqf
+++ b/A3-Antistasi/Templates/Loadouts/rhs_usaf_grenadier.sqf
@@ -1,13 +1,13 @@
 [//Loadout
 	[//Primary Weapon
-		"RHS_Weap_M4A1",									//Weapon
+		"RHS_Weap_M4A1_M203S",								//Weapon
 		"",													//Muzzle
-		"RHSUSF_Acc_ANPEQ15A",								//Rail
+		"RHSUSF_Acc_WMX_Bk",								//Rail
 		selectRandom										//Sight
-		["RHSUSF_Acc_Acog", "RHSUSF_Acc_Elcan"],
+		["RHSUSF_Acc_CompM4", "RHSUSF_Acc_Eotech_552"],
 		["RHS_Mag_30Rnd_556x45_M855A1_Stanag",30],			//Primary Magazine
-		[],													//Secondary Magazine
-		"RHSUSF_Acc_Grip3"									//Bipod
+		["RHS_Mag_M441_HE",1],								//Secondary Magazine
+		""													//Bipod
 	],
 
 	[//Launcher
@@ -36,27 +36,20 @@
 	],
 
 	[//Vest
-		"RHSUSF_SPCS_OCP_SquadLeader",						//Vest
+		"RHSUSF_SPCS_OCP_Grenadier",
 		[//Inventory
 			["RHSUSF_ANPVS_14",1],
 			["RHS_Mag_An_M8HC",2,1],
-			["RHS_Mag_M67",1,1],
-			["RHS_Mag_Mk84",2,1],
+			["RHS_Mag_M67",2,1],
+			["RHS_Mag_Mk84",1,1],
+			["RHS_Mag_30Rnd_556x45_M855A1_Stanag",4,30],
 			["RHSUSF_Mag_7x45ACP_MHP",2,7],
-			["RHS_Mag_30Rnd_556x45_M855A1_Stanag",4,30]
-		]
-		+ _aceFlashlight
+			["RHS_Mag_M441_HE",6,1],
+			["RHS_Mag_M714_White",4,1]
+		] + _aceFlashlight
 	],
 
 	[//Backpack
-		([hasTFAR, "TF_RT1523G_RHS", "RHSUSF_Assault_EagleAIII_OCP"] call _fnc_modItemNoArray),
-		[//Inventory
-			["SmokeshellBlue",3,1],
-			["SmokeshellRed",3,1],
-			["SmokeshellYellow",3,1]
-		]
-		+ ([hasACE, ["ACE_Handflare_Red",2,1]] call _fnc_modItem)
-		+ ([hasACE, ["ACE_Chemlight_IR",15,1]] call _fnc_modItem)
 	],
 
 		"rhsusf_mich_bare_norotos_headset",				//Headgear
@@ -64,7 +57,7 @@
 		["RHSUSF_Shemagh_Grn", "RHSUSF_Shemagh2_Grn", "RHSUSF_Shemagh_Gogg_Grn", "RHSUSF_Shemagh2_Gogg_Grn", "RHSUSF_Oakley_Goggles_Blk"],
 
 	[//Binocular
-		"RHSUSF_Bino_Lerca_1200_Black",						//Binocular
+		"Binocular",										//Binocular
 		"",
 		"",
 		"",
@@ -75,7 +68,7 @@
 
 	[//Item
 		"ItemMap",											//Map
-		"ItemGPS",											//Terminal
+		"",													//Terminal
 		["TF_RF7800STR"] call _fnc_tfarRadio,				//Radio
 		"ItemCompass",										//Compass
 		_tfarMicroDAGRNoArray,										//Watch

--- a/A3-Antistasi/Templates/Loadouts/rhs_usaf_machineGunner.sqf
+++ b/A3-Antistasi/Templates/Loadouts/rhs_usaf_machineGunner.sqf
@@ -4,7 +4,7 @@
 		"",													//Muzzle
 		"",													//Rail
 		selectRandom										//Sight
-		["RHSUSF_Acc_Acog", "RHSUSF_Acc_Eotech_552"],
+		["RHSUSF_Acc_CompM4", "RHSUSF_Acc_Eotech_552"],
 		["RHSUSF_200Rnd_556x45_Box",200],					//Primary Magazine
 		[],													//Secondary Magazine
 		""													//Bipod

--- a/A3-Antistasi/Templates/Loadouts/rhs_usaf_marksman.sqf
+++ b/A3-Antistasi/Templates/Loadouts/rhs_usaf_marksman.sqf
@@ -1,12 +1,12 @@
 [//Loadout
 	[//Primary Weapon
-		"RHS_Weap_Sr25",								//Weapon
+		"RHS_Weap_M14EBRRI",								//Weapon
 		"",													//Muzzle
 		"RHSUSF_Acc_ANPEQ15A",								//Rail
-		"RHSUSF_Acc_leupoldmk4_2_mrds",								//Sight
-		["RHSUSF_20Rnd_762x51_SR25_M118_Special_Mag",20],				//Primary Magazine
+		"RHSUSF_Acc_M8541_Low",								//Sight
+		["RHSUSF_20Rnd_762x51_M993_Mag",20],				//Primary Magazine
 		[],													//Secondary Magazine
-		"RHSUSF_Acc_Harris_Bipod"								//Bipod
+		"RHS_Acc_Harris_Swivel"								//Bipod
 	],
 
 	[//Launcher
@@ -38,10 +38,10 @@
 		"RHSUSF_SPCS_OCP_Sniper",							//Vest
 		[//Inventory
 			["RHSUSF_ANPVS_14",1],
-			["RHS_Mag_An_M8HC",1,1],
+			["RHS_Mag_An_M8HC",2,1],
 			["RHS_Mag_M67",1,1],
 			["RHS_Mag_Mk84",1,1],
-			["RHSUSF_20Rnd_762x51_SR25_M118_Special_Mag",5,30],
+			["RHSUSF_20Rnd_762x51_M993_Mag",5,30],
 			["RHSUSF_Mag_7x45ACP_MHP",2,7]
 		]
 		+ _aceFlashlight
@@ -57,7 +57,7 @@
 		["RHSUSF_Shemagh_Grn", "RHSUSF_Shemagh2_Grn", "RHSUSF_Shemagh_Gogg_Grn", "RHSUSF_Shemagh2_Gogg_Grn", "RHSUSF_Oakley_Goggles_Blk"],
 
 	[//Binocular
-		"RHSUSF_Bino_Lerca_1200_Black",							//Binocular
+		"Binocular",										//Binocular
 		"",
 		"",
 		"",
@@ -68,7 +68,7 @@
 
 	[//Item
 		"ItemMap",											//Map
-		"ItemGPS",													//Terminal
+		"",													//Terminal
 		["TF_RF7800STR"] call _fnc_tfarRadio,				//Radio
 		"ItemCompass",										//Compass
 		_tfarMicroDAGRNoArray,										//Watch

--- a/A3-Antistasi/Templates/Loadouts/rhs_usaf_medic.sqf
+++ b/A3-Antistasi/Templates/Loadouts/rhs_usaf_medic.sqf
@@ -22,11 +22,11 @@
 	],
 
 	[//Secondary Weapon
-		"RHS_Weap_M320",								//Weapon
+		"RHSUSF_Weap_M1911A1",								//Weapon
 		"",													//Muzzle
 		"",													//Rail
 		"",													//Sight
-		["RHS_Mag_M714_White",1],						//Primary Magazine
+		["RHSUSF_Mag_7x45ACP_MHP",7],						//Primary Magazine
 		[],													//Secondary Magazine
 		""													//Bipod
 	],
@@ -44,7 +44,7 @@
 			["RHS_Mag_M67",1,1],
 			["RHS_Mag_Mk84",2,1],
 			["RHS_Mag_30Rnd_556x45_M855A1_Stanag",4,30],
-			["RHS_Mag_M714_White",3,1]
+			["RHSUSF_Mag_7x45ACP_MHP",2,7]
 		]
 		+ _aceFlashlight
 	],
@@ -70,7 +70,7 @@
 
 	[//Item
 		"ItemMap",											//Map
-		"ItemGPS",													//Terminal
+		"",													//Terminal
 		["TF_RF7800STR"] call _fnc_tfarRadio,				//Radio
 		"ItemCompass",										//Compass
 		_tfarMicroDAGRNoArray,										//Watch

--- a/A3-Antistasi/Templates/Loadouts/rhs_usaf_rifleman.sqf
+++ b/A3-Antistasi/Templates/Loadouts/rhs_usaf_rifleman.sqf
@@ -1,11 +1,11 @@
 [//Loadout
 	[//Primary Weapon
-		"RHS_Weap_Mk17_STD",									//Weapon
+		"RHS_Weap_M16A4",									//Weapon
 		"",													//Muzzle
-		"RHSUSF_Acc_Anpeq15a",								//Rail
+		"RHSUSF_Acc_WMX_Bk",								//Rail
 		selectRandom										//Sight
-		["RHSUSF_Acc_Acog", "RHSUSF_Acc_Eotech_552"],
-		["RHS_Mag_20Rnd_SCAR_762x51_m61_AP",20],			//Primary Magazine
+		["RHSUSF_Acc_CompM4", "RHSUSF_Acc_Eotech_552"],
+		["RHS_Mag_30Rnd_556x45_M855A1_Stanag",30],			//Primary Magazine
 		[],													//Secondary Magazine
 		"RHSUSF_Acc_Grip3"									//Bipod
 	],
@@ -42,7 +42,7 @@
 			["RHS_Mag_An_M8HC",2,1],
 			["RHS_Mag_M67",1,1],
 			["RHS_Mag_Mk84",1,1],
-			["RHS_Mag_20Rnd_SCAR_762x51_m61_AP",6,20],
+			["RHS_Mag_30Rnd_556x45_M855A1_Stanag",6,30],
 			["RHSUSF_Mag_7x45ACP_MHP",2,7]
 		]
 		+ _aceFlashlight
@@ -67,7 +67,7 @@
 
 	[//Item
 		"ItemMap",											//Map
-		"itemGPS",											//Terminal
+		"",													//Terminal
 		["TF_RF7800STR"] call _fnc_tfarRadio,				//Radio
 		"ItemCompass",										//Compass
 		_tfarMicroDAGRNoArray,										//Watch

--- a/A3-Antistasi/Templates/Loadouts/rhs_usaf_teamLeader.sqf
+++ b/A3-Antistasi/Templates/Loadouts/rhs_usaf_teamLeader.sqf
@@ -1,13 +1,13 @@
 [//Loadout
 	[//Primary Weapon
-		"RHS_Weap_M4A1_M203S",								//Weapon
+		"RHS_Weap_M4A1",									//Weapon
 		"",													//Muzzle
-		"RHSUSF_Acc_Anpeq15a",								//Rail
+		"RHSUSF_Acc_ANPEQ15A",								//Rail
 		selectRandom										//Sight
-		["RHSUSF_Acc_Acog", "RHSUSF_Acc_Eotech_552"],
+		["RHSUSF_Acc_Acog", "RHSUSF_Acc_Elcan"],
 		["RHS_Mag_30Rnd_556x45_M855A1_Stanag",30],			//Primary Magazine
-		["RHS_Mag_M441_HE",1],								//Secondary Magazine
-		""													//Bipod
+		[],													//Secondary Magazine
+		"RHSUSF_Acc_Grip3"									//Bipod
 	],
 
 	[//Launcher
@@ -36,21 +36,27 @@
 	],
 
 	[//Vest
-		"RHSUSF_SPCS_OCP_Grenadier",
+		"RHSUSF_SPCS_OCP_SquadLeader",						//Vest
 		[//Inventory
 			["RHSUSF_ANPVS_14",1],
 			["RHS_Mag_An_M8HC",2,1],
-			["RHS_Mag_M67",2,1],
-			["RHS_Mag_Mk84",1,1],
-			["RHS_Mag_30Rnd_556x45_M855A1_Stanag",5,30],
+			["RHS_Mag_M67",1,1],
+			["RHS_Mag_Mk84",2,1],
 			["RHSUSF_Mag_7x45ACP_MHP",2,7],
-			["RHS_Mag_M441_HE",5,1],
-			["RHS_Mag_M585_White",2,1],
-			["RHS_Mag_M714_White",2,1]
-		] + _aceFlashlight
+			["RHS_Mag_30Rnd_556x45_M855A1_Stanag",4,30]
+		]
+		+ _aceFlashlight
 	],
 
 	[//Backpack
+		([hasTFAR, "TF_RT1523G_RHS", "RHSUSF_Assault_EagleAIII_OCP"] call _fnc_modItemNoArray),
+		[//Inventory
+			["SmokeshellBlue",3,1],
+			["SmokeshellRed",3,1],
+			["SmokeshellYellow",3,1]
+		]
+		+ ([hasACE, ["ACE_Handflare_Red",2,1]] call _fnc_modItem)
+		+ ([hasACE, ["ACE_Chemlight_IR",15,1]] call _fnc_modItem)
 	],
 
 		"rhsusf_mich_bare_norotos_headset",				//Headgear
@@ -58,7 +64,7 @@
 		["RHSUSF_Shemagh_Grn", "RHSUSF_Shemagh2_Grn", "RHSUSF_Shemagh_Gogg_Grn", "RHSUSF_Shemagh2_Gogg_Grn", "RHSUSF_Oakley_Goggles_Blk"],
 
 	[//Binocular
-		"Binocular",										//Binocular
+		"RHSUSF_Bino_Lerca_1200_Black",						//Binocular
 		"",
 		"",
 		"",
@@ -69,7 +75,7 @@
 
 	[//Item
 		"ItemMap",											//Map
-		"",													//Terminal
+		"ItemGPS",											//Terminal
 		["TF_RF7800STR"] call _fnc_tfarRadio,				//Radio
 		"ItemCompass",										//Compass
 		_tfarMicroDAGRNoArray,										//Watch


### PR DESCRIPTION
Recent loadout changes have broken some implicit rules regarding how strong PvP loadouts should be. This reverts the recent changes in their entirety (except for changes to AT), so that the changes can be re-reviewed, adjusted and re-implemented.