### PR TITLE
Restored map name function in Server browser

### DIFF
--- a/Map-Templates/Antistasi-Altis-BLUFOR.Altis/mission.sqm
+++ b/Map-Templates/Antistasi-Altis-BLUFOR.Altis/mission.sqm
@@ -162,6 +162,7 @@ class Mission
 {
 	class Intel
 	{
+		briefingName=$STR_antistasi_mission_info_altisB_mapname_text;
 		resistanceWest=0;
 		year=2035;
 		month=6;

--- a/Map-Templates/Antistasi-Altis.Altis/mission.sqm
+++ b/Map-Templates/Antistasi-Altis.Altis/mission.sqm
@@ -170,6 +170,7 @@ class Mission
 {
 	class Intel
 	{
+		briefingName=$STR_antistasi_mission_info_altis_mapname_text;
 		resistanceWest=0;
 		year=2035;
 		month=6;

--- a/Map-Templates/Antistasi-ArmiaKrajowa.chernarus_summer/mission.sqm
+++ b/Map-Templates/Antistasi-ArmiaKrajowa.chernarus_summer/mission.sqm
@@ -149,6 +149,7 @@ class Mission
 {
 	class Intel
 	{
+		briefingName=$STR_antistasi_mission_info_cherna_mapname_text;
 		resistanceWest=0;
 		year=1942;
 		month=6;

--- a/Map-Templates/Antistasi-Kunduz.Kunduz/mission.sqm
+++ b/Map-Templates/Antistasi-Kunduz.Kunduz/mission.sqm
@@ -232,6 +232,7 @@ class Mission
 {
 	class Intel
 	{
+		briefingName=$STR_antistasi_mission_info_kunduz_mapname_text;
 		resistanceWest=0;
 		startWind=0.1;
 		forecastWind=0.1;

--- a/Map-Templates/Antistasi-Livonia.Enoch/mission.sqm
+++ b/Map-Templates/Antistasi-Livonia.Enoch/mission.sqm
@@ -224,6 +224,7 @@ class Mission
 {
 	class Intel
 	{
+		briefingName=$STR_antistasi_mission_info_livonia_mapname_text;
 		resistanceWest=0;
 		startWind=0.1;
 		forecastWind=0.1;

--- a/Map-Templates/Antistasi-Malden.Malden/mission.sqm
+++ b/Map-Templates/Antistasi-Malden.Malden/mission.sqm
@@ -220,6 +220,7 @@ class Mission
 {
 	class Intel
 	{
+		briefingName=$STR_antistasi_mission_info_malden_mapname_text;
 		resistanceWest=0;
 		startWind=0.1;
 		forecastWind=0.1;

--- a/Map-Templates/Antistasi-Tembelan-Island.Tembelan/mission.sqm
+++ b/Map-Templates/Antistasi-Tembelan-Island.Tembelan/mission.sqm
@@ -195,6 +195,7 @@ class Mission
 {
 	class Intel
 	{
+		briefingName=$STR_antistasi_mission_info_tembelan_mapname_text;
 		resistanceWest=0;
 		startWind=0.1;
 		forecastWind=0.1;

--- a/Map-Templates/Antistasi-WotP.Tanoa/mission.sqm
+++ b/Map-Templates/Antistasi-WotP.Tanoa/mission.sqm
@@ -153,6 +153,7 @@ class Mission
 {
 	class Intel
 	{
+		briefingName=$STR_antistasi_mission_info_tanoa_mapname_text;
 		resistanceWest=0;
 		year=2035;
 		month=6;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Enhancement

### What have you changed and why?
Information:
    Reverted some changes made in #474 as they removed identifiable information from the Server browser for the Antistasi map names, and from the in-game menu where you would see the Mission name.

### Please specify which Issue this PR Resolves.
None

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the Mission in Singleplayer?
2. [X] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:
