### PR TITLE
Fix radio tower marker not showing after rebuild

### DIFF
--- a/A3-Antistasi/functions/Base/fn_rebuildAssets.sqf
+++ b/A3-Antistasi/functions/Base/fn_rebuildAssets.sqf
@@ -70,7 +70,7 @@ else
 	_antenna = createVehicle ["Land_Communication_F", _antennaDead, [], 0, "NONE"];
 	antennas pushBack _antenna; publicVariable "antennas";
 	{if ([antennas,_x] call BIS_fnc_nearestPosition == _antenna) then {[_x,true] spawn A3A_fnc_blackout}} forEach citiesX;
-	_mrkFinal = createMarker [format ["Ant%1", count antennas], _antennaDead];
+	_mrkFinal = createMarker [format ["Ant%1", mapGridPosition _antennaDead], _antennaDead];
 	_mrkFinal setMarkerShape "ICON";
 	_mrkFinal setMarkerType "loc_Transmitter";
 	_mrkFinal setMarkerColor "ColorBlack";

--- a/A3-Antistasi/functions/Missions/fn_REP_Antenna.sqf
+++ b/A3-Antistasi/functions/Missions/fn_REP_Antenna.sqf
@@ -77,7 +77,7 @@ if (dateToNumber date > _dateLimitNum) then
 	[_antenna] call A3A_fnc_repairRuinedBuilding;
 	antennas pushBack _antenna; publicVariable "antennas";
 	{if ([antennas,_x] call BIS_fnc_nearestPosition == _antenna) then {[_x,true] spawn A3A_fnc_blackout}} forEach citiesX;
-	_mrkFinal = createMarker [format ["Ant%1", count antennas], _positionX];
+	_mrkFinal = createMarker [format ["Ant%1", mapGridPosition _positionX], _positionX];
 	_mrkFinal setMarkerShape "ICON";
 	_mrkFinal setMarkerType "loc_Transmitter";
 	_mrkFinal setMarkerColor "ColorBlack";

--- a/A3-Antistasi/initZones.sqf
+++ b/A3-Antistasi/initZones.sqf
@@ -191,7 +191,7 @@ switch (worldName) do {
 		banks = nearestObjects [[worldSize /2, worldSize/2], ["Land_Offices_01_V1_F"], worldSize];
 
 		antennas apply {
-			_mrkFinal = createMarker [format ["Ant%1", _x], position _x];
+			_mrkFinal = createMarker [format ["Ant%1", mapGridPosition _x], position _x];
 			_mrkFinal setMarkerShape "ICON";
 			_mrkFinal setMarkerType "loc_Transmitter";
 			_mrkFinal setMarkerColor "ColorBlack";
@@ -236,7 +236,7 @@ if (count _posAntennas > 0) then {
 				_antenna setdamage 1;
 			} else {
 				antennas pushBack _antenna;
-				_mrkFinal = createMarker [format ["Ant%1", _i], _posAntennas select _i];
+				_mrkFinal = createMarker [format ["Ant%1", mapGridPosition _antenna], _posAntennas select _i];
 				_mrkFinal setMarkerShape "ICON";
 				_mrkFinal setMarkerType "loc_Transmitter";
 				_mrkFinal setMarkerColor "ColorBlack";


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Enhancement

### What have you changed and why?
Information:
    Fixed a bug where a radio tower marker would not show after a radio tower is rebuilt. It was because the marker name was already in use.
    I changed it to use map grid position in the name of the marker, so they should be unique now, as long as we don't have multiple antennas in the same grid.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the Mission in Singleplayer?
2. [x] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:
