### PR TITLE
Fix rebel recruit GL ammo type & quantity

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_randomRifle.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_randomRifle.sqf
@@ -10,14 +10,20 @@ if (_pool isEqualTo []) then {
 	};
 };
 private _rifleFinal = selectRandom _pool;
-if (_rifleFinal == primaryWeapon _unit) exitWith {};
 
-private _magazines = getArray (configFile / "CfgWeapons" / (primaryWeapon _unit) / "magazines");
-{_unit removeMagazines _x} forEach _magazines;
-_unit removeWeaponGlobal (primaryWeapon _unit);
+if !(primaryWeapon _unit isEqualTo "") then {
+	if (_rifleFinal == primaryWeapon _unit) exitWith {};
+	private _magazines = getArray (configFile / "CfgWeapons" / (primaryWeapon _unit) / "magazines");
+	{_unit removeMagazines _x} forEach _magazines;
+	_unit removeWeapon (primaryWeapon _unit);
+};
 
 if (_rifleFinal in unlockedGrenadeLaunchers) then {
-	_unit addMagazine ["1Rnd_HE_Grenade_shell", 3];
+	// lookup real underbarrel GL magazine, because not everything is 40mm
+	private _config = configFile >> "CfgWeapons" >> _rifleFinal;
+	private _glmuzzle = getArray (_config >> "muzzles") select 1;		// guaranteed by category
+	private _glmag = getArray (_config >> _glmuzzle >> "magazines") select 0;
+	_unit addMagazines [_glmag, 5];
 };
 
 [_unit, _rifleFinal, 5, 0] call BIS_fnc_addWeapon;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Rebel recruits now get the correct type of GL round for the weapon used, instead of assuming that it's 40mm. Fixed a typo (addMagazine vs addMagazines) that limited troops to one round. Also fenced off some currently-unused code that assumed the target unit already had a primary weapon.

### Please specify which Issue this PR Resolves.
Small part of #406.

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
