### PR TITLE
Disable DES_heli mission as RHS templates lack data for it

### DIFF
--- a/A3-Antistasi/functions/Missions/fn_missionRequest.sqf
+++ b/A3-Antistasi/functions/Missions/fn_missionRequest.sqf
@@ -115,7 +115,8 @@ if (_typeX == "DES") then
 	else
 		{
 		_siteX = selectRandom _potentials;
-		if (_siteX in airportsX) then {if (random 10 < 8) then {[[_siteX],"A3A_fnc_DES_Vehicle"] remoteExec ["A3A_fnc_scheduler",2]} else {[[_siteX],"A3A_fnc_DES_Heli"] remoteExec ["A3A_fnc_scheduler",2]}};
+//		if (_siteX in airportsX) then {if (random 10 < 8) then {[[_siteX],"A3A_fnc_DES_Vehicle"] remoteExec ["A3A_fnc_scheduler",2]} else {[[_siteX],"A3A_fnc_DES_Heli"] remoteExec ["A3A_fnc_scheduler",2]}};
+		if (_siteX in airportsX) then {[[_siteX],"A3A_fnc_DES_Vehicle"] remoteExec ["A3A_fnc_scheduler",2]};
 		if (_siteX in antennas) then {[[_siteX],"DES_antenna"] remoteExec ["A3A_fnc_scheduler",2]}
 		};
 	};


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Prevented DES_heli (destroy helicopter) missions from being created by mission requests, as the RHS templates lack the flatbed truck data for it, causing errors on launch. Fixing it would require too much work at this stage.

### Please specify which Issue this PR Resolves.
closes #636 

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Ideally fix up the mission at some stage, or something like it. Currently it's attempting to load helicopters onto flatbed trucks, which might be a bit unreasonable unless we can make use of JNL.
