### PR TITLE
Fix arsenal duplicating equipped nvgs and binoculars

### DIFF
--- a/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_loadInventory.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_loadInventory.sqf
@@ -93,7 +93,7 @@ _inventory = [];
 }foreach magazinesAmmoFull player;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// assinged items
-_assignedItems_old = assignedItems player + [headgear player] + [goggles player] + [hmd player] + [binocular player];
+_assignedItems_old = assignedItems player + [headgear player] + [goggles player];
 {
 	_item = _x;
 	_amount = 1;


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Enhancement

### What have you changed and why?
Information:
    This fixes a bug in arsenal loading saved loadout.
If the player has NVGs or binoculars equipped and loads a saved loadout then the binos and nvgs are added to arsenal twice. It's because nvgs and binos are returned by `assignedItems` but the code was also adding them to the list explicitly.

It can be used as an exploit to unlock equipment.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:
