### PR TITLE
Add RHS M112, M112x4 and tetrytol charges to the breaching lists

### DIFF
--- a/A3-Antistasi/initVarServer.sqf
+++ b/A3-Antistasi/initVarServer.sqf
@@ -634,8 +634,8 @@ DECLARE_SERVER_VAR(breachExplosiveLarge, ["SatchelCharge_Remote_Mag"]);
 
 if(hasRHS && !hasIFA) then
 {
-	breachExplosiveSmall = ["rhs_ec200_mag", "rhs_ec200_camo_mag"];
-	breachExplosiveLarge = ["rhs_ec400_mag", "rhs_ec400_camo_mag"];
+	breachExplosiveSmall = ["rhs_ec200_mag", "rhs_ec200_camo_mag", "rhsusf_m112_mag"];
+	breachExplosiveLarge = ["rhs_ec400_mag", "rhs_ec400_camo_mag", "rhsusf_m112x4_mag", "rhs_charge_M2tet_x2_mag"];
 }
 else
 {


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug-ish
2. [ ] Enhancement

### What have you changed and why?
Added the M112 and M112x4 charges to the breaching lists, plus the tetrytol charge in case someone gets that out of a crate. The M112s are by far the most common charges in most RHS configs, but would generate the message "You need a small explosive charge to breach an APC open!".

### Please specify which Issue this PR Resolves.
Mentioned in #570, issue raised on Discord test reports.

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

This will do for 2.2. Later we can automate, or move the lists to templates.