### PR TITLE
Fix marker init order on game load

### DIFF
--- a/A3-Antistasi/functions/init/fn_initGarrisons.sqf
+++ b/A3-Antistasi/functions/init/fn_initGarrisons.sqf
@@ -51,26 +51,19 @@ _fnc_initMarker =
 		_mrk setMarkerType _mrkType;
 		_mrk setMarkerText _mrkText;
 
-		[_x] spawn A3A_fnc_createControls;
+		[_x] call A3A_fnc_createControls;
 	} forEach _target;
 };
 
 
 _fnc_initGarrison =
 {
-	if((!(isNil "loadLastSave")) && {loadLastSave}) exitWith {};
 	params ["_markerArray", "_type"];
 	private ["_side", "_groupsRandom", "_garrNum", "_garrisonOld", "_marker"];
 	{
 	    _marker = _x;
 			_garrNum = ([_marker] call A3A_fnc_garrisonSize) / 8;
 			_side = sidesX getVariable [_marker, sideUnknown];
-			while {_side == sideUnknown} do
-			{
-				diag_log format ["Side unknown for %1, sleeping 1!", _marker];
-				sleep 1;
-				_side = sidesX getVariable [_marker, sideUnknown];
-			};
 			if(_side != Occupants) then
 			{
 				_groupsRandom = [groupsCSATSquad, groupsFIASquad] select ((_marker in outposts) && (gameMode == 4));
@@ -96,6 +89,7 @@ _fnc_initGarrison =
 
 			//Old system, keeping it runing for now
 			garrison setVariable [_marker, _garrisonOld, true];
+
 	} forEach _markerArray;
 };
 
@@ -151,51 +145,51 @@ else
 {sidesX setVariable [_x, Occupants, true]} forEach _controlsNATO;
 {sidesX setVariable [_x, Invaders, true]} forEach _controlsCSAT;
 
+[_mrkCSAT, airportsX, flagCSATmrk, "%1 Airbase", true] call _fnc_initMarker;
+[_mrkCSAT, resourcesX, "loc_rock", "Resources"] call _fnc_initMarker;
+[_mrkCSAT, factories, "u_installation", "Factory"] call _fnc_initMarker;
+[_mrkCSAT, outposts, "loc_bunker", "%1 Outpost", true] call _fnc_initMarker;
+[_mrkCSAT, seaports, "b_naval", "Sea Port"] call _fnc_initMarker;
+
+if (!(isNil "loadLastSave") && {loadLastSave}) exitWith {};
+
+
 if (debug) then {
 	diag_log format ["%1: [Antistasi] | DEBUG | initGarrisons.sqf | Setting up Airbase stuff.", servertime];
 };
 
-[_mrkCSAT, airportsX, flagCSATmrk, "%1 Airbase", true] spawn _fnc_initMarker;
 [airportsX, "Airport"] call _fnc_initGarrison;								//Old system
-[airportsX, "Airport", [0,0,0]] spawn A3A_fnc_createGarrison;	//New system
-
+[airportsX, "Airport", [0,0,0]] call A3A_fnc_createGarrison;	//New system
 
 if (debug) then {
 	diag_log format ["%1: [Antistasi] | DEBUG | initGarrisons.sqf | Setting up Resource stuff.", servertime];
 };
 
-[_mrkCSAT, resourcesX, "loc_rock", "Resources"] spawn _fnc_initMarker;
 [resourcesX, "Resource"] call _fnc_initGarrison;							//Old system
-[resourcesX, "Other", [0,0,0]] spawn A3A_fnc_createGarrison;	//New system
+[resourcesX, "Other", [0,0,0]] call A3A_fnc_createGarrison;	//New system
 
 if (debug) then {
 	diag_log format ["%1: [Antistasi] | DEBUG | initGarrisons.sqf | Setting up Factory stuff.", servertime];
 };
 
-[_mrkCSAT, factories, "u_installation", "Factory"] spawn _fnc_initMarker;
 [factories, "Factory"] call _fnc_initGarrison;
-[factories, "Other", [0,0,0]] spawn A3A_fnc_createGarrison;
+[factories, "Other", [0,0,0]] call A3A_fnc_createGarrison;
 
 if (debug) then {
 	diag_log format ["%1: [Antistasi] | DEBUG | initGarrisons.sqf | Setting up Outpost stuff.", servertime];
 };
 
-[_mrkCSAT, outposts, "loc_bunker", "%1 Outpost", true] spawn _fnc_initMarker;
 [outposts, "Outpost"] call _fnc_initGarrison;
-[outposts, "Outpost", [1,1,0]] spawn A3A_fnc_createGarrison;
+[outposts, "Outpost", [1,1,0]] call A3A_fnc_createGarrison;
 
 if (debug) then {
 	diag_log format ["%1: [Antistasi] | DEBUG | initGarrisons.sqf | Setting up Seaport stuff.", servertime];
 };
 
-[_mrkCSAT, seaports, "b_naval", "Sea Port"] spawn _fnc_initMarker;
 [seaports, "Seaport"] call _fnc_initGarrison;
-[seaports, "Other", [1,0,0]] spawn A3A_fnc_createGarrison;
+[seaports, "Other", [1,0,0]] call A3A_fnc_createGarrison;
 
 //New system, adding cities
-[citiesX, "City", [0,0,0]] spawn A3A_fnc_createGarrison;
-
-sidesX setVariable ["NATO_carrier", Occupants, true];
-sidesX setVariable ["CSAT_carrier", Invaders, true];
+[citiesX, "City", [0,0,0]] call A3A_fnc_createGarrison;
 
 diag_log format ["%1: [Antistasi] | INFO | InitGarrison Completed.", servertime];


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
The marker flips to government after loading a game problem mentioned in #454 persists. This version switches all spawns in initGarrisons to calls to make sure the markers are initialised in the right order, and avoids the unnecessary garrison init calls when loading a game.

### Please specify which Issue this PR Resolves.
Mentioned as a secondary problem in #453 and #454.

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the Mission in Singleplayer?
Singleplayer only calls initGarrisons when starting a new game. Seems to work fine in that case.
2. [X] Have you loaded the Mission in a Dedicated Server?
Yes, and hosted.

### Is further testing or are further changes required?
1. [X] No
Well, the init order is nasty, initGarrisons contains critical functionality that isn't related to garrisons and the roadblock creation is horribly slow, but as a bugfix this should be fine.
2. [ ] Yes (Please provide further detail below.)
