### PR TITLE
Fix rounding bug that could potentially prevent finding an attack target

### DIFF
--- a/A3-Antistasi/functions/Base/fn_rebelAttack.sqf
+++ b/A3-Antistasi/functions/Base/fn_rebelAttack.sqf
@@ -119,7 +119,7 @@ if !(_tmpObjectives isEqualTo []) then
 				{
 				if !(_x in _easyArray) then
 					{
-					_siteX = _x;
+					private _siteX = _x;
 					if (((!(_siteX in airportsX)) or (_isSDK)) and !(_base in ["NATO_carrier","CSAT_carrier"])) then
 						{
 						_sideEnemy = if (_baseNATO) then {Invaders} else {Occupants};
@@ -263,10 +263,11 @@ if !(_tmpObjectives isEqualTo []) then
 			if (_x == _nearX) then {_times = _times * 5};
 			if (_x in _killZones) then
 				{
-				_siteX = _x;
+				private _siteX = _x;
 				_times = _times / (({_x == _siteX} count _killZones) + 1);
 				};
-			_times = round (_times);
+// don't do this because it may round down to zero, breaking selectRandomWeighted
+//			_times = round (_times);
 			_index = _objectivesFinal find _x;
 			if (_index == -1) then
 				{


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
As far as I can tell, the only way #625 can happen is as follows:
1. You're either playing reb vs (gov+inv) or at war tier 1, which reduces the range of attack targets.
2. Enemy launches a few counterattacks, adding player-taken locations to killZones.
3. When calculating the possible targets for an attack, killZones reduce all target weights below 0.5, which are then rounded down to zero.
4. selectRandomWeighted is called with an array only containing zeros, returning nil.

As a caveat, it'd take a lot more time to figure how killZones work in detail, so I can't be sure that this is possible. Maybe I missed another way for this code to break.    

Fixed by removing the rounding, as there's no reason not to use fractional inputs to selectRandomWeighted. I'm guessing that the rounding was a hangover from the old code that used selectRandom. Also cleared up a couple of missing private variables which probably caused no harm.

### Please specify which Issue this PR Resolves.
closes #625, at least until it happens again

### Is further testing or are further changes required?
1. [X] No, hopefully
2. [ ] Yes (Please provide further detail below.)
