### PR TITLE
Fix static save

### DIFF
--- a/A3-Antistasi/functions/Base/fn_markerChange.sqf
+++ b/A3-Antistasi/functions/Base/fn_markerChange.sqf
@@ -215,6 +215,11 @@ if (_winner == teamPlayer) then
 	}
 else
 	{
+	//Remove static weapons near the marker from the saved statics array
+	private _staticWeapons = nearestObjects [_positionX, ["StaticWeapon"], _size * 1.5, true];
+	staticsToSave = staticsToSave - _staticWeapons;
+	publicVariable "staticsToSave";
+
 	if (!isNull _flagX) then
 		{
 		//_flagX setVariable ["isGettingCaptured", nil, true];

--- a/A3-Antistasi/statSave/saveFuncs.sqf
+++ b/A3-Antistasi/statSave/saveFuncs.sqf
@@ -318,7 +318,7 @@ fn_SetStat = {
 				_veh = createVehicle [_typeVehX,[0,0,1000],[],0,"NONE"];
 				_veh setDir _dirVeh;_veh setDir _dirVeh;
 				_veh setVectorUp surfaceNormal (_posVeh);
-				_veh setPos _posVeh;
+				_veh setPosATL _posVeh;
 				if ((_veh isKindOf "StaticWeapon") or (_veh isKindOf "Building")) then {
 					staticsToSave pushBack _veh;
 				};

--- a/A3-Antistasi/statSave/saveLoop.sqf
+++ b/A3-Antistasi/statSave/saveLoop.sqf
@@ -93,7 +93,7 @@ _sites = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
 {
 	_positionX = position _x;
 	if ((alive _x) and !(surfaceIsWater _positionX) and !(isNull _x)) then {
-		_arrayEst pushBack [typeOf _x,getPos _x,getDir _x];
+		_arrayEst pushBack [typeOf _x,getPosATL _x,getDir _x];
 	};
 } forEach staticsToSave;
 


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
Also arguably an enhancement, as players can now retain some above-ground statics.

### What have you changed and why?
At some point, markerChange gained a feature to add local statics to the save list when a marker was captured by the rebels. There are two issues related to this:

1. Enemy statics are usually placed on building surfaces rather than terrain, and the load/save code didn't support that, so the statics moved to the ground after a save/load cycle. This was fixed by using getPosATL and setPosATL rather than getPos and setPos. Apparently getPos returns the distance from the nearest surface, so it loses information. Old saves will work as before, as setPosATL and setPos have the same effect over land.

2. markerChange didn't clear the local statics from the save list when a marker was recaptured by an enemy faction. As a result, they multiplied (and then moved to the ground) with various combinations of capture/loss/save/load.

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the Mission in Singleplayer?
2. [X] Have you loaded the Mission in a Dedicated Server?
Yes, but some functionality was only tested on Hosted, as capture/loss/save/load takes ages. Also I tested with #498 included because otherwise markers frequently flip side on load without calling markerChange.

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
There's an additional bug with static weapons where the garrison creation code currently places static MGs on destroyed buildings, but that's a separate issue. Also it would be nice to be able to build static weapons on top of buildings, rather than requiring enemy factions to put them there for you.
