### PR TITLE
Fix error cases in crate generation, change from call to spawn

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_CSATCrate.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_CSATCrate.sqf
@@ -134,6 +134,8 @@ else
 {
 	{
 		private _category = selectRandomWeighted _weaponLootWeighting;
+		if (isNil "_category") exitWith {};
+
 		[3, format ["Selected Weapon Category: %1", _category],"fn_CSATCrate"] call A3A_fnc_log;
 		//Category is in format [allX, unlockedX];
 		[_category select 0, _category select 1] call _fnc_pickRandomFromAProbablyNotInB;
@@ -160,13 +162,13 @@ else
 [3, "Generating Weapons", "fn_CSATOCrate"] call A3A_fnc_log;
 for "_i" from 0 to floor random _crateWepTypeMax do {
 	private _loot = call _fnc_pickWeapon;
-	[3, format ["Adding weapon: %1", _loot],"fn_CSATCrate"] call A3A_fnc_log;
 
 	if (isNil "_loot") then {
 		[3, "No Weapons Left in Loot List Or Pick Random Failed","fn_CSATCrate"] call A3A_fnc_log;
 	}
 	else
 	{
+		[3, format ["Adding weapon: %1", _loot],"fn_CSATCrate"] call A3A_fnc_log;
 		_amount = crateWepNumMax call _fnc_pickAmount;
 		_crate addWeaponWithAttachmentsCargoGlobal [[ _loot, "", "", "", [], [], ""], _amount];
 		for "_i" from 0 to _amount do {
@@ -187,11 +189,11 @@ for "_i" from 0 to floor random _crateItemTypeMax do {
 	[3, format ["Breakdown: %1, %2, %3", lootItem, _unlocks, itemCargo _crate],"fn_CSATCrate"] call A3A_fnc_log;
 	[3, format ["Items available: %1", _available],"fn_CSATCrate"] call A3A_fnc_log;
 	_loot = selectRandom _available;
-	[3, format ["Item chosen: %1", _loot],"fn_CSATCrate"] call A3A_fnc_log;
 	if (isNil "_loot") then {
 		[3, "No Items Left in Loot List","fn_CSATCrate"] call A3A_fnc_log;
 	}
 	else {
+		[3, format ["Item chosen: %1", _loot],"fn_CSATCrate"] call A3A_fnc_log;
 		_amount = floor random crateItemNumMax;
 		_crate addItemCargoGlobal [_loot,_amount];
 		[3, format ["Spawning %2 of %3", _amount,_loot],"fn_CSATCrate"] call A3A_fnc_log;

--- a/A3-Antistasi/functions/Ammunition/fn_NATOCrate.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_NATOCrate.sqf
@@ -134,6 +134,8 @@ else
 {
 	{
 		private _category = selectRandomWeighted _weaponLootWeighting;
+		if (isNil "_category") exitWith {};
+
 		[3, format ["Selected Weapon Category: %1", _category],"fn_NATOCrate"] call A3A_fnc_log;
 		//Category is in format [allX, unlockedX];
 		[_category select 0, _category select 1] call _fnc_pickRandomFromAProbablyNotInB;
@@ -160,13 +162,13 @@ else
 [3, "Generating Weapons", "fn_NATOCrate"] call A3A_fnc_log;
 for "_i" from 0 to floor random _crateWepTypeMax do {
 	private _loot = call _fnc_pickWeapon;
-	[3, format ["Adding weapon: %1", _loot],"fn_NATOCrate"] call A3A_fnc_log;
 
 	if (isNil "_loot") then {
 		[3, "No Weapons Left in Loot List Or Pick Random Failed","fn_NATOCrate"] call A3A_fnc_log;
 	}
 	else 
 	{
+		[3, format ["Adding weapon: %1", _loot],"fn_NATOCrate"] call A3A_fnc_log;
 		_amount = crateWepNumMax call _fnc_pickAmount;
 		_crate addWeaponWithAttachmentsCargoGlobal [[ _loot, "", "", "", [], [], ""], _amount];
 		for "_i" from 0 to _amount do {
@@ -187,11 +189,11 @@ for "_i" from 0 to floor random _crateItemTypeMax do {
 	[3, format ["Breakdown: %1, %2, %3", lootItem, _unlocks, itemCargo _crate],"fn_NATOCrate"] call A3A_fnc_log;
 	[3, format ["Items available: %1", _available],"fn_NATOCrate"] call A3A_fnc_log;
 	_loot = selectRandom _available;
-	[3, format ["Item chosen: %1", _loot],"fn_NATOCrate"] call A3A_fnc_log;
 	if (isNil "_loot") then {
 		[3, "No Items Left in Loot List","fn_NATOCrate"] call A3A_fnc_log;
 	}
 	else {
+		[3, format ["Item chosen: %1", _loot],"fn_NATOCrate"] call A3A_fnc_log;
 		_amount = floor random crateItemNumMax;
 		_crate addItemCargoGlobal [_loot,_amount];
 		[3, format ["Spawning %2 of %3", _amount,_loot],"fn_NATOCrate"] call A3A_fnc_log;

--- a/A3-Antistasi/functions/CREATE/fn_createAIAirplane.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAIAirplane.sqf
@@ -317,14 +317,14 @@ _vehiclesX pushBack _flagX;
 if (_sideX == Occupants) then
 {
 	_veh = NATOAmmoBox createVehicle _positionX;
-	_nul = [_veh] call A3A_fnc_NATOcrate;
+	[_veh] spawn A3A_fnc_NATOcrate;
 	_vehiclesX pushBack _veh;
 	_veh call jn_fnc_logistics_addAction;
 }
 else
 {
 	_veh = CSATAmmoBox createVehicle _positionX;
-	_nul = [_veh] call A3A_fnc_CSATcrate;
+	[_veh] spawn A3A_fnc_CSATcrate;
 	_vehiclesX pushBack _veh;
 	_veh call jn_fnc_logistics_addAction;
 };

--- a/A3-Antistasi/functions/CREATE/fn_createAIOutposts.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAIOutposts.sqf
@@ -132,12 +132,12 @@ _boxX = objNull;
 if (_sideX == Occupants) then
 {
 	_boxX = NATOAmmoBox createVehicle _positionX;
-	_nul = [_boxX] call A3A_fnc_NATOcrate;
+	[_boxX] spawn A3A_fnc_NATOcrate;
 }
 else
 {
 	_boxX = CSATAmmoBox createVehicle _positionX;
-	_nul = [_boxX] call A3A_fnc_CSATcrate;
+	[_boxX] spawn A3A_fnc_CSATcrate;
 };
 _vehiclesX pushBack _boxX;
 _boxX call jn_fnc_logistics_addAction;

--- a/A3-Antistasi/functions/CREATE/fn_createAISite.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAISite.sqf
@@ -75,12 +75,12 @@ if(_marker in airportsX || {_marker in seaports || {_marker in outposts}}) then
   if (_side == Occupants) then
   {
   	_box = NATOAmmoBox createVehicle _markerPos;
-  	[_box] call A3A_fnc_NATOcrate;
+    [_box] spawn A3A_fnc_NATOcrate;
   }
   else
   {
   	_box = CSATAmmoBox createVehicle _markerPos;
-  	[_box] call A3A_fnc_CSATcrate;
+    [_box] spawn A3A_fnc_CSATcrate;
   };
   _box call jn_fnc_logistics_addAction;
 

--- a/A3-Antistasi/functions/Missions/fn_LOG_Ammo.sqf
+++ b/A3-Antistasi/functions/Missions/fn_LOG_Ammo.sqf
@@ -41,7 +41,7 @@ if ((spawner getVariable _markerX != 2) and !(sidesX getVariable [_markerX,sideU
 	_truckX = _typeVehX createVehicle _pos;
 	_truckX setDir (getDir _road);
 	_truckCreated = true;
-	if (_sideX == Occupants) then {[_truckX] call A3A_fnc_NATOcrate} else {[_truckX] call A3A_fnc_CSATcrate};
+	if (_sideX == Occupants) then {[_truckX] spawn A3A_fnc_NATOcrate} else {[_truckX] spawn A3A_fnc_CSATcrate};
 
 	_mrk = createMarkerLocal [format ["%1patrolarea", floor random 100], _pos];
 	_mrk setMarkerShapeLocal "RECTANGLE";


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Fixed one common and two unlikely cases where the crate loot generation code would error out due to accessing nil variables, blocking some crate items and possibly breaking the marker spawning.

Also switched the crate loot generation calls to spawn, as they're not time- or order-critical, and it protects the marker spawning code from other potential errors.

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
