### PR TITLE
Fixes a bad variable in arsenalManage.sqf and public declares a missi…

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_arsenalManage.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_arsenalManage.sqf
@@ -41,7 +41,7 @@ private _allExceptNVs = _weapons + _explosives + _backpacks + _items + _optics +
 			_item call A3A_fnc_unlockEquipment;
 			
 			private _name = switch (true) do {
-				case ("Magazines" in _categories): {getText (configFile >> "CfgMagazines" >> _weaponMagazine >> "displayName")};
+				case ("Magazines" in _categories): {getText (configFile >> "CfgMagazines" >> _item >> "displayName")};
 				case ("Backpacks" in _categories): {getText (configFile >> "CfgVehicles" >> _item >> "displayName")};
 				default {getText (configFile >> "CfgWeapons" >> _item >> "displayName")};
 			};

--- a/A3-Antistasi/functions/CREATE/fn_FIAinitBASES.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_FIAinitBASES.sqf
@@ -123,7 +123,7 @@ switch (true) do {
 		};
 	};
 	default {
-		[_unit,unlockedRifles] call A3A_fnc_randomRifle;
+		[_unit,unlockedSMGs] call A3A_fnc_randomRifle;
 		diag_log format ["%1: [Antistasi] | DEBUG | FIAinitBASES.sqf | Could not identify type of _unit: %2 %3.",servertime,_unit,_typeX];
 	};
 

--- a/A3-Antistasi/functions/REINF/fn_FIAinit.sqf
+++ b/A3-Antistasi/functions/REINF/fn_FIAinit.sqf
@@ -87,7 +87,7 @@ switch (true) do {
 		_unit setskill ["commanding",_skill + 0.2];
 	};
 	default {
-		[_unit,unlockedRifles] call A3A_fnc_randomRifle;
+		[_unit,unlockedSMGs] call A3A_fnc_randomRifle;
 		diag_log format ["%1: [Antistasi] | DEBUG | FIAinit.sqf | Could not identify type of _unit: %2 %3.",servertime,_unit,_typeX];
 	};
 };

--- a/A3-Antistasi/functions/REINF/fn_FIAinit.sqf
+++ b/A3-Antistasi/functions/REINF/fn_FIAinit.sqf
@@ -19,7 +19,7 @@ if (unlockedBackpacks isEqualTo []) then {removeBackpack _unit} else {removeBack
 _unit setSkill _skill;
 
 switch (true) do {
-	case (_typeX in SKDSniper): {
+	case (_typeX in SDKSniper): {
 		if (count unlockedSniperRifles > 0) then {
 			private _magazines = getArray (configFile / "CfgWeapons" / (primaryWeapon _unit) / "magazines");
 			{_unit removeMagazines _x} forEach _magazines;

--- a/A3-Antistasi/initVar.sqf
+++ b/A3-Antistasi/initVar.sqf
@@ -684,6 +684,7 @@ publicVariable "allSMGs";
 publicVariable "allSniperRifles";
 
 publicVariable "allCivilianUniforms";
+publicVariable "allCivilianHeadgear";
 publicVariable "allRebelUniforms";
 publicVariable "allArmoredHeadgear";
 publicVariable "allSmokeGrenades";


### PR DESCRIPTION
…ng gear array

## What type of PR is this.
1. [x] Bug
2. [ ] Enhancement

### What have you changed and why?
Information: arsenalManage.sqf had a bad variable reference that caused a lot of error spam when looking for the name of a magazine to display to players during updates. 'allCivilianHeadgear' was not broadcast publicly and threw errors on clients on spawn/respawn because of loadout grabs.

I have also changed the weapon class of choice for default in FIAinit and FIAinitBASES to 'unlockedSMGs'. This class seems to include gunners for static weapons on rebel roadblocks, and they need at least some weapon if the truck somehow gets destroyed and they survive. As the man assigned to a heavy weapon though, it probably shouldn't be a full sized assault rifle.

### Please specify which Issue this PR Resolves.
closes #461

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the Mission in Singleplayer?
2. [x] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:
