### PR TITLE
Fix RHS rifle underbarrel GL categorisation

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_equipmentClassToCategories.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentClassToCategories.sqf
@@ -121,7 +121,7 @@ if (_baseCategory == "Rifles") then {
 	private _config = configfile >> "CfgWeapons" >> _className;
 	private _muzzles = getArray (_config >> "muzzles");
 	// workaround for RHS having an extra muzzle for "SAFE"
-	if (count _muzzles >= 2 && {"gl" == getText (_config >> (_muzzles # 1) >> "cursorAim")}) then {
+	if (count _muzzles >= 2 && {"gl" == getText (_config >> (_muzzles select 1) >> "cursorAim")}) then {
 		_categories pushBack "GrenadeLaunchers";
 	};
 };

--- a/A3-Antistasi/functions/Ammunition/fn_equipmentClassToCategories.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentClassToCategories.sqf
@@ -117,8 +117,13 @@ if (_baseCategory == "MissileLaunchers") then {
 	};
 };
 
-if (_baseCategory == "Rifles" && {count (getArray (configfile >> "CfgWeapons" >> _className >> "muzzles")) == 2}) then {
-	_categories pushBack "GrenadeLaunchers";
+if (_baseCategory == "Rifles") then {
+	private _config = configfile >> "CfgWeapons" >> _className;
+	private _muzzles = getArray (_config >> "muzzles");
+	// workaround for RHS having an extra muzzle for "SAFE"
+	if (count _muzzles >= 2 && {"gl" == getText (_config >> (_muzzles # 1) >> "cursorAim")}) then {
+		_categories pushBack "GrenadeLaunchers";
+	};
 };
 
 _categories;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
RHS rifles (both with and without GL) have an additional muzzle called "SAFE", so the simple `muzzles == 2` check doesn't work. This instead checks `cursorAim` in the muzzle config for the second muzzle. Looks like a dirty hack, but it's the same dirty hack that BIS_fnc_itemType uses internally.

A slightly simpler test would be be to check if muzzle 2 has the name "SAFE", but that would include other non-GL underbarrels, like that weird CSAT gun in Apex with the underbarrel 50cal.

Tested with vanilla and RHS. Will also work with CUP weapons.

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)
Should ideally be checked with 3CB, although it should work unless 3CB is even weirder than RHS. I don't have 3CB installed at the moment.