### PR TITLE
Spawned convoy fixes and reorganisation

### DIFF
--- a/A3-Antistasi/FSMs/ConvoyTravel.fsm
+++ b/A3-Antistasi/FSMs/ConvoyTravel.fsm
@@ -2,21 +2,21 @@
 /*%FSM<HEAD>*/
 /*
 item0[] = {"Start",0,250,-258.071289,-342.907776,-168.071396,-292.907776,0.000000,"Start"};
-item1[] = {"End_and_Rejoin",1,250,106.370567,-187.960236,196.370605,-137.960251,0.000000,"End and Rejoin"};
-item2[] = {"HasArrived",4,218,-120.327332,-98.101013,-30.327332,-48.101074,10.000000,"HasArrived"};
-item3[] = {"Abort",4,218,-84.991821,-242.269623,5.008179,-192.269608,100.000000,"Abort"};
+item1[] = {"End_and_Rejoin",1,4346,64.791161,-139.450836,154.791199,-89.450851,0.000000,"End and Rejoin"};
+item2[] = {"HasArrived",4,218,-256.153625,-77.311310,-166.153625,-27.311371,10.000000,"HasArrived"};
+item3[] = {"Abort",4,218,-91.228699,-251.971512,-1.228698,-201.971497,100.000000,"Abort"};
 item4[] = {"Head_to__Next_Po",2,250,-256.894318,-166.599014,-166.894302,-116.599007,0.000000,"Head to " \n "Next Pos"};
 item5[] = {"True",8,218,-257.487732,-253.817780,-167.487717,-203.817780,0.000000,"True"};
-item6[] = {"At_Next_Pos",4,218,-256.300751,-66.920471,-166.300781,-16.920471,5.000000,"At Next Pos"};
-item7[] = {"Fucked_Waypoint",4,218,-398.105469,-164.819061,-308.105469,-114.819061,0.000000,"Fucked" \n "Waypoint"};
-item8[] = {"Veh_or_Crew_Dead",4,218,-85.022217,-182.489105,4.977783,-132.489105,20.000000,"Veh or Crew" \n "Dead"};
-item9[] = {"Abort",1,250,116.100433,-342.075500,206.100464,-292.075500,0.000000,"Abort"};
-item10[] = {"Hard_Abort_",4,218,-86.479492,-341.346832,3.520508,-291.346832,100.000000,"Hard Abort?"};
-item11[] = {"End_and_Unload",1,4346,36.671631,-11.243378,126.671661,38.756607,0.000000,"End and Unload"};
+item6[] = {"At_Next_Pos",4,218,-403.907898,-167.404144,-313.907928,-117.404137,5.000000,"At Next Pos"};
+item7[] = {"Veh_stuck",4,218,-92.573151,-109.810966,-2.573151,-59.810974,0.000000,"Veh stuck"};
+item8[] = {"Veh_or_Crew_Dead",4,218,-91.259125,-177.638184,-1.259125,-127.638184,20.000000,"Veh or Crew" \n "Dead"};
+item9[] = {"End_and_Unload",1,250,-256.463623,15.090240,-166.463593,65.090225,0.000000,"End and Unload"};
+item10[] = {"Hard_Abort",4,218,-92.573059,-344.041931,-2.573059,-294.041931,100.000000,"Hard Abort"};
+item11[] = {"End_and_Abort",1,250,66.121887,-341.269958,156.121918,-291.269989,0.000000,"End and Abort"};
 link0[] = {0,5};
 link1[] = {0,10};
-link2[] = {2,11};
-link3[] = {3,1};
+link2[] = {2,9};
+link3[] = {3,11};
 link4[] = {4,2};
 link5[] = {4,3};
 link6[] = {4,6};
@@ -24,11 +24,11 @@ link7[] = {4,7};
 link8[] = {4,8};
 link9[] = {5,4};
 link10[] = {6,4};
-link11[] = {7,4};
+link11[] = {7,1};
 link12[] = {8,1};
-link13[] = {10,9};
-globals[] = {0.000000,0,0,0,0,640,480,1,45,6316128,1,-599.925232,291.426941,184.195313,-524.397522,1112,884,1};
-window[] = {2,-1,-1,-32000,-32000,889,130,1570,130,3,1130};
+link13[] = {10,11};
+globals[] = {0.000000,0,0,0,0,640,480,1,52,6316128,1,-539.552429,231.053772,136.200928,-476.403259,1112,884,1};
+window[] = {2,-1,-1,-1,-1,889,130,1570,130,3,1130};
 *//*%FSM</HEAD>*/
 class FSM
 {
@@ -43,36 +43,38 @@ class FSM
                         init = /*%FSM<STATEINIT""">*/"// _markers is [origin, destination]" \n
                          "params [""_vehicle"", ""_route"", ""_markers"", ""_convoyType""];" \n
                          "" \n
-                         "private _hardAbort = false;" \n
                          "private _state = ""START"";" \n
+                         "private _abort = false;" \n
                          "" \n
-                         "if (isNull _vehicle || count _route == 0) exitWith {};" \n
+                         "// log some broken input errors" \n
+                         "if (isNull _vehicle) exitWith { _abort = true; [1, ""Null vehicle input"", ""ConvoyTravel""] call A3A_fnc_log };" \n
+                         "if (count _route == 0) exitWith { _abort = true; [1, ""No route specified"", ""ConvoyTravel""] call A3A_fnc_log };" \n
+                         "if (driver _vehicle == objNull) exitWith { _abort = true; [1, ""No driver in vehicle"", ""ConvoyTravel""] call A3A_fnc_log };" \n
+                         "if (!alive driver _vehicle) exitWith { _abort = true; [1, ""Dead driver in vehicle"", ""ConvoyTravel""] call A3A_fnc_log };" \n
                          "" \n
-                         "private _destination = _route select (count _route - 1);" \n
-                         "private _accuracy = 50;			// Slows down too much at 20" \n
-                         "" \n
-                         "// assumes that there are no non-crew in the crew group, otherwise horror" \n
+                         "// Make sure our driver doesn't give a shit about the whole 'being shot' thing" \n
+                         "// Might need this for commander too?" \n
                          "private _splitCrew = [_vehicle] call A3A_fnc_splitVehicleCrewIntoOwnGroups;" \n
-                         "if (_splitCrew select 0 isEqualTo []) exitWith {" \n
-                         "	_hardAbort = true;" \n
-                         "};" \n
-                         "" \n
-                         "//Make sure our driver doesn't give a shit about the whole 'being shot' thing" \n
                          "(group driver _vehicle) setBehaviour ""CARELESS"";" \n
                          "(group driver _vehicle) setCombatMode ""BLUE"";" \n
                          "" \n
+                         "private _cargoUnits = assignedCargo _vehicle;" \n
+                         "private _cargoGroup = if (count _cargoUnits > 0) then {group (_cargoUnits # 0)} else {grpNull};" \n
+                         "" \n
+                         "private _destination = _route select (count _route - 1);" \n
+                         "private _accuracy = 50;			// Slows down too much at 20" \n
                          "private _currentNode = 0;"/*%FSM</STATEINIT""">*/;
                         precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
                         class Links
                         {
-                                /*%FSM<LINK "Hard_Abort_">*/
-                                class Hard_Abort_
+                                /*%FSM<LINK "Hard_Abort">*/
+                                class Hard_Abort
                                 {
                                         itemno = 10;
                                         priority = 100.000000;
-                                        to="Abort";
+                                        to="End_and_Abort";
                                         precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
-                                        condition=/*%FSM<CONDITION""">*/"_hardAbort;"/*%FSM</CONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"_abort;"/*%FSM</CONDITION""">*/;
                                         action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
                                 };
                                 /*%FSM</LINK>*/
@@ -97,8 +99,25 @@ class FSM
                         itemno = 1;
                         init = /*%FSM<STATEINIT""">*/"_state = ""END"";" \n
                          "" \n
-                         "//Fresh group, to wipe out any lingering orders." \n
-                         "_splitCrew call A3A_fnc_joinMultipleGroups;"/*%FSM</STATEINIT""">*/;
+                         "if !(isNull _vehicle) then { _vehicle setVariable[""fsmresult"", -1] };" \n
+                         "" \n
+                         "private _crewGroup = _splitCrew call A3A_fnc_joinMultipleGroups;" \n
+                         "if (_crewGroup == grpNull) exitwith {};" \n
+                         "" \n
+                         "{ unassignVehicle _x } forEach (crew _vehicle);" \n
+                         "if (_cargoGroup != grpNull) then {" \n
+                         "	(units _cargoGroup) joinSilent _crewGroup;" \n
+                         "	deleteGroup _cargoGroup;" \n
+                         "};" \n
+                         "[_crewGroup] spawn A3A_fnc_groupDespawner;" \n
+                         "" \n
+                         "// Send back to base" \n
+                         "private _wp3 = _crewGroup addWaypoint [getMarkerPos (_markers # 0), 100];" \n
+                         "_wp3 setWaypointType ""MOVE"";" \n
+                         "_wp3 setWaypointBehaviour ""SAFE"";" \n
+                         "_crewGroup setCurrentWaypoint _wp3;" \n
+                         "" \n
+                         ""/*%FSM</STATEINIT""">*/;
                         precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
                         class Links
                         {
@@ -115,20 +134,13 @@ class FSM
                          "private _nextPos = _route # _currentNode;" \n
                          "" \n
                          "//Move all of the groups, as we don't know who is in command." \n
-                         "// Why do we care? Can't we just order the driver?" \n
                          "{" \n
-                         "	//while {count waypoints _x > 0} do {" \n
-                         "	//	deleteWaypoint (waypoints _x select 0);" \n
-                         "	//};" \n
-                         "" \n
-                         "	//_x addWaypoint [getPosASL _vehicle, -1];" \n
                          "	private _nextWaypoint = _x addWaypoint [AGLToASL _nextPos, -1];" \n
-                         "" \n
-                         "" \n
                          "	_x setCurrentWaypoint _nextWaypoint;" \n
+                         "} forEach (_splitCrew # 0);" \n
                          "" \n
-                         "	//_x move _nextPos;" \n
-                         "} forEach (_splitCrew # 0);"/*%FSM</STATEINIT""">*/;
+                         "// to make sure that vehicles don't get stuck forever and never despawn" \n
+                         "private _timeout = time + (_vehicle distance2d _nextPos);"/*%FSM</STATEINIT""">*/;
                         precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
                         class Links
                         {
@@ -137,9 +149,9 @@ class FSM
                                 {
                                         itemno = 3;
                                         priority = 100.000000;
-                                        to="End_and_Rejoin";
+                                        to="End_and_Abort";
                                         precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
-                                        condition=/*%FSM<CONDITION""">*/"!(isNil ""_abort"");"/*%FSM</CONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"_abort;"/*%FSM</CONDITION""">*/;
                                         action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
                                 };
                                 /*%FSM</LINK>*/
@@ -150,8 +162,8 @@ class FSM
                                         priority = 20.000000;
                                         to="End_and_Rejoin";
                                         precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
-                                        condition=/*%FSM<CONDITION""">*/"!alive _vehicle || { driver _vehicle == objNull } || { !alive driver _vehicle };"/*%FSM</CONDITION""">*/;
-                                        action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"!alive _vehicle || !canMove _vehicle || { driver _vehicle == objNull } || { !alive driver _vehicle };"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/"[2, ""Vehicle or driver died during travel, abandoning"", ""ConvoyTravel""] call A3A_fnc_log;"/*%FSM</ACTION""">*/;
                                 };
                                 /*%FSM</LINK>*/
                                 /*%FSM<LINK "HasArrived">*/
@@ -162,7 +174,7 @@ class FSM
                                         to="End_and_Unload";
                                         precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
                                         condition=/*%FSM<CONDITION""">*/"_vehicle distance _destination < 100;"/*%FSM</CONDITION""">*/;
-                                        action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
+                                        action=/*%FSM<ACTION""">*/"[3, ""Convoy vehicle arrived at destination"", ""ConvoyTravel""] call A3A_fnc_log;"/*%FSM</ACTION""">*/;
                                 };
                                 /*%FSM</LINK>*/
                                 /*%FSM<LINK "At_Next_Pos">*/
@@ -180,37 +192,17 @@ class FSM
                                          ""/*%FSM</ACTION""">*/;
                                 };
                                 /*%FSM</LINK>*/
-                                /*%FSM<LINK "Fucked_Waypoint">*/
-                                class Fucked_Waypoint
+                                /*%FSM<LINK "Veh_stuck">*/
+                                class Veh_stuck
                                 {
                                         itemno = 7;
                                         priority = 0.000000;
-                                        to="Head_to__Next_Po";
+                                        to="End_and_Rejoin";
                                         precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
-                                        condition=/*%FSM<CONDITION""">*/"private _result = false;" \n
-                                         "" \n
-                                         "{" \n
-                                         "	if (currentWaypoint _x + 1 > count waypoints _x) then {" \n
-                                         "		_result = true;" \n
-                                         "	};" \n
-                                         "} forEach (_splitCrew # 0);" \n
-                                         "" \n
-                                         "_result;"/*%FSM</CONDITION""">*/;
-                                        action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"time > _timeout;"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/"[2, ""Vehicle stuck during travel, abandoning"", ""ConvoyTravel""] call A3A_fnc_log;"/*%FSM</ACTION""">*/;
                                 };
                                 /*%FSM</LINK>*/
-                        };
-                };
-                /*%FSM</STATE>*/
-                /*%FSM<STATE "Abort">*/
-                class Abort
-                {
-                        name = "Abort";
-                        itemno = 9;
-                        init = /*%FSM<STATEINIT""">*/"_state = ""END"";"/*%FSM</STATEINIT""">*/;
-                        precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
-                        class Links
-                        {
                         };
                 };
                 /*%FSM</STATE>*/
