### PR TITLE
Upgrade AltisB start LR

### DIFF
--- a/A3-Antistasi/Templates/RHS_Reb_CDF_Arid.sqf
+++ b/A3-Antistasi/Templates/RHS_Reb_CDF_Arid.sqf
@@ -105,4 +105,4 @@ initialRebelEquipment append ["rhsgref_chestrig","rhsgref_chicom","rhs_vydra_3m"
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular"];
 //TFAR Unlocks
 if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_rf7800str"]};
-if (startLR) then {initialRebelEquipment pushBack "tf_rt1523g_rhs"};
+if (startLR) then {initialRebelEquipment pushBack "tf_rt1523g_big_rhs"};

--- a/A3-Antistasi/Templates/RHS_Reb_CDF_Wdl.sqf
+++ b/A3-Antistasi/Templates/RHS_Reb_CDF_Wdl.sqf
@@ -105,4 +105,4 @@ initialRebelEquipment append ["rhsgref_chestrig","rhsgref_chicom","rhs_vydra_3m"
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular"];
 //TFAR Unlocks
 if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_rf7800str"]};
-if (startLR) then {initialRebelEquipment pushBack "tf_rt1523g_rhs"};
+if (startLR) then {initialRebelEquipment pushBack "tf_rt1523g_big_rhs"};


### PR DESCRIPTION
Changed the blufor version's startLR to make it the same size as the other versions. This was brought up in the community meeting in so far as several squad leaders refusing to take an LR at all because, and i quote, "It has no carry capacity."

To be fair, startLR could be disabled for 2.2 since the radios now appear in loot, which is what startLR was, partially, a temporary fix for.