### PR TITLE
Fix magazines loaded to weapons getting lost when transferring to arsenal

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_ammunitionTransfer.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_ammunitionTransfer.sqf
@@ -42,6 +42,16 @@ if (!isNil "_weaponsItemsCargo") then
 			if (_thingX isEqualType "") then
 				{
 				if (_thingX != "") then {_items pushBack _thingX};
+				}
+			else
+				{
+				if (_thingX isEqualType []) then
+					{
+					if (count _thingX > 0) then
+						{
+						_ammunition pushBack (_thingX select 0);
+						};
+					};
 				};
 			};
 		} forEach _weaponsItemsCargo;


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Enhancement

### What have you changed and why?
Information:
    If a weapon has a magazine/grenade/missile loaded then the ammo gets lost and is not transferred to arsenal. Because of this bug I now have 3 Javelin launchers and no rockets.

I looked in git history and found that this code had been there at some point but was commented out and subsequently removed. I wonder why. It works fine for me.
https://github.com/official-antistasi-community/A3-Antistasi/commit/1cde46509a0b11e5bae4a32ebf7667fa7a38d684#diff-fff9ca636b2f6c7b1d986d4b3b111bfeL45-L57

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:
