### PR TITLE
Cdf traitors

### DIFF
--- a/A3-Antistasi/Templates/RHS_Occ_USAF_Arid.sqf
+++ b/A3-Antistasi/Templates/RHS_Occ_USAF_Arid.sqf
@@ -48,8 +48,8 @@ vehNATOPVP = ["rhsusf_m1025_w_s","rhsusf_m998_w_s_2dr","rhsusf_m998_w_s_2dr_full
 //Military Units
 NATOGrunt = "rhsusf_usmc_marpat_wd_rifleman_light";
 NATOOfficer = "rhsusf_usmc_marpat_wd_officer";
-NATOOfficer2 = "rhsgref_cdf_b_para_officer";
-NATOBodyG = "rhsgref_cdf_b_para_squadleader";
+NATOOfficer2 = "rhsusf_army_ucp_rifleman_101st";
+NATOBodyG = "rhsusf_army_ucp_rifleman_1stcav";
 NATOCrew = "rhsusf_usmc_marpat_wd_crewman";
 NATOUnarmed = "B_G_Survivor_F";
 NATOMarksman = "rhsusf_usmc_marpat_wd_marksman";

--- a/A3-Antistasi/Templates/RHS_Occ_USAF_Wdl.sqf
+++ b/A3-Antistasi/Templates/RHS_Occ_USAF_Wdl.sqf
@@ -48,8 +48,8 @@ vehNATOPVP = ["rhsusf_m1025_w_s","rhsusf_m998_w_s_2dr","rhsusf_m998_w_s_2dr_full
 //Military Units
 NATOGrunt = "rhsusf_usmc_marpat_wd_rifleman_light";
 NATOOfficer = "rhsusf_usmc_marpat_wd_officer";
-NATOOfficer2 = "rhsgref_cdf_b_para_officer";
-NATOBodyG = "rhsgref_cdf_b_para_squadleader";
+NATOOfficer2 = "rhsusf_army_ucp_rifleman_101st";
+NATOBodyG = "rhsusf_army_ucp_rifleman_1stcav";
 NATOCrew = "rhsusf_usmc_marpat_wd_crewman";
 NATOUnarmed = "B_G_Survivor_F";
 NATOMarksman = "rhsusf_usmc_marpat_wd_marksman";


### PR DESCRIPTION
Closes #556 

Had some CDF officers to make the traitor missions look like a meeting between US and Local forces. Because CDF is GREF their uniforms can be picked up by rebels. They are now 101st and 1st cavalry troops.