### PR TITLE
Add a check to prevent breaching an empty or teamPlayer vehicle

### DIFF
--- a/A3-Antistasi/functions/Base/fn_startBreachVehicle.sqf
+++ b/A3-Antistasi/functions/Base/fn_startBreachVehicle.sqf
@@ -15,6 +15,22 @@ if(!alive _vehicle) exitWith
     _vehicle removeAction _actionID;
 };
 
+private _vehCrew = crew _vehicle;
+private _aliveCrew = _vehCrew select {alive _x};
+if(count _aliveCrew == 0) exitWith
+{
+    hint "There is no living crew left, no need for breaching!";
+    _vehicle lock false;
+    _vehicle removeAction _actionID;
+};
+
+if(side (_aliveCrew select 0) == teamPlayer) exitWith
+{
+    hint "You cannot breach a vehicle which is controlled by the rebels!";
+    _vehicle removeAction _actionID;
+};
+
+
 private _isAPC = (typeOf _vehicle) in vehAPCs;
 private _isTank = (typeOf _vehicle) in vehTanks;
 


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Information: Vehicles are not longer breachable if they have no crew or are crewed by someone from the teamPlayer faction. This includes PvP players. They are no longer able to breach vehicles of the rebels.

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

********************************************************
Notes: Needs testing (laptop again), but as it is only minor, there should be no problems
