### PR TITLE
Marker change logging

### DIFF
--- a/A3-Antistasi/functions/Base/fn_markerChange.sqf
+++ b/A3-Antistasi/functions/Base/fn_markerChange.sqf
@@ -10,6 +10,10 @@ if ((_winner == Occupants) and (sidesX getVariable [_markerX,sideUnknown] == Occ
 if ((_winner == Invaders) and (sidesX getVariable [_markerX,sideUnknown] == Invaders)) exitWith {};
 if (_markerX in markersChanging) exitWith {};
 markersChanging pushBackUnique _markerX;
+
+private _filename = "fn_markerChange";
+[2, format ["Marker %1 changing to %2", _markerX, str _winner], _filename, true] call A3A_fnc_log;
+
 _positionX = getMarkerPos _markerX;
 _looser = sidesX getVariable [_markerX,sideUnknown];
 _sides = [teamPlayer,Occupants,Invaders];

--- a/A3-Antistasi/functions/Base/fn_mrkWIN.sqf
+++ b/A3-Antistasi/functions/Base/fn_mrkWIN.sqf
@@ -29,6 +29,9 @@ _flagX spawn
 	_this setVariable ["isGettingCaptured", nil, true];
 };
 
+private _filename = "fn_mrkWIN";
+[2, format ["Flag capture at %1 initiated by %2", _markerX, str _playerX], _filename, true] call A3A_fnc_log;
+
 if (!isNull _playerX) then
 {
 	if (_size > 300) then
@@ -56,11 +59,12 @@ if (!isNull _playerX) then
 
 if ((count _revealX) > 2*({([_x,_markerX] call A3A_fnc_canConquer) and (side _x == teamPlayer)} count allUnits)) exitWith
 {
+	[2, format ["Flag capture by %1 abandoned due to outnumbering", str _playerX], _filename, true] call A3A_fnc_log;
 	hint "The enemy still outnumber us, check the map and clear the rest of the area";
 };
 //if (!isServer) exitWith {};
 
-
+[2, format ["Flag capture by %1 rewarded", str _playerX], _filename, true] call A3A_fnc_log;
 
 {
 	if (isPlayer _x) then

--- a/A3-Antistasi/functions/Utility/fn_log.sqf
+++ b/A3-Antistasi/functions/Utility/fn_log.sqf
@@ -25,7 +25,7 @@ switch (_level) do {
 		_logLine = format ["%1: [Antistasi] | DEBUG | %2 | %3", servertime, _file, _message];
 	};
 	default {
-		_logLine = format ["%1: [Antistasi] | Unknown Log Level Specified, please use 1= Errors, 2= Info, 3= Debug. Original error: %2", servertime, _message]
+		_logLine = format ["%1: [Antistasi] | Unknown Log Level Specified, please use 1= Errors, 2= Info, 3= Debug | %2 | %3", servertime, _file, _message];
 	};
 };
 

--- a/A3-Antistasi/functions/Utility/fn_log.sqf
+++ b/A3-Antistasi/functions/Utility/fn_log.sqf
@@ -8,30 +8,31 @@
 		Log to server (optional): bool - true for logging to server RPT instead of client
 **/
 
-params ["_logLevel", "_message", ["_file", "No File Specified"], ["_toServer", false]];
+params ["_level", "_message", ["_file", "No File Specified"], ["_toServer", false]];
 
-if (_logLevel > LogLevel) exitwith {};
+if (_level > LogLevel) exitwith {};
 
 // Sets up the actual log event.
-_typex = "";
-switch (_logLevel) do {
-    case 1: {
-        _typex = format ["%1: [Antistasi] | ERROR | %2 | %3", servertime, _file, _message];
-    };
-    case 2: {
-        _typex = format ["%1: [Antistasi] | INFO | %2 | %3", servertime, _file, _message];
-    };
-    case 3: {
-        _typex = format ["%1: [Antistasi] | DEBUG | %2 | %3", servertime, _file, _message];
-    };
-    default {
-        _typex = format ["%1: [Antistasi] | Unknown Log Level Specified, please use 1= Errors, 2= Info, 3= Debug. Original error: %2", servertime, _message]
-    };
+private _logLine = "";
+switch (_level) do {
+	case 1: {
+		_logLine = format ["%1: [Antistasi] | ERROR | %2 | %3", servertime, _file, _message];
+	};
+	case 2: {
+		_logLine = format ["%1: [Antistasi] | INFO | %2 | %3", servertime, _file, _message];
+	};
+	case 3: {
+		_logLine = format ["%1: [Antistasi] | DEBUG | %2 | %3", servertime, _file, _message];
+	};
+	default {
+		_logLine = format ["%1: [Antistasi] | Unknown Log Level Specified, please use 1= Errors, 2= Info, 3= Debug. Original error: %2", servertime, _message]
+	};
 };
 
-if (_toServer && !isServer) then {
-	_typex remoteExec ["diag_log", 2];
+// Lazy evaluation should be removed if default value of _toServer is changed
+if (_toServer && {!isServer}) then {
+	_logLine remoteExec ["diag_log", 2];
 } else {
-	diag_log _typex;
+	diag_log _logLine;
 };
 

--- a/A3-Antistasi/functions/Utility/fn_log.sqf
+++ b/A3-Antistasi/functions/Utility/fn_log.sqf
@@ -4,9 +4,34 @@
 	Params:
 		Log level: number - Error, Info or Debug. Levels 1, 2 and 3 respectively.
 		Log Message: string - Message to log
-		File: string - File in which the log message originated
+		File (optional): string - File in which the log message originated
+		Log to server (optional): bool - true for logging to server RPT instead of client
 **/
 
-params ["_logLevel", "_message", "_file"];
+params ["_logLevel", "_message", ["_file", "No File Specified"], ["_toServer", false]];
 
-[_logLevel, _message, _file] execvm "log.sqf";
+if (_logLevel > LogLevel) exitwith {};
+
+// Sets up the actual log event.
+_typex = "";
+switch (_logLevel) do {
+    case 1: {
+        _typex = format ["%1: [Antistasi] | ERROR | %2 | %3", servertime, _file, _message];
+    };
+    case 2: {
+        _typex = format ["%1: [Antistasi] | INFO | %2 | %3", servertime, _file, _message];
+    };
+    case 3: {
+        _typex = format ["%1: [Antistasi] | DEBUG | %2 | %3", servertime, _file, _message];
+    };
+    default {
+        _typex = format ["%1: [Antistasi] | Unknown Log Level Specified, please use 1= Errors, 2= Info, 3= Debug. Original error: %2", servertime, _message]
+    };
+};
+
+if (_toServer && !isServer) then {
+	_typex remoteExec ["diag_log", 2];
+} else {
+	diag_log _typex;
+};
+


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Enhancement

### What have you changed and why?
Added logging to mrkWIN and markerChange to track the effects of take-the-flag actions. Because that process is split between client and server, I added some functionality to log to the server RPT instead of the client. Also moved the logging code to utilities/fn_log for sanity. 

log.sqf now appears to be unused and can probably be deleted, but I haven't checked.

### Please specify which Issue this PR Resolves.
closes #527 

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the Mission in Singleplayer?
2. [X] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)
log.sqf could be deleted if unused. Log-to-server param should probably default to true, as I can't think of many cases where you'd want to log to the client separately, but I retained the previous behaviour.