### PR TITLE
Fixed the bug with the garrison spawning in wrong

### DIFF
--- a/A3-Antistasi/functions/init/fn_initGarrisons.sqf
+++ b/A3-Antistasi/functions/init/fn_initGarrisons.sqf
@@ -58,6 +58,7 @@ _fnc_initMarker =
 
 _fnc_initGarrison =
 {
+	if(loadLastSave) exitWith {};
 	params ["_markerArray", "_type"];
 	private ["_side", "_groupsRandom", "_garrNum", "_garrisonOld", "_marker"];
 	{

--- a/A3-Antistasi/functions/init/fn_initGarrisons.sqf
+++ b/A3-Antistasi/functions/init/fn_initGarrisons.sqf
@@ -5,6 +5,7 @@ diag_log format ["%1: [Antistasi] | INFO | InitGarrisons Started.", servertime];
 
 _fnc_initMarker =
 {
+	if(loadLastSave) exitWith {};
 	params ["_mrkCSAT", "_target", "_mrkType", "_mrkText", ["_useSideName", false]];
 	private ["_pos", "_mrk", "_garrNum", "_garrison", "_groupsRandom"];
 
@@ -156,7 +157,7 @@ if (debug) then {
 };
 
 [_mrkCSAT, airportsX, flagCSATmrk, "%1 Airbase", true] spawn _fnc_initMarker;
-[airportsX, "Airport"] spawn _fnc_initGarrison;								//Old system
+[airportsX, "Airport"] call _fnc_initGarrison;								//Old system
 [airportsX, "Airport", [0,0,0]] spawn A3A_fnc_createGarrison;	//New system
 
 
@@ -165,7 +166,7 @@ if (debug) then {
 };
 
 [_mrkCSAT, resourcesX, "loc_rock", "Resources"] spawn _fnc_initMarker;
-[resourcesX, "Resource"] spawn _fnc_initGarrison;							//Old system
+[resourcesX, "Resource"] call _fnc_initGarrison;							//Old system
 [resourcesX, "Other", [0,0,0]] spawn A3A_fnc_createGarrison;	//New system
 
 if (debug) then {
@@ -173,7 +174,7 @@ if (debug) then {
 };
 
 [_mrkCSAT, factories, "u_installation", "Factory"] spawn _fnc_initMarker;
-[factories, "Factory"] spawn _fnc_initGarrison;
+[factories, "Factory"] call _fnc_initGarrison;
 [factories, "Other", [0,0,0]] spawn A3A_fnc_createGarrison;
 
 if (debug) then {
@@ -181,7 +182,7 @@ if (debug) then {
 };
 
 [_mrkCSAT, outposts, "loc_bunker", "%1 Outpost", true] spawn _fnc_initMarker;
-[outposts, "Outpost"] spawn _fnc_initGarrison;
+[outposts, "Outpost"] call _fnc_initGarrison;
 [outposts, "Outpost", [1,1,0]] spawn A3A_fnc_createGarrison;
 
 if (debug) then {
@@ -189,7 +190,7 @@ if (debug) then {
 };
 
 [_mrkCSAT, seaports, "b_naval", "Sea Port"] spawn _fnc_initMarker;
-[seaports, "Seaport"] spawn _fnc_initGarrison;
+[seaports, "Seaport"] call _fnc_initGarrison;
 [seaports, "Other", [1,0,0]] spawn A3A_fnc_createGarrison;
 
 //New system, adding cities

--- a/A3-Antistasi/initServer.sqf
+++ b/A3-Antistasi/initServer.sqf
@@ -67,7 +67,6 @@ waitUntil {(count playableUnits) > 0};
 waitUntil {({(isPlayer _x) and (!isNull _x) and (_x == _x)} count allUnits) == (count playableUnits)};//ya estamos todos
 [] spawn A3A_fnc_modBlacklist;
 
-call A3A_fnc_initGarrisons;
 if (loadLastSave) then {
 	diag_log format ["%1: [Antistasi] | INFO | Persitent Load selected.",servertime];
 	["membersX"] call fn_LoadStat;
@@ -77,6 +76,9 @@ if (loadLastSave) then {
 	};
 };
 publicVariable "loadLastSave";
+
+call A3A_fnc_initGarrisons;
+
 if (loadLastSave) then {
 	[] spawn A3A_fnc_loadServer;
 	waitUntil {!isNil"statsLoaded"};


### PR DESCRIPTION
The garrison will now be loaded after the check if there is a old save to load, if thats so, the system will not create new garrison.

However, this system will be replaced by the new (already in the background working) system for the new garrisons, so it is only a temporary fix and does not have to be absolutely solid