### PR TITLE
Prevent missile launcher ammo unlocking without allowGuidedLaunchers

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_arsenalManage.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_arsenalManage.sqf
@@ -18,14 +18,22 @@ private _vests = (jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_VEST) select {_x
 
 private _type = objNull;
 private _magazine = [];
+private _magConfig = objNull;
 private _capacity = objNull;
+private _bullets = objNull;
 private _count = objNull;
 {
 	_type = _x select 0;
-	_capacity = getNumber (configFile >> "CfgMagazines" >> _type >> "count");
-	_bullets = _x select 1;
-	_count = floor (_bullets/_capacity);
-	_magazine pushBack [_type,_count];
+	_magConfig = configFile >> "CfgMagazines" >> _type;
+	_capacity = getNumber (_magConfig >> "count");
+
+	// control unlocking missile launcher magazines
+	if (_capacity != 1 || allowGuidedLaunchers isEqualTo 1 ||
+		{!(getText (_magConfig >> "ammo") isKindOf "MissileBase")}) then {
+		_bullets = _x select 1;
+		_count = floor (_bullets/_capacity);
+		_magazine pushBack [_type,_count];
+	};
 } forEach _magazines;
 
 private _allExceptNVs = _weapons + _explosives + _backpacks + _items + _optics + _helmets + _vests + _magazine;

--- a/A3-Antistasi/functions/Ammunition/fn_arsenalManage.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_arsenalManage.sqf
@@ -28,6 +28,7 @@ private _count = objNull;
 	_capacity = getNumber (_magConfig >> "count");
 
 	// control unlocking missile launcher magazines
+	// the capacity check is an optimisation to bypass the config check. ~18% perf gain on the loop.
 	if (_capacity != 1 || allowGuidedLaunchers isEqualTo 1 ||
 		{!(getText (_magConfig >> "ammo") isKindOf "MissileBase")}) then {
 		_bullets = _x select 1;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
On unstable, missile launcher ammo currently unlocks at minWeaps, regardless of whether missile launcher unlocking is allowed. This code prevents missile ammunition unlocking unless `allowGuidedLaunchers` is true.

I retained the style of declaring the private variables outside the loop, but the performance gain is very small (checked with diag_codeperformance) even for trivial loops, so I wouldn't recommend it here.

One oddity is that this code blocks PCML ammunition from unlocking, because the PCML is classified as a rocket launcher by BIS_fnc_itemType, but the ammunition is a missile. As it's probably a BIS bug, it could be worked around with a `_type == "NLAW_F"` check if necessary, rather than grinding through all the launchers and categorising their ammo accordingly.

### Please specify which Issue this PR Resolves.
closes #509 

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the Mission in Singleplayer?
2. [X] Have you loaded the Mission in a Dedicated Server?
Not relevant but I did it anyway.

### Is further testing or are further changes required?
1. [X] No, Unless you want the PCML hack.
2. [ ] Yes (Please provide further detail below.)