@@ -218,50 +210,66 @@ class FSM
                 class End_and_Unload
                 {
                         name = "End_and_Unload";
-                        itemno = 11;
+                        itemno = 9;
                         init = /*%FSM<STATEINIT""">*/"_state = ""END"";" \n
                          "" \n
-                         "_splitCrew call A3A_fnc_joinMultipleGroups;" \n
+                         "if !(isNull _vehicle) then { _vehicle setVariable[""fsmresult"", 1] };" \n
                          "" \n
-                         "private _crewGroup = group driver _vehicle;" \n
-                         "_crewGroup setBehaviour ""SAFE"";" \n
-                         "_crewGroup setCombatMode ""YELLOW"";" \n
+                         "private _crewGroup = _splitCrew call A3A_fnc_joinMultipleGroups;" \n
                          "" \n
                          "// Don't force all vehicles to drive into the outpost" \n
-                         "private _wp0 = _crewGroup addWaypoint [_destination, 70];" \n
-                         "//_wp0 setWaypointCompletionRadius 50;		// doesn't do anything in tests" \n
+                         "private _wp0 = _crewGroup addWaypoint [_destination, 50];" \n
+                         "_wp0 setWaypointCompletionRadius 50;" \n
                          "_wp0 setWaypointType ""TR UNLOAD"";" \n
                          "_wp0 setWaypointStatements [""true"", ""{ unassignVehicle _x; } forEach (assignedCargo (vehicle this));""];" \n
                          "_crewGroup setCurrentWaypoint _wp0;" \n
                          "" \n
-                         "// could use assignedCargo or fullCrew instead of this getVariable" \n
-                         "private _cargoGroup = _vehicle getVariable [""cargoGroup"", grpNull];" \n
-                         "private _wp2 = _cargoGroup addWaypoint [_destination, 5];" \n
-                         "_wp2 setWaypointType ""MOVE"";" \n
-                         "_wp2 setWaypointStatements [""true"", ""(group this) spawn A3A_fnc_attackDrillAI;""];" \n
-                         "_cargoGroup setCurrentWaypoint _wp2;" \n
+                         "if (_cargoGroup != grpNull) then {" \n
+                         "	// Move cargo group towards centre of outpost" \n
+                         "	private _wp2 = _cargoGroup addWaypoint [_destination, 10];" \n
+                         "	_wp2 setWaypointType ""MOVE"";" \n
+                         "	_wp2 setWaypointStatements [""true"", ""(group this) spawn A3A_fnc_attackDrillAI;""];" \n
+                         "	_cargoGroup setCurrentWaypoint _wp2;" \n
+                         "};" \n
                          "" \n
+                         "// Despawning before the unload is completed is fine. We've arrived." \n
                          "if (_convoyType isEqualTo ""reinforce"") then {" \n
+                         "" \n
+                         "	// add units to garrison immediately, otherwise it'll keep sending them" \n
+                         "	private _garrison = [typeOf _vehicle, [], []];" \n
+                         "	{ (_garrison # 1) pushBack (typeOf _x) } foreach units _crewGroup;" \n
+                         "	{ (_garrison # 2) pushBack (typeOf _x) } foreach units _cargoGroup;" \n
+                         "	[_markers # 1, [_garrison]] call A3A_fnc_addGarrison;" \n
+                         "" \n
                          "	// synchronize despawning with the target marker" \n
-                         "	waitUntil {sleep 5; (spawner getVariable (_markers # 1) == 2)};" \n
-                         "	[_markers # 1, [[_vehicle, units _crewGroup, units _cargoGroup]]] call A3A_fnc_addGarrison;" \n
-                         "	{ deleteVehicle _x } forEach units _cargoGroup;" \n
-                         "	{ deleteVehicle _x } forEach units _crewGroup;" \n
-                         "	deleteGroup _cargoGroup;" \n
-                         "	deleteGroup _crewGroup;" \n
-                         "	deleteVehicle _vehicle;" \n
-                         "{" \n
-                         "else {" \n
+                         "	// remove this once addGarrison takes control of the units" \n
+                         "	[_crewGroup, _cargoGroup, _markers # 1] spawn {" \n
+                         "		params[""_crew"", ""_cargo"", ""_marker""];" \n
+                         "		waitUntil {sleep 5; (spawner getVariable _marker == 2)};" \n
+                         "		{ deleteVehicle _x } forEach units _cargo;" \n
+                         "		{ deleteVehicle _x } forEach units _crew;" \n
+                         "		deleteGroup _cargo;" \n
+                         "		deleteGroup _crew;" \n
+                         "	};" \n
+                         "} else {" \n
                          "	// otherwise just use the stock despawning" \n
                          "	[_crewGroup] spawn A3A_fnc_groupDespawner;" \n
                          "	[_cargoGroup] spawn A3A_fnc_groupDespawner;" \n
-                         "	// despawn the vehicle once it has no crew" \n
-                         "	[_vehicle] spawn {" \n
-                         "		params[""_veh""];" \n
-                         "		waituntil { sleep 5; (units _veh) isEqualTo [] };" \n
-                         "		deleteVehicle _veh;" \n
-                         "	};" \n
                          "};"/*%FSM</STATEINIT""">*/;
+                        precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
+                        class Links
+                        {
+                        };
+                };
+                /*%FSM</STATE>*/
+                /*%FSM<STATE "End_and_Abort">*/
+                class End_and_Abort
+                {
+                        name = "End_and_Abort";
+                        itemno = 11;
+                        init = /*%FSM<STATEINIT""">*/"_state = ""END"";" \n
+                         "" \n
+                         "if !(isNull _vehicle) then { _vehicle setVariable[""fsmresult"", -2] };"/*%FSM</STATEINIT""">*/;
                         precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
                         class Links
                         {
@@ -273,8 +281,8 @@ class FSM
         finalStates[] =
         {
                 "End_and_Rejoin",
-                "Abort",
                 "End_and_Unload",
+                "End_and_Abort",
         };
 };
 /*%FSM</COMPILE>*/

--- a/A3-Antistasi/FSMs/ConvoyTravel.fsm
+++ b/A3-Antistasi/FSMs/ConvoyTravel.fsm
@@ -1,0 +1,280 @@
+/*%FSM<COMPILE "scriptedFSM.cfg, ConvoyTravel">*/
+/*%FSM<HEAD>*/
+/*
+item0[] = {"Start",0,250,-258.071289,-342.907776,-168.071396,-292.907776,0.000000,"Start"};
+item1[] = {"End_and_Rejoin",1,250,106.370567,-187.960236,196.370605,-137.960251,0.000000,"End and Rejoin"};
+item2[] = {"HasArrived",4,218,-120.327332,-98.101013,-30.327332,-48.101074,10.000000,"HasArrived"};
+item3[] = {"Abort",4,218,-84.991821,-242.269623,5.008179,-192.269608,100.000000,"Abort"};
+item4[] = {"Head_to__Next_Po",2,250,-256.894318,-166.599014,-166.894302,-116.599007,0.000000,"Head to " \n "Next Pos"};
+item5[] = {"True",8,218,-257.487732,-253.817780,-167.487717,-203.817780,0.000000,"True"};
+item6[] = {"At_Next_Pos",4,218,-256.300751,-66.920471,-166.300781,-16.920471,5.000000,"At Next Pos"};
+item7[] = {"Fucked_Waypoint",4,218,-398.105469,-164.819061,-308.105469,-114.819061,0.000000,"Fucked" \n "Waypoint"};
+item8[] = {"Veh_or_Crew_Dead",4,218,-85.022217,-182.489105,4.977783,-132.489105,20.000000,"Veh or Crew" \n "Dead"};
+item9[] = {"Abort",1,250,116.100433,-342.075500,206.100464,-292.075500,0.000000,"Abort"};
+item10[] = {"Hard_Abort_",4,218,-86.479492,-341.346832,3.520508,-291.346832,100.000000,"Hard Abort?"};
+item11[] = {"End_and_Unload",1,4346,36.671631,-11.243378,126.671661,38.756607,0.000000,"End and Unload"};
+link0[] = {0,5};
+link1[] = {0,10};
+link2[] = {2,11};
+link3[] = {3,1};
+link4[] = {4,2};
+link5[] = {4,3};
+link6[] = {4,6};
+link7[] = {4,7};
+link8[] = {4,8};
+link9[] = {5,4};
+link10[] = {6,4};
+link11[] = {7,4};
+link12[] = {8,1};
+link13[] = {10,9};
+globals[] = {0.000000,0,0,0,0,640,480,1,45,6316128,1,-599.925232,291.426941,184.195313,-524.397522,1112,884,1};
+window[] = {2,-1,-1,-32000,-32000,889,130,1570,130,3,1130};
+*//*%FSM</HEAD>*/
+class FSM
+{
+        fsmName = "ConvoyTravel";
+        class States
+        {
+                /*%FSM<STATE "Start">*/
+                class Start
+                {
+                        name = "Start";
+                        itemno = 0;
+                        init = /*%FSM<STATEINIT""">*/"// _markers is [origin, destination]" \n
+                         "params [""_vehicle"", ""_route"", ""_markers"", ""_convoyType""];" \n
+                         "" \n
+                         "private _hardAbort = false;" \n
+                         "private _state = ""START"";" \n
+                         "" \n
+                         "if (isNull _vehicle || count _route == 0) exitWith {};" \n
+                         "" \n
+                         "private _destination = _route select (count _route - 1);" \n
+                         "private _accuracy = 50;			// Slows down too much at 20" \n
+                         "" \n
+                         "// assumes that there are no non-crew in the crew group, otherwise horror" \n
+                         "private _splitCrew = [_vehicle] call A3A_fnc_splitVehicleCrewIntoOwnGroups;" \n
+                         "if (_splitCrew select 0 isEqualTo []) exitWith {" \n
+                         "	_hardAbort = true;" \n
+                         "};" \n
+                         "" \n
+                         "//Make sure our driver doesn't give a shit about the whole 'being shot' thing" \n
+                         "(group driver _vehicle) setBehaviour ""CARELESS"";" \n
+                         "(group driver _vehicle) setCombatMode ""BLUE"";" \n
+                         "" \n
+                         "private _currentNode = 0;"/*%FSM</STATEINIT""">*/;
+                        precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
+                        class Links
+                        {
+                                /*%FSM<LINK "Hard_Abort_">*/
+                                class Hard_Abort_
+                                {
+                                        itemno = 10;
+                                        priority = 100.000000;
+                                        to="Abort";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"_hardAbort;"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                                /*%FSM<LINK "True">*/
+                                class True
+                                {
+                                        itemno = 5;
+                                        priority = 0.000000;
+                                        to="Head_to__Next_Po";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/""/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                        };
+                };
+                /*%FSM</STATE>*/
+                /*%FSM<STATE "End_and_Rejoin">*/
+                class End_and_Rejoin
+                {
+                        name = "End_and_Rejoin";
+                        itemno = 1;
+                        init = /*%FSM<STATEINIT""">*/"_state = ""END"";" \n
+                         "" \n
+                         "//Fresh group, to wipe out any lingering orders." \n
+                         "_splitCrew call A3A_fnc_joinMultipleGroups;"/*%FSM</STATEINIT""">*/;
+                        precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
+                        class Links
+                        {
+                        };
+                };
+                /*%FSM</STATE>*/
+                /*%FSM<STATE "Head_to__Next_Po">*/
+                class Head_to__Next_Po
+                {
+                        name = "Head_to__Next_Po";
+                        itemno = 4;
+                        init = /*%FSM<STATEINIT""">*/"_state = ""FOLLOW"";" \n
+                         "" \n
+                         "private _nextPos = _route # _currentNode;" \n
+                         "" \n
+                         "//Move all of the groups, as we don't know who is in command." \n
+                         "// Why do we care? Can't we just order the driver?" \n
+                         "{" \n
+                         "	//while {count waypoints _x > 0} do {" \n
+                         "	//	deleteWaypoint (waypoints _x select 0);" \n
+                         "	//};" \n
+                         "" \n
+                         "	//_x addWaypoint [getPosASL _vehicle, -1];" \n
+                         "	private _nextWaypoint = _x addWaypoint [AGLToASL _nextPos, -1];" \n
+                         "" \n
+                         "" \n
+                         "	_x setCurrentWaypoint _nextWaypoint;" \n
+                         "" \n
+                         "	//_x move _nextPos;" \n
+                         "} forEach (_splitCrew # 0);"/*%FSM</STATEINIT""">*/;
+                        precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
+                        class Links
+                        {
+                                /*%FSM<LINK "Abort">*/
+                                class Abort
+                                {
+                                        itemno = 3;
+                                        priority = 100.000000;
+                                        to="End_and_Rejoin";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"!(isNil ""_abort"");"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                                /*%FSM<LINK "Veh_or_Crew_Dead">*/
+                                class Veh_or_Crew_Dead
+                                {
+                                        itemno = 8;
+                                        priority = 20.000000;
+                                        to="End_and_Rejoin";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"!alive _vehicle || { driver _vehicle == objNull } || { !alive driver _vehicle };"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                                /*%FSM<LINK "HasArrived">*/
+                                class HasArrived
+                                {
+                                        itemno = 2;
+                                        priority = 10.000000;
+                                        to="End_and_Unload";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"_vehicle distance _destination < 100;"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                                /*%FSM<LINK "At_Next_Pos">*/
+                                class At_Next_Pos
+                                {
+                                        itemno = 6;
+                                        priority = 5.000000;
+                                        to="Head_to__Next_Po";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"_vehicle distance _nextPos < _accuracy;"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/"if (_currentNode < count _route) then {" \n
+                                         "	_currentNode =	_currentNode + 1;" \n
+                                         "};" \n
+                                         "" \n
+                                         ""/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                                /*%FSM<LINK "Fucked_Waypoint">*/
+                                class Fucked_Waypoint
+                                {
+                                        itemno = 7;
+                                        priority = 0.000000;
+                                        to="Head_to__Next_Po";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"private _result = false;" \n
+                                         "" \n
+                                         "{" \n
+                                         "	if (currentWaypoint _x + 1 > count waypoints _x) then {" \n
+                                         "		_result = true;" \n
+                                         "	};" \n
+                                         "} forEach (_splitCrew # 0);" \n
+                                         "" \n
+                                         "_result;"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                        };
+                };
+                /*%FSM</STATE>*/
+                /*%FSM<STATE "Abort">*/
+                class Abort
+                {
+                        name = "Abort";
+                        itemno = 9;
+                        init = /*%FSM<STATEINIT""">*/"_state = ""END"";"/*%FSM</STATEINIT""">*/;
+                        precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
+                        class Links
+                        {
+                        };
+                };
+                /*%FSM</STATE>*/
+                /*%FSM<STATE "End_and_Unload">*/
+                class End_and_Unload
+                {
+                        name = "End_and_Unload";
+                        itemno = 11;
+                        init = /*%FSM<STATEINIT""">*/"_state = ""END"";" \n
+                         "" \n
+                         "_splitCrew call A3A_fnc_joinMultipleGroups;" \n
+                         "" \n
+                         "private _crewGroup = group driver _vehicle;" \n
+                         "_crewGroup setBehaviour ""SAFE"";" \n
+                         "_crewGroup setCombatMode ""YELLOW"";" \n
+                         "" \n
+                         "// Don't force all vehicles to drive into the outpost" \n
+                         "private _wp0 = _crewGroup addWaypoint [_destination, 70];" \n
+                         "//_wp0 setWaypointCompletionRadius 50;		// doesn't do anything in tests" \n
+                         "_wp0 setWaypointType ""TR UNLOAD"";" \n
+                         "_wp0 setWaypointStatements [""true"", ""{ unassignVehicle _x; } forEach (assignedCargo (vehicle this));""];" \n
+                         "_crewGroup setCurrentWaypoint _wp0;" \n
+                         "" \n
+                         "// could use assignedCargo or fullCrew instead of this getVariable" \n
+                         "private _cargoGroup = _vehicle getVariable [""cargoGroup"", grpNull];" \n
+                         "private _wp2 = _cargoGroup addWaypoint [_destination, 5];" \n
+                         "_wp2 setWaypointType ""MOVE"";" \n
+                         "_wp2 setWaypointStatements [""true"", ""(group this) spawn A3A_fnc_attackDrillAI;""];" \n
+                         "_cargoGroup setCurrentWaypoint _wp2;" \n
+                         "" \n
+                         "if (_convoyType isEqualTo ""reinforce"") then {" \n
+                         "	// synchronize despawning with the target marker" \n
+                         "	waitUntil {sleep 5; (spawner getVariable (_markers # 1) == 2)};" \n
+                         "	[_markers # 1, [[_vehicle, units _crewGroup, units _cargoGroup]]] call A3A_fnc_addGarrison;" \n
+                         "	{ deleteVehicle _x } forEach units _cargoGroup;" \n
+                         "	{ deleteVehicle _x } forEach units _crewGroup;" \n
+                         "	deleteGroup _cargoGroup;" \n
+                         "	deleteGroup _crewGroup;" \n
+                         "	deleteVehicle _vehicle;" \n
+                         "{" \n
+                         "else {" \n
+                         "	// otherwise just use the stock despawning" \n
+                         "	[_crewGroup] spawn A3A_fnc_groupDespawner;" \n
+                         "	[_cargoGroup] spawn A3A_fnc_groupDespawner;" \n
+                         "	// despawn the vehicle once it has no crew" \n
+                         "	[_vehicle] spawn {" \n
+                         "		params[""_veh""];" \n
+                         "		waituntil { sleep 5; (units _veh) isEqualTo [] };" \n
+                         "		deleteVehicle _veh;" \n
+                         "	};" \n
+                         "};"/*%FSM</STATEINIT""">*/;
+                        precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
+                        class Links
+                        {
+                        };
+                };
+                /*%FSM</STATE>*/
+        };
+        initState="Start";
+        finalStates[] =
+        {
+                "End_and_Rejoin",
+                "Abort",
+                "End_and_Unload",
+        };
+};
+/*%FSM</COMPILE>*/

--- a/A3-Antistasi/FSMs/ConvoyTravelAir.fsm
+++ b/A3-Antistasi/FSMs/ConvoyTravelAir.fsm
@@ -1,0 +1,410 @@
+/*%FSM<COMPILE "scriptedFSM.cfg, ConvoyTravelAir">*/
+/*%FSM<HEAD>*/
+/*
+item0[] = {"Start",0,250,-298.857239,-326.554596,-208.857346,-276.554596,0.000000,"Start"};
+item1[] = {"End_and_Cleanup",1,250,-520.181091,90.358856,-430.181274,140.358841,0.000000,"End and" \n "Cleanup"};
+item2[] = {"HasArrived",4,218,-291.937164,-33.624756,-201.937164,16.375183,10.000000,"HasArrived"};
+item3[] = {"Abort",4,218,-153.526245,-30.271576,-63.526245,19.728432,100.000000,"Abort"};
+item4[] = {"Head_to__Target",2,250,-207.354156,-154.398788,-117.354134,-104.398773,0.000000,"Head to " \n "Target"};
+item5[] = {"Veh_Incapacitate",4,218,-436.459442,-36.922272,-346.459381,13.077728,20.000000,"Veh" \n "Incapacitated"};
+item6[] = {"Land_and_Unload",2,250,-290.550201,82.651550,-200.550171,132.651550,0.000000,"Land and" \n "Unload"};
+item7[] = {"Hard_Abort",4,218,-155.373779,-324.019623,-65.373779,-274.019623,100.000000,"Hard Abort"};
+item8[] = {"End_and_Abort",1,250,-38.607544,-190.627563,51.392487,-140.627609,0.000000,"End and Abort"};
+item9[] = {"HasUnloaded",4,218,-287.743927,178.504852,-197.743927,228.504852,0.000000,"HasUnloaded"};
+item10[] = {"Return__to_Base",1,4346,-286.589111,265.751678,-196.589081,315.751648,0.000000,"Return " \n "to Base"};
+item11[] = {"Follow_position",2,250,-380.936310,-148.474747,-290.936279,-98.474747,0.000000,"Follow" \n "position"};
+item12[] = {"Nothing_to_follo",4,218,-259.165253,-237.241608,-169.165253,-187.241623,5.000000,"Nothing to" \n "follow"};
+item13[] = {"Timed_position_u",4,218,-526.917358,-147.361725,-436.917297,-97.361679,1.000000,"Timed position" \n "update"};
+item14[] = {"True",8,218,-404.879303,-242.822372,-314.879303,-192.822388,0.000000,"True"};
+link0[] = {0,7};
+link1[] = {0,12};
+link2[] = {0,14};
+link3[] = {2,6};
+link4[] = {3,8};
+link5[] = {4,2};
+link6[] = {4,3};
+link7[] = {4,5};
+link8[] = {5,1};
+link9[] = {6,3};
+link10[] = {6,5};
+link11[] = {6,9};
+link12[] = {7,8};
+link13[] = {9,10};
+link14[] = {11,2};
+link15[] = {11,3};
+link16[] = {11,5};
+link17[] = {11,12};
+link18[] = {11,13};
+link19[] = {12,4};
+link20[] = {13,11};
+link21[] = {14,11};
+globals[] = {0.000000,0,0,0,0,640,480,1,70,6316128,1,-725.928467,294.090576,352.494415,-458.383972,1112,884,1};
+window[] = {2,-1,-1,-32000,-32000,889,130,1570,130,3,1130};
+*//*%FSM</HEAD>*/
+class FSM
+{
+        fsmName = "ConvoyTravelAir";
+        class States
+        {
+                /*%FSM<STATE "Start">*/
+                class Start
+                {
+                        name = "Start";
+                        itemno = 0;
+                        init = /*%FSM<STATEINIT""">*/"// _offset is this vehicle's target offset from followpos" \n
+                         "// _markers is [origin, destination]" \n
+                         "params [""_vehicle"", ""_offset"", ""_markers"", ""_convoyType""];" \n
+                         "" \n
+                         "private _state = ""START"";" \n
+                         "private _abort = false;" \n
+                         "" \n
+                         "// log some broken input errors" \n
+                         "if (isNull _vehicle) exitWith { _abort = true; [1, ""Null vehicle input"", ""ConvoyTravelAir""] call A3A_fnc_log };" \n
+                         "if (driver _vehicle == objNull) exitWith { _abort = true; [1, ""No driver in vehicle"", ""ConvoyTravelAir""] call A3A_fnc_log };" \n
+                         "" \n
+                         "//private _cargoGroup = getVariable [""cargoGroup"", grpNull];" \n
+                         "private _cargo = assignedCargo _vehicle;" \n
+                         "private _cargoGroup = if (_cargo isEqualTo []) then { grpNull } else { group (_cargo # 0) };" \n
+                         "private _crewGroup = group driver _vehicle;" \n
+                         "" \n
+                         "private _destPos = getMarkerPos (_markers # 1);" \n
+                         "private _originPos = getMarkerPos (_markers # 0);" \n
+                         "" \n
+                         ""/*%FSM</STATEINIT""">*/;
+                        precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
+                        class Links
+                        {
+                                /*%FSM<LINK "Hard_Abort">*/
+                                class Hard_Abort
+                                {
+                                        itemno = 7;
+                                        priority = 100.000000;
+                                        to="End_and_Abort";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"_abort;"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                                /*%FSM<LINK "Nothing_to_follo">*/
+                                class Nothing_to_follo
+                                {
+                                        itemno = 12;
+                                        priority = 5.000000;
+                                        to="Head_to__Target";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"isNil {_vehicle getVariable ""followpos""};"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                                /*%FSM<LINK "True">*/
+                                class True
+                                {
+                                        itemno = 14;
+                                        priority = 0.000000;
+                                        to="Follow_position";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/""/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                        };
+                };
+                /*%FSM</STATE>*/
+                /*%FSM<STATE "End_and_Cleanup">*/
+                class End_and_Cleanup
+                {
+                        name = "End_and_Cleanup";
+                        itemno = 1;
+                        init = /*%FSM<STATEINIT""">*/"_state = ""END"";" \n
+                         "" \n
+                         "if !(isNull _vehicle) then { _vehicle setVariable[""fsmresult"", -1] };" \n
+                         "" \n
+                         "if !(isNil ""_landPad"") then { deleteVehicle _landPad };" \n
+                         "" \n
+                         "// Might be soft-landed somewhere, so clean up" \n
+                         "{ unassignVehicle _x } forEach (crew _vehicle);" \n
+                         "if (_cargoGroup != grpNull) then {" \n
+                         "	(units _cargoGroup) joinSilent _crewGroup;" \n
+                         "	deleteGroup _cargoGroup;" \n
+                         "};" \n
+                         "[_crewGroup] spawn A3A_fnc_groupDespawner;" \n
+                         "" \n
+                         "// Send back to base" \n
+                         "private _wp3 = _crewGroup addWaypoint [_originPos, 100];" \n
+                         "_wp3 setWaypointType ""MOVE"";" \n
+                         "_wp3 setWaypointBehaviour ""SAFE"";" \n
+                         "_crewGroup setCurrentWaypoint _wp3;"/*%FSM</STATEINIT""">*/;
+                        precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
+                        class Links
+                        {
+                        };
+                };
+                /*%FSM</STATE>*/
+                /*%FSM<STATE "Head_to__Target">*/
+                class Head_to__Target
+                {
+                        name = "Head_to__Target";
+                        itemno = 4;
+                        init = /*%FSM<STATEINIT""">*/"_state = ""FLYTO"";" \n
+                         "" \n
+                         "private _wp0 = _crewGroup addWaypoint [_destPos vectorAdd [0,0,50], 100];" \n
+                         "_wp0 setWaypointType ""MOVE"";" \n
+                         "_crewGroup setCurrentWaypoint _wp0;" \n
+                         ""/*%FSM</STATEINIT""">*/;
+                        precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
+                        class Links
+                        {
+                                /*%FSM<LINK "Abort">*/
+                                class Abort
+                                {
+                                        itemno = 3;
+                                        priority = 100.000000;
+                                        to="End_and_Abort";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"_abort;"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/"[3, ""Abort called on FSM"", ""ConvoyTravelAir""] call A3A_fnc_log;"/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                                /*%FSM<LINK "Veh_Incapacitate">*/
+                                class Veh_Incapacitate
+                                {
+                                        itemno = 5;
+                                        priority = 20.000000;
+                                        to="End_and_Cleanup";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"!alive _vehicle || !canMove _vehicle || driver _vehicle == objNull || !alive driver _vehicle;"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/"[2, ""Vehicle or driver died during travel, abandoning"", ""ConvoyTravelAir""] call A3A_fnc_log;"/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                                /*%FSM<LINK "HasArrived">*/
+                                class HasArrived
+                                {
+                                        itemno = 2;
+                                        priority = 10.000000;
+                                        to="Land_and_Unload";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"_vehicle distance _destPos < 500;"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/"[3, ""Helicopter arrived at destination"", ""ConvoyTravelAir""] call A3A_fnc_log;"/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                        };
+                };
+                /*%FSM</STATE>*/
+                /*%FSM<STATE "Land_and_Unload">*/
+                class Land_and_Unload
+                {
+                        name = "Land_and_Unload";
+                        itemno = 6;
+                        init = /*%FSM<STATEINIT""">*/"_state = ""LAND"";" \n
+                         "" \n
+                         "// trying this because of weird behaviour" \n
+                         "//while {count (waypoints _crewGroup) > 0} do {" \n
+                         "//	deleteWaypoint ((waypoints _crewGroup) select 0);" \n
+                         "//};" \n
+                         "" \n
+                         "private _landPos = [_destPos, 0, 300, 10, 0, 0.20, 0,[],[[0,0,0],[0,0,0]]] call BIS_fnc_findSafePos;" \n
+                         "_landPos set [2, 0];" \n
+                         "private _landPad = createVehicle [""Land_HelipadEmpty_F"", _landpos, [], 0, ""NONE""];	// cancollide?" \n
+                         "" \n
+                         "private _wp1 = _crewGroup addWaypoint [_landpos, 0];" \n
+                         "_wp1 setWaypointType ""TR UNLOAD"";" \n
+                         "_wp1 setWaypointStatements [""true"", ""(vehicle this) land 'GET OUT';""];" \n
+                         "_wp1 setWaypointBehaviour ""CARELESS"";" \n
+                         "_crewGroup setCurrentWaypoint _wp1;		// otherwise it's still on the previous waypoint" \n
+                         "" \n
+                         "// Move cargo group towards centre of outpost" \n
+                         "if (_cargoGroup != grpNull) then {" \n
+                         "	{ unassignVehicle _x } forEach units _cargoGroup;" \n
+                         "	private _wp2 = _cargoGroup addWaypoint [_destPos, 10];" \n
+                         "	_wp2 setWaypointType ""MOVE"";" \n
+                         "	_wp2 setWaypointStatements [""true"", ""(group this) spawn A3A_fnc_attackDrillAI;""];" \n
+                         "	_cargoGroup setCurrentWaypoint _wp2;" \n
+                         "};"/*%FSM</STATEINIT""">*/;
+                        precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
+                        class Links
+                        {
+                                /*%FSM<LINK "Abort">*/
+                                class Abort
+                                {
+                                        itemno = 3;
+                                        priority = 100.000000;
+                                        to="End_and_Abort";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"_abort;"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/"[3, ""Abort called on FSM"", ""ConvoyTravelAir""] call A3A_fnc_log;"/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                                /*%FSM<LINK "Veh_Incapacitate">*/
+                                class Veh_Incapacitate
+                                {
+                                        itemno = 5;
+                                        priority = 20.000000;
+                                        to="End_and_Cleanup";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"!alive _vehicle || !canMove _vehicle || driver _vehicle == objNull || !alive driver _vehicle;"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/"[2, ""Vehicle or driver died during travel, abandoning"", ""ConvoyTravelAir""] call A3A_fnc_log;"/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                                /*%FSM<LINK "HasUnloaded">*/
+                                class HasUnloaded
+                                {
+                                        itemno = 9;
+                                        priority = 0.000000;
+                                        to="Return__to_Base";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"{ vehicle _x != _x } count units _cargoGroup == 0;" \n
+                                         ""/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/"[3, ""Helicopter has unloaded cargo"", ""ConvoyTravelAir""] call A3A_fnc_log;"/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                        };
+                };
+                /*%FSM</STATE>*/
+                /*%FSM<STATE "End_and_Abort">*/
+                class End_and_Abort
+                {
+                        name = "End_and_Abort";
+                        itemno = 8;
+                        init = /*%FSM<STATEINIT""">*/"_state = ""END"";" \n
+                         "" \n
+                         "if !(isNull _vehicle) then { _vehicle setVariable[""fsmresult"", -2] };" \n
+                         "" \n
+                         "if !(isNil ""_landPad"") then { deleteVehicle _landPad };" \n
+                         "" \n
+                         ""/*%FSM</STATEINIT""">*/;
+                        precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
+                        class Links
+                        {
+                        };
+                };
+                /*%FSM</STATE>*/
+                /*%FSM<STATE "Return__to_Base">*/
+                class Return__to_Base
+                {
+                        name = "Return__to_Base";
+                        itemno = 10;
+                        init = /*%FSM<STATEINIT""">*/"_state = ""END"";" \n
+                         "" \n
+                         "if !(isNull _vehicle) then { _vehicle setVariable[""fsmresult"", 1] };" \n
+                         "" \n
+                         "if !(isNil ""_landPad"") then { deleteVehicle _landPad };" \n
+                         "" \n
+                         "// Transport vehicle returns home" \n
+                         "_crewGroup deleteGroupWhenEmpty true;" \n
+                         "private _wp3 = _crewGroup addWaypoint [_originPos vectorAdd [0,0,50], 100];" \n
+                         "_wp3 setWaypointType ""MOVE"";" \n
+                         "_wp3 setWaypointStatements [""true"", ""[3, """"heli return completed"""", """"ConvoyTravelAir""""] call A3A_fnc_log; deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList""];" \n
+                         "_wp3 setWaypointBehaviour ""SAFE"";" \n
+                         "" \n
+                         "//_wp3 setWaypointCompletionRadius 200;			// bugged, often causes waypoint non-termination" \n
+                         "//_crewGroup setCurrentWaypoint _wp3;			// bugged, prevents takeoff" \n
+                         "" \n
+                         "if (_cargoGroup == grpNull) exitWith {};" \n
+                         "" \n
+                         "if (_convoyType isEqualTo ""reinforce"") then {" \n
+                         "" \n
+                         "	// add units to garrison immediately, otherwise it'll keep sending them" \n
+                         "	private _unitTypes = [];" \n
+                         "	{ _unitTypes pushBack (typeOf _x) } foreach units _cargoGroup;" \n
+                         "	[_markers # 1, [["""", [], _unitTypes]]] call A3A_fnc_addGarrison;" \n
+                         "" \n
+                         "	// synchronize despawning with the target marker" \n
+                         "	// remove this once addGarrison takes control of the units" \n
+                         "	[_cargoGroup, _markers # 1] spawn {" \n
+                         "		params[""_cargo"", ""_marker""];" \n
+                         "		[3, ""Entering garrison reinf despawn loop"", ""ConvoyTravelAir""] call A3A_fnc_log;" \n
+                         "		waitUntil {sleep 5; (spawner getVariable _marker == 2)};" \n
+                         "		{ deleteVehicle _x } forEach units _cargo;" \n
+                         "		deleteGroup _cargo;" \n
+                         "	};" \n
+                         "}" \n
+                         "else { [_cargoGroup] spawn A3A_fnc_groupDespawner; };" \n
+                         "" \n
+                         ""/*%FSM</STATEINIT""">*/;
+                        precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
+                        class Links
+                        {
+                        };
+                };
+                /*%FSM</STATE>*/
+                /*%FSM<STATE "Follow_position">*/
+                class Follow_position
+                {
+                        name = "Follow_position";
+                        itemno = 11;
+                        init = /*%FSM<STATEINIT""">*/"private _followPos = _vehicle getVariable ""followpos"";" \n
+                         "" \n
+                         "_vehicle move (_followPos vectorAdd _offset);" \n
+                         "" \n
+                         "private _timeout = time + 2;"/*%FSM</STATEINIT""">*/;
+                        precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
+                        class Links
+                        {
+                                /*%FSM<LINK "Abort">*/
+                                class Abort
+                                {
+                                        itemno = 3;
+                                        priority = 100.000000;
+                                        to="End_and_Abort";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"_abort;"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/"[3, ""Abort called on FSM"", ""ConvoyTravelAir""] call A3A_fnc_log;"/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                                /*%FSM<LINK "Veh_Incapacitate">*/
+                                class Veh_Incapacitate
+                                {
+                                        itemno = 5;
+                                        priority = 20.000000;
+                                        to="End_and_Cleanup";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"!alive _vehicle || !canMove _vehicle || driver _vehicle == objNull || !alive driver _vehicle;"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/"[2, ""Vehicle or driver died during travel, abandoning"", ""ConvoyTravelAir""] call A3A_fnc_log;"/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                                /*%FSM<LINK "HasArrived">*/
+                                class HasArrived
+                                {
+                                        itemno = 2;
+                                        priority = 10.000000;
+                                        to="Land_and_Unload";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"_vehicle distance _destPos < 500;"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/"[3, ""Helicopter arrived at destination"", ""ConvoyTravelAir""] call A3A_fnc_log;"/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                                /*%FSM<LINK "Nothing_to_follo">*/
+                                class Nothing_to_follo
+                                {
+                                        itemno = 12;
+                                        priority = 5.000000;
+                                        to="Head_to__Target";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"isNil {_vehicle getVariable ""followpos""};"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                                /*%FSM<LINK "Timed_position_u">*/
+                                class Timed_position_u
+                                {
+                                        itemno = 13;
+                                        priority = 1.000000;
+                                        to="Follow_position";
+                                        precondition = /*%FSM<CONDPRECONDITION""">*/""/*%FSM</CONDPRECONDITION""">*/;
+                                        condition=/*%FSM<CONDITION""">*/"time >= _timeout;"/*%FSM</CONDITION""">*/;
+                                        action=/*%FSM<ACTION""">*/""/*%FSM</ACTION""">*/;
+                                };
+                                /*%FSM</LINK>*/
+                        };
+                };
+                /*%FSM</STATE>*/
+        };
+        initState="Start";
+        finalStates[] =
+        {
+                "End_and_Cleanup",
+                "End_and_Abort",
+                "Return__to_Base",
+        };
+};
+/*%FSM</COMPILE>*/

--- a/A3-Antistasi/functions/CREATE/fn_reinforcementsAI.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_reinforcementsAI.sqf
@@ -97,6 +97,7 @@ if ((count _reinfPlaces == 0) and (AAFpatrols <= 3)) then {[] spawn A3A_fnc_AAFr
 	{
 		_target = (_x select 1);
 		[_target, "Reinforce", _side, [_canReinf]] remoteExec ["A3A_fnc_createAIAction", 2];
+		sleep 10;		// prevents convoys spawning on top of each other
 		//TODO add a feedback if something was send or not
 	} forEach _reinfMarker;
 } forEach [Occupants, Invaders];

--- a/A3-Antistasi/functions/Convoy/fn_convoyMovement.sqf
+++ b/A3-Antistasi/functions/Convoy/fn_convoyMovement.sqf
@@ -81,7 +81,7 @@ for "_i" from 1 to (_pointsCount - 1) do
         if(spawner getVariable _currentRoadBlock == 2) then
         {
           _isSimulated = false;
-          [_convoyID, _units, _currentPos, _remainingRoute, _markerArray, _convoySide, _convoyType, _maxSpeed] call A3A_fnc_spawnConvoy;
+          [_convoyID, _units, _currentPos, _remainingRoute, _markerArray, _convoySide, _convoyType, _maxSpeed, _isAir] call A3A_fnc_spawnConvoy;
         }
         else
         {
@@ -110,7 +110,7 @@ for "_i" from 1 to (_pointsCount - 1) do
     if([distanceSPWN, 1, _currentPos, teamPlayer] call A3A_fnc_distanceUnits) then
     {
       _isSimulated = false;
-      [_convoyID, _units, _currentPos, _remainingRoute, _markerArray, _convoySide, _convoyType, _maxSpeed] call A3A_fnc_spawnConvoy;
+      [_convoyID, _units, _currentPos, _remainingRoute, _markerArray, _convoySide, _convoyType, _maxSpeed, _isAir] call A3A_fnc_spawnConvoy;
     };
   };
 

--- a/A3-Antistasi/functions/Convoy/fn_convoyMovement.sqf
+++ b/A3-Antistasi/functions/Convoy/fn_convoyMovement.sqf
@@ -13,7 +13,7 @@ params ["_convoyID" ,"_route", "_markerArray", "_maxSpeed", "_units", "_convoySi
 *   Returns:
       Nothing
 */
-_convoyMarker = format ["convoy%1", _convoyID];
+private _convoyMarker = format ["convoy%1", _convoyID];
 
 if(!(_maxSpeed > 0)) exitWith
 {
@@ -24,26 +24,28 @@ if(!(_maxSpeed > 0)) exitWith
 _maxSpeed = _maxSpeed * 0.8; //Only drive with 80% of max speed
 
 
-_isDebug = !(isNil "_debugObject");
+private _isDebug = !(isNil "_debugObject");
 
-_pointsCount = count _route;
-_currentPos = _route select 0;
+private _pointsCount = count _route;
+private _currentPos = _route select 0;
+private _remainingRoute = +_route;
+_remainingRoute deleteAt 0;
 
-_isSimulated = true;
-_isDestroyed = false;
-_roadBlockCountdown = 0;
-_currentRoadBlock = "";
+private _isSimulated = true;
+private _isDestroyed = false;
+private _roadBlockCountdown = 0;
+private _currentRoadBlock = "";
 
 if(_isDebug) then {_debugObject setPos _currentPos;};
 
 for "_i" from 1 to (_pointsCount - 1) do
 {
-  _lastPoint = _route select (_i - 1);
-  _nextPoint = _route select (_i);
+  private _lastPoint = _route select (_i - 1);
+  private _nextPoint = _route select (_i);
 
-  _movementVector = (_lastPoint vectorFromTo _nextPoint) vectorMultiply _maxSpeed;
-  _movementLength = _lastPoint vectorDistance _nextPoint;
-  _currentLength = 0;
+  private _movementVector = (_lastPoint vectorFromTo _nextPoint) vectorMultiply _maxSpeed;
+  private _movementLength = _lastPoint vectorDistance _nextPoint;
+  private _currentLength = 0;
 
   while {_isSimulated && {_currentLength < _movementLength}} do
   {
@@ -62,12 +64,14 @@ for "_i" from 1 to (_pointsCount - 1) do
     {
       _currentPos = _currentPos vectorAdd _movementVector;
       _currentLength = _currentLength + _maxSpeed;
-      if(_currentLength < _movementLength) then
+      if(_currentLength > _movementLength) then
       {
-        _convoyMarker setMarkerPos _currentPos;
+         // Moved here so spawnConvoy gets an accurate position
+         _remainingRoute deleteAt 0;
+         _currentPos = _nextPoint;
       };
-
-      if(_isDebug && {_currentLength < _movementLength}) then {_debugObject setPos _currentPos;};
+      _convoyMarker setMarkerPos _currentPos;
+      if(_isDebug) then {_debugObject setPos _currentPos;};
 
       //Search for nearby roadblocks
       _roadBlocks = outpostsFIA select {(getMarkerPos _x distance _currentPos < 250) && {isOnRoad (getMarkerPos _x)}};
@@ -77,8 +81,7 @@ for "_i" from 1 to (_pointsCount - 1) do
         if(spawner getVariable _currentRoadBlock == 2) then
         {
           _isSimulated = false;
-          private _posArray = [_currentPos, _nextPoint, (_route select (_pointsCount - 1))];
-          [_convoyID, _units, _posArray, _markerArray, _convoySide, _convoyType, _maxSpeed] call A3A_fnc_spawnConvoy;
+          [_convoyID, _units, _currentPos, _remainingRoute, _markerArray, _convoySide, _convoyType, _maxSpeed] call A3A_fnc_spawnConvoy;
         }
         else
         {
@@ -107,17 +110,10 @@ for "_i" from 1 to (_pointsCount - 1) do
     if([distanceSPWN, 1, _currentPos, teamPlayer] call A3A_fnc_distanceUnits) then
     {
       _isSimulated = false;
-
-      //deleteMarker _convoyMarker;
-      // - 2 as it is the last point on a street (or maybe not needs testing) _currentPos, _nextPoint,
-      private _posArray = [_currentPos, _nextPoint, (_route select (_pointsCount - 1))];
-      [_convoyID, _units, _posArray, _markerArray, _convoySide, _convoyType, _maxSpeed] call A3A_fnc_spawnConvoy;
+      [_convoyID, _units, _currentPos, _remainingRoute, _markerArray, _convoySide, _convoyType, _maxSpeed] call A3A_fnc_spawnConvoy;
     };
   };
 
-  _currentPos = _nextPoint;
-  _convoyMarker setMarkerPos _currentPos;
-  if(_isDebug) then {_debugObject setPos _currentPos;};
 };
 
 if(_isDestroyed) exitWith {deleteMarker _convoyMarker};

--- a/A3-Antistasi/functions/Convoy/fn_despawnConvoy.sqf
+++ b/A3-Antistasi/functions/Convoy/fn_despawnConvoy.sqf
@@ -1,70 +1,47 @@
 params ["_convoyID", "_unitObjects", "_convoyPos", "_target", "_markerArray", "_convoyType", "_convoySide"];
 
-_convoyData = [];
+[2, format ["Despawning convoy %1", _convoyID], "fn_despawnConvoy"] call A3A_fnc_log;
+
+// Exit any vehicle's FSM if it's still running
+{
+	private _fsm = (_x select 0) getVariable "fsm";
+	if !(isNil "_fsm" || {completedFSM _fsm}) then { _fsm setFSMVariable["_abort", true] };
+} forEach _unitObjects;
+
+private _convoyData = [];
 for "_i" from 0 to ((count _unitObjects) - 1) do
 {
-  _data = _unitObjects select _i;
-  _vehicle = _data select 0;
-  _crew = _data select 1;
-  _cargo = _data select 2;
+	private _data = _unitObjects select _i;
+	private _vehicle = _data select 0;
+	private _convoyLine = [];
 
-  _convoyLine = [];
-
-  //Deleting cargo first
-  _cargoData = [];
-  if(count _cargo > 0) then
-  {
-    //waitUntil {sleep 1; !([distanceSPWN * 1.2, 1, getPos (leader (_cargo select 0)), teamPlayer] call A3A_fnc_distanceUnits)};
-    {
-      if(alive _x) then
-      {
-        _cargoData pushBack (typeOf _x);
-        deleteVehicle _x;
-      };
-    } forEach _cargo;
-  };
-  _convoyLine set [2, _cargoData];
-
-  //Deleting crew after it
-  _crewData = [];
-  if(count _crew > 0) then
-  {
-    waitUntil {sleep 1; !([distanceSPWN * 1.2, 1, getPos (leader (_crew select 0)), teamPlayer] call A3A_fnc_distanceUnits)};
-    {
-      if(alive _x) then
-      {
-        _crewData pushBack (typeOf _x);
-        deleteVehicle _x;
-      };
-    } forEach _crew;
-  };
-  _convoyLine set [1, _crewData];
-
-  //Deleting vehicle last
-  if(!isNull _vehicle) then
-  {
-    //waitUntil {sleep 0.25; !([distanceSPWN * 1.2, 1, getPos _vehicle, teamPlayer] call A3A_fnc_distanceUnits)};
-    //_vehicle setVelocity [0,0,0];
-    if(alive _vehicle) then
-    {
-      _convoyLine set [0, typeOf _vehicle];
-    }
-    else
-    {
-      _convoyLine set [0, ""];
-    };
-    deleteVehicle _vehicle;
-  }
-  else
-  {
-    _convoyLine set [0, ""];
-  };
-
-  _convoyData pushBack _convoyLine;
+	private _cargoData = [];
+	{
+		if(alive _x) then
+		{
+			_cargoData pushBack (typeOf _x);
+			(group _x) deleteGroupWhenEmpty true;
+			deleteVehicle _x;
+		};
+	} forEach (_data select 2);
+	_convoyLine set [2, _cargoData];
+	
+	private _crewData = [];
+	{
+		if(alive _x) then
+		{
+			_crewData pushBack (typeOf _x);
+			(group _x) deleteGroupWhenEmpty true;
+			deleteVehicle _x;
+		};
+	} forEach (_data select 1);
+	_convoyLine set [1, _crewData];
+	
+	//Vehicle is alive, otherwise it would have been dropped from _unitObjects
+	_convoyLine set [0, typeOf _vehicle];
+	deleteVehicle _vehicle;
+	
+	_convoyData pushBack _convoyLine;
 };
-
-{
-    deleteGroup _x;
-} forEach _allGroups;
 
 [_convoyID, _convoyData, _convoyPos, _target, _markerArray, _convoyType, _convoySide] spawn A3A_fnc_createConvoy;

--- a/A3-Antistasi/functions/Convoy/fn_onSpawnedArrival.sqf
+++ b/A3-Antistasi/functions/Convoy/fn_onSpawnedArrival.sqf
@@ -17,26 +17,33 @@ switch (_convoyType) do
           _landPos set [2, 0];
           _pad = createVehicle ["Land_HelipadEmpty_F", _landpos, [], 0, "NONE"];
           _vehicleGroup setVariable ["myPad",_pad];
+
           _wp0 = _vehicleGroup addWaypoint [_landpos, 0];
           _wp0 setWaypointType "TR UNLOAD";
-          _wp0 setWaypointStatements ["true", "(vehicle this) land 'GET OUT';deleteVehicle ((group this) getVariable [""myPad"",objNull])"];
+          _wp0 setWaypointStatements ["true", "(vehicle this) land 'GET OUT'; deleteVehicle ((group this) getVariable [""myPad"",objNull])"];
           _wp0 setWaypointBehaviour "CARELESS";
-          _wp3 = _cargoGroup addWaypoint [_landpos, 0];
-          _wp3 setWaypointType "GETOUT";
-          _wp3 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI"];
-          _wp0 synchronizeWaypoint [_wp3];
-          _wp4 = _cargoGroup addWaypoint [_target, 1];
-          _wp4 setWaypointType "MOVE";
-          _wp4 setWaypointStatements ["true", "[group this] spawn A3A_fnc_groupDespawner;"];
-          _wp2 = _vehicleGroup addWaypoint [getMarkerPos (_markerArray select 0), 1];
+
+          _wp2 = _vehicleGroup addWaypoint [getMarkerPos (_markerArray select 0), 10];
           _wp2 setWaypointType "MOVE";
           _wp2 setWaypointStatements ["true", "deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
-          [_vehicleGroup,1] setWaypointBehaviour "AWARE";
+          _wp2 setWaypointBehaviour "AWARE";
+          _vehicleGroup setCurrentWaypoint _wp0;		// otherwise it's still on the previous waypoint
+
+//          _wp3 = _cargoGroup addWaypoint [_landpos, 0];
+//          _wp3 setWaypointType "GETOUT";			//
+//          _wp3 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI"];
+//          _wp0 synchronizeWaypoint [_wp3];
+
+          _wp4 = _cargoGroup addWaypoint [_target, 5];
+          _wp4 setWaypointType "MOVE";
+          _wp4 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI; [group this] spawn A3A_fnc_groupDespawner;"];
+          _cargoGroup setCurrentWaypoint _wp4;
         }
         else
         {
           if ((typeOf _vehicle) in vehFastRope) then
           {
+            // Branch probably never taken because all vehFastRope are also helicopters, assume untested.
             [_vehicle, _cargoGroup, _target, getMarkerPos (_markerArray select 0), _vehicleGroup, true] spawn A3A_fnc_fastrope;
           }
           else
@@ -44,27 +51,39 @@ switch (_convoyType) do
             [_vehicle, _cargoGroup, _target, (_markerArray select 0), true] spawn A3A_fnc_airdrop;
           };
         };
-      }
-      else
+      };
+
+// nothing for ground vehicles, built into the FSM
+/*      else
       {
-        //Create marker for the cargo
+        _wp0 = _vehicleGroup addWaypoint [_target, 50];		// Mix it up a bit so that it works sometimes
+        _wp0 setWaypointCompletionRadius 50;
+
         if(_cargoGroup != grpNull) then
         {
-          _wp0 = _vehicleGroup addWaypoint [_target, count (wayPoints _vehicleGroup)];
           _wp0 setWaypointType "TR UNLOAD";
           _wp0 setWaypointStatements ["true","[group this] spawn A3A_fnc_groupDespawner;"];
-          _wp3 = _cargoGroup addWaypoint [_target, 0];
-					_wp3 setWaypointType "GETOUT";
-					_wp3 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI; [group this] spawn A3A_fnc_groupDespawner"];
-					_wp0 synchronizeWaypoint [_wp3];
+          _vehicleGroup setCurrentWaypoint _wp0;
+
+//          _wp3 = _cargoGroup addWaypoint [_target, 0];
+//          _wp3 setWaypointType "GETOUT";
+//          _wp3 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI;"];
+//          _wp0 synchronizeWaypoint [_wp3];
+
+          _wp4 = _cargoGroup addWaypoint [_target, 5];
+          _wp4 setWaypointType "MOVE";
+          _wp4 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI; [group this] spawn A3A_fnc_groupDespawner;"];
+          _cargoGroup setCurrentWaypoint _wp4;
         }
         else
         {
-          _wp0 = _vehicleGroup addWaypoint [_target, count (wayPoints _vehicleGroup)];
-        	_wp0 setWaypointType "GETOUT";
-        	_wp0 setWaypointStatements ["true","[group this] spawn A3A_fnc_groupDespawner; (group this) spawn A3A_fnc_attackDrillAI;"];
+          _wp0 setWaypointType "GETOUT";						// err, why?
+          _wp0 setWaypointStatements ["true","[group this] spawn A3A_fnc_groupDespawner; (group this) spawn A3A_fnc_attackDrillAI;"];
+          _vehicleGroup setCurrentWaypoint _wp0;
         };
       };
+*/
+
     } forEach _unitObjects;
   };
 };

--- a/A3-Antistasi/functions/Convoy/fn_onSpawnedArrival.sqf
+++ b/A3-Antistasi/functions/Convoy/fn_onSpawnedArrival.sqf
@@ -17,33 +17,26 @@ switch (_convoyType) do
           _landPos set [2, 0];
           _pad = createVehicle ["Land_HelipadEmpty_F", _landpos, [], 0, "NONE"];
           _vehicleGroup setVariable ["myPad",_pad];
-
           _wp0 = _vehicleGroup addWaypoint [_landpos, 0];
           _wp0 setWaypointType "TR UNLOAD";
-          _wp0 setWaypointStatements ["true", "(vehicle this) land 'GET OUT'; deleteVehicle ((group this) getVariable [""myPad"",objNull])"];
+          _wp0 setWaypointStatements ["true", "(vehicle this) land 'GET OUT';deleteVehicle ((group this) getVariable [""myPad"",objNull])"];
           _wp0 setWaypointBehaviour "CARELESS";
-
-          _wp2 = _vehicleGroup addWaypoint [getMarkerPos (_markerArray select 0), 10];
+          _wp3 = _cargoGroup addWaypoint [_landpos, 0];
+          _wp3 setWaypointType "GETOUT";
+          _wp3 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI"];
+          _wp0 synchronizeWaypoint [_wp3];
+          _wp4 = _cargoGroup addWaypoint [_target, 1];
+          _wp4 setWaypointType "MOVE";
+          _wp4 setWaypointStatements ["true", "[group this] spawn A3A_fnc_groupDespawner;"];
+          _wp2 = _vehicleGroup addWaypoint [getMarkerPos (_markerArray select 0), 1];
           _wp2 setWaypointType "MOVE";
           _wp2 setWaypointStatements ["true", "deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
-          _wp2 setWaypointBehaviour "AWARE";
-          _vehicleGroup setCurrentWaypoint _wp0;		// otherwise it's still on the previous waypoint
-
-//          _wp3 = _cargoGroup addWaypoint [_landpos, 0];
-//          _wp3 setWaypointType "GETOUT";			//
-//          _wp3 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI"];
-//          _wp0 synchronizeWaypoint [_wp3];
-
-          _wp4 = _cargoGroup addWaypoint [_target, 5];
-          _wp4 setWaypointType "MOVE";
-          _wp4 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI; [group this] spawn A3A_fnc_groupDespawner;"];
-          _cargoGroup setCurrentWaypoint _wp4;
+          [_vehicleGroup,1] setWaypointBehaviour "AWARE";
         }
         else
         {
           if ((typeOf _vehicle) in vehFastRope) then
           {
-            // Branch probably never taken because all vehFastRope are also helicopters, assume untested.
             [_vehicle, _cargoGroup, _target, getMarkerPos (_markerArray select 0), _vehicleGroup, true] spawn A3A_fnc_fastrope;
           }
           else
@@ -51,39 +44,27 @@ switch (_convoyType) do
             [_vehicle, _cargoGroup, _target, (_markerArray select 0), true] spawn A3A_fnc_airdrop;
           };
         };
-      };
-
-// nothing for ground vehicles, built into the FSM
-/*      else
+      }
+      else
       {
-        _wp0 = _vehicleGroup addWaypoint [_target, 50];		// Mix it up a bit so that it works sometimes
-        _wp0 setWaypointCompletionRadius 50;
-
+        //Create marker for the cargo
         if(_cargoGroup != grpNull) then
         {
+          _wp0 = _vehicleGroup addWaypoint [_target, count (wayPoints _vehicleGroup)];
           _wp0 setWaypointType "TR UNLOAD";
           _wp0 setWaypointStatements ["true","[group this] spawn A3A_fnc_groupDespawner;"];
-          _vehicleGroup setCurrentWaypoint _wp0;
-
-//          _wp3 = _cargoGroup addWaypoint [_target, 0];
-//          _wp3 setWaypointType "GETOUT";
-//          _wp3 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI;"];
-//          _wp0 synchronizeWaypoint [_wp3];
-
-          _wp4 = _cargoGroup addWaypoint [_target, 5];
-          _wp4 setWaypointType "MOVE";
-          _wp4 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI; [group this] spawn A3A_fnc_groupDespawner;"];
-          _cargoGroup setCurrentWaypoint _wp4;
+          _wp3 = _cargoGroup addWaypoint [_target, 0];
+					_wp3 setWaypointType "GETOUT";
+					_wp3 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI; [group this] spawn A3A_fnc_groupDespawner"];
+					_wp0 synchronizeWaypoint [_wp3];
         }
         else
         {
-          _wp0 setWaypointType "GETOUT";						// err, why?
-          _wp0 setWaypointStatements ["true","[group this] spawn A3A_fnc_groupDespawner; (group this) spawn A3A_fnc_attackDrillAI;"];
-          _vehicleGroup setCurrentWaypoint _wp0;
+          _wp0 = _vehicleGroup addWaypoint [_target, count (wayPoints _vehicleGroup)];
+        	_wp0 setWaypointType "GETOUT";
+        	_wp0 setWaypointStatements ["true","[group this] spawn A3A_fnc_groupDespawner; (group this) spawn A3A_fnc_attackDrillAI;"];
         };
       };
-*/
-
     } forEach _unitObjects;
   };
 };

--- a/A3-Antistasi/functions/Convoy/fn_spawnConvoy.sqf
+++ b/A3-Antistasi/functions/Convoy/fn_spawnConvoy.sqf
@@ -17,6 +17,7 @@ _convoyMarker setMarkerText (format ["%1 Convoy [%2]: Spawned", _convoyType, _co
 
 //Find near road segments
 // Should already be on or near a road
+// Shouldn't do this for all-air convoys
 _road = roadAt _pos;
 if(isNull _road) then
 {
@@ -93,7 +94,7 @@ for "_i" from 0 to ((count _units) - 1) do
     _vehicle setVariable ["vehGroup", _vehicleGroup];
     _vehicle setVariable ["cargoGroup", _cargoGroup];
 
-    // Removed because spawning looks visually weird anyway due to spawn lag prevention delays
+    // Removed (for ground) because spawning looks visually weird anyway due to spawn lag prevention delays
     // plus extra logic is necessary to avoid throwing vehicles off corners
 	// Consider adding back in if vehicles are moved into position after spawning is complete
     //    _vehicle setVelocity ((vectorDir _vehicle) vectorMultiply (_maxSpeed / 3.6));
@@ -106,6 +107,7 @@ for "_i" from 0 to ((count _units) - 1) do
       _wp0 = (group _vehicle) addWaypoint [(_targetPos vectorAdd [0,0,30]), -1, 0];
       _wp0 setWaypointBehaviour "SAFE";
       (group _vehicle) setCurrentWaypoint _wp0;
+	  _vehicle setVelocity ((vectorDir _vehicle) vectorMultiply (_maxSpeed / 3.6));
     }
     else
     {
@@ -119,7 +121,7 @@ for "_i" from 0 to ((count _units) - 1) do
 
 	// lastSpawn time check will try anyway if a vehicle gets stuck
 	private _lastSpawn = time;
-    waituntil {sleep 1; ((_vehicle distance _pos) > 15) or ((time - _lastSpawn) > 20)};
+    waituntil {sleep 1; ((_vehicle distance2d _pos) > 15) or ((time - _lastSpawn) > 20)};
   };
 };
 

--- a/A3-Antistasi/functions/Convoy/fn_spawnConvoy.sqf
+++ b/A3-Antistasi/functions/Convoy/fn_spawnConvoy.sqf
@@ -1,205 +1,134 @@
-//params ["_convoyID", "_units", "_posArray", "_markers", "_convoySide", "_convoyType", "_maxSpeed"];
-params ["_convoyID", "_units", "_pos", "_route", "_markers", "_convoySide", "_convoyType", "_maxSpeed"];
+params ["_convoyID", "_units", "_pos", "_route", "_markers", "_convoySide", "_convoyType", "_maxSpeed", "_isAir"];
 
 
-private ["_targetPos", "_dir", "_startMarker", "_targetMarker", "_convoyMarker", "_road"];
+private ["_targetPos", "_dir", "_convoyMarker"];
 
 _targetPos = _route select (count _route - 1);
-
-//Disabled markers as there isn't sufficient information in createConvoy to give them to spawnConvoy.
-//There is now :D
-_startMarker = _markers select 0;
-_targetMarker = _markers select 1;
-//Temporary start marker, to send the convoy off to the carrier.
 
 _convoyMarker = format ["convoy%1", _convoyID];
 _convoyMarker setMarkerText (format ["%1 Convoy [%2]: Spawned", _convoyType, _convoyID]);
 
-//Find near road segments
-// Usually already on or near a road
-// Shouldn't do this for all-air convoys...
-_road = roadAt _pos;
-if(isNull _road) then
-{
-  private _radius = 3;
-  private _possibleRoads = [];
-  while {isNull _road && {_radius < 50}} do
-  {
-    _possibleRoads = _pos nearRoads _radius;
-    if(count _possibleRoads > 0) then
-    {
-      _road = _possibleRoads select 0;
-    }
-    else
-    {
-      _radius = _radius * 1.5;
-    };
-  };
-  if(!(isNull _road)) then
-  {
-    _pos = (getPos _road);
-  };
+if (!_isAir) then {
+	private _road = roadAt _pos;
+	// don't reposition if we're already near a road, can cause backwards driving
+	if(isNull _road) then
+	{
+		private _radius = 3;
+		private _possibleRoads = [];
+		while {isNull _road && {_radius < 50}} do
+		{
+			_possibleRoads = _pos nearRoads _radius;
+			if(count _possibleRoads > 0) then { _road = _possibleRoads select 0 }
+			else { _radius = _radius * 1.5 };
+		};
+		if(!(isNull _road)) then { _pos = (getPos _road) };
+	};
 };
-// Don't reposition if we're on a road. Might move past waypoint because roadAt doesn't guarantee nearest.
-
-
-//Conversion back to km/h
-_maxSpeed = _maxSpeed * 3.6;
 
 //Spawn a bit above the ground
 _pos = _pos vectorAdd [0,0,0.1];
 _dir = _pos getDir (_route select 0);
-
-private ["_data", "_lineData", "_cargoGroup", "_vehicle", "_wp0"];
+private _targetDir = _pos vectorFromTo _targetPos;
+private _airOffset = (_targetDir vectorMultiply 200) vectorAdd [0,0,50];
 
 private _createdUnits = [];
-private _allGroups = [];
 private _airVehicles = [];
 private _landVehicles = [];
 
-diag_log format ["Spawning in convoy %1", _convoyID];
+[2, format ["Spawning in convoy %1", _convoyID], "fn_spawnConvoy"] call A3A_fnc_log;
 [_units, "Convoy Units"] call A3A_fnc_logArray;
-
 
 for "_i" from 0 to ((count _units) - 1) do
 {
-  _data = _units select _i;
-  _lineData = [_data, _convoySide, _pos, _dir] call A3A_fnc_spawnConvoyLine;
+	private _lineData = [_units select _i, _convoySide, _pos, _dir] call A3A_fnc_spawnConvoyLine;
+	
+	//Pushback the spawned objects
+	private _unitObjects = _lineData select 0;
+	_createdUnits pushBack _unitObjects;
+	
+	private _vehicle = _unitObjects select 0;
+	if (_vehicle != objNull) then {
+	
+		if(_vehicle isKindOf "Air") then
+		{
+			_airVehicles pushBack _vehicle;
+			_vehicle setVelocity ((vectorDir _vehicle) vectorMultiply (30));
+			private _fsm = [_vehicle, _airOffset, _markers, _convoyType] execFSM "FSMs\ConvoyTravelAir.fsm";
+			_vehicle setVariable ["fsm", _fsm];
 
-  //Pushback the spawned objects
-  _unitObjects = _lineData select 0;
-  _createdUnits pushBack _unitObjects;
-
-  //Pushback the groups
-  private _vehicleGroup = (_lineData select 1);
-  // Driver will be set to CARELESS/BLUE by the FSM. If set for everyone, gunners remain unbuttoned
-  _vehicleGroup setBehaviour "SAFE";
-//  _vehicleGroup setCombatMode "BLUE";
-  _allGroups pushBackUnique _vehicleGroup;
-
-  _cargoGroup = (_lineData select 2);
-  if(_cargoGroup != grpNull) then
-  {
-    _allGroups pushBack _cargoGroup;
-    _cargoGroup setBehaviour "SAFE";
-  };
-
-  //Select vehicle type
-  _vehicle = _unitObjects select 0;
-  if (_vehicle != objNull) then {
-
-    // In theory you could have foot convoys? I don't think they're properly supported yet.
-    // everything here acts on vehicles anyway
-
-    _vehicle setVariable ["vehGroup", _vehicleGroup];
-    _vehicle setVariable ["cargoGroup", _cargoGroup];
-
-    // Removed (for ground) because spawning looks visually weird anyway due to spawn lag prevention delays
-    // plus extra logic is necessary to avoid throwing vehicles off corners
-	// Consider adding back in if vehicles are moved into position after spawning is complete
-    //    _vehicle setVelocity ((vectorDir _vehicle) vectorMultiply (_maxSpeed / 3.6));
-
-    if(_vehicle isKindOf "Air") then
-    {
-      _airVehicles pushBack _vehicle;
-	  _vehicle setVelocity ((vectorDir _vehicle) vectorMultiply (30));
-
-private _curwp = currentWaypoint _vehicleGroup; private _nwp = count waypoints _vehicleGroup;
-[2, format["Waypoint %1 of %2, position %3", str _curwp, str _nwp, str (waypointPosition [_vehicleGroup, _curwp]) ], "fn_spawnConvoy"] call A3A_fnc_log;
-
-      // Just direct it above the target for now
-      _wp0 = (group _vehicle) addWaypoint [(_targetPos vectorAdd [0,0,30]), -1];
-      _wp0 setWaypointBehaviour "SAFE";
-      (group _vehicle) setCurrentWaypoint _wp0;
-
-private _curwp = currentWaypoint _vehicleGroup; private _nwp = count waypoints _vehicleGroup;
-[2, format["Waypoint %1 of %2, position %3", str _curwp, str _nwp, str (waypointPosition [_vehicleGroup, _curwp]) ], "fn_spawnConvoy"] call A3A_fnc_log;
-
-    }
-    else
-    {
-      _landVehicles pushBack _vehicle;
-      _vehicle limitSpeed _maxSpeed;
-      private _fsmhandle = [_vehicle, _route, _markers, _convoyType] execFSM "FSMs\ConvoyTravel.fsm";
-      _vehicle setVariable ["fsmhandle", _fsmhandle];
-    };
-
-    // This probably does nothing with the FSM?
-    _vehicle setConvoySeparation (if(_i == 1 && {_convoyType == "convoy"}) then {80} else {30});
-
-	// lastSpawn time check will try anyway if a vehicle gets stuck
-	private _lastSpawn = time;
-    waituntil {sleep 1; ((_vehicle distance2d _pos) > 15) or ((time - _lastSpawn) > 20)};
-  };
-};
-
-diag_log format ["Convoy[%1]: Convoy consists of %1 air vehicles and %2 land vehicles", count _airVehicles, count _landVehicles];
-
-//Let helicopter follow the vehicles and vehicles
-// Crashes probably happen with multiple air vehicles
-if(count _landVehicles > 0) then {
-  {
-      [selectRandom _landVehicles, _x, _targetPos, _maxSpeed * 1.5] spawn A3A_fnc_followVehicle;
-  } forEach _airVehicles;
-};
-
-private _fnc_firstAliveUnit = {
-	private _result = objNull;
-	{
-		private _units = units _x;
-		private _unitIndex =  _units findIf {alive _x};
-		if (_unitIndex > -1) exitWith {
-			_result = _units select _unitIndex;
+			_airOffset = _airOffset vectorAdd (_targetDir vectorMultiply -200);
+			if (!_isAir) then { _vehicle setVariable ["followpos", _pos] };
+		}
+		else
+		{
+			_landVehicles pushBack _vehicle;
+			_vehicle limitSpeed _maxSpeed * 3.6;
+			private _fsm = [_vehicle, _route, _markers, _convoyType] execFSM "FSMs\ConvoyTravel.fsm";
+			_vehicle setVariable ["fsm", _fsm];
 		};
-	} forEach _allGroups;
-	_result;
+				
+		// lastSpawn time check will try anyway if a vehicle gets stuck
+		private _lastSpawn = time;
+		waituntil {sleep 1; ((_vehicle distance2d _pos) > 15) or ((time - _lastSpawn) > 20)};
+	}
+	else {
+		[3, "Convoy line has no vehicle, unhandled", "fn_spawnConvoy"] call A3A_fnc_log;
+	};
 };
 
-private _markedUnit = call _fnc_firstAliveUnit;
-private _checkPos = [];
-private _convoyDead = false;
 
-waitUntil
+// Monitor convoy vehicles for FSM completion and spawn distance
+while {true} do
 {
-  sleep 1;
-  _markedUnit = if (alive _markedUnit) then {_markedUnit} else {call _fnc_firstAliveUnit};
-  if (_markedUnit == objNull) exitWith {_convoyDead = true; true;};
+	sleep 2;
+	private _despawn = true;
+	
+	// Check whether each vehicle in the convoy (controlled by FSM) has completed its mission
+	// check last-to-first so that array deletion works correctly
+	for "_i" from ((count _createdUnits) - 1) to 0 step -1 do {
 
-  _checkPos = getPos _markedUnit;
-  _convoyMarker setMarkerPos _checkPos;
-  (_checkPos distance2D _targetPos < 100) ||
-  {!([distanceSPWN * 1.2, 1, _checkPos, teamPlayer] call A3A_fnc_distanceUnits)}
+		private _units = _createdUnits select _i;
+		private _veh = _units select 0;
+		private _result = _veh getVariable["fsmresult", 0];
+		// should also check whether vehicle still exists, to handle forced despawns?
+
+		// could test for success vs failure here but we don't care yet
+		if (_result != 0) then {		// completed or abandoned mission, don't track here anymore
+			_createdUnits deleteAt _i;
+			_airVehicles deleteAt (_airVehicles find _veh);
+			_landVehicles deleteAt (_landVehicles find _veh);
+			[_veh] spawn A3A_fnc_VEHdespawner;		// FSM handles the groups, vehicle remains for tracking
+			[3, format["Vehicle FSM result %1, rem units %2", _result, count _createdUnits], "fn_spawnConvoy"] call A3A_fnc_log;
+		}
+		else {
+			if ([distanceSPWN*1.2, 1, getPos _veh, teamPlayer] call A3A_fnc_distanceUnits) then { _despawn = false };
+		};
+	};
+
+	// no tracked vehicles remaining in convoy, terminate
+	if (count _createdUnits == 0) exitWith {
+		deleteMarker _convoyMarker;
+		server setVariable [format ["Con%1", _convoyID], nil, true];
+		[2, format ["%1 Convoy [%2]: Terminated", _convoyType, _convoyID], "fn_spawnConvoy"] call A3A_fnc_log;
+	};
+
+	// Have at least one remaining vehicle if we got here
+	private _convoyPos = [0,0,0];
+	if (count _landVehicles != 0) then {
+		_convoyPos = getPos (_landVehicles select 0);
+		{ _x setVariable["followpos", _convoyPos] } forEach _airVehicles;		// used by FSM to circle around
+		// can potentially set ground vehicle follow chain here too
+	}
+	else {
+		_convoyPos = getPos (_airVehicles select 0);
+		{ _x setVariable["followpos", nil] } forEach _airVehicles;
+	};
+	_convoyMarker setMarkerPos _convoyPos;
+
+	// all convoy vehicles out of spawn distance, switch back to simulation
+	if (_despawn) exitWith {
+		deleteMarker _convoyMarker;			// because we're using createConvoy rather than convoyMovement to restart sim
+		[_convoyID, _createdUnits, _convoyPos, _targetPos, _markerArray, _convoyType, _convoySide] call A3A_fnc_despawnConvoy;
+	};
 };
 
-{
-private _curwp = currentWaypoint (group _x); private _nwp = count waypoints (group _x);
-[2, format["Waypoint %1 of %2, position %3", str _curwp, str _nwp, str (waypointPosition [group _x, _curwp]) ], "fn_spawnConvoy"] call A3A_fnc_log;
-} forEach _airVehicles;
-
-deleteMarker _convoyMarker;
-
-if (_convoyDead) exitWith
-{
-  server setVariable [format ["Con%1", _convoyID], nil, true];
-	diag_log format ["%1 Convoy [%2]: All units dead. Convoy terminated.", _convoyType, _convoyID];
-	{
-		_x deleteGroupWhenEmpty true;
-	} forEach _allGroups;
-};
-
-if(_checkPos distance2D _targetPos < 100) then
-{
-  // not ideal, because the other convoy units may be miles behind
-  // plus they'll fight rather than forced-moving
-//  {
-//   private _fsm = (_x select 0) getVariable "fsmhandle";
-//   if !(isNil "_fsm") then { _fsm setFSMVariable["_abort", true] };
-//  } forEach _createdUnits;
-//  sleep 5;		// should be enough for the FSM to bail out
-
-  [_convoyID, _createdUnits, _checkPos, _targetPos, _markerArray, _convoyType, _convoySide] call A3A_fnc_onSpawnedArrival;
-}
-else
-{
-  [_convoyID, _createdUnits, _checkPos, _targetPos, _markerArray, _convoyType, _convoySide] call A3A_fnc_despawnConvoy;
-};

--- a/A3-Antistasi/functions/Convoy/fn_spawnConvoyLine.sqf
+++ b/A3-Antistasi/functions/Convoy/fn_spawnConvoyLine.sqf
@@ -15,6 +15,8 @@ if(_vehicleType != "") then
   if(!(_vehicleType isKindOf "Air")) then
   {
     _vehicleObj = createVehicle [_vehicleType, _pos, [], 0 , "CAN_COLLIDE"];
+    // Hopefully doesn't make vehicles drive backwards unless they'd explode otherwise
+//    _vehicleObj = [_vehicleType, _pos, 10, 3, true] call A3A_fnc_safeVehicleSpawn;
   }
   else
   {

--- a/A3-Antistasi/functions/Convoy/fn_spawnConvoyLine.sqf
+++ b/A3-Antistasi/functions/Convoy/fn_spawnConvoyLine.sqf
@@ -72,9 +72,11 @@ private _crewObjs = [];
 
 sleep 0.5;
 
-private _cargoGroup = grpNull;
+// Removed same-group case because split/join is broken for it
+private _cargoGroup = createGroup _side;
 private _cargoObjs = [];
 
+/*
 //Put cargo into a seperate group if they are cargo of a plane or large
 if(_vehicleObj isKindOf "Air" || {count _cargoData >= 6}) then
 {
@@ -84,6 +86,7 @@ else
 {
   _cargoGroup = _vehicleGroup;
 };
+*/
 
 private _unit = objNull;
 //Spawning in cargo


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Enhancement

### What have you changed and why?
A ton of reinforcement convoy spawning and spawned-management code. See below.

### Is further testing or are further changes required?
1. [X] No, but you can't have too much testing for this stuff.
2. [ ] Yes (Please provide further detail below.)

Initial bugs fixed, relatively easy stuff:

1. Convoys with multiple ground vehicles annihilating on spawn, caused by moving vehicles being teleported backwards with findEmptyPosition.
2. At least three different bugs where a spawned convoy could initially drive backwards, often causing explosions and/or stuck vehicles.
3. Pure air convoys flying to [0,0,0].
4. Various arrival glitches with troops refusing to disembark.
5. Vehicle gunner/commander not using the vehicle's weapons.

Reorganisation

Then it gets ugly. Frustrated with trying to add functioning despawn code to onSpawnedArrival and misbehaviour involving stuck vehicles, I tried an experimental reorganisation where per-vehicle FSMs (one each for air and ground vehicles) are responsible for handling most spawned-convoy behaviour, with spawnConvoy checking for their result reports and removing them from the convoy once completed. 

It works reasonably well, but I'm not sure it's the best solution. For the AI commander and simulation stuff, we will need a really robust and well-defined way to manage the commander->missions->units chain, both spawned and unspawned, and this might not be part of it. In any case, most of the termination code in the FSMs should be considered temporary: For example, when a reinforcement convoy unloads, its units could be taken over by the garrison commander. Returning helicopters would be added back to the airport, or sent on another mission.

Issues fixed along the way:

1. Ground vehicles now detect when they're stuck, and are removed from the convoy so that they don't block progress. Currently the crew bail out and RTB, as they also do for the dead vehicle case.
2. Vehicles will now unload and add units to the garrison on individual arrival. Previously a spawned convoy would never add units to the garrison, so the same reinforcement convoy would be re-sent every 10 minutes.
3. Groups and vehicles are now fed to despawners once their mission is complete or abandoned. Units from a spawned convoy would remain forever before.

Some remaining or new issues:

1. The pathfinder currently chooses the nearest node to the origin and target as the starting point. This doesn't work well when they're on a road, because the nearest node is often backwards. Ideally the pathfinder would open nodes in both directions. I worked around this for the convoy spawning, but it would be a useful feature generally. I'll open an issue for it.
2. More effort should ideally be taken to free a stuck vehicle rather then bailing out and walking back to base. Some of them are false positives anyway, although genuinely stuck vehicles were much more common in my testing.
3. AI-driven ground vehicles have serious trouble driving past static civilian vehicles, often refusing when there's a huge gap. Assuming that there's no direct solution, we could look into shifting cars away from major roads and junctions.
4. VEHdespawner is very strict (no groups of any kind within spawn range) and so may frequently leave empty convoy vehicles near bases. This should probably be changed, but I didn't touch it as it could have much wider consequences.

Non-reinforcement spawned convoys are not currently supported, although they weren't before either. They would need some additional termination code at minimum. Foot troops can no longer be part of a convoy as a design decision.