### PR TITLE
Petros gear init

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_unlockEquipment.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_unlockEquipment.sqf
@@ -2,7 +2,8 @@
 	Unlocks the specified item of equipment for use in the arsenal.
 	
 	Updates the appropriate global arrays for quick reference.
-	
+	You can also find unlockedRifles and other variables constructed here. - FrostsBite.
+
 	Params:
 		_className - Class of the equipment to unlock.
 		

--- a/A3-Antistasi/functions/Base/fn_createPetros.sqf
+++ b/A3-Antistasi/functions/Base/fn_createPetros.sqf
@@ -32,6 +32,6 @@ if (petros == leader groupPetros) then {
 	[Petros,"buildHQ"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],petros]
 };
 
-[] spawn A3A_fnc_initPetros;
+call A3A_fnc_initPetros;
 
 deleteVehicle _oldPetros;

--- a/A3-Antistasi/functions/init/fn_initServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initServer.sqf
@@ -93,7 +93,6 @@ if (gameMode != 1) then {
 	if (gameMode == 3) then {"CSAT_carrier" setMarkerAlpha 0};
 	if (gameMode == 4) then {"NATO_carrier" setMarkerAlpha 0};
 };
-[] spawn A3A_fnc_initPetros;
 ["Initialize"] call BIS_fnc_dynamicGroups;//Exec on Server
 hcArray = [];
 
@@ -168,6 +167,7 @@ if !(loadLastSave) then {
 	} foreach initialRebelEquipment;
 	[2,"Initial arsenal unlocks completed",_fileName] call A3A_fnc_log;
 };
+call A3A_fnc_createPetros;
 
 [[petros,"hint","Server load finished"],"A3A_fnc_commsMP"] call BIS_fnc_MP;
 

--- a/A3-Antistasi/functions/init/fn_initServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initServer.sqf
@@ -98,7 +98,7 @@ if (gameMode != 1) then {
 hcArray = [];
 
 waitUntil {count (call A3A_fnc_playableUnits) > 0};
-waitUntil {({(isPlayer _x) and (!isNull _x) and (_x == _x)} count allUnits) == (count (call A3A_fnc_playableUnits))};//ya estamos todos
+waitUntil {({(isPlayer _x) and (!isNull _x) and (_x == _x)} count allUnits) == (count (call A3A_fnc_playableUnits))};
 [] spawn A3A_fnc_modBlacklist;
 
 if (loadLastSave) then {


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Enhancement

### What have you changed and why?
(Mod) fn_unlockEquipment.sqf
(Mod) fn_createPetros.sqf
(Mod) fn_initServer.sqf 

`//ya estamos todos` removed from `fn_initServer.sqf` It is obvious that playerUnits contains "all of us". Therefore, it is a violation of comment rules.
Changed `spawn A3A_fnc_initPetros` to `call A3A_fnc_createPetros` in fn_initServer.sqf.
Changed `spawn A3A_fnc_initPetros` to `call A3A_fnc_initPetros` in fn_createPetros.sqf.
Moved call `A3A_fnc_createPetros` to a position after `_x call A3A_fnc_unlockEquipment` in fn_initServer.sqf.
comment `You can also find unlockedRifles and other variables constructed here. - FrostsBite.` added to `fn_unlockEquipment.sqf` to make it easier to find in the future.

This allows Petros to init with the correct gear and classname without having to respawn him.

### Please specify which Issue this PR Resolves.
closes #601 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the Mission in Singleplayer?
2. [x] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:
Petros will have a promt at start to `Build HQ`. However, this is harmless.