### PR TITLE
Fix CGRCAT vehicle typo in USAF templates

### DIFF
--- a/A3-Antistasi/Templates/RHS_Occ_USAF_Arid.sqf
+++ b/A3-Antistasi/Templates/RHS_Occ_USAF_Arid.sqf
@@ -120,7 +120,7 @@ groupsNATOGen = [policeOfficer,policeGrunt];
 //Military Vehicles
 //Lite
 vehNATOBike = "B_T_Quadbike_01_F";
-vehNATOLightArmed = ["rhsusf_m1025_w_s_m2","rhsusf_CGRCAT1A2_M2_usmc_wd","rhsusf_CGRAT1A2_Mk19_usmc_wd","rhsusf_M1117_W","rhsusf_M1220_M2_usarmy_wd","rhsusf_M1237_M2_usarmy_wd","rhsusf_M1238A1_M2_socom_d","rhsusf_m1045_w_s"];
+vehNATOLightArmed = ["rhsusf_m1025_w_s_m2","rhsusf_CGRCAT1A2_M2_usmc_wd","rhsusf_CGRCAT1A2_Mk19_usmc_wd","rhsusf_M1117_W","rhsusf_M1220_M2_usarmy_wd","rhsusf_M1237_M2_usarmy_wd","rhsusf_M1238A1_M2_socom_d","rhsusf_m1045_w_s"];
 vehNATOLightUnarmed = ["rhsusf_m1025_w_s","rhsusf_m998_w_s_2dr","rhsusf_m998_w_s_2dr_fulltop","rhsusf_m998_w_s_4dr","rhsusf_CGRCAT1A2_usmc_wd","rhsusf_M1232_usarmy_wd"];
 vehNATOTrucks = ["rhsusf_M1078A1P2_wd_open_fmtv_usarmy","rhsusf_M1078A1P2_B_wd_fmtv_usarmy","rhsusf_M1078A1P2_B_wd_open_fmtv_usarmy","rhsusf_M1083A1P2_wd_fmtv_usarmy","rhsusf_M1083A1P2_B_M2_wd_fmtv_usarmy"];
 vehNATOCargoTrucks = [];

--- a/A3-Antistasi/Templates/RHS_Occ_USAF_Wdl.sqf
+++ b/A3-Antistasi/Templates/RHS_Occ_USAF_Wdl.sqf
@@ -120,7 +120,7 @@ groupsNATOGen = [policeOfficer,policeGrunt];
 //Military Vehicles
 //Lite
 vehNATOBike = "B_T_Quadbike_01_F";
-vehNATOLightArmed = ["rhsusf_m1025_w_s_m2","rhsusf_CGRCAT1A2_M2_usmc_wd","rhsusf_CGRAT1A2_Mk19_usmc_wd","rhsusf_M1117_W","rhsusf_M1220_M2_usarmy_wd","rhsusf_M1237_M2_usarmy_wd","rhsusf_M1238A1_M2_socom_d","rhsusf_m1045_w_s"];
+vehNATOLightArmed = ["rhsusf_m1025_w_s_m2","rhsusf_CGRCAT1A2_M2_usmc_wd","rhsusf_CGRCAT1A2_Mk19_usmc_wd","rhsusf_M1117_W","rhsusf_M1220_M2_usarmy_wd","rhsusf_M1237_M2_usarmy_wd","rhsusf_M1238A1_M2_socom_d","rhsusf_m1045_w_s"];
 vehNATOLightUnarmed = ["rhsusf_m1025_w_s","rhsusf_m998_w_s_2dr","rhsusf_m998_w_s_2dr_fulltop","rhsusf_m998_w_s_4dr","rhsusf_CGRCAT1A2_usmc_wd","rhsusf_M1232_usarmy_wd"];
 vehNATOTrucks = ["rhsusf_M1078A1P2_wd_open_fmtv_usarmy","rhsusf_M1078A1P2_B_wd_fmtv_usarmy","rhsusf_M1078A1P2_B_wd_open_fmtv_usarmy","rhsusf_M1083A1P2_wd_fmtv_usarmy","rhsusf_M1083A1P2_B_M2_wd_fmtv_usarmy"];
 vehNATOCargoTrucks = [];


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
One-letter vehicle classname typo in two RHS templates that actually caused the quadbike spam (since #544, larger vehicle spam) by a slightly bizarre chain, which I will document because some other steps may need cleaning up:

1. A couple of the USAF templates have "rhsusf_CGRAT1A2_Mk19_usmc_wd" in them, which is missing a C.
2. These sometimes get passed as requested garrison vehicles, and end up hitting selectReinfUnits.
3. The BIS seat count functions on non-existent vehicles return 0, which causes selectReinfUnits to fail the _allSeats > _seatCount check.
4. These vehicles are therefore ignored, but remain in the requested array. 
5. If there are no other vehicles or units remaining in the requested array (which is inevitable, as the rest are eventually removed), a random vehicle will be generated for zero cargo.
6. The loop will continue generating random zero-cargo vehicles until _currentUnitCount exceeds the maximum, typically at five vehicles with five crew.
7. This will then repeat at the next resourcecheck tick.

Note that because the requested arrays are saved, this bug will persist over saves, even after the bogus vehicle classes are removed. Hopefully they will be blanked when the marker changes hands at least.

### Please specify which Issue this PR Resolves.
I think they were prematurely closed.

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)
Handle the zero cargo + no selected vehicle case more appropriately at least. It shouldn't happen, but it certainly escalates when it does.

I feel that this sort of bugchain is partly caused by storing classnames too early, and ideally you keep things abstract (and therefore accurately quantifiable, and hopefully simpler) until you're at the point of spawning vehicles.