### PR TITLE
Removed duplicated Class preventing Tanoa load.

### DIFF
--- a/Map-Templates/Antistasi-WotP.Tanoa/mission.sqm
+++ b/Map-Templates/Antistasi-WotP.Tanoa/mission.sqm
@@ -161,6 +161,7 @@ class ScenarioData
 		minPlayers=1;
 		maxPlayers=64;
 	};
+	author=$STR_antistasi_credits_generic_author_text;
 };
 class CustomAttributes
 {
@@ -433,10 +434,6 @@ class CustomAttributes
 		};
 		nAttributes=1;
 	};
-};
-class ScenarioData
-{
-	author=$STR_antistasi_credits_generic_author_text;
 };
 class Mission
 {


### PR DESCRIPTION
Signed-off-by: Tad <tdaykin@live.co.uk>

## What type of PR is this.
1. [X] Bug

### What have you changed and why?
Information:
    This seems to have been created when the Tanoa map was updated to include a Min player cap. It duplicated the `ScenarioData` class which was then throwing errors.

### Please specify which Issue this PR Resolves.
closes #449 

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [X] Yes (Please provide further detail below.)

********************************************************
Notes:
Needs additional load check as the map loaded on my server.