### PR TITLE
Fixed a bad parameter name and made the system a bit more failsafe

### DIFF
--- a/A3-Antistasi/functions/Garrison/fn_getVehicleCrew.sqf
+++ b/A3-Antistasi/functions/Garrison/fn_getVehicleCrew.sqf
@@ -11,7 +11,7 @@ params ["_vehicleType", "_crewType"];
 
 private ["_seatCount", "_result"];
 
-if(_vehicleType == "") exitWith {[]};
+if(_vehicleType == "" || _vehicleType == "Empty") exitWith {[]};
 
 _seatCount = [_vehicleType, false] call BIS_fnc_crewCount;
 _result = [];

--- a/A3-Antistasi/functions/Garrison/fn_selectVehicleType.sqf
+++ b/A3-Antistasi/functions/Garrison/fn_selectVehicleType.sqf
@@ -9,14 +9,9 @@ params ["_preference", "_side"];
 *     _result : STRING : The typename of the selected vehicle
 */
 
+private _fileName = "SelectVehicleType";
 
-private ["_debug", "_possibleVehicles", "_result"];
-
-_debug = debug;
-if(_debug) then
-{
-  diag_log format ["SelectVehicleType: Selecting vehicle now, preferred is %1, side is %2", _preference, _side];
-};
+[3, format ["SelectVehicleType: Selecting vehicle now, preferred is %1, side is %2", _preference, _side], _fileName] call A3A_fnc_log;
 
 if(_preference == "LAND_AIR") exitWith
 {
@@ -27,7 +22,7 @@ if(_preference == "LAND_TANK") exitWith
   if(_side == Occupants) then {vehNATOTank} else {vehCSATTank};
 };
 
-_possibleVehicles = [];
+private _possibleVehicles = [];
 if(_preference in ["EMPTY", "LAND_START", "HELI_PATROL", "AIR_DRONE"]) then
 {
   _possibleVehicles pushBack "";
@@ -121,10 +116,13 @@ if(_preference in ["AIR_GENERIC", "AIR_DEFAULT"]) then
   };
 };
 
-if(_debug) then
+if(count _possibleVehicles == 0) exitWith
 {
-  diag_log format ["SelectVehicleType: Preselection done, possible vehicles are %1", str _possibleVehicles];
+    [1, format ["No result for %1, assuming bad parameter!", _preference], _fileName] call A3A_fnc_log;
+    "Empty";
 };
 
-_result = selectRandom _possibleVehicles;
+[3, format ["SelectVehicleType: Preselection done, possible vehicles are %1", str _possibleVehicles], _fileName] call A3A_fnc_log;
+
+private _result = selectRandom _possibleVehicles;
 _result;

--- a/A3-Antistasi/functions/Garrison/fn_updatePreference.sqf
+++ b/A3-Antistasi/functions/Garrison/fn_updatePreference.sqf
@@ -31,7 +31,7 @@ for "_i" from (tierPreference + 1) to tierWar do
     else
     {
       _preference pushBack ["LAND_AIR", -1, "AA"];
-      _preference pushBack ["PLANE_GENERIC", -1, "EMPTY"];
+      _preference pushBack ["AIR_GENERIC", -1, "EMPTY"];
     };
 
     if(true || debug) then


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Information:
Read title

If the selectVehicleType does not have any results it will drop an error and returns "Empty". The following functions will return [] when given an "Empty" parameter
    

### Please specify which Issue this PR Resolves.
closes #626 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

********************************************************
Notes: Laptop again, someone better start it once
