### PR TITLE
Rhs launcher change

### DIFF
--- a/A3-Antistasi/Templates/RHS_Reb_NAPA_Arid.sqf
+++ b/A3-Antistasi/Templates/RHS_Reb_NAPA_Arid.sqf
@@ -91,7 +91,7 @@ APERSMineMag = "rhs_mine_ozm72_b_mag";
 //Starting Unlocks
 initialRebelEquipment append ["rhs_weap_type94_new","rhs_weap_tt33","rhs_weap_Izh18","rhs_weap_kar98k","rhs_weap_panzerfaust60"];
 initialRebelEquipment append ["rhs_weap_Izh18","rhs_weap_kar98k"];
-initialRebelEquipment append ["rhs_weap_panzerfaust60"];
+initialRebelEquipment append ["rhs_weap_rpg75"];
 initialRebelEquipment append ["rhs_mag_6x8mm_mhp","rhs_mag_762x25_8","rhsgref_1Rnd_00Buck","rhsgref_1Rnd_Slug","rhsgref_5Rnd_792x57_kar98k","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["B_FieldPack_oli","B_FieldPack_blk","B_FieldPack_ocamo","B_FieldPack_oucamo","B_FieldPack_cbr"];
 initialRebelEquipment append ["rhsgref_chestrig","rhsgref_chicom","rhs_vydra_3m","rhs_vest_pistol_holster","rhs_vest_commander","rhs_6sh46","rhsgref_alice_webbing"];

--- a/A3-Antistasi/Templates/RHS_Reb_NAPA_Wdl.sqf
+++ b/A3-Antistasi/Templates/RHS_Reb_NAPA_Wdl.sqf
@@ -91,7 +91,7 @@ APERSMineMag = "rhs_mine_ozm72_b_mag";
 //Starting Unlocks
 initialRebelEquipment append ["rhs_weap_type94_new","rhs_weap_tt33","rhs_weap_Izh18","rhs_weap_kar98k","rhs_weap_panzerfaust60"];
 initialRebelEquipment append ["rhs_weap_Izh18","rhs_weap_m1garand_sa43"];
-initialRebelEquipment append ["rhs_weap_panzerfaust60"];
+initialRebelEquipment append ["rhs_weap_rpg75"];
 initialRebelEquipment append ["rhs_mag_6x8mm_mhp","rhs_mag_762x25_8","rhsgref_1Rnd_00Buck","rhsgref_1Rnd_Slug","rhsgref_5Rnd_792x57_kar98k","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["B_FieldPack_oli","B_FieldPack_blk","B_FieldPack_ocamo","B_FieldPack_oucamo","B_FieldPack_cbr"];
 initialRebelEquipment append ["rhsgref_chestrig","rhsgref_chicom","rhs_vydra_3m","rhs_vest_pistol_holster","rhs_vest_commander","rhs_6sh46","rhsgref_alice_webbing"];


### PR DESCRIPTION
Changes the Panzerfaust to the RPG-75 as the panzerfaust has no weight until equipped by a soldier. This is due to RHS not assigning a weight to the tube and it not having a warhead until equipped by a soldier.