### PR TITLE
Fix missing bomb type param in HE case

### DIFF
--- a/A3-Antistasi/functions/REINF/fn_NATObomb.sqf
+++ b/A3-Antistasi/functions/REINF/fn_NATObomb.sqf
@@ -71,7 +71,7 @@ _wp1 setWaypointBehaviour "CARELESS";
 
 if (_typeX == "NAPALM" && napalmEnabled) then {_wp1 setWaypointStatements ["true", "[this,""NAPALM""] spawn A3A_fnc_airbomb"]} else {_typeX = "HE"};
 if (_typeX == "CARPET") then {_wp1 setWaypointStatements ["true", "[this,""CARPET""] spawn A3A_fnc_airbomb"]};
-if (_typeX == "HE") then {_wp1 setWaypointStatements ["true", "[this] spawn A3A_fnc_airbomb"]};
+if (_typeX == "HE") then {_wp1 setWaypointStatements ["true", "[this,""HE""] spawn A3A_fnc_airbomb"]};
 
 
 


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
NATObomb is missing the type input parameter for the HE case. NATObomb is the function used for rebel airstrikes. The name probably dates back from NATO-supported Antistasi versions.

### Please specify which Issue this PR Resolves.
closes #633 

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)
Could do with changing the filename.