### PR TITLE
Fix bad radio tower substitution on Altis

### DIFF
--- a/A3-Antistasi/initZones.sqf
+++ b/A3-Antistasi/initZones.sqf
@@ -184,7 +184,8 @@ private _replaceBadAntenna = {
 		};
 		private _antennaPos = getPos _antenna;
 		_antennaPos set [2, 0];
-		_antenna = createVehicle ["Land_Telek1", _antennaPos, [], 0, "NONE"];
+		private _antennaClass = if (worldName == "chernarus_summer") then { "Land_Telek1" } else { "Land_TTowerBig_2_F" };
+		_antenna = createVehicle [_antennaClass, _antennaPos, [], 0, "NONE"];
 	};
 	_antenna;
 };
@@ -213,15 +214,18 @@ switch (worldName) do {
 
 		banks = nearestObjects [[worldSize /2, worldSize/2], ["Land_Offices_01_V1_F"], worldSize];
 
+		private _replacedAntennas = [];
+		{ _replacedAntennas pushBack ([_x] call _replaceBadAntenna); } forEach antennas;
+		antennas = _replacedAntennas;
+
 		antennas apply {
-			private _antenna = ([_x] call _replaceBadAntenna);
-			_mrkFinal = createMarker [format ["Ant%1", mapGridPosition _antenna], position _antenna];
+			_mrkFinal = createMarker [format ["Ant%1", mapGridPosition _x], position _x];
 			_mrkFinal setMarkerShape "ICON";
 			_mrkFinal setMarkerType "loc_Transmitter";
 			_mrkFinal setMarkerColor "ColorBlack";
 			_mrkFinal setMarkerText "Radio Tower";
 			mrkAntennas pushBack _mrkFinal;
-			_antenna addEventHandler [
+			_x addEventHandler [
 				"Killed",
 				{
 					_antenna = _this select 0;
@@ -258,7 +262,7 @@ if (count _posAntennas > 0) then {
 			_antenna = _antennaProv select 0;
 
 			if (_i in _blacklistPos) then {
-				_antenna setdamage 1;
+				_antenna setdamage 1;	
 			} else {
 				_antenna = ([_antenna] call _replaceBadAntenna);
 				antennas pushBack _antenna;


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Enhancement

### What have you changed and why?
Information:
    I fixed an issue with radio towers that I introduced in pull request #534.
The tower class that I previously used to replace the bad ones comes from CUP mod, so it wasn't available when playing Altis without CUP. I had previously tested it on chernarus_summer. I now replace it with a vanilla model but I don't like it much because that tower is really big. But at least it's functional now.

While debugging it I also discovered that the check on map name doesn't work in https://github.com/rurku/A3-Antistasi/blob/9d4234ca70a36aba48306c00eca9e635799b176d/A3-Antistasi/initZones.sqf#L201 becasue switch - case is case sensitive.
This means that the radio towers present on altis are not what was intended. But I don't dare to touch that.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:
