### PR TITLE
Fast travel towing fix

### DIFF
--- a/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -3,7 +3,7 @@ private ["_roads","_pos","_positionX","_groupX"];
 _markersX = markersX + [respawnTeamPlayer];
 
 _esHC = false;
-
+if !(isNull (player getVariable ["SA_Tow_Ropes_Vehicle", objNull])) exitWith {hint "You cannot Fast Travel while towing a vehicle!"};
 if (count hcSelected player > 1) exitWith {hint "You can select one group only to Fast Travel"};
 if (count hcSelected player == 1) then {_groupX = hcSelected player select 0; _esHC = true} else {_groupX = group player};
 _checkForPlayer = false;

--- a/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -3,7 +3,7 @@ private ["_roads","_pos","_positionX","_groupX"];
 _markersX = markersX + [respawnTeamPlayer];
 
 _esHC = false;
-if !((vehicle player getVariable "SA_Tow_Ropes") isEqualTo objNull) exitWith {hint "You cannot Fast Travel while towing another vehicle"};
+if !((vehicle player getVariable "SA_Tow_Ropes") isEqualTo objNull) exitWith {hint "You cannot Fast Travel with your Tow Rope out"};
 if (count hcSelected player > 1) exitWith {hint "You can select one group only to Fast Travel"};
 if (count hcSelected player == 1) then {_groupX = hcSelected player select 0; _esHC = true} else {_groupX = group player};
 _checkForPlayer = false;

--- a/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -3,7 +3,7 @@ private ["_roads","_pos","_positionX","_groupX"];
 _markersX = markersX + [respawnTeamPlayer];
 
 _esHC = false;
-if !(isNull (player getVariable ["SA_Tow_Ropes_Vehicle", objNull])) exitWith {hint "You cannot Fast Travel while towing a vehicle!"};
+if !(isNull(vehicle player getVariable "SA_Tow_Ropes")) exitWith {hint "You cannot Fast Travel while towing another vehicle!"};
 if (count hcSelected player > 1) exitWith {hint "You can select one group only to Fast Travel"};
 if (count hcSelected player == 1) then {_groupX = hcSelected player select 0; _esHC = true} else {_groupX = group player};
 _checkForPlayer = false;

--- a/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -3,7 +3,7 @@ private ["_roads","_pos","_positionX","_groupX"];
 _markersX = markersX + [respawnTeamPlayer];
 
 _esHC = false;
-if !(objNull(vehicle player getVariable "SA_Tow_Ropes")) exitWith {hint "You cannot Fast Travel while towing another vehicle"};
+if !((vehicle player getVariable "SA_Tow_Ropes") isEqualTo objNull) exitWith {hint "You cannot Fast Travel while towing another vehicle"};
 if (count hcSelected player > 1) exitWith {hint "You can select one group only to Fast Travel"};
 if (count hcSelected player == 1) then {_groupX = hcSelected player select 0; _esHC = true} else {_groupX = group player};
 _checkForPlayer = false;

--- a/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -3,7 +3,7 @@ private ["_roads","_pos","_positionX","_groupX"];
 _markersX = markersX + [respawnTeamPlayer];
 
 _esHC = false;
-if !(isNull(vehicle player getVariable "SA_Tow_Ropes")) exitWith {hint "You cannot Fast Travel while towing another vehicle!"};
+if !(isNull(vehicle player getVariable "SA_Tow_Ropes")) exitWith {hint "You cannot Fast Travel while towing another vehicle"};
 if (count hcSelected player > 1) exitWith {hint "You can select one group only to Fast Travel"};
 if (count hcSelected player == 1) then {_groupX = hcSelected player select 0; _esHC = true} else {_groupX = group player};
 _checkForPlayer = false;

--- a/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -3,7 +3,7 @@ private ["_roads","_pos","_positionX","_groupX"];
 _markersX = markersX + [respawnTeamPlayer];
 
 _esHC = false;
-if !(isNull(vehicle player getVariable "SA_Tow_Ropes")) exitWith {hint "You cannot Fast Travel while towing another vehicle"};
+if !(objNull(vehicle player getVariable "SA_Tow_Ropes")) exitWith {hint "You cannot Fast Travel while towing another vehicle"};
 if (count hcSelected player > 1) exitWith {hint "You can select one group only to Fast Travel"};
 if (count hcSelected player == 1) then {_groupX = hcSelected player select 0; _esHC = true} else {_groupX = group player};
 _checkForPlayer = false;

--- a/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -3,7 +3,7 @@ private ["_roads","_pos","_positionX","_groupX"];
 _markersX = markersX + [respawnTeamPlayer];
 
 _esHC = false;
-if !((vehicle player getVariable "SA_Tow_Ropes") isEqualTo objNull) exitWith {hint "You cannot Fast Travel with your Tow Rope out"};
+if !((vehicle player getVariable "SA_Tow_Ropes") isEqualTo objNull) exitWith {hint "You cannot Fast Travel with your Tow Rope out or a Vehicle attached"};
 if (count hcSelected player > 1) exitWith {hint "You can select one group only to Fast Travel"};
 if (count hcSelected player == 1) then {_groupX = hcSelected player select 0; _esHC = true} else {_groupX = group player};
 _checkForPlayer = false;


### PR DESCRIPTION
just adds a simple check in the fast travel script for any rope cargo, if it detects anything it will fail. This does mean that an empty tow rope will also prevent fast traveling. If anyone has any tips to fix that please let me know.

resloves #420 