### PR TITLE
2.2.1 map overhauls

### DIFF
--- a/A3-Antistasi/functions/Templates/fn_aceModCompat.sqf
+++ b/A3-Antistasi/functions/Templates/fn_aceModCompat.sqf
@@ -18,7 +18,8 @@ aceItems = [
 	"ACE_SpottingScope",
 	"ACE_Tripod",
 	"ACE_Spraypaintred",
-	"ACE_UAVBattery"
+	"ACE_UAVBattery",
+	"ACE_SpareBarrel"
 ];
 
 aceMedItems = [

--- a/A3-Antistasi/functions/Templates/fn_aceModCompat.sqf
+++ b/A3-Antistasi/functions/Templates/fn_aceModCompat.sqf
@@ -18,8 +18,7 @@ aceItems = [
 	"ACE_SpottingScope",
 	"ACE_Tripod",
 	"ACE_Spraypaintred",
-	"ACE_UAVBattery",
-	"ACE_SpareBarrel"
+	"ACE_UAVBattery"
 ];
 
 aceMedItems = [

--- a/Map-Templates/Antistasi-Altis-BLUFOR.Altis/mission.sqm
+++ b/Map-Templates/Antistasi-Altis-BLUFOR.Altis/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=514;
 	class ItemIDProvider
 	{
-		nextID=2964;
+		nextID=3003;
 	};
 	class MarkerIDProvider
 	{
@@ -16,14 +16,14 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=498;
+		nextID=508;
 	};
 	class Camera
 	{
-		pos[]={13556.234,41.887928,12059.663};
-		dir[]={-0.66024649,-0.60780692,0.44120061};
-		up[]={-0.5053609,0.79408169,0.33770081};
-		aside[]={0.55560595,1.5355181e-007,0.83145243};
+		pos[]={3637.04,40.355995,10282.369};
+		dir[]={-0.66807073,-0.74400634,0.012217433};
+		up[]={-0.74388564,0.66816783,0.013604266};
+		aside[]={0.01828455,-1.077151e-007,0.99983603};
 	};
 };
 binarizationWanted=0;
@@ -34,7 +34,6 @@ addons[]=
 	"A3_Modules_F",
 	"A3_Characters_F",
 	"A3_Structures_F_EPC_Civ_InfoBoards",
-	"A3_Weapons_F",
 	"A3_Structures_F_Mil_Flags",
 	"A3_Ui_F_Exp",
 	"A3_Characters_F_Exp",
@@ -50,7 +49,8 @@ addons[]=
 	"A3_Structures_F_Walls",
 	"A3_Structures_F_Ind_Transmitter_Tower",
 	"A3_Structures_F_Ind_Cargo",
-	"A3_Modules_F_Hc"
+	"A3_Modules_F_Hc",
+	"A3_Weapons_F"
 };
 class AddonsMetaData
 {
@@ -169,7 +169,6 @@ class Mission
 		day=1;
 		hour=10;
 		minute=0;
-
 	};
 	class Entities
 	{
@@ -409,3847 +408,6 @@ class Mission
 			side="West";
 			class Entities
 			{
-				items=60;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3606.198,15.751395,10275.502};
-					};
-					side="West";
-					flags=7;
-					class Attributes
-					{
-						name="commanderX";
-						description="Default Commander";
-						isPlayer=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1487;
-					type="B_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male04GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item1
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3611.3052,15.357435,10272.316};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1492;
-					type="B_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.94999999;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item2
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3620.7786,14.942623,10277.655};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1502;
-					type="B_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.94999999;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item3
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3623.3313,14.7978,10277.673};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1504;
-					type="B_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male05GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.99000001;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item4
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3626.3606,14.680888,10277.655};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1506;
-					type="B_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.03;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item5
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3629.23,14.596958,10277.691};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1508;
-					type="B_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male04GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.01;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item6
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3631.9236,14.522006,10277.673};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1510;
-					type="B_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item7
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3618.2109,15.07185,10277.62};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1512;
-					type="B_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male04GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item8
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3620.6335,14.914344,10280.802};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1514;
-					type="B_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.94999999;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item9
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3623.1863,14.765662,10280.819};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1516;
-					type="B_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male05GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.99000001;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item10
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3626.2156,14.677603,10280.802};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1518;
-					type="B_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.03;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item11
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3629.085,14.608832,10280.838};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1520;
-					type="B_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male04GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.01;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item12
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3631.7786,14.536454,10280.819};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1522;
-					type="B_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item13
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3618.0659,15.082511,10280.767};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1524;
-					type="B_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male04GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item14
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3620.5249,14.972713,10283.839};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1526;
-					type="B_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.94999999;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item15
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3623.0776,14.776744,10283.856};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1528;
-					type="B_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male05GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.99000001;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item16
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3626.1069,14.703787,10283.839};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1530;
-					type="B_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.03;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item17
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3628.9763,14.635045,10283.875};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1532;
-					type="B_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male04GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.01;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item18
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3631.6699,14.622231,10283.856};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1534;
-					type="B_G_Soldier_GL_F";
-					atlOffset=-9.5367432e-007;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item19
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3617.9573,15.138463,10283.804};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1536;
-					type="B_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male04GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item20
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3620.4529,15.050589,10286.695};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1538;
-					type="B_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.94999999;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item21
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3623.0056,14.820369,10286.713};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1540;
-					type="B_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male05GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.99000001;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item22
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3626.0349,14.747169,10286.695};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1542;
-					type="B_G_medic_F";
-					atlOffset=-9.5367432e-007;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.03;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item23
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3628.9043,14.674952,10286.731};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1544;
-					type="B_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male04GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.01;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item24
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3631.5979,14.65974,10286.713};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1546;
-					type="B_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item25
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3617.8853,15.303119,10286.66};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1548;
-					type="B_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male04GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item26
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3620.4165,15.095855,10289.518};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1550;
-					type="B_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.94999999;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item27
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3622.9692,14.862626,10289.535};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1552;
-					type="B_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male05GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.99000001;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item28
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3625.9985,14.785713,10289.518};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1554;
-					type="B_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.03;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item29
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3628.8679,14.713508,10289.554};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1556;
-					type="B_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male04GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.01;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item30
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3631.5615,14.698468,10289.535};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1558;
-					type="B_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item31
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3617.8489,15.369222,10289.482};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1560;
-					type="B_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male04GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item32
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3620.5378,15.507857,10292.378};
-					};
-					side="West";
-					flags=1;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1583;
-					type="B_G_Soldier_AR_F";
-					atlOffset=0.31138611;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.94999999;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item33
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3623.0906,15.274629,10292.396};
-					};
-					side="West";
-					flags=1;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1585;
-					type="B_G_Soldier_LAT_F";
-					atlOffset=0.31738853;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male05GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.99000001;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item34
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3626.1199,15.197716,10292.378};
-					};
-					side="West";
-					flags=1;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1587;
-					type="B_G_medic_F";
-					atlOffset=0.31792545;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.03;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item35
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3628.9893,15.12551,10292.414};
-					};
-					side="West";
-					flags=1;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1589;
-					type="B_G_engineer_F";
-					atlOffset=0.33147812;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male04GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.01;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item36
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3631.6829,15.110471,10292.396};
-					};
-					side="West";
-					flags=1;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1591;
-					type="B_G_Soldier_GL_F";
-					atlOffset=0.33759689;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item37
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3617.9702,15.781224,10292.343};
-					};
-					side="West";
-					flags=1;
-					class Attributes
-					{
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1593;
-					type="B_G_officer_F";
-					atlOffset=0.3096056;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male04GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item38
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3620.4919,15.320822,10294.948};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1595;
-					type="B_G_Soldier_AR_F";
-					atlOffset=0.019706726;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.94999999;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item39
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3623.0447,15.087593,10294.966};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1597;
-					type="B_G_Soldier_LAT_F";
-					atlOffset=0.029860497;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male05GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.99000001;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item40
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3626.074,15.01068,10294.948};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1599;
-					type="B_G_medic_F";
-					atlOffset=0.040740967;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.03;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item41
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3628.9434,14.938475,10294.984};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1601;
-					type="B_G_engineer_F";
-					atlOffset=0.070830345;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male04GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.01;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item42
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3631.637,14.923435,10294.966};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1603;
-					type="B_G_Soldier_GL_F";
-					atlOffset=0.07905674;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item43
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3617.9243,15.594189,10294.913};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1605;
-					type="B_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male04GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item44
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3620.3542,15.447033,10297.748};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1607;
-					type="B_G_Soldier_AR_F";
-					atlOffset=0.019241333;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.94999999;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item45
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3622.907,15.213804,10297.766};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1609;
-					type="B_G_Soldier_LAT_F";
-					atlOffset=0.048957825;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male05GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.99000001;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item46
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3625.9363,15.136891,10297.748};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1611;
-					type="B_G_medic_F";
-					atlOffset=0.081747055;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.03;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item47
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3628.8057,15.064686,10297.784};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1613;
-					type="B_G_engineer_F";
-					atlOffset=0.11147594;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male04GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.01;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item48
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3631.4993,15.049646,10297.766};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1615;
-					type="B_G_Soldier_GL_F";
-					atlOffset=0.094394684;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item49
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3617.7866,15.7204,10297.713};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1617;
-					type="B_G_officer_F";
-					atlOffset=-9.5367432e-007;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male04GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item50
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3620.4919,15.557705,10300.18};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1619;
-					type="B_G_Soldier_AR_F";
-					atlOffset=0.028369904;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.94999999;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item51
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3623.0447,15.324476,10300.197};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1621;
-					type="B_G_Soldier_LAT_F";
-					atlOffset=0.07380867;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male05GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.99000001;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item52
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3626.074,15.247563,10300.18};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1623;
-					type="B_G_medic_F";
-					atlOffset=0.1065979;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.03;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item53
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3628.9434,15.175358,10300.216};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1625;
-					type="B_G_engineer_F";
-					atlOffset=0.093374252;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male04GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.01;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item54
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3631.637,15.160318,10300.197};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1627;
-					type="B_G_Soldier_GL_F";
-					atlOffset=0.045767784;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item55
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3617.9243,15.831072,10300.145};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1629;
-					type="B_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male04GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item56
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3622.4502,14.762181,10272.334};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1500;
-					type="B_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item57
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3619.7566,14.877787,10272.353};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1498;
-					type="B_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male04GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.01;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item58
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3616.8872,15.00565,10272.316};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1496;
-					type="B_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male02GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.03;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item59
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3613.8579,15.180957,10272.334};
-					};
-					side="West";
-					flags=5;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1494;
-					type="B_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male05GRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.99000001;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-			};
-			class Attributes
-			{
-			};
-			id=1486;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="groupID";
-					expression="_this setGroupID [_value];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"STRING"
-								};
-							};
-							value="Guerillas";
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item15
-		{
-			dataType="Group";
-			side="West";
-			class Entities
-			{
 				items=1;
 				class Item0
 				{
@@ -4339,7 +497,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item16
+		class Item15
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4357,7 +515,7 @@ class Mission
 			type="Flag_FIA_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item17
+		class Item16
 		{
 			dataType="Group";
 			side="Independent";
@@ -4734,7 +892,7 @@ class Mission
 			id=1561;
 			atlOffset=1.1369991;
 		};
-		class Item18
+		class Item17
 		{
 			dataType="Marker";
 			position[]={8431.7119,115.93193,25106.738};
@@ -4743,7 +901,7 @@ class Mission
 			id=1571;
 			atlOffset=5.68927;
 		};
-		class Item19
+		class Item18
 		{
 			dataType="Group";
 			side="East";
@@ -5117,7 +1275,7 @@ class Mission
 			};
 			id=1572;
 		};
-		class Item20
+		class Item19
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5131,7 +1289,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=1.7166138e-005;
 		};
-		class Item21
+		class Item20
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5145,7 +1303,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=2.9563904e-005;
 		};
-		class Item22
+		class Item21
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5163,7 +1321,7 @@ class Mission
 			type="Land_TentSolar_01_olive_F";
 			atlOffset=-0.14473438;
 		};
-		class Item23
+		class Item22
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5253,7 +1411,7 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item24
+		class Item23
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5265,7 +1423,7 @@ class Mission
 			type="Logic";
 			atlOffset=9.5367432e-007;
 		};
-		class Item25
+		class Item24
 		{
 			dataType="Marker";
 			position[]={11722.869,-186.03819,4256.5566};
@@ -5273,7 +1431,7 @@ class Mission
 			type="flag_AltisColonial";
 			id=23;
 		};
-		class Item26
+		class Item25
 		{
 			dataType="Marker";
 			position[]={15372.398,-56.407341,14833.389};
@@ -5282,7 +1440,7 @@ class Mission
 			id=176;
 			atlOffset=3.8146973e-006;
 		};
-		class Item27
+		class Item26
 		{
 			dataType="Marker";
 			position[]={15388.874,-90.985153,12976.936};
@@ -5291,7 +1449,7 @@ class Mission
 			id=175;
 			atlOffset=7.6293945e-006;
 		};
-		class Item28
+		class Item27
 		{
 			dataType="Marker";
 			position[]={15241.775,0,13870.712};
@@ -5301,7 +1459,7 @@ class Mission
 			id=1180;
 			atlOffset=67.766624;
 		};
-		class Item29
+		class Item28
 		{
 			dataType="Marker";
 			position[]={24070.148,-0.050999999,29143.369};
@@ -5310,7 +1468,7 @@ class Mission
 			id=22;
 			atlOffset=185.91901;
 		};
-		class Item30
+		class Item29
 		{
 			dataType="Marker";
 			position[]={3337.3398,130.54485,17042.906};
@@ -5319,7 +1477,7 @@ class Mission
 			id=2278;
 			atlOffset=206.54761;
 		};
-		class Item31
+		class Item30
 		{
 			dataType="Marker";
 			position[]={3247.0752,100.62038,15367.988};
@@ -5328,7 +1486,7 @@ class Mission
 			id=2279;
 			atlOffset=207.06781;
 		};
-		class Item32
+		class Item31
 		{
 			dataType="Marker";
 			position[]={3004.0684,174.38411,13716.562};
@@ -5337,7 +1495,7 @@ class Mission
 			id=2280;
 			atlOffset=207.08414;
 		};
-		class Item33
+		class Item32
 		{
 			dataType="Marker";
 			position[]={2779.2949,184.87955,12867.355};
@@ -5346,7 +1504,7 @@ class Mission
 			id=2281;
 			atlOffset=206.94388;
 		};
-		class Item34
+		class Item33
 		{
 			dataType="Marker";
 			position[]={2678.4688,179.98424,12424.213};
@@ -5355,7 +1513,7 @@ class Mission
 			id=2282;
 			atlOffset=206.71344;
 		};
-		class Item35
+		class Item34
 		{
 			dataType="Marker";
 			position[]={2717.3252,155.85457,10870.713};
@@ -5364,7 +1522,7 @@ class Mission
 			id=2283;
 			atlOffset=207.29001;
 		};
-		class Item36
+		class Item35
 		{
 			dataType="Marker";
 			position[]={14518.147,69.005302,9158.7578};
@@ -5373,7 +1531,7 @@ class Mission
 			id=2284;
 			atlOffset=207.1091;
 		};
-		class Item37
+		class Item36
 		{
 			dataType="Marker";
 			position[]={13564.181,111.91078,11123.83};
@@ -5382,7 +1540,7 @@ class Mission
 			id=2285;
 			atlOffset=206.22696;
 		};
-		class Item38
+		class Item37
 		{
 			dataType="Marker";
 			position[]={15389.546,116.11678,12979.282};
@@ -5391,7 +1549,7 @@ class Mission
 			id=2286;
 			atlOffset=207.32629;
 		};
-		class Item39
+		class Item38
 		{
 			dataType="Marker";
 			position[]={15373.07,150.69458,14835.735};
@@ -5400,7 +1558,7 @@ class Mission
 			id=2287;
 			atlOffset=207.19003;
 		};
-		class Item40
+		class Item39
 		{
 			dataType="Marker";
 			position[]={27998.807,179.53445,24281.582};
@@ -5409,7 +1567,7 @@ class Mission
 			id=2288;
 			atlOffset=207.30873;
 		};
-		class Item41
+		class Item40
 		{
 			dataType="Marker";
 			position[]={28478.389,168.63277,24857.613};
@@ -5418,7 +1576,7 @@ class Mission
 			id=2289;
 			atlOffset=206.64738;
 		};
-		class Item42
+		class Item41
 		{
 			dataType="Marker";
 			position[]={28748.992,174.2493,25990.926};
@@ -5427,7 +1585,7 @@ class Mission
 			id=2290;
 			atlOffset=207.14847;
 		};
-		class Item43
+		class Item42
 		{
 			dataType="Marker";
 			position[]={27755,165.46266,25878.398};
@@ -5436,7 +1594,7 @@ class Mission
 			id=2291;
 			atlOffset=207.02464;
 		};
-		class Item44
+		class Item43
 		{
 			dataType="Marker";
 			position[]={26996.783,176.42392,25465.797};
@@ -5445,7 +1603,7 @@ class Mission
 			id=2292;
 			atlOffset=206.93188;
 		};
-		class Item45
+		class Item44
 		{
 			dataType="Marker";
 			position[]={25962.609,186.89674,24431.621};
@@ -5454,7 +1612,7 @@ class Mission
 			id=2293;
 			atlOffset=207.10718;
 		};
-		class Item46
+		class Item45
 		{
 			dataType="Marker";
 			position[]={26495.033,191.812,25001.895};
@@ -5463,7 +1621,7 @@ class Mission
 			id=2294;
 			atlOffset=207.35278;
 		};
-		class Item47
+		class Item46
 		{
 			dataType="Marker";
 			position[]={21037.496,200.95976,19986.074};
@@ -5472,7 +1630,7 @@ class Mission
 			id=2295;
 			atlOffset=207.03401;
 		};
-		class Item48
+		class Item47
 		{
 			dataType="Marker";
 			position[]={21440.449,172.8671,20567.477};
@@ -5481,7 +1639,7 @@ class Mission
 			id=2296;
 			atlOffset=207.3761;
 		};
-		class Item49
+		class Item48
 		{
 			dataType="Marker";
 			position[]={20829.973,95.750183,21009.922};
@@ -5490,7 +1648,7 @@ class Mission
 			id=2297;
 			atlOffset=207.43275;
 		};
-		class Item50
+		class Item49
 		{
 			dataType="Marker";
 			position[]={19649.236,149.68198,20360.035};
@@ -5499,7 +1657,7 @@ class Mission
 			id=2298;
 			atlOffset=207.43951;
 		};
-		class Item51
+		class Item50
 		{
 			dataType="Marker";
 			position[]={18765.988,137.21149,19434.543};
@@ -5508,7 +1666,7 @@ class Mission
 			id=2299;
 			atlOffset=206.81441;
 		};
-		class Item52
+		class Item51
 		{
 			dataType="Marker";
 			position[]={18105.475,192.92429,18436.09};
@@ -5517,7 +1675,7 @@ class Mission
 			id=2300;
 			atlOffset=207.00026;
 		};
-		class Item53
+		class Item52
 		{
 			dataType="Marker";
 			position[]={17655.588,161.94582,19880.805};
@@ -5526,7 +1684,7 @@ class Mission
 			id=2301;
 			atlOffset=206.98421;
 		};
-		class Item54
+		class Item53
 		{
 			dataType="Marker";
 			position[]={17094.916,172.08469,20418.434};
@@ -5535,7 +1693,7 @@ class Mission
 			id=2302;
 			atlOffset=207.6337;
 		};
-		class Item55
+		class Item54
 		{
 			dataType="Marker";
 			position[]={24402.568,160.39333,24634.41};
@@ -5544,7 +1702,7 @@ class Mission
 			id=2303;
 			atlOffset=207.66992;
 		};
-		class Item56
+		class Item55
 		{
 			dataType="Marker";
 			position[]={21877.943,122.56293,22559.484};
@@ -5553,7 +1711,7 @@ class Mission
 			id=2304;
 			atlOffset=207.25781;
 		};
-		class Item57
+		class Item56
 		{
 			dataType="Marker";
 			position[]={22722.113,113.7464,24121.598};
@@ -5562,17 +1720,17 @@ class Mission
 			id=2305;
 			atlOffset=207.11432;
 		};
-		class Item58
+		class Item57
 		{
 			dataType="Marker";
 			position[]={21333.643,225.95993,7324.0293};
 			name="spawnPoint";
 			type="hd_start";
-			angle=28.146917;
+			angle=28.146914;
 			id=2384;
 			atlOffset=207.1053;
 		};
-		class Item59
+		class Item58
 		{
 			dataType="Marker";
 			position[]={22913.398,217.03192,19081.605};
@@ -5582,7 +1740,7 @@ class Mission
 			id=2385;
 			atlOffset=205.69991;
 		};
-		class Item60
+		class Item59
 		{
 			dataType="Marker";
 			position[]={26833.752,234.14293,24436.691};
@@ -5592,7 +1750,7 @@ class Mission
 			id=2386;
 			atlOffset=207.12477;
 		};
-		class Item61
+		class Item60
 		{
 			dataType="Marker";
 			position[]={14415.887,223.65625,16813.977};
@@ -5602,7 +1760,7 @@ class Mission
 			id=2387;
 			atlOffset=207.05586;
 		};
-		class Item62
+		class Item61
 		{
 			dataType="Marker";
 			position[]={11565.752,232.28767,12099.108};
@@ -5612,7 +1770,7 @@ class Mission
 			id=2388;
 			atlOffset=206.98756;
 		};
-		class Item63
+		class Item62
 		{
 			dataType="Marker";
 			position[]={9185.0156,221.89238,21736.594};
@@ -5622,7 +1780,7 @@ class Mission
 			id=2389;
 			atlOffset=207.08432;
 		};
-		class Item64
+		class Item63
 		{
 			dataType="Marker";
 			position[]={3181.8047,209.52193,12484.441};
@@ -5635,7 +1793,7 @@ class Mission
 			id=2390;
 			atlOffset=207.08269;
 		};
-		class Item65
+		class Item64
 		{
 			dataType="Marker";
 			position[]={4219.875,253.21332,12253.836};
@@ -5648,7 +1806,7 @@ class Mission
 			id=2391;
 			atlOffset=207.16989;
 		};
-		class Item66
+		class Item65
 		{
 			dataType="Marker";
 			position[]={5097.6211,231.5822,13861.521};
@@ -5661,7 +1819,7 @@ class Mission
 			id=2392;
 			atlOffset=207.02454;
 		};
-		class Item67
+		class Item66
 		{
 			dataType="Marker";
 			position[]={5203.1016,225.64362,14487.979};
@@ -5674,7 +1832,7 @@ class Mission
 			id=2393;
 			atlOffset=207.16223;
 		};
-		class Item68
+		class Item67
 		{
 			dataType="Marker";
 			position[]={3631.9053,214.55852,13876.935};
@@ -5687,7 +1845,7 @@ class Mission
 			id=2394;
 			atlOffset=207.10887;
 		};
-		class Item69
+		class Item68
 		{
 			dataType="Marker";
 			position[]={4387.4189,278.14285,16017.934};
@@ -5700,7 +1858,7 @@ class Mission
 			id=2395;
 			atlOffset=207.22113;
 		};
-		class Item70
+		class Item69
 		{
 			dataType="Marker";
 			position[]={5953.5791,443.88956,19867.109};
@@ -5713,7 +1871,7 @@ class Mission
 			id=2396;
 			atlOffset=207.08942;
 		};
-		class Item71
+		class Item70
 		{
 			dataType="Marker";
 			position[]={9128.9141,227.78291,22071.156};
@@ -5726,7 +1884,7 @@ class Mission
 			id=2397;
 			atlOffset=207.10239;
 		};
-		class Item72
+		class Item71
 		{
 			dataType="Marker";
 			position[]={8409.6992,262.42349,20836.609};
@@ -5739,7 +1897,7 @@ class Mission
 			id=2398;
 			atlOffset=206.81137;
 		};
-		class Item73
+		class Item72
 		{
 			dataType="Marker";
 			position[]={9351.9639,245.55682,21245.773};
@@ -5752,7 +1910,7 @@ class Mission
 			id=2399;
 			atlOffset=207.35381;
 		};
-		class Item74
+		class Item73
 		{
 			dataType="Marker";
 			position[]={9466.8467,221.96548,21873.234};
@@ -5765,7 +1923,7 @@ class Mission
 			id=2400;
 			atlOffset=207.09254;
 		};
-		class Item75
+		class Item74
 		{
 			dataType="Marker";
 			position[]={8784.1973,306.97516,15790.667};
@@ -5778,7 +1936,7 @@ class Mission
 			id=2401;
 			atlOffset=207.06302;
 		};
-		class Item76
+		class Item75
 		{
 			dataType="Marker";
 			position[]={7241.6289,211.59077,11031.837};
@@ -5791,7 +1949,7 @@ class Mission
 			id=2402;
 			atlOffset=207.0925;
 		};
-		class Item77
+		class Item76
 		{
 			dataType="Marker";
 			position[]={10772.411,210.57669,10875.501};
@@ -5804,7 +1962,7 @@ class Mission
 			id=2403;
 			atlOffset=207.00285;
 		};
-		class Item78
+		class Item77
 		{
 			dataType="Marker";
 			position[]={10831.6,224.31812,12158.453};
@@ -5817,7 +1975,7 @@ class Mission
 			id=2404;
 			atlOffset=207.11411;
 		};
-		class Item79
+		class Item78
 		{
 			dataType="Marker";
 			position[]={10094.229,225.83615,12922.144};
@@ -5830,7 +1988,7 @@ class Mission
 			id=2405;
 			atlOffset=207.04605;
 		};
-		class Item80
+		class Item79
 		{
 			dataType="Marker";
 			position[]={12378.049,228.68013,15873.92};
@@ -5843,7 +2001,7 @@ class Mission
 			id=2406;
 			atlOffset=207.11403;
 		};
-		class Item81
+		class Item80
 		{
 			dataType="Marker";
 			position[]={11293.979,265.90872,17519.941};
@@ -5856,7 +2014,7 @@ class Mission
 			id=2407;
 			atlOffset=207.0988;
 		};
-		class Item82
+		class Item81
 		{
 			dataType="Marker";
 			position[]={13548.217,226.20168,18671.605};
@@ -5869,7 +2027,7 @@ class Mission
 			id=2408;
 			atlOffset=207.08403;
 		};
-		class Item83
+		class Item82
 		{
 			dataType="Marker";
 			position[]={14300.13,235.71681,19469.402};
@@ -5882,7 +2040,7 @@ class Mission
 			id=2409;
 			atlOffset=207.17482;
 		};
-		class Item84
+		class Item83
 		{
 			dataType="Marker";
 			position[]={13645.948,226.2572,16086.868};
@@ -5895,7 +2053,7 @@ class Mission
 			id=2410;
 			atlOffset=207.08447;
 		};
-		class Item85
+		class Item84
 		{
 			dataType="Marker";
 			position[]={15868.847,221.71736,17423.516};
@@ -5908,7 +2066,7 @@ class Mission
 			id=2411;
 			atlOffset=207.0769;
 		};
-		class Item86
+		class Item85
 		{
 			dataType="Marker";
 			position[]={15987.165,215.13191,16133.075};
@@ -5921,7 +2079,7 @@ class Mission
 			id=2412;
 			atlOffset=207.0587;
 		};
-		class Item87
+		class Item86
 		{
 			dataType="Marker";
 			position[]={18362.799,226.33023,17344.508};
@@ -5934,7 +2092,7 @@ class Mission
 			id=2413;
 			atlOffset=207.12338;
 		};
-		class Item88
+		class Item87
 		{
 			dataType="Marker";
 			position[]={17491.359,212.65886,14327.144};
@@ -5947,7 +2105,7 @@ class Mission
 			id=2414;
 			atlOffset=207.10353;
 		};
-		class Item89
+		class Item88
 		{
 			dataType="Marker";
 			position[]={18272.131,234.37762,12903.081};
@@ -5960,7 +2118,7 @@ class Mission
 			id=2415;
 			atlOffset=207.0889;
 		};
-		class Item90
+		class Item89
 		{
 			dataType="Marker";
 			position[]={20229.326,259.12195,9770.4014};
@@ -5973,7 +2131,7 @@ class Mission
 			id=2416;
 			atlOffset=207.05414;
 		};
-		class Item91
+		class Item90
 		{
 			dataType="Marker";
 			position[]={21587.594,221.20706,7804.3369};
@@ -5986,7 +2144,7 @@ class Mission
 			id=2417;
 			atlOffset=207.10014;
 		};
-		class Item92
+		class Item91
 		{
 			dataType="Marker";
 			position[]={20792.701,244.05165,16647.652};
@@ -5999,7 +2157,7 @@ class Mission
 			id=2418;
 			atlOffset=207.07555;
 		};
-		class Item93
+		class Item92
 		{
 			dataType="Marker";
 			position[]={21686.252,229.47137,17645.633};
@@ -6012,7 +2170,7 @@ class Mission
 			id=2419;
 			atlOffset=207.1114;
 		};
-		class Item94
+		class Item93
 		{
 			dataType="Marker";
 			position[]={22971.781,220.59483,19368.418};
@@ -6025,7 +2183,7 @@ class Mission
 			id=2420;
 			atlOffset=207.12585;
 		};
-		class Item95
+		class Item94
 		{
 			dataType="Marker";
 			position[]={24790.805,227.57651,20723.227};
@@ -6038,7 +2196,7 @@ class Mission
 			id=2421;
 			atlOffset=207.11124;
 		};
-		class Item96
+		class Item95
 		{
 			dataType="Marker";
 			position[]={25990.932,231.85326,21570.633};
@@ -6051,7 +2209,7 @@ class Mission
 			id=2422;
 			atlOffset=206.9996;
 		};
-		class Item97
+		class Item96
 		{
 			dataType="Marker";
 			position[]={26981.951,218.94193,23833.32};
@@ -6064,7 +2222,7 @@ class Mission
 			id=2423;
 			atlOffset=207.10193;
 		};
-		class Item98
+		class Item97
 		{
 			dataType="Marker";
 			position[]={5931.9932,242.60175,22075.207};
@@ -6077,7 +2235,7 @@ class Mission
 			id=2424;
 			atlOffset=27.08403;
 		};
-		class Item99
+		class Item98
 		{
 			dataType="Marker";
 			position[]={4079.6465,340.33676,22093.223};
@@ -6090,7 +2248,7 @@ class Mission
 			id=2425;
 			atlOffset=207.93146;
 		};
-		class Item100
+		class Item99
 		{
 			dataType="Marker";
 			position[]={3877.3984,357.211,21274.602};
@@ -6103,7 +2261,7 @@ class Mission
 			id=2426;
 			atlOffset=206.75163;
 		};
-		class Item101
+		class Item100
 		{
 			dataType="Marker";
 			position[]={7788.5166,305.2428,21687.223};
@@ -6116,7 +2274,7 @@ class Mission
 			id=2427;
 			atlOffset=181.51501;
 		};
-		class Item102
+		class Item101
 		{
 			dataType="Marker";
 			position[]={3262.584,329.63889,19388.117};
@@ -6129,7 +2287,7 @@ class Mission
 			id=2428;
 			atlOffset=164.57132;
 		};
-		class Item103
+		class Item102
 		{
 			dataType="Marker";
 			position[]={4095.8125,497.85452,19933.289};
@@ -6142,7 +2300,7 @@ class Mission
 			id=2429;
 			atlOffset=206.00711;
 		};
-		class Item104
+		class Item103
 		{
 			dataType="Marker";
 			position[]={5529.1685,380.71536,21302.027};
@@ -6155,7 +2313,7 @@ class Mission
 			id=2430;
 			atlOffset=205.84341;
 		};
-		class Item105
+		class Item104
 		{
 			dataType="Marker";
 			position[]={8185.6787,290.59659,22895.996};
@@ -6168,7 +2326,7 @@ class Mission
 			id=2431;
 			atlOffset=206.11313;
 		};
-		class Item106
+		class Item105
 		{
 			dataType="Marker";
 			position[]={14259.37,303.48303,22078.895};
@@ -6181,7 +2339,7 @@ class Mission
 			id=2432;
 			atlOffset=232.04526;
 		};
-		class Item107
+		class Item106
 		{
 			dataType="Marker";
 			position[]={8006.9063,278.0835,20045.223};
@@ -6194,7 +2352,7 @@ class Mission
 			id=2433;
 			atlOffset=207.25772;
 		};
-		class Item108
+		class Item107
 		{
 			dataType="Marker";
 			position[]={5772.4678,396.59335,19096.383};
@@ -6207,7 +2365,7 @@ class Mission
 			id=2434;
 			atlOffset=206.20912;
 		};
-		class Item109
+		class Item108
 		{
 			dataType="Marker";
 			position[]={11739.365,252.59326,8852.958};
@@ -6220,7 +2378,7 @@ class Mission
 			id=2435;
 			atlOffset=207.39941;
 		};
-		class Item110
+		class Item109
 		{
 			dataType="Marker";
 			position[]={21061.072,208.47031,14719.993};
@@ -6233,7 +2391,7 @@ class Mission
 			id=2436;
 			atlOffset=207.11006;
 		};
-		class Item111
+		class Item110
 		{
 			dataType="Marker";
 			position[]={17992.754,277.02676,10674.25};
@@ -6246,7 +2404,7 @@ class Mission
 			id=2437;
 			atlOffset=206.83978;
 		};
-		class Item112
+		class Item111
 		{
 			dataType="Marker";
 			position[]={22961.645,232.05942,21889.684};
@@ -6259,7 +2417,7 @@ class Mission
 			id=2438;
 			atlOffset=206.50633;
 		};
-		class Item113
+		class Item112
 		{
 			dataType="Marker";
 			position[]={24233.471,273.37555,21798.02};
@@ -6272,7 +2430,7 @@ class Mission
 			id=2439;
 			atlOffset=207.77448;
 		};
-		class Item114
+		class Item113
 		{
 			dataType="Marker";
 			position[]={23924.107,252.82391,22726.109};
@@ -6285,7 +2443,7 @@ class Mission
 			id=2440;
 			atlOffset=207.53732;
 		};
-		class Item115
+		class Item114
 		{
 			dataType="Marker";
 			position[]={24348.051,232.91309,23562.535};
@@ -6298,7 +2456,7 @@ class Mission
 			id=2441;
 			atlOffset=207.0984;
 		};
-		class Item116
+		class Item115
 		{
 			dataType="Marker";
 			position[]={28046.412,246.60393,25411.922};
@@ -6311,7 +2469,7 @@ class Mission
 			id=2442;
 			atlOffset=206.91652;
 		};
-		class Item117
+		class Item116
 		{
 			dataType="Marker";
 			position[]={25964.469,273.6788,22491.207};
@@ -6324,7 +2482,7 @@ class Mission
 			id=2443;
 			atlOffset=207.02988;
 		};
-		class Item118
+		class Item117
 		{
 			dataType="Marker";
 			position[]={8800.2266,336.78128,15253.247};
@@ -6337,7 +2495,7 @@ class Mission
 			id=2444;
 			atlOffset=206.35326;
 		};
-		class Item119
+		class Item118
 		{
 			dataType="Marker";
 			position[]={10823.294,313.38348,15027.392};
@@ -6350,7 +2508,7 @@ class Mission
 			id=2445;
 			atlOffset=206.99362;
 		};
-		class Item120
+		class Item119
 		{
 			dataType="Marker";
 			position[]={6642.3921,339.61301,12200.023};
@@ -6363,7 +2521,7 @@ class Mission
 			id=2446;
 			atlOffset=205.74603;
 		};
-		class Item121
+		class Item120
 		{
 			dataType="Marker";
 			position[]={9523.2363,259.60046,7535.1172};
@@ -6376,7 +2534,7 @@ class Mission
 			id=2447;
 			atlOffset=201.50053;
 		};
-		class Item122
+		class Item121
 		{
 			dataType="Marker";
 			position[]={23663.305,212.40474,16241.952};
@@ -6389,7 +2547,7 @@ class Mission
 			id=2448;
 			atlOffset=207.0988;
 		};
-		class Item123
+		class Item122
 		{
 			dataType="Marker";
 			position[]={3377.2734,207.10193,12755.404};
@@ -6398,7 +2556,7 @@ class Mission
 			id=2449;
 			atlOffset=209.90524;
 		};
-		class Item124
+		class Item123
 		{
 			dataType="Marker";
 			position[]={3535.8174,207.10193,13776.693};
@@ -6407,7 +2565,7 @@ class Mission
 			id=2450;
 			atlOffset=208.26828;
 		};
-		class Item125
+		class Item124
 		{
 			dataType="Marker";
 			position[]={3807.7119,207.10193,17344.215};
@@ -6416,7 +2574,7 @@ class Mission
 			id=2451;
 			atlOffset=211.43423;
 		};
-		class Item126
+		class Item125
 		{
 			dataType="Marker";
 			position[]={16582.803,207.10193,12306.157};
@@ -6425,7 +2583,7 @@ class Mission
 			id=2452;
 			atlOffset=215.26413;
 		};
-		class Item127
+		class Item126
 		{
 			dataType="Marker";
 			position[]={12750.637,207.10193,14200.559};
@@ -6434,7 +2592,7 @@ class Mission
 			id=2453;
 			atlOffset=216.75415;
 		};
-		class Item128
+		class Item127
 		{
 			dataType="Marker";
 			position[]={11838.184,207.10193,13532.533};
@@ -6443,7 +2601,7 @@ class Mission
 			id=2454;
 			atlOffset=211.54929;
 		};
-		class Item129
+		class Item128
 		{
 			dataType="Marker";
 			position[]={2256.4541,207.10193,13237.144};
@@ -6453,7 +2611,7 @@ class Mission
 			id=2455;
 			atlOffset=333.48044;
 		};
-		class Item130
+		class Item129
 		{
 			dataType="Marker";
 			position[]={3173.6484,207.10193,16759.453};
@@ -6463,7 +2621,7 @@ class Mission
 			id=2456;
 			atlOffset=314.88629;
 		};
-		class Item131
+		class Item130
 		{
 			dataType="Marker";
 			position[]={19879.965,207.10193,21961.16};
@@ -6473,7 +2631,7 @@ class Mission
 			id=2457;
 			atlOffset=378.37085;
 		};
-		class Item132
+		class Item131
 		{
 			dataType="Marker";
 			position[]={25806.242,207.10193,25993.34};
@@ -6483,7 +2641,7 @@ class Mission
 			id=2458;
 			atlOffset=385.92563;
 		};
-		class Item133
+		class Item132
 		{
 			dataType="Marker";
 			position[]={24006.816,207.10193,6605.4922};
@@ -6493,7 +2651,7 @@ class Mission
 			id=2459;
 			atlOffset=387.65833;
 		};
-		class Item134
+		class Item133
 		{
 			dataType="Marker";
 			position[]={15242.447,207.10193,13873.059};
@@ -6503,7 +2661,7 @@ class Mission
 			id=2460;
 			atlOffset=274.9671;
 		};
-		class Item135
+		class Item134
 		{
 			dataType="Marker";
 			position[]={13682.604,207.10193,10428.973};
@@ -6513,7 +2671,7 @@ class Mission
 			id=2461;
 			atlOffset=348.68527;
 		};
-		class Item136
+		class Item135
 		{
 			dataType="Marker";
 			position[]={3239.709,207.10193,12863.792};
@@ -6522,7 +2680,7 @@ class Mission
 			id=2462;
 			atlOffset=215.90306;
 		};
-		class Item137
+		class Item136
 		{
 			dataType="Marker";
 			position[]={20650.537,207.10193,19499.43};
@@ -6531,7 +2689,7 @@ class Mission
 			id=2463;
 			atlOffset=209.23535;
 		};
-		class Item138
+		class Item137
 		{
 			dataType="Marker";
 			position[]={27620.217,207.10193,24545.668};
@@ -6540,7 +2698,7 @@ class Mission
 			id=2464;
 			atlOffset=211.59435;
 		};
-		class Item139
+		class Item138
 		{
 			dataType="Marker";
 			position[]={15383.626,207.10193,15816.063};
@@ -6549,7 +2707,7 @@ class Mission
 			id=2465;
 			atlOffset=213.25826;
 		};
-		class Item140
+		class Item139
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6565,7 +2723,7 @@ class Mission
 			type="Land_Airport_Tower_F";
 			atlOffset=0.0086307526;
 		};
-		class Item141
+		class Item140
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6581,7 +2739,7 @@ class Mission
 			id=2467;
 			type="Land_Hangar_F";
 		};
-		class Item142
+		class Item141
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6597,7 +2755,7 @@ class Mission
 			id=2468;
 			type="Land_Cargo_HQ_V1_F";
 		};
-		class Item143
+		class Item142
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6613,7 +2771,7 @@ class Mission
 			id=2469;
 			type="Land_Cargo_HQ_V1_F";
 		};
-		class Item144
+		class Item143
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6629,7 +2787,7 @@ class Mission
 			id=2470;
 			type="Land_Cargo_HQ_V1_F";
 		};
-		class Item145
+		class Item144
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6714,7 +2872,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item146
+		class Item145
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6731,7 +2889,7 @@ class Mission
 			type="Land_Cargo_HQ_V1_F";
 			atlOffset=0.11933517;
 		};
-		class Item147
+		class Item146
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6748,7 +2906,7 @@ class Mission
 			type="Land_Cargo_HQ_V1_F";
 			atlOffset=0.1354351;
 		};
-		class Item148
+		class Item147
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6765,7 +2923,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=-0.026918411;
 		};
-		class Item149
+		class Item148
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6782,7 +2940,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=0.014034271;
 		};
-		class Item150
+		class Item149
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6799,7 +2957,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=0.039430618;
 		};
-		class Item151
+		class Item150
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6816,7 +2974,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=-0.01877594;
 		};
-		class Item152
+		class Item151
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6833,7 +2991,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=0.20433426;
 		};
-		class Item153
+		class Item152
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6849,7 +3007,7 @@ class Mission
 			id=2479;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item154
+		class Item153
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6866,7 +3024,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=0.12693214;
 		};
-		class Item155
+		class Item154
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6882,7 +3040,7 @@ class Mission
 			type="Land_Cargo_Tower_V1_F";
 			atlOffset=-0.00058269501;
 		};
-		class Item156
+		class Item155
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6899,7 +3057,7 @@ class Mission
 			type="Land_Cargo_Tower_V1_F";
 			atlOffset=-1.9073486e-006;
 		};
-		class Item157
+		class Item156
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6916,7 +3074,7 @@ class Mission
 			type="Land_Cargo_Tower_V1_F";
 			atlOffset=0.098054171;
 		};
-		class Item158
+		class Item157
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6933,7 +3091,7 @@ class Mission
 			type="Land_Cargo_Tower_V1_F";
 			atlOffset=-0.94850731;
 		};
-		class Item159
+		class Item158
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6949,7 +3107,7 @@ class Mission
 			type="Land_Cargo_Tower_V1_F";
 			atlOffset=0.26329422;
 		};
-		class Item160
+		class Item159
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6966,7 +3124,7 @@ class Mission
 			type="Land_TentHangar_V1_F";
 			atlOffset=0.04709816;
 		};
-		class Item161
+		class Item160
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6982,7 +3140,7 @@ class Mission
 			id=2487;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item162
+		class Item161
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6999,7 +3157,7 @@ class Mission
 			type="Land_TentHangar_V1_F";
 			atlOffset=-0.029521942;
 		};
-		class Item163
+		class Item162
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7016,7 +3174,7 @@ class Mission
 			type="Land_TentHangar_V1_F";
 			atlOffset=0.10547829;
 		};
-		class Item164
+		class Item163
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7032,7 +3190,7 @@ class Mission
 			id=2490;
 			type="Land_Airport_01_hangar_F";
 		};
-		class Item165
+		class Item164
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7048,7 +3206,7 @@ class Mission
 			id=2491;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item166
+		class Item165
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7065,7 +3223,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=0.024765015;
 		};
-		class Item167
+		class Item166
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7082,7 +3240,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=0.087217331;
 		};
-		class Item168
+		class Item167
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7099,7 +3257,7 @@ class Mission
 			type="Land_Airport_Tower_F";
 			atlOffset=0.46519089;
 		};
-		class Item169
+		class Item168
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7115,7 +3273,7 @@ class Mission
 			id=2495;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item170
+		class Item169
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7131,7 +3289,7 @@ class Mission
 			id=2496;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item171
+		class Item170
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7147,7 +3305,7 @@ class Mission
 			id=2497;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item172
+		class Item171
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7163,7 +3321,7 @@ class Mission
 			id=2498;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item173
+		class Item172
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7179,7 +3337,7 @@ class Mission
 			id=2499;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item174
+		class Item173
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7196,7 +3354,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=-0.0054092407;
 		};
-		class Item175
+		class Item174
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7212,7 +3370,7 @@ class Mission
 			id=2501;
 			type="Land_Cargo_Tower_V1_F";
 		};
-		class Item176
+		class Item175
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7228,7 +3386,7 @@ class Mission
 			id=2502;
 			type="Land_Cargo_HQ_V1_F";
 		};
-		class Item177
+		class Item176
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7245,7 +3403,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=0.0009021759;
 		};
-		class Item178
+		class Item177
 		{
 			dataType="Marker";
 			position[]={10028.254,224.69717,12817.005};
@@ -7255,7 +3413,7 @@ class Mission
 			id=2514;
 			atlOffset=207.04475;
 		};
-		class Item179
+		class Item178
 		{
 			dataType="Marker";
 			position[]={8781.5693,242.69424,12046.101};
@@ -7265,7 +3423,7 @@ class Mission
 			id=2515;
 			atlOffset=207.11841;
 		};
-		class Item180
+		class Item179
 		{
 			dataType="Marker";
 			position[]={7337.1489,223.14734,11420.635};
@@ -7275,7 +3433,7 @@ class Mission
 			id=2516;
 			atlOffset=210.4803;
 		};
-		class Item181
+		class Item180
 		{
 			dataType="Marker";
 			position[]={10433.247,221.79193,11984.847};
@@ -7285,7 +3443,7 @@ class Mission
 			id=2517;
 			atlOffset=207.10417;
 		};
-		class Item182
+		class Item181
 		{
 			dataType="Marker";
 			position[]={9615.7051,219.70853,11698.256};
@@ -7295,7 +3453,7 @@ class Mission
 			id=2518;
 			atlOffset=207.72679;
 		};
-		class Item183
+		class Item182
 		{
 			dataType="Marker";
 			position[]={11035.04,270.21774,12975.45};
@@ -7305,7 +3463,7 @@ class Mission
 			id=2519;
 			atlOffset=250.81619;
 		};
-		class Item184
+		class Item183
 		{
 			dataType="Marker";
 			position[]={11739.101,220.42517,13915.596};
@@ -7315,7 +3473,7 @@ class Mission
 			id=2520;
 			atlOffset=207.09477;
 		};
-		class Item185
+		class Item184
 		{
 			dataType="Marker";
 			position[]={13483.799,222.38394,16031.15};
@@ -7325,7 +3483,7 @@ class Mission
 			id=2521;
 			atlOffset=207.07001;
 		};
-		class Item186
+		class Item185
 		{
 			dataType="Marker";
 			position[]={12480.492,239.24866,15888.915};
@@ -7335,7 +3493,7 @@ class Mission
 			id=2522;
 			atlOffset=219.98683;
 		};
-		class Item187
+		class Item186
 		{
 			dataType="Marker";
 			position[]={14287.046,224.37161,18163.477};
@@ -7345,7 +3503,7 @@ class Mission
 			id=2523;
 			atlOffset=207.09567;
 		};
-		class Item188
+		class Item187
 		{
 			dataType="Marker";
 			position[]={14311.098,233.83075,19602.867};
@@ -7355,7 +3513,7 @@ class Mission
 			id=2524;
 			atlOffset=207.10059;
 		};
-		class Item189
+		class Item188
 		{
 			dataType="Marker";
 			position[]={14772.826,221.88092,17177.539};
@@ -7365,7 +3523,7 @@ class Mission
 			id=2525;
 			atlOffset=207.11859;
 		};
-		class Item190
+		class Item189
 		{
 			dataType="Marker";
 			position[]={16953.717,223.38274,17815.453};
@@ -7375,7 +3533,7 @@ class Mission
 			id=2526;
 			atlOffset=207.0988;
 		};
-		class Item191
+		class Item190
 		{
 			dataType="Marker";
 			position[]={15897.321,218.30458,16180.612};
@@ -7385,7 +3543,7 @@ class Mission
 			id=2527;
 			atlOffset=207.07936;
 		};
-		class Item192
+		class Item191
 		{
 			dataType="Marker";
 			position[]={17470.652,211.46404,14446.198};
@@ -7395,7 +3553,7 @@ class Mission
 			id=2528;
 			atlOffset=207.13133;
 		};
-		class Item193
+		class Item192
 		{
 			dataType="Marker";
 			position[]={17046.191,222.78551,12895.485};
@@ -7405,7 +3563,7 @@ class Mission
 			id=2529;
 			atlOffset=207.10774;
 		};
-		class Item194
+		class Item193
 		{
 			dataType="Marker";
 			position[]={9381.4385,254.64844,21154.723};
@@ -7415,7 +3573,7 @@ class Mission
 			id=2530;
 			atlOffset=207.071;
 		};
-		class Item195
+		class Item194
 		{
 			dataType="Marker";
 			position[]={9719.1211,390.66769,19931.555};
@@ -7425,7 +3583,7 @@ class Mission
 			id=2531;
 			atlOffset=207.17831;
 		};
-		class Item196
+		class Item195
 		{
 			dataType="Marker";
 			position[]={9819.6953,301.79428,18542.309};
@@ -7435,7 +3593,7 @@ class Mission
 			id=2532;
 			atlOffset=207.17839;
 		};
-		class Item197
+		class Item196
 		{
 			dataType="Marker";
 			position[]={7528.8491,378.86459,17283.188};
@@ -7445,7 +3603,7 @@ class Mission
 			id=2533;
 			atlOffset=206.94324;
 		};
-		class Item198
+		class Item197
 		{
 			dataType="Marker";
 			position[]={6923.1553,396.07712,19242.508};
@@ -7455,7 +3613,7 @@ class Mission
 			id=2534;
 			atlOffset=207.02161;
 		};
-		class Item199
+		class Item198
 		{
 			dataType="Marker";
 			position[]={5246.8613,437.67661,20361.473};
@@ -7465,7 +3623,7 @@ class Mission
 			id=2535;
 			atlOffset=207.15965;
 		};
-		class Item200
+		class Item199
 		{
 			dataType="Marker";
 			position[]={21952.133,221.23347,7365.5059};
@@ -7475,7 +3633,7 @@ class Mission
 			id=2536;
 			atlOffset=207.02257;
 		};
-		class Item201
+		class Item200
 		{
 			dataType="Marker";
 			position[]={21275.615,222.55862,8188.9502};
@@ -7485,7 +3643,7 @@ class Mission
 			id=2537;
 			atlOffset=207.08943;
 		};
-		class Item202
+		class Item201
 		{
 			dataType="Marker";
 			position[]={20047,262.94885,8867.416};
@@ -7495,7 +3653,7 @@ class Mission
 			id=2538;
 			atlOffset=207.10971;
 		};
-		class Item203
+		class Item202
 		{
 			dataType="Marker";
 			position[]={20574.352,226.96756,10698.154};
@@ -7505,7 +3663,7 @@ class Mission
 			id=2539;
 			atlOffset=207.00183;
 		};
-		class Item204
+		class Item203
 		{
 			dataType="Marker";
 			position[]={22283.16,222.5508,18424.008};
@@ -7515,7 +3673,7 @@ class Mission
 			id=2540;
 			atlOffset=207.09207;
 		};
-		class Item205
+		class Item204
 		{
 			dataType="Marker";
 			position[]={21706.771,229.67892,17681.234};
@@ -7525,7 +3683,7 @@ class Mission
 			id=2541;
 			atlOffset=207.11749;
 		};
-		class Item206
+		class Item205
 		{
 			dataType="Marker";
 			position[]={21006.381,242.58272,17678.875};
@@ -7535,7 +3693,7 @@ class Mission
 			id=2542;
 			atlOffset=207.26607;
 		};
-		class Item207
+		class Item206
 		{
 			dataType="Marker";
 			position[]={20652.164,241.22063,18728.516};
@@ -7545,7 +3703,7 @@ class Mission
 			id=2543;
 			atlOffset=207.00783;
 		};
-		class Item208
+		class Item207
 		{
 			dataType="Marker";
 			position[]={20633.988,237.71661,16460.012};
@@ -7555,7 +3713,7 @@ class Mission
 			id=2544;
 			atlOffset=207.07196;
 		};
-		class Item209
+		class Item208
 		{
 			dataType="Marker";
 			position[]={19814.883,223.16016,15689.729};
@@ -7565,7 +3723,7 @@ class Mission
 			id=2545;
 			atlOffset=207.07376;
 		};
-		class Item210
+		class Item209
 		{
 			dataType="Marker";
 			position[]={23162.822,221.3853,19609.68};
@@ -7575,7 +3733,7 @@ class Mission
 			id=2546;
 			atlOffset=207.12292;
 		};
-		class Item211
+		class Item210
 		{
 			dataType="Marker";
 			position[]={22555.842,234.20135,20591.816};
@@ -7585,7 +3743,7 @@ class Mission
 			id=2547;
 			atlOffset=207.09488;
 		};
-		class Item212
+		class Item211
 		{
 			dataType="Marker";
 			position[]={23030.576,258.94626,21115.848};
@@ -7595,7 +3753,7 @@ class Mission
 			id=2548;
 			atlOffset=207.08276;
 		};
-		class Item213
+		class Item212
 		{
 			dataType="Marker";
 			position[]={24638.145,228.38713,20651.25};
@@ -7605,7 +3763,7 @@ class Mission
 			id=2549;
 			atlOffset=207.08659;
 		};
-		class Item214
+		class Item213
 		{
 			dataType="Marker";
 			position[]={25175.039,221.76308,20625.598};
@@ -7615,7 +3773,7 @@ class Mission
 			id=2550;
 			atlOffset=207.07173;
 		};
-		class Item215
+		class Item214
 		{
 			dataType="Marker";
 			position[]={25326.443,224.68488,21113.227};
@@ -7625,7 +3783,7 @@ class Mission
 			id=2551;
 			atlOffset=207.00446;
 		};
-		class Item216
+		class Item215
 		{
 			dataType="Marker";
 			position[]={24740.145,282.32803,21813.039};
@@ -7635,7 +3793,7 @@ class Mission
 			id=2552;
 			atlOffset=207.01666;
 		};
-		class Item217
+		class Item216
 		{
 			dataType="Marker";
 			position[]={26281.104,247.36038,21791.027};
@@ -7645,7 +3803,7 @@ class Mission
 			id=2553;
 			atlOffset=206.93509;
 		};
-		class Item218
+		class Item217
 		{
 			dataType="Marker";
 			position[]={26493.738,227.28189,21327.176};
@@ -7655,7 +3813,7 @@ class Mission
 			id=2554;
 			atlOffset=207.00717;
 		};
-		class Item219
+		class Item218
 		{
 			dataType="Marker";
 			position[]={27081.205,218.9371,24021.121};
@@ -7665,7 +3823,7 @@ class Mission
 			id=2555;
 			atlOffset=207.10999;
 		};
-		class Item220
+		class Item219
 		{
 			dataType="Marker";
 			position[]={26717.316,230.62947,22930.988};
@@ -7675,7 +3833,7 @@ class Mission
 			id=2556;
 			atlOffset=207.14931;
 		};
-		class Item221
+		class Item220
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7692,7 +3850,7 @@ class Mission
 			id=2565;
 			type="Flag_Viper_F";
 		};
-		class Item222
+		class Item221
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7703,12 +3861,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2574;
 			type="Land_HelipadCircle_F";
 			atlOffset=7.1189671;
 		};
-		class Item223
+		class Item222
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7719,12 +3878,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2575;
 			type="Land_HelipadCircle_F";
 			atlOffset=7.2019939;
 		};
-		class Item224
+		class Item223
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7735,12 +3895,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2576;
 			type="Land_HelipadCircle_F";
 			atlOffset=7.1081963;
 		};
-		class Item225
+		class Item224
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7757,7 +3918,7 @@ class Mission
 			type="Land_TentHangar_V1_F";
 			atlOffset=-1.9073486e-006;
 		};
-		class Item226
+		class Item225
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7774,7 +3935,7 @@ class Mission
 			type="Land_TentHangar_V1_F";
 			atlOffset=-1.9073486e-006;
 		};
-		class Item227
+		class Item226
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7786,12 +3947,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2579;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.16606903;
 		};
-		class Item228
+		class Item227
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7803,12 +3965,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2580;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.074874878;
 		};
-		class Item229
+		class Item228
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7820,12 +3983,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2581;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.12126541;
 		};
-		class Item230
+		class Item229
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7837,12 +4001,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2582;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.12021446;
 		};
-		class Item231
+		class Item230
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7858,7 +4023,7 @@ class Mission
 			id=2583;
 			type="Land_Hangar_F";
 		};
-		class Item232
+		class Item231
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7870,11 +4035,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2584;
 			type="Land_HelipadCircle_F";
 		};
-		class Item233
+		class Item232
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7886,11 +4052,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2585;
 			type="Land_HelipadCircle_F";
 		};
-		class Item234
+		class Item233
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7902,11 +4069,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2586;
 			type="Land_HelipadCircle_F";
 		};
-		class Item235
+		class Item234
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7918,11 +4086,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2587;
 			type="Land_HelipadCircle_F";
 		};
-		class Item236
+		class Item235
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7934,11 +4103,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2588;
 			type="Land_HelipadCircle_F";
 		};
-		class Item237
+		class Item236
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7954,7 +4124,7 @@ class Mission
 			id=2589;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item238
+		class Item237
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7971,7 +4141,7 @@ class Mission
 			type="Land_TentHangar_V1_F";
 			atlOffset=-0.41496658;
 		};
-		class Item239
+		class Item238
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7988,7 +4158,7 @@ class Mission
 			type="Land_TentHangar_V1_F";
 			atlOffset=-0.0004234314;
 		};
-		class Item240
+		class Item239
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8000,12 +4170,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2592;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.062786102;
 		};
-		class Item241
+		class Item240
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8017,11 +4188,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2593;
 			type="Land_HelipadCircle_F";
 		};
-		class Item242
+		class Item241
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8033,12 +4205,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2594;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.058639526;
 		};
-		class Item243
+		class Item242
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8050,12 +4223,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2595;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.042076111;
 		};
-		class Item244
+		class Item243
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8067,12 +4241,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2596;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.014266968;
 		};
-		class Item245
+		class Item244
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8084,12 +4259,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2597;
 			type="Land_HelipadCircle_F";
 			atlOffset=-0.0034770966;
 		};
-		class Item246
+		class Item245
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8101,12 +4277,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2598;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.008939743;
 		};
-		class Item247
+		class Item246
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8118,12 +4295,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2599;
 			type="Land_HelipadCircle_F";
 			atlOffset=-0.0062427521;
 		};
-		class Item248
+		class Item247
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8135,12 +4313,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2600;
 			type="Land_HelipadCircle_F";
 			atlOffset=1.7166138e-005;
 		};
-		class Item249
+		class Item248
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8152,12 +4331,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2601;
 			type="Land_HelipadCircle_F";
 			atlOffset=-0.0030708313;
 		};
-		class Item250
+		class Item249
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8169,12 +4349,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2602;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.00091362;
 		};
-		class Item251
+		class Item250
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8186,11 +4367,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2603;
 			type="Land_HelipadSquare_F";
 		};
-		class Item252
+		class Item251
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8202,12 +4384,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2604;
 			type="Land_HelipadSquare_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item253
+		class Item252
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8219,12 +4402,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2605;
 			type="Land_HelipadSquare_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item254
+		class Item253
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8236,12 +4420,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2606;
 			type="Land_HelipadCircle_F";
 			atlOffset=-0.067829132;
 		};
-		class Item255
+		class Item254
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8252,12 +4437,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2607;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.31982994;
 		};
-		class Item256
+		class Item255
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8269,12 +4455,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2608;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.017000198;
 		};
-		class Item257
+		class Item256
 		{
 			dataType="Layer";
 			name="Airports";
@@ -8427,7 +4614,7 @@ class Mission
 					colorName="ColorGreen";
 					a=35.460999;
 					b=6;
-					angle=225.2576;
+					angle=225.25757;
 					id=2620;
 					atlOffset=207.10193;
 				};
@@ -8603,7 +4790,7 @@ class Mission
 			id=2609;
 			atlOffset=181.23535;
 		};
-		class Item258
+		class Item257
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8615,11 +4802,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2633;
 			type="Land_HelipadCircle_F";
 		};
-		class Item259
+		class Item258
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8631,11 +4819,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2634;
 			type="Land_HelipadCircle_F";
 		};
-		class Item260
+		class Item259
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8647,12 +4836,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2635;
 			type="Land_HelipadCircle_F";
 			atlOffset=5.7220459e-006;
 		};
-		class Item261
+		class Item260
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8664,11 +4854,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2636;
 			type="Land_HelipadCircle_F";
 		};
-		class Item262
+		class Item261
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8679,12 +4870,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2637;
 			type="Land_HelipadCircle_F";
 			atlOffset=7.1380177;
 		};
-		class Item263
+		class Item262
 		{
 			dataType="Layer";
 			name="Factories";
@@ -8841,7 +5033,7 @@ class Mission
 					colorName="ColorGreen";
 					a=15.529018;
 					b=5.5;
-					angle=56.906193;
+					angle=56.906185;
 					id=2649;
 					atlOffset=207.01587;
 				};
@@ -9127,7 +5319,7 @@ class Mission
 			id=2638;
 			atlOffset=160.58017;
 		};
-		class Item264
+		class Item263
 		{
 			dataType="Layer";
 			name="Resources";
@@ -9200,7 +5392,7 @@ class Mission
 					colorName="ColorGreen";
 					a=19.902;
 					b=5.5;
-					angle=56.794907;
+					angle=56.794899;
 					id=2675;
 					atlOffset=207.30643;
 				};
@@ -9376,7 +5568,7 @@ class Mission
 			id=2670;
 			atlOffset=90.896408;
 		};
-		class Item265
+		class Item264
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9388,11 +5580,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2688;
 			type="Land_HelipadCircle_F";
 		};
-		class Item266
+		class Item265
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9403,12 +5596,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2689;
 			type="Land_HelipadCircle_F";
 			atlOffset=206.42648;
 		};
-		class Item267
+		class Item266
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9420,11 +5614,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2690;
 			type="Land_HelipadCircle_F";
 		};
-		class Item268
+		class Item267
 		{
 			dataType="Layer";
 			name="Seaports";
@@ -9575,7 +5770,7 @@ class Mission
 			id=2691;
 			atlOffset=246.84656;
 		};
-		class Item269
+		class Item268
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9587,11 +5782,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2702;
 			type="Land_HelipadCircle_F";
 		};
-		class Item270
+		class Item269
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9603,12 +5799,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2703;
 			type="Land_HelipadCircle_F";
 			atlOffset=-0.10459518;
 		};
-		class Item271
+		class Item270
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9620,11 +5817,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2704;
 			type="Land_HelipadCircle_F";
 		};
-		class Item272
+		class Item271
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9636,12 +5834,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2705;
 			type="Land_HelipadCircle_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item273
+		class Item272
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9652,12 +5851,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2706;
 			type="Land_HelipadCircle_F";
 			atlOffset=8.1710167;
 		};
-		class Item274
+		class Item273
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9668,12 +5868,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2707;
 			type="Land_HelipadCircle_F";
 			atlOffset=8.1646986;
 		};
-		class Item275
+		class Item274
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9685,11 +5886,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2708;
 			type="Land_HelipadSquare_F";
 		};
-		class Item276
+		class Item275
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9701,11 +5903,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2709;
 			type="Land_HelipadCircle_F";
 		};
-		class Item277
+		class Item276
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9716,12 +5919,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2710;
 			type="Land_HelipadCircle_F";
 			atlOffset=207.18915;
 		};
-		class Item278
+		class Item277
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9732,12 +5936,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2711;
 			type="Land_HelipadCircle_F";
 			atlOffset=207.10306;
 		};
-		class Item279
+		class Item278
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9749,11 +5954,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2712;
 			type="Land_HelipadCircle_F";
 		};
-		class Item280
+		class Item279
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9765,12 +5971,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2713;
 			type="Land_HelipadCircle_F";
 			atlOffset=-4.1425972;
 		};
-		class Item281
+		class Item280
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9782,12 +5989,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2714;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.079021454;
 		};
-		class Item282
+		class Item281
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9799,11 +6007,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2715;
 			type="Land_HelipadCircle_F";
 		};
-		class Item283
+		class Item282
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9815,11 +6024,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2716;
 			type="Land_HelipadCircle_F";
 		};
-		class Item284
+		class Item283
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9831,12 +6041,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2717;
 			type="Land_HelipadCircle_F";
 			atlOffset=-0.10194397;
 		};
-		class Item285
+		class Item284
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9848,11 +6059,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2718;
 			type="Land_HelipadCircle_F";
 		};
-		class Item286
+		class Item285
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9864,11 +6076,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2719;
 			type="Land_HelipadSquare_F";
 		};
-		class Item287
+		class Item286
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9880,12 +6093,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2720;
 			type="Land_HelipadCircle_F";
 			atlOffset=-0.46903992;
 		};
-		class Item288
+		class Item287
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9897,11 +6111,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2721;
 			type="Land_HelipadCircle_F";
 		};
-		class Item289
+		class Item288
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9913,12 +6128,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2722;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.14759827;
 		};
-		class Item290
+		class Item289
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9929,12 +6145,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2723;
 			type="Land_HelipadCircle_F";
 			atlOffset=9.0383759;
 		};
-		class Item291
+		class Item290
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9945,12 +6162,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2724;
 			type="Land_HelipadCircle_F";
 			atlOffset=207.16562;
 		};
-		class Item292
+		class Item291
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9961,12 +6179,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2725;
 			type="Land_HelipadCircle_F";
 			atlOffset=207.06699;
 		};
-		class Item293
+		class Item292
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9977,12 +6196,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2726;
 			type="Land_HelipadCircle_F";
 			atlOffset=207.16269;
 		};
-		class Item294
+		class Item293
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9993,12 +6213,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2727;
 			type="Land_HelipadCircle_F";
 			atlOffset=207.12726;
 		};
-		class Item295
+		class Item294
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10010,11 +6231,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2728;
 			type="Land_HelipadSquare_F";
 		};
-		class Item296
+		class Item295
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10025,12 +6247,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2729;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.4276886;
 		};
-		class Item297
+		class Item296
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10041,12 +6264,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2730;
 			type="Land_HelipadSquare_F";
 			atlOffset=1.8909988;
 		};
-		class Item298
+		class Item297
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10057,12 +6281,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2731;
 			type="Land_HelipadSquare_F";
 			atlOffset=1.093998;
 		};
-		class Item299
+		class Item298
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10073,12 +6298,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2732;
 			type="Land_HelipadCircle_F";
 			atlOffset=7.4586487;
 		};
-		class Item300
+		class Item299
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10090,11 +6316,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2733;
 			type="Land_HelipadSquare_F";
 		};
-		class Item301
+		class Item300
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10106,11 +6333,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2734;
 			type="Land_HelipadCircle_F";
 		};
-		class Item302
+		class Item301
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10122,12 +6350,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2735;
 			type="Land_HelipadCircle_F";
 			atlOffset=-0.19012451;
 		};
-		class Item303
+		class Item302
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10138,12 +6367,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2736;
 			type="Land_HelipadCircle_F";
 			atlOffset=7.1169586;
 		};
-		class Item304
+		class Item303
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10154,12 +6384,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2737;
 			type="Land_HelipadCircle_F";
 			atlOffset=6.9489403;
 		};
-		class Item305
+		class Item304
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10171,12 +6402,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2738;
 			type="Land_HelipadSquare_F";
 			atlOffset=-0.078055382;
 		};
-		class Item306
+		class Item305
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10188,12 +6420,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2739;
 			type="Land_HelipadSquare_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item307
+		class Item306
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10205,11 +6438,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2740;
 			type="Land_HelipadSquare_F";
 		};
-		class Item308
+		class Item307
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10220,12 +6454,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2741;
 			type="Land_HelipadCircle_F";
 			atlOffset=7.8716507;
 		};
-		class Item309
+		class Item308
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10237,12 +6472,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2742;
 			type="Land_HelipadSquare_F";
 			atlOffset=-0.019302368;
 		};
-		class Item310
+		class Item309
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10254,11 +6490,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2743;
 			type="Land_HelipadSquare_F";
 		};
-		class Item311
+		class Item310
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10269,12 +6506,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2744;
 			type="Land_HelipadCircle_F";
 			atlOffset=207.56033;
 		};
-		class Item312
+		class Item311
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10285,12 +6523,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2745;
 			type="Land_HelipadCircle_F";
 			atlOffset=208.94418;
 		};
-		class Item313
+		class Item312
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10301,12 +6540,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2746;
 			type="Land_HelipadCircle_F";
 			atlOffset=7.0029793;
 		};
-		class Item314
+		class Item313
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10317,12 +6557,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2747;
 			type="Land_HelipadCircle_F";
 			atlOffset=7.0029793;
 		};
-		class Item315
+		class Item314
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10333,12 +6574,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2748;
 			type="Land_HelipadCircle_F";
 			atlOffset=7.0029793;
 		};
-		class Item316
+		class Item315
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10349,12 +6591,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2749;
 			type="Land_HelipadSquare_F";
 			atlOffset=7.0029793;
 		};
-		class Item317
+		class Item316
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10366,11 +6609,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2750;
 			type="Land_HelipadCircle_F";
 		};
-		class Item318
+		class Item317
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10382,12 +6626,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2751;
 			type="Land_HelipadSquare_F";
 			atlOffset=-0.27038574;
 		};
-		class Item319
+		class Item318
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10399,12 +6644,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2752;
 			type="Land_HelipadSquare_F";
 			atlOffset=-0.23748779;
 		};
-		class Item320
+		class Item319
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10416,12 +6662,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2753;
 			type="Land_HelipadCircle_F";
 			atlOffset=-0.072425842;
 		};
-		class Item321
+		class Item320
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10433,11 +6680,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2754;
 			type="Land_HelipadCircle_F";
 		};
-		class Item322
+		class Item321
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10449,11 +6697,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2755;
 			type="Land_HelipadCircle_F";
 		};
-		class Item323
+		class Item322
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10465,12 +6714,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2756;
 			type="Land_HelipadCircle_F";
 			atlOffset=-0.096824646;
 		};
-		class Item324
+		class Item323
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10482,12 +6732,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2757;
 			type="Land_HelipadCircle_F";
 			atlOffset=-0.089668274;
 		};
-		class Item325
+		class Item324
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10499,12 +6750,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2758;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.076579094;
 		};
-		class Item326
+		class Item325
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10516,12 +6768,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2759;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.024902344;
 		};
-		class Item327
+		class Item326
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10533,11 +6786,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2760;
 			type="Land_HelipadCircle_F";
 		};
-		class Item328
+		class Item327
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10549,12 +6803,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2761;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.0084524155;
 		};
-		class Item329
+		class Item328
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10566,12 +6821,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2762;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.022742271;
 		};
-		class Item330
+		class Item329
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10582,12 +6838,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2763;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.70133972;
 		};
-		class Item331
+		class Item330
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10599,11 +6856,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2764;
 			type="Land_HelipadCircle_F";
 		};
-		class Item332
+		class Item331
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10614,12 +6872,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2765;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.64060044;
 		};
-		class Item333
+		class Item332
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10631,12 +6890,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2766;
 			type="Land_HelipadCircle_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item334
+		class Item333
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10648,12 +6908,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2767;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.076263428;
 		};
-		class Item335
+		class Item334
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10665,12 +6926,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2768;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.22304535;
 		};
-		class Item336
+		class Item335
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10682,11 +6944,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2769;
 			type="Land_HelipadCircle_F";
 		};
-		class Item337
+		class Item336
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10697,12 +6960,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2770;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.42436981;
 		};
-		class Item338
+		class Item337
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10714,11 +6978,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2771;
 			type="Land_HelipadSquare_F";
 		};
-		class Item339
+		class Item338
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10729,12 +6994,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2772;
 			type="Land_HelipadCircle_F";
 			atlOffset=7.9072399;
 		};
-		class Item340
+		class Item339
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10745,12 +7011,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2773;
 			type="Land_HelipadCircle_F";
 			atlOffset=7.9235306;
 		};
-		class Item341
+		class Item340
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10761,12 +7028,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2774;
 			type="Land_HelipadCircle_F";
 			atlOffset=1.3495522;
 		};
-		class Item342
+		class Item341
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10777,12 +7045,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2775;
 			type="Land_HelipadCircle_F";
 			atlOffset=1.4686909;
 		};
-		class Item343
+		class Item342
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10793,12 +7062,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2776;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.39395142;
 		};
-		class Item344
+		class Item343
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10810,12 +7080,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2777;
 			type="Land_HelipadCircle_F";
 			atlOffset=-1.0588913;
 		};
-		class Item345
+		class Item344
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10827,12 +7098,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2778;
 			type="Land_HelipadCircle_F";
 			atlOffset=-0.83277893;
 		};
-		class Item346
+		class Item345
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10844,12 +7116,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2779;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.013858795;
 		};
-		class Item347
+		class Item346
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10861,11 +7134,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2780;
 			type="Land_HelipadCircle_F";
 		};
-		class Item348
+		class Item347
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10877,11 +7151,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2781;
 			type="Land_HelipadCircle_F";
 		};
-		class Item349
+		class Item348
 		{
 			dataType="Layer";
 			name="Outposts";
@@ -12444,7 +8719,7 @@ class Mission
 			id=2782;
 			atlOffset=126.60043;
 		};
-		class Item350
+		class Item349
 		{
 			dataType="Marker";
 			position[]={14253.987,224.8902,15840.211};
@@ -12457,7 +8732,7 @@ class Mission
 			id=2893;
 			atlOffset=206.99365;
 		};
-		class Item351
+		class Item350
 		{
 			dataType="Marker";
 			position[]={15347.921,224.37141,17059.684};
@@ -12470,7 +8745,7 @@ class Mission
 			id=2894;
 			atlOffset=206.46141;
 		};
-		class Item352
+		class Item351
 		{
 			dataType="Marker";
 			position[]={14631.026,224.02478,16666.316};
@@ -12483,7 +8758,7 @@ class Mission
 			id=2895;
 			atlOffset=206.11478;
 		};
-		class Item353
+		class Item352
 		{
 			dataType="Marker";
 			position[]={21150.719,228.69763,7173.3672};
@@ -12496,7 +8771,7 @@ class Mission
 			id=2896;
 			atlOffset=206.11505;
 		};
-		class Item354
+		class Item353
 		{
 			dataType="Marker";
 			position[]={21181.049,225.48235,7539.1064};
@@ -12509,7 +8784,7 @@ class Mission
 			id=2897;
 			atlOffset=206.72942;
 		};
-		class Item355
+		class Item354
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12526,7 +8801,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=0.00016593933;
 		};
-		class Item356
+		class Item355
 		{
 			dataType="Marker";
 			position[]={11094.279,56.207184,15710.343};
@@ -12538,7 +8813,7 @@ class Mission
 			angle=231.22296;
 			id=2901;
 		};
-		class Item357
+		class Item356
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12550,11 +8825,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2902;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item358
+		class Item357
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12566,11 +8842,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2903;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item359
+		class Item358
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12582,11 +8859,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2904;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item360
+		class Item359
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12598,11 +8876,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2905;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item361
+		class Item360
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12614,11 +8893,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2906;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item362
+		class Item361
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12630,11 +8910,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2907;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item363
+		class Item362
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12646,11 +8927,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2908;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item364
+		class Item363
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12662,11 +8944,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2909;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item365
+		class Item364
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12678,11 +8961,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2910;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item366
+		class Item365
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12694,11 +8978,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2911;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item367
+		class Item366
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12710,11 +8995,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2912;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item368
+		class Item367
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12726,11 +9012,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2913;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item369
+		class Item368
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12742,11 +9029,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2914;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item370
+		class Item369
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12758,11 +9046,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2915;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item371
+		class Item370
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12774,11 +9063,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2916;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item372
+		class Item371
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12790,11 +9080,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2917;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item373
+		class Item372
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12806,11 +9097,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2918;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item374
+		class Item373
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12822,11 +9114,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2919;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item375
+		class Item374
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12838,11 +9131,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2920;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item376
+		class Item375
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12854,12 +9148,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2921;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-0.25000381;
 		};
-		class Item377
+		class Item376
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12871,11 +9166,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2922;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item378
+		class Item377
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12887,11 +9183,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2923;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item379
+		class Item378
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12903,11 +9200,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2924;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item380
+		class Item379
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12919,12 +9217,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2925;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item381
+		class Item380
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12936,11 +9235,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2926;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item382
+		class Item381
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12952,11 +9252,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2927;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item383
+		class Item382
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12968,11 +9269,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2928;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item384
+		class Item383
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12988,7 +9290,7 @@ class Mission
 			id=2929;
 			type="Land_BarGate_F";
 		};
-		class Item385
+		class Item384
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13004,7 +9306,7 @@ class Mission
 			id=2930;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item386
+		class Item385
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13016,11 +9318,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2931;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item387
+		class Item386
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13032,11 +9335,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2932;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item388
+		class Item387
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13048,11 +9352,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2933;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item389
+		class Item388
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13064,11 +9369,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2934;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item390
+		class Item389
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13080,11 +9386,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2935;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item391
+		class Item390
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13096,11 +9403,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2936;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item392
+		class Item391
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13112,11 +9420,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2937;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item393
+		class Item392
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13132,7 +9441,7 @@ class Mission
 			id=2938;
 			type="Land_BarGate_F";
 		};
-		class Item394
+		class Item393
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13148,7 +9457,7 @@ class Mission
 			id=2939;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item395
+		class Item394
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13165,7 +9474,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=0.42819977;
 		};
-		class Item396
+		class Item395
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13181,7 +9490,7 @@ class Mission
 			id=2941;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item397
+		class Item396
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13198,7 +9507,7 @@ class Mission
 			type="Land_Cargo_House_V1_F";
 			atlOffset=0.10601425;
 		};
-		class Item398
+		class Item397
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13215,7 +9524,7 @@ class Mission
 			type="Land_TTowerSmall_1_F";
 			atlOffset=0.38066864;
 		};
-		class Item399
+		class Item398
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13232,7 +9541,7 @@ class Mission
 			type="Land_TTowerSmall_2_F";
 			atlOffset=-1.0318947;
 		};
-		class Item400
+		class Item399
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13248,7 +9557,7 @@ class Mission
 			id=2945;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item401
+		class Item400
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13261,11 +9570,12 @@ class Mission
 			class Attributes
 			{
 				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=2946;
 			type="Land_Cargo40_military_green_F";
 		};
-		class Item402
+		class Item401
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13278,12 +9588,13 @@ class Mission
 			class Attributes
 			{
 				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=2947;
 			type="Land_Cargo40_military_green_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item403
+		class Item402
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13295,12 +9606,13 @@ class Mission
 			class Attributes
 			{
 				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=2948;
 			type="Land_Cargo40_military_green_F";
 			atlOffset=2.4690018;
 		};
-		class Item404
+		class Item403
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13316,7 +9628,7 @@ class Mission
 			id=2949;
 			type="Land_Medevac_house_V1_F";
 		};
-		class Item405
+		class Item404
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13328,11 +9640,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2951;
 			type="Land_HelipadCircle_F";
 		};
-		class Item406
+		class Item405
 		{
 			dataType="Marker";
 			position[]={26895.244,20.950012,24798.67};
@@ -13345,7 +9658,7 @@ class Mission
 			id=2957;
 			atlOffset=0.82716751;
 		};
-		class Item407
+		class Item406
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13362,7 +9675,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=6.1035156e-005;
 		};
-		class Item408
+		class Item407
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13379,7 +9692,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=3.2424927e-005;
 		};
-		class Item409
+		class Item408
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -13391,7 +9704,7 @@ class Mission
 			type="HighCommand";
 			atlOffset=-0.0594244;
 		};
-		class Item410
+		class Item409
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -13402,7 +9715,7 @@ class Mission
 			type="HighCommandSubordinate";
 			atlOffset=0.059479713;
 		};
-		class Item411
+		class Item410
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13417,17 +9730,896 @@ class Mission
 			};
 			id=2963;
 			type="Flag_Altis_F";
+			atlOffset=9.5367432e-007;
+		};
+		class Item411
+		{
+			dataType="Group";
+			side="West";
+			class Entities
+			{
+				items=38;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3611.3611,15.394545,10277.721};
+					};
+					side="West";
+					flags=7;
+					class Attributes
+					{
+						name="commanderX";
+						description="Default Commander";
+						isPlayer=1;
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2965;
+					type="B_G_officer_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male05GRE";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1.02;
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3614.9319,15.194558,10276};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2966;
+					type="B_G_officer_F";
+					atlOffset=-8.5830688e-006;
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3615.071,15.211149,10278.12};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2967;
+					type="B_G_officer_F";
+					atlOffset=-6.6757202e-006;
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3615.0435,15.234458,10280.193};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2968;
+					type="B_G_officer_F";
+					atlOffset=1.0490417e-005;
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3614.9729,15.259294,10282.238};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2969;
+					type="B_G_officer_F";
+					atlOffset=-1.335144e-005;
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3615.1814,15.353321,10284.402};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2970;
+					type="B_G_officer_F";
+					atlOffset=-2.9563904e-005;
+				};
+				class Item6
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3615.3076,15.456325,10286.389};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2971;
+					type="B_G_officer_F";
+					atlOffset=-2.5749207e-005;
+				};
+				class Item7
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3615.6064,15.558286,10288.559};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2972;
+					type="B_G_officer_F";
+					atlOffset=-6.0081482e-005;
+				};
+				class Item8
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3616.7424,15.118722,10276.14};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2973;
+					type="B_G_Soldier_F";
+					atlOffset=7.6293945e-006;
+				};
+				class Item9
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3616.8762,15.136186,10278.313};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2974;
+					type="B_G_Soldier_F";
+					atlOffset=9.5367432e-007;
+				};
+				class Item10
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3616.8508,15.158612,10280.313};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2975;
+					type="B_G_Soldier_F";
+					atlOffset=-4.7683716e-006;
+				};
+				class Item11
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3617.0266,15.130725,10282.411};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2976;
+					type="B_G_Soldier_F";
+					atlOffset=4.0054321e-005;
+				};
+				class Item12
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3617.0325,15.239642,10284.531};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2977;
+					type="B_G_Soldier_F";
+					atlOffset=7.6293945e-006;
+				};
+				class Item13
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3617.074,15.346433,10286.487};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2978;
+					type="B_G_Soldier_F";
+					atlOffset=-7.6293945e-006;
+				};
+				class Item14
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3618.6152,15.041072,10276.352};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2979;
+					type="B_G_Soldier_AR_F";
+					atlOffset=3.8146973e-006;
+				};
+				class Item15
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3618.4863,15.068346,10278.394};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2980;
+					type="B_G_Soldier_AR_F";
+					atlOffset=-7.6293945e-006;
+				};
+				class Item16
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3618.3367,15.068675,10280.449};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2981;
+					type="B_G_Soldier_AR_F";
+					atlOffset=4.196167e-005;
+				};
+				class Item17
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3618.2476,15.049272,10282.549};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2982;
+					type="B_G_Soldier_AR_F";
+					atlOffset=2.3841858e-005;
+				};
+				class Item18
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3618.51,15.148995,10284.637};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2983;
+					type="B_G_Soldier_AR_F";
+					atlOffset=-1.0490417e-005;
+				};
+				class Item19
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3618.7559,15.230732,10286.638};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2984;
+					type="B_G_Soldier_AR_F";
+					atlOffset=-4.1007996e-005;
+				};
+				class Item20
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3620.1489,14.975923,10276.378};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2985;
+					type="B_G_Soldier_GL_F";
+					atlOffset=1.1444092e-005;
+				};
+				class Item21
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3620.0842,14.978161,10278.477};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2986;
+					type="B_G_Soldier_GL_F";
+					atlOffset=3.3378601e-005;
+				};
+				class Item22
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3620.0723,14.952924,10280.644};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2987;
+					type="B_G_Soldier_GL_F";
+					atlOffset=1.335144e-005;
+				};
+				class Item23
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3619.8572,14.946092,10282.585};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2988;
+					type="B_G_Soldier_GL_F";
+					atlOffset=-1.9073486e-006;
+				};
+				class Item24
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3620.0989,15.041965,10284.578};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2989;
+					type="B_G_Soldier_GL_F";
+					atlOffset=4.863739e-005;
+				};
+				class Item25
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3620.1707,15.084365,10286.946};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2990;
+					type="B_G_Soldier_GL_F";
+					atlOffset=-5.7220459e-006;
+				};
+				class Item26
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3621.677,14.89887,10276.411};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2991;
+					type="B_G_medic_F";
+					atlOffset=2.0027161e-005;
+				};
+				class Item27
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3621.6338,14.880065,10278.215};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2992;
+					type="B_G_medic_F";
+					atlOffset=3.2424927e-005;
+				};
+				class Item28
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3621.5623,14.859242,10280.339};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2993;
+					type="B_G_medic_F";
+					atlOffset=3.2424927e-005;
+				};
+				class Item29
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3621.5225,14.83554,10282.531};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2994;
+					type="B_G_medic_F";
+					atlOffset=2.8610229e-005;
+				};
+				class Item30
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3621.4763,14.911756,10284.673};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2995;
+					type="B_G_medic_F";
+					atlOffset=-1.5258789e-005;
+				};
+				class Item31
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3621.5913,14.929896,10286.746};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2996;
+					type="B_G_medic_F";
+					atlOffset=4.7683716e-006;
+				};
+				class Item32
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3623.0779,14.822458,10276.438};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2997;
+					type="B_G_engineer_F";
+					atlOffset=2.9563904e-005;
+				};
+				class Item33
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3623.009,14.803505,10278.239};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2998;
+					type="B_G_engineer_F";
+					atlOffset=3.3378601e-005;
+				};
+				class Item34
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3623.0012,14.780713,10280.164};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2999;
+					type="B_G_engineer_F";
+					atlOffset=4.4822693e-005;
+				};
+				class Item35
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3622.8801,14.762211,10282.511};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3000;
+					type="B_G_engineer_F";
+					atlOffset=3.8146973e-006;
+				};
+				class Item36
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3623.0234,14.787869,10284.526};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3001;
+					type="B_G_engineer_F";
+					atlOffset=-5.7220459e-006;
+				};
+				class Item37
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3623.0771,14.816882,10286.593};
+					};
+					side="West";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3002;
+					type="B_G_engineer_F";
+					atlOffset=-1.335144e-005;
+				};
+			};
+			class Attributes
+			{
+			};
+			id=2964;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="Guerillas";
+						};
+					};
+				};
+				nAttributes=1;
+			};
 		};
 	};
 	class Connections
 	{
 		class LinkIDProvider
 		{
-			nextID=61;
+			nextID=39;
 		};
 		class Links
 		{
-			items=61;
+			items=39;
 			class Item0
 			{
 				linkID=0;
@@ -13441,7 +10633,7 @@ class Mission
 			class Item1
 			{
 				linkID=1;
-				item0=1487;
+				item0=2965;
 				item1=2960;
 				class CustomData
 				{
@@ -13451,7 +10643,7 @@ class Mission
 			class Item2
 			{
 				linkID=2;
-				item0=1492;
+				item0=2979;
 				item1=2960;
 				class CustomData
 				{
@@ -13461,7 +10653,7 @@ class Mission
 			class Item3
 			{
 				linkID=3;
-				item0=1502;
+				item0=2980;
 				item1=2960;
 				class CustomData
 				{
@@ -13471,7 +10663,7 @@ class Mission
 			class Item4
 			{
 				linkID=4;
-				item0=1504;
+				item0=2981;
 				item1=2960;
 				class CustomData
 				{
@@ -13481,7 +10673,7 @@ class Mission
 			class Item5
 			{
 				linkID=5;
-				item0=1506;
+				item0=2982;
 				item1=2960;
 				class CustomData
 				{
@@ -13491,7 +10683,7 @@ class Mission
 			class Item6
 			{
 				linkID=6;
-				item0=1508;
+				item0=2983;
 				item1=2960;
 				class CustomData
 				{
@@ -13501,7 +10693,7 @@ class Mission
 			class Item7
 			{
 				linkID=7;
-				item0=1510;
+				item0=2984;
 				item1=2960;
 				class CustomData
 				{
@@ -13511,7 +10703,7 @@ class Mission
 			class Item8
 			{
 				linkID=8;
-				item0=1512;
+				item0=2991;
 				item1=2960;
 				class CustomData
 				{
@@ -13521,7 +10713,7 @@ class Mission
 			class Item9
 			{
 				linkID=9;
-				item0=1514;
+				item0=2992;
 				item1=2960;
 				class CustomData
 				{
@@ -13531,7 +10723,7 @@ class Mission
 			class Item10
 			{
 				linkID=10;
-				item0=1516;
+				item0=2993;
 				item1=2960;
 				class CustomData
 				{
@@ -13541,7 +10733,7 @@ class Mission
 			class Item11
 			{
 				linkID=11;
-				item0=1518;
+				item0=2994;
 				item1=2960;
 				class CustomData
 				{
@@ -13551,7 +10743,7 @@ class Mission
 			class Item12
 			{
 				linkID=12;
-				item0=1520;
+				item0=2995;
 				item1=2960;
 				class CustomData
 				{
@@ -13561,7 +10753,7 @@ class Mission
 			class Item13
 			{
 				linkID=13;
-				item0=1522;
+				item0=2996;
 				item1=2960;
 				class CustomData
 				{
@@ -13571,7 +10763,7 @@ class Mission
 			class Item14
 			{
 				linkID=14;
-				item0=1524;
+				item0=2997;
 				item1=2960;
 				class CustomData
 				{
@@ -13581,7 +10773,7 @@ class Mission
 			class Item15
 			{
 				linkID=15;
-				item0=1526;
+				item0=2998;
 				item1=2960;
 				class CustomData
 				{
@@ -13591,7 +10783,7 @@ class Mission
 			class Item16
 			{
 				linkID=16;
-				item0=1528;
+				item0=2999;
 				item1=2960;
 				class CustomData
 				{
@@ -13601,7 +10793,7 @@ class Mission
 			class Item17
 			{
 				linkID=17;
-				item0=1530;
+				item0=3000;
 				item1=2960;
 				class CustomData
 				{
@@ -13611,7 +10803,7 @@ class Mission
 			class Item18
 			{
 				linkID=18;
-				item0=1532;
+				item0=3001;
 				item1=2960;
 				class CustomData
 				{
@@ -13621,7 +10813,7 @@ class Mission
 			class Item19
 			{
 				linkID=19;
-				item0=1534;
+				item0=3002;
 				item1=2960;
 				class CustomData
 				{
@@ -13631,7 +10823,7 @@ class Mission
 			class Item20
 			{
 				linkID=20;
-				item0=1536;
+				item0=2985;
 				item1=2960;
 				class CustomData
 				{
@@ -13641,7 +10833,7 @@ class Mission
 			class Item21
 			{
 				linkID=21;
-				item0=1538;
+				item0=2986;
 				item1=2960;
 				class CustomData
 				{
@@ -13651,7 +10843,7 @@ class Mission
 			class Item22
 			{
 				linkID=22;
-				item0=1540;
+				item0=2987;
 				item1=2960;
 				class CustomData
 				{
@@ -13661,7 +10853,7 @@ class Mission
 			class Item23
 			{
 				linkID=23;
-				item0=1542;
+				item0=2988;
 				item1=2960;
 				class CustomData
 				{
@@ -13671,7 +10863,7 @@ class Mission
 			class Item24
 			{
 				linkID=24;
-				item0=1544;
+				item0=2989;
 				item1=2960;
 				class CustomData
 				{
@@ -13681,7 +10873,7 @@ class Mission
 			class Item25
 			{
 				linkID=25;
-				item0=1546;
+				item0=2990;
 				item1=2960;
 				class CustomData
 				{
@@ -13691,7 +10883,7 @@ class Mission
 			class Item26
 			{
 				linkID=26;
-				item0=1548;
+				item0=2966;
 				item1=2960;
 				class CustomData
 				{
@@ -13701,7 +10893,7 @@ class Mission
 			class Item27
 			{
 				linkID=27;
-				item0=1550;
+				item0=2967;
 				item1=2960;
 				class CustomData
 				{
@@ -13711,7 +10903,7 @@ class Mission
 			class Item28
 			{
 				linkID=28;
-				item0=1552;
+				item0=2968;
 				item1=2960;
 				class CustomData
 				{
@@ -13721,7 +10913,7 @@ class Mission
 			class Item29
 			{
 				linkID=29;
-				item0=1554;
+				item0=2969;
 				item1=2960;
 				class CustomData
 				{
@@ -13731,7 +10923,7 @@ class Mission
 			class Item30
 			{
 				linkID=30;
-				item0=1556;
+				item0=2970;
 				item1=2960;
 				class CustomData
 				{
@@ -13741,7 +10933,7 @@ class Mission
 			class Item31
 			{
 				linkID=31;
-				item0=1558;
+				item0=2971;
 				item1=2960;
 				class CustomData
 				{
@@ -13751,7 +10943,7 @@ class Mission
 			class Item32
 			{
 				linkID=32;
-				item0=1560;
+				item0=2972;
 				item1=2960;
 				class CustomData
 				{
@@ -13761,7 +10953,7 @@ class Mission
 			class Item33
 			{
 				linkID=33;
-				item0=1583;
+				item0=2973;
 				item1=2960;
 				class CustomData
 				{
@@ -13771,7 +10963,7 @@ class Mission
 			class Item34
 			{
 				linkID=34;
-				item0=1585;
+				item0=2974;
 				item1=2960;
 				class CustomData
 				{
@@ -13781,7 +10973,7 @@ class Mission
 			class Item35
 			{
 				linkID=35;
-				item0=1587;
+				item0=2975;
 				item1=2960;
 				class CustomData
 				{
@@ -13791,7 +10983,7 @@ class Mission
 			class Item36
 			{
 				linkID=36;
-				item0=1589;
+				item0=2976;
 				item1=2960;
 				class CustomData
 				{
@@ -13801,7 +10993,7 @@ class Mission
 			class Item37
 			{
 				linkID=37;
-				item0=1591;
+				item0=2977;
 				item1=2960;
 				class CustomData
 				{
@@ -13811,227 +11003,7 @@ class Mission
 			class Item38
 			{
 				linkID=38;
-				item0=1593;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item39
-			{
-				linkID=39;
-				item0=1595;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item40
-			{
-				linkID=40;
-				item0=1597;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item41
-			{
-				linkID=41;
-				item0=1599;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item42
-			{
-				linkID=42;
-				item0=1601;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item43
-			{
-				linkID=43;
-				item0=1603;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item44
-			{
-				linkID=44;
-				item0=1605;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item45
-			{
-				linkID=45;
-				item0=1607;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item46
-			{
-				linkID=46;
-				item0=1609;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item47
-			{
-				linkID=47;
-				item0=1611;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item48
-			{
-				linkID=48;
-				item0=1613;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item49
-			{
-				linkID=49;
-				item0=1615;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item50
-			{
-				linkID=50;
-				item0=1617;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item51
-			{
-				linkID=51;
-				item0=1619;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item52
-			{
-				linkID=52;
-				item0=1621;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item53
-			{
-				linkID=53;
-				item0=1623;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item54
-			{
-				linkID=54;
-				item0=1625;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item55
-			{
-				linkID=55;
-				item0=1627;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item56
-			{
-				linkID=56;
-				item0=1629;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item57
-			{
-				linkID=57;
-				item0=1500;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item58
-			{
-				linkID=58;
-				item0=1498;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item59
-			{
-				linkID=59;
-				item0=1496;
-				item1=2960;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item60
-			{
-				linkID=60;
-				item0=1494;
+				item0=2978;
 				item1=2960;
 				class CustomData
 				{

--- a/Map-Templates/Antistasi-Altis.Altis/mission.sqm
+++ b/Map-Templates/Antistasi-Altis.Altis/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=1666;
 	class ItemIDProvider
 	{
-		nextID=2076;
+		nextID=2115;
 	};
 	class MarkerIDProvider
 	{
@@ -16,14 +16,14 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=503;
+		nextID=518;
 	};
 	class Camera
 	{
-		pos[]={3643.606,51.059433,10276.297};
-		dir[]={-0.63776839,-0.7528035,-0.16295114};
-		up[]={-0.72937334,0.65824056,-0.18635601};
-		aside[]={-0.24755117,-9.6391886e-008,0.96888137};
+		pos[]={14079.244,59.815231,22944.676};
+		dir[]={0,-0.70710683,0.70710683};
+		up[]={0,0.70710677,0.70710677};
+		aside[]={0.99999994,0,-0};
 	};
 };
 binarizationWanted=0;
@@ -33,7 +33,6 @@ addons[]=
 	"A3_Weapons_F_Ammoboxes",
 	"A3_Modules_F",
 	"A3_Characters_F",
-	"A3_Weapons_F",
 	"A3_Structures_F_EPC_Civ_InfoBoards",
 	"A3_Structures_F_Ind_AirPort",
 	"A3_Structures_F_Mil_Cargo",
@@ -51,7 +50,8 @@ addons[]=
 	"A3_Structures_F_Walls",
 	"A3_Structures_F_Ind_Transmitter_Tower",
 	"A3_Structures_F_Ind_Cargo",
-	"A3_Modules_F_Hc"
+	"A3_Modules_F_Hc",
+	"A3_Weapons_F"
 };
 class AddonsMetaData
 {
@@ -678,3898 +678,6 @@ class Mission
 			side="Independent";
 			class Entities
 			{
-				items=60;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3607.4099,15.69819,10275.639};
-						angles[]={0.014660765,0,6.2232509};
-					};
-					side="Independent";
-					flags=6;
-					class Attributes
-					{
-						skill=1;
-						name="commanderX";
-						description="Default Commander";
-						isPlayer=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1013;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item1
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3610.9431,15.376605,10272.114};
-						angles[]={6.253861,6.2412972,6.213963};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1014;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item2
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3622.4028,14.829173,10278.267};
-						angles[]={0.012000273,6.2412972,6.2179451};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1020;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item3
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3625.4768,14.704896,10278.502};
-						angles[]={0.012000273,0,6.2445378};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1022;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item4
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3628.4067,14.617949,10278.153};
-						angles[]={6.2805333,0,6.259192};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1024;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item5
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3631.3059,14.541884,10278.332};
-						angles[]={6.2805333,0,6.253861};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1026;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item6
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3634.2937,14.465902,10278.552};
-						angles[]={6.2432079,0,0.0080009829};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1028;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item7
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3619.9419,14.99068,10278.206};
-						angles[]={0.012000273,0,6.2179451};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1030;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item8
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3622.2998,14.802361,10281.062};
-						angles[]={0.012000273,6.2412972,6.2179451};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1032;
-					type="I_G_Soldier_AR_F";
-					atlOffset=-9.5367432e-007;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item9
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3625.3738,14.699122,10281.297};
-						angles[]={6.2805333,0,6.259192};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1034;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item10
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3628.3037,14.627873,10280.948};
-						angles[]={6.2805333,0,6.259192};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1036;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item11
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3631.2029,14.552358,10281.127};
-						angles[]={6.2805333,0,6.253861};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1038;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item12
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3634.1907,14.576846,10281.347};
-						angles[]={6.2432079,0,0.0080009829};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1040;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item13
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3619.8389,14.963868,10281.001};
-						angles[]={0.012000273,0,6.2179451};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1042;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item14
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3625.3738,14.728109,10284.298};
-						angles[]={6.2685165,0,6.2591896};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1046;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item15
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3628.3037,14.652675,10283.949};
-						angles[]={6.2685165,0,6.2591896};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1048;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item16
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3631.2029,14.622108,10284.128};
-						angles[]={6.2698507,0,0.0079936078};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1050;
-					type="I_G_engineer_F";
-					atlOffset=9.5367432e-007;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item17
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3634.1907,14.64894,10284.348};
-						angles[]={6.2698536,0,0.0079935296};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1052;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item18
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3619.8389,15.026655,10284.002};
-						angles[]={6.2272439,0,6.2179451};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1054;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item19
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3625.27,14.76855,10286.885};
-						angles[]={6.2685165,0,6.2591896};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1058;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item20
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3628.2,14.690199,10286.536};
-						angles[]={6.2698536,0,6.2578602};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1060;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item21
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3631.0991,14.655776,10286.715};
-						angles[]={6.2698536,0,0.0079935296};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1062;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item22
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3634.0869,14.683905,10286.935};
-						angles[]={6.2685208,0,0.0093286335};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1064;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item23
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3619.7351,15.12558,10286.589};
-						angles[]={6.2685208,0,6.1769204};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1066;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item24
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3622.3989,14.806094,10284.178};
-						angles[]={6.2685208,6.1574922,6.1769204};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1044;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item25
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3622.4939,14.833896,10286.765};
-						angles[]={6.2685208,0,6.1769204};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1056;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item26
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3625.6023,14.795665,10289.511};
-						angles[]={6.2698536,0,6.2578602};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1417;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item27
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3628.5322,14.716789,10289.162};
-						angles[]={6.2698536,0,6.2578602};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1419;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item28
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3631.4314,14.694407,10289.341};
-						angles[]={6.2685208,0,0.0093286335};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1421;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item29
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3634.4192,14.725517,10289.561};
-						angles[]={6.2685208,0,0.0093286335};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1423;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item30
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3620.0674,15.128654,10289.215};
-						angles[]={6.2685208,0,6.1769204};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1425;
-					type="I_G_officer_F";
-					atlOffset=-9.5367432e-007;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item31
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3622.8262,14.863952,10289.391};
-						angles[]={6.2685165,0,6.2591896};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1427;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item32
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3625.6758,14.89904,10292.585};
-						angles[]={6.2445378,0,6.2578578};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1429;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item33
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3628.6057,14.802868,10292.236};
-						angles[]={6.2551947,0,6.247201};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1431;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item34
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3631.5049,14.771727,10292.415};
-						angles[]={6.2551947,0,0.0093286335};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1433;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item35
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3634.4927,14.805766,10292.635};
-						angles[]={6.2551947,0,0.0093286335};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1435;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item36
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3620.1409,15.237556,10292.289};
-						angles[]={6.2365522,0,6.1769204};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1437;
-					type="I_G_officer_F";
-					atlOffset=9.5367432e-007;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item37
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3622.8997,14.964696,10292.465};
-						angles[]={6.2445378,0,6.2578578};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1439;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item38
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3622.709,15.089675,10295.571};
-						angles[]={6.2445378,0,6.2578578};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1498;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item39
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3625.6389,14.993293,10295.223};
-						angles[]={6.2551947,0,6.247201};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1500;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item40
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3628.5381,14.893919,10295.401};
-						angles[]={6.2551947,0,6.247201};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1502;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item41
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3631.5259,14.861694,10295.621};
-						angles[]={6.2551947,0,0.0093286335};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1504;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item42
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3617.1741,15.693403,10295.275};
-						angles[]={6.2365522,0,6.1769204};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1506;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item43
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3619.9329,15.384641,10295.451};
-						angles[]={6.2445378,0,6.1690178};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1508;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item44
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3622.5605,15.217278,10298.836};
-						angles[]={6.2458687,0,6.247201};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1510;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item45
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3625.4905,15.098813,10298.487};
-						angles[]={6.2458687,0,6.247201};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1512;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item46
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3628.3896,15.001105,10298.666};
-						angles[]={6.2458687,0,6.247201};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1514;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item47
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3631.3774,15.023723,10298.886};
-						angles[]={6.2192731,0,0.02666023};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1516;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item48
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3617.0256,15.850656,10298.54};
-						angles[]={6.2312322,0,6.1690178};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1518;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item49
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3619.7844,15.543464,10298.716};
-						angles[]={6.2312322,0,6.1690178};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1520;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item50
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3621.3738,15.467607,10301.581};
-						angles[]={6.2458706,0,6.1545658};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1522;
-					type="I_G_Soldier_LAT_F";
-					atlOffset=-9.5367432e-007;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item51
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3624.3037,15.524534,10301.232};
-						angles[]={5.957521,0,0.24143139};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1524;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item52
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3627.2029,15.174692,10301.411};
-						angles[]={6.2192731,0,6.2738566};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1526;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item53
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3630.1907,15.167741,10301.631};
-						angles[]={6.2192731,0,0.02666023};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1528;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item54
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3615.8389,16.323023,10301.285};
-						angles[]={5.8855929,0,5.4282241};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1530;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item55
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3618.5977,15.822173,10301.461};
-						angles[]={6.2458706,0,6.1545658};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1532;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item56
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3616.947,14.993358,10272.001};
-						angles[]={6.253861,0,6.2325621};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1016;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item57
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3619.9722,14.865136,10272.26};
-						angles[]={6.2458687,0,6.2405448};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1017;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item58
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3622.5569,14.771102,10272.666};
-						angles[]={6.2458706,0,6.259192};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1018;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item59
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={3614.0171,15.170384,10272.35};
-						angles[]={6.253861,0,6.213963};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=1015;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-			};
-			class Attributes
-			{
-			};
-			id=1067;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="groupID";
-					expression="_this setGroupID [_value];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"STRING"
-								};
-							};
-							value="Guerillas";
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item43
-		{
-			dataType="Group";
-			side="Independent";
-			class Entities
-			{
 				items=1;
 				class Item0
 				{
@@ -4678,7 +786,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item44
+		class Item43
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4718,17 +826,17 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item45
+		class Item44
 		{
 			dataType="Marker";
 			position[]={21332.971,18.858,7321.6831};
 			name="spawnPoint";
 			type="hd_start";
-			angle=28.146921;
+			angle=28.146914;
 			id=1099;
 			atlOffset=0.00024414063;
 		};
-		class Item46
+		class Item45
 		{
 			dataType="Marker";
 			position[]={22912.727,9.9300003,19079.26};
@@ -4738,7 +846,7 @@ class Mission
 			id=1100;
 			atlOffset=-1.441308;
 		};
-		class Item47
+		class Item46
 		{
 			dataType="Marker";
 			position[]={26833.08,27.041002,24434.344};
@@ -4747,7 +855,7 @@ class Mission
 			angle=220.45634;
 			id=1102;
 		};
-		class Item48
+		class Item47
 		{
 			dataType="Marker";
 			position[]={14415.215,16.554316,16811.631};
@@ -4756,7 +864,7 @@ class Mission
 			angle=223.34677;
 			id=1103;
 		};
-		class Item49
+		class Item48
 		{
 			dataType="Marker";
 			position[]={11565.08,25.18574,12096.762};
@@ -4765,7 +873,7 @@ class Mission
 			angle=286.13657;
 			id=1104;
 		};
-		class Item50
+		class Item49
 		{
 			dataType="Marker";
 			position[]={9184.3438,14.790446,21734.248};
@@ -4774,7 +882,7 @@ class Mission
 			angle=143.57869;
 			id=1105;
 		};
-		class Item51
+		class Item50
 		{
 			dataType="Marker";
 			position[]={3181.1331,2.4200001,12482.095};
@@ -4787,7 +895,7 @@ class Mission
 			id=1107;
 			atlOffset=9.059906e-006;
 		};
-		class Item52
+		class Item51
 		{
 			dataType="Marker";
 			position[]={4219.2031,46.111389,12251.489};
@@ -4799,7 +907,7 @@ class Mission
 			angle=231.22296;
 			id=1108;
 		};
-		class Item53
+		class Item52
 		{
 			dataType="Marker";
 			position[]={5096.9497,24.480274,13859.174};
@@ -4811,7 +919,7 @@ class Mission
 			angle=231.22296;
 			id=1109;
 		};
-		class Item54
+		class Item53
 		{
 			dataType="Marker";
 			position[]={5202.4297,18.541693,14485.633};
@@ -4823,7 +931,7 @@ class Mission
 			angle=231.22296;
 			id=1110;
 		};
-		class Item55
+		class Item54
 		{
 			dataType="Marker";
 			position[]={3631.2336,7.4565849,13874.588};
@@ -4835,7 +943,7 @@ class Mission
 			angle=231.22296;
 			id=1111;
 		};
-		class Item56
+		class Item55
 		{
 			dataType="Marker";
 			position[]={4386.7471,71.040924,16015.587};
@@ -4847,7 +955,7 @@ class Mission
 			angle=231.22296;
 			id=1112;
 		};
-		class Item57
+		class Item56
 		{
 			dataType="Marker";
 			position[]={5952.9072,236.78763,19864.762};
@@ -4859,7 +967,7 @@ class Mission
 			angle=231.22296;
 			id=1113;
 		};
-		class Item58
+		class Item57
 		{
 			dataType="Marker";
 			position[]={9128.2422,20.68099,22068.809};
@@ -4871,7 +979,7 @@ class Mission
 			angle=231.22296;
 			id=1114;
 		};
-		class Item59
+		class Item58
 		{
 			dataType="Marker";
 			position[]={8409.0273,55.321545,20834.262};
@@ -4883,7 +991,7 @@ class Mission
 			angle=231.22296;
 			id=1115;
 		};
-		class Item60
+		class Item59
 		{
 			dataType="Marker";
 			position[]={9351.292,38.454903,21243.428};
@@ -4895,7 +1003,7 @@ class Mission
 			angle=231.22296;
 			id=1116;
 		};
-		class Item61
+		class Item60
 		{
 			dataType="Marker";
 			position[]={9466.1748,14.863552,21870.887};
@@ -4907,7 +1015,7 @@ class Mission
 			angle=231.22296;
 			id=1117;
 		};
-		class Item62
+		class Item61
 		{
 			dataType="Marker";
 			position[]={8783.5254,99.873222,15788.32};
@@ -4919,7 +1027,7 @@ class Mission
 			angle=231.22296;
 			id=1118;
 		};
-		class Item63
+		class Item62
 		{
 			dataType="Marker";
 			position[]={7240.957,4.4888473,11029.49};
@@ -4931,7 +1039,7 @@ class Mission
 			angle=231.22296;
 			id=1119;
 		};
-		class Item64
+		class Item63
 		{
 			dataType="Marker";
 			position[]={10771.739,3.4747643,10873.154};
@@ -4943,7 +1051,7 @@ class Mission
 			angle=231.22296;
 			id=1120;
 		};
-		class Item65
+		class Item64
 		{
 			dataType="Marker";
 			position[]={10830.928,17.216188,12156.106};
@@ -4955,7 +1063,7 @@ class Mission
 			angle=231.22296;
 			id=1121;
 		};
-		class Item66
+		class Item65
 		{
 			dataType="Marker";
 			position[]={10093.558,18.734219,12919.797};
@@ -4967,7 +1075,7 @@ class Mission
 			angle=231.22296;
 			id=1122;
 		};
-		class Item67
+		class Item66
 		{
 			dataType="Marker";
 			position[]={12377.377,21.578207,15871.573};
@@ -4979,7 +1087,7 @@ class Mission
 			angle=231.22296;
 			id=1123;
 		};
-		class Item68
+		class Item67
 		{
 			dataType="Marker";
 			position[]={11293.307,58.806793,17517.594};
@@ -4991,7 +1099,7 @@ class Mission
 			angle=231.22296;
 			id=1124;
 		};
-		class Item69
+		class Item68
 		{
 			dataType="Marker";
 			position[]={13547.545,19.099752,18669.258};
@@ -5003,7 +1111,7 @@ class Mission
 			angle=231.22296;
 			id=1125;
 		};
-		class Item70
+		class Item69
 		{
 			dataType="Marker";
 			position[]={14299.458,28.614883,19467.055};
@@ -5015,7 +1123,7 @@ class Mission
 			angle=231.22296;
 			id=1126;
 		};
-		class Item71
+		class Item70
 		{
 			dataType="Marker";
 			position[]={13645.276,19.155266,16084.521};
@@ -5028,7 +1136,7 @@ class Mission
 			id=1127;
 			atlOffset=-3.8146973e-006;
 		};
-		class Item72
+		class Item71
 		{
 			dataType="Marker";
 			position[]={15868.175,14.615435,17421.17};
@@ -5040,7 +1148,7 @@ class Mission
 			angle=231.22296;
 			id=1128;
 		};
-		class Item73
+		class Item72
 		{
 			dataType="Marker";
 			position[]={15986.493,8.0299902,16130.729};
@@ -5053,7 +1161,7 @@ class Mission
 			id=1129;
 			atlOffset=3.1471252e-005;
 		};
-		class Item74
+		class Item73
 		{
 			dataType="Marker";
 			position[]={18362.127,19.228302,17342.16};
@@ -5065,7 +1173,7 @@ class Mission
 			angle=231.22296;
 			id=1130;
 		};
-		class Item75
+		class Item74
 		{
 			dataType="Marker";
 			position[]={17490.688,5.5569239,14324.797};
@@ -5077,7 +1185,7 @@ class Mission
 			angle=231.22296;
 			id=1131;
 		};
-		class Item76
+		class Item75
 		{
 			dataType="Marker";
 			position[]={18271.459,27.275703,12900.734};
@@ -5089,7 +1197,7 @@ class Mission
 			angle=231.22296;
 			id=1132;
 		};
-		class Item77
+		class Item76
 		{
 			dataType="Marker";
 			position[]={20228.654,52.020004,9768.0547};
@@ -5101,7 +1209,7 @@ class Mission
 			angle=231.22296;
 			id=1133;
 		};
-		class Item78
+		class Item77
 		{
 			dataType="Marker";
 			position[]={21586.922,14.105127,7801.9902};
@@ -5113,7 +1221,7 @@ class Mission
 			angle=231.22296;
 			id=1134;
 		};
-		class Item79
+		class Item78
 		{
 			dataType="Marker";
 			position[]={20792.029,36.949718,16645.305};
@@ -5125,7 +1233,7 @@ class Mission
 			angle=231.22296;
 			id=1135;
 		};
-		class Item80
+		class Item79
 		{
 			dataType="Marker";
 			position[]={21685.58,22.36945,17643.285};
@@ -5137,7 +1245,7 @@ class Mission
 			angle=231.22296;
 			id=1136;
 		};
-		class Item81
+		class Item80
 		{
 			dataType="Marker";
 			position[]={22971.109,13.492899,19366.07};
@@ -5149,7 +1257,7 @@ class Mission
 			angle=231.22296;
 			id=1137;
 		};
-		class Item82
+		class Item81
 		{
 			dataType="Marker";
 			position[]={24790.133,20.474581,20720.881};
@@ -5161,7 +1269,7 @@ class Mission
 			angle=231.22296;
 			id=1138;
 		};
-		class Item83
+		class Item82
 		{
 			dataType="Marker";
 			position[]={25990.26,24.751326,21568.287};
@@ -5173,7 +1281,7 @@ class Mission
 			angle=231.22296;
 			id=1139;
 		};
-		class Item84
+		class Item83
 		{
 			dataType="Marker";
 			position[]={26981.279,11.84,23830.973};
@@ -5185,7 +1293,7 @@ class Mission
 			angle=231.22296;
 			id=1140;
 		};
-		class Item85
+		class Item84
 		{
 			dataType="Marker";
 			position[]={5931.3213,35.499817,22072.861};
@@ -5198,7 +1306,7 @@ class Mission
 			id=1141;
 			atlOffset=-180.69971;
 		};
-		class Item86
+		class Item85
 		{
 			dataType="Marker";
 			position[]={4078.9751,133.23485,22090.877};
@@ -5210,7 +1318,7 @@ class Mission
 			angle=231.22296;
 			id=1142;
 		};
-		class Item87
+		class Item86
 		{
 			dataType="Marker";
 			position[]={3876.7268,150.10907,21272.254};
@@ -5222,7 +1330,7 @@ class Mission
 			angle=231.22296;
 			id=1143;
 		};
-		class Item88
+		class Item87
 		{
 			dataType="Marker";
 			position[]={7787.8447,98.140869,21684.877};
@@ -5235,7 +1343,7 @@ class Mission
 			id=1144;
 			atlOffset=-25.776688;
 		};
-		class Item89
+		class Item88
 		{
 			dataType="Marker";
 			position[]={3261.9119,122.53696,19385.77};
@@ -5248,7 +1356,7 @@ class Mission
 			id=1145;
 			atlOffset=-42.672791;
 		};
-		class Item90
+		class Item89
 		{
 			dataType="Marker";
 			position[]={4095.1401,290.75259,19930.941};
@@ -5260,7 +1368,7 @@ class Mission
 			angle=231.22296;
 			id=1146;
 		};
-		class Item91
+		class Item90
 		{
 			dataType="Marker";
 			position[]={5528.4966,173.61342,21299.682};
@@ -5272,7 +1380,7 @@ class Mission
 			angle=231.22296;
 			id=1147;
 		};
-		class Item92
+		class Item91
 		{
 			dataType="Marker";
 			position[]={8185.0068,83.494675,22893.648};
@@ -5284,7 +1392,7 @@ class Mission
 			angle=231.22296;
 			id=1148;
 		};
-		class Item93
+		class Item92
 		{
 			dataType="Marker";
 			position[]={14258.698,96.381104,22076.549};
@@ -5297,7 +1405,7 @@ class Mission
 			id=1149;
 			atlOffset=24.824684;
 		};
-		class Item94
+		class Item93
 		{
 			dataType="Marker";
 			position[]={8006.2344,70.981575,20042.875};
@@ -5309,7 +1417,7 @@ class Mission
 			angle=231.22296;
 			id=1150;
 		};
-		class Item95
+		class Item94
 		{
 			dataType="Marker";
 			position[]={5771.7959,189.49142,19094.035};
@@ -5321,7 +1429,7 @@ class Mission
 			angle=231.22296;
 			id=1151;
 		};
-		class Item96
+		class Item95
 		{
 			dataType="Marker";
 			position[]={11738.693,45.491325,8850.6113};
@@ -5333,7 +1441,7 @@ class Mission
 			angle=231.22296;
 			id=1152;
 		};
-		class Item97
+		class Item96
 		{
 			dataType="Marker";
 			position[]={21060.4,1.3683789,14717.646};
@@ -5346,7 +1454,7 @@ class Mission
 			id=1153;
 			atlOffset=-3.4213066e-005;
 		};
-		class Item98
+		class Item97
 		{
 			dataType="Marker";
 			position[]={17992.082,69.924828,10671.903};
@@ -5358,7 +1466,7 @@ class Mission
 			angle=231.22296;
 			id=1154;
 		};
-		class Item99
+		class Item98
 		{
 			dataType="Marker";
 			position[]={22960.973,24.957481,21887.336};
@@ -5370,7 +1478,7 @@ class Mission
 			angle=231.22296;
 			id=1155;
 		};
-		class Item100
+		class Item99
 		{
 			dataType="Marker";
 			position[]={24232.799,66.273628,21795.674};
@@ -5382,7 +1490,7 @@ class Mission
 			angle=231.22296;
 			id=1156;
 		};
-		class Item101
+		class Item100
 		{
 			dataType="Marker";
 			position[]={23923.436,45.721985,22723.762};
@@ -5394,7 +1502,7 @@ class Mission
 			angle=231.22296;
 			id=1157;
 		};
-		class Item102
+		class Item101
 		{
 			dataType="Marker";
 			position[]={24347.379,25.81115,23560.189};
@@ -5406,7 +1514,7 @@ class Mission
 			angle=231.22296;
 			id=1158;
 		};
-		class Item103
+		class Item102
 		{
 			dataType="Marker";
 			position[]={28045.74,39.501999,25409.574};
@@ -5419,7 +1527,7 @@ class Mission
 			id=1159;
 			atlOffset=0.00048828125;
 		};
-		class Item104
+		class Item103
 		{
 			dataType="Marker";
 			position[]={25963.797,66.576874,22488.859};
@@ -5431,7 +1539,7 @@ class Mission
 			angle=231.22296;
 			id=1160;
 		};
-		class Item105
+		class Item104
 		{
 			dataType="Marker";
 			position[]={8799.5547,129.67937,15250.9};
@@ -5443,7 +1551,7 @@ class Mission
 			angle=231.22296;
 			id=1161;
 		};
-		class Item106
+		class Item105
 		{
 			dataType="Marker";
 			position[]={10822.622,106.28155,15025.045};
@@ -5455,7 +1563,7 @@ class Mission
 			angle=231.22296;
 			id=1162;
 		};
-		class Item107
+		class Item106
 		{
 			dataType="Marker";
 			position[]={6641.7202,132.51106,12197.677};
@@ -5467,7 +1575,7 @@ class Mission
 			angle=231.22296;
 			id=1163;
 		};
-		class Item108
+		class Item107
 		{
 			dataType="Marker";
 			position[]={9522.5645,52.498535,7532.7705};
@@ -5480,7 +1588,7 @@ class Mission
 			id=1165;
 			atlOffset=-6.007225;
 		};
-		class Item109
+		class Item108
 		{
 			dataType="Marker";
 			position[]={23662.633,5.3028078,16239.605};
@@ -5492,7 +1600,7 @@ class Mission
 			angle=231.22296;
 			id=1166;
 		};
-		class Item110
+		class Item109
 		{
 			dataType="Marker";
 			position[]={3376.6011,0,12753.058};
@@ -5501,7 +1609,7 @@ class Mission
 			id=1167;
 			atlOffset=2.941112;
 		};
-		class Item111
+		class Item110
 		{
 			dataType="Marker";
 			position[]={3535.1458,2.8441161e-009,13774.347};
@@ -5510,7 +1618,7 @@ class Mission
 			id=1168;
 			atlOffset=1.2454736;
 		};
-		class Item112
+		class Item111
 		{
 			dataType="Marker";
 			position[]={3807.0403,8.2976584e-008,17341.869};
@@ -5519,7 +1627,7 @@ class Mission
 			id=1169;
 			atlOffset=4.6103921;
 		};
-		class Item113
+		class Item112
 		{
 			dataType="Marker";
 			position[]={16582.131,0,12303.811};
@@ -5528,7 +1636,7 @@ class Mission
 			id=1170;
 			atlOffset=8.3859863;
 		};
-		class Item114
+		class Item113
 		{
 			dataType="Marker";
 			position[]={12749.965,2.2184195e-006,14198.212};
@@ -5537,7 +1645,7 @@ class Mission
 			id=1171;
 			atlOffset=9.9826164;
 		};
-		class Item115
+		class Item114
 		{
 			dataType="Marker";
 			position[]={11837.512,-2.1113763e-006,13530.187};
@@ -5546,7 +1654,7 @@ class Mission
 			id=1172;
 			atlOffset=4.5436969;
 		};
-		class Item116
+		class Item115
 		{
 			dataType="Marker";
 			position[]={2255.782,0,13234.797};
@@ -5556,7 +1664,7 @@ class Mission
 			id=1174;
 			atlOffset=126.38051;
 		};
-		class Item117
+		class Item116
 		{
 			dataType="Marker";
 			position[]={3172.9761,2.8623674e-008,16757.107};
@@ -5566,7 +1674,7 @@ class Mission
 			id=1176;
 			atlOffset=107.35194;
 		};
-		class Item118
+		class Item117
 		{
 			dataType="Marker";
 			position[]={19879.293,0,21958.814};
@@ -5576,7 +1684,7 @@ class Mission
 			id=1177;
 			atlOffset=171.26703;
 		};
-		class Item119
+		class Item118
 		{
 			dataType="Marker";
 			position[]={25805.57,0,25990.992};
@@ -5586,7 +1694,7 @@ class Mission
 			id=1178;
 			atlOffset=178.77411;
 		};
-		class Item120
+		class Item119
 		{
 			dataType="Marker";
 			position[]={24006.145,-6.4275355e-008,6603.1455};
@@ -5596,7 +1704,7 @@ class Mission
 			id=1179;
 			atlOffset=180.55885;
 		};
-		class Item121
+		class Item120
 		{
 			dataType="Marker";
 			position[]={15241.775,0,13870.712};
@@ -5606,7 +1714,7 @@ class Mission
 			id=1180;
 			atlOffset=67.766624;
 		};
-		class Item122
+		class Item121
 		{
 			dataType="Marker";
 			position[]={13681.933,-8.68244e-008,10426.626};
@@ -5616,7 +1724,7 @@ class Mission
 			id=1181;
 			atlOffset=141.36031;
 		};
-		class Item123
+		class Item122
 		{
 			dataType="Marker";
 			position[]={3239.0374,7.4641165e-010,12861.445};
@@ -5625,7 +1733,7 @@ class Mission
 			id=1184;
 			atlOffset=8.8429317;
 		};
-		class Item124
+		class Item123
 		{
 			dataType="Marker";
 			position[]={20649.865,0,19497.082};
@@ -5634,7 +1742,7 @@ class Mission
 			id=1185;
 			atlOffset=2.1248169;
 		};
-		class Item125
+		class Item124
 		{
 			dataType="Marker";
 			position[]={27619.545,1.5190345e-008,24543.322};
@@ -5643,7 +1751,7 @@ class Mission
 			id=1186;
 			atlOffset=5.0577831;
 		};
-		class Item126
+		class Item125
 		{
 			dataType="Marker";
 			position[]={15382.954,-4.1486221e-008,15813.717};
@@ -5652,7 +1760,7 @@ class Mission
 			id=1187;
 			atlOffset=6.1902537;
 		};
-		class Item127
+		class Item126
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5667,7 +1775,7 @@ class Mission
 			id=1188;
 			type="Land_Airport_Tower_F";
 		};
-		class Item128
+		class Item127
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5683,7 +1791,7 @@ class Mission
 			id=1200;
 			type="Land_Hangar_F";
 		};
-		class Item129
+		class Item128
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5700,7 +1808,7 @@ class Mission
 			type="Land_Cargo_HQ_V1_F";
 			atlOffset=0.3626709;
 		};
-		class Item130
+		class Item129
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5716,7 +1824,7 @@ class Mission
 			id=1237;
 			type="Land_Cargo_HQ_V1_F";
 		};
-		class Item131
+		class Item130
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5733,7 +1841,7 @@ class Mission
 			type="Land_Cargo_HQ_V1_F";
 			atlOffset=1.0188999;
 		};
-		class Item132
+		class Item131
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5818,7 +1926,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item133
+		class Item132
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5834,7 +1942,7 @@ class Mission
 			id=1244;
 			type="Land_Cargo_HQ_V1_F";
 		};
-		class Item134
+		class Item133
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5851,7 +1959,7 @@ class Mission
 			type="Land_Cargo_HQ_V1_F";
 			atlOffset=9.5367432e-006;
 		};
-		class Item135
+		class Item134
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5867,7 +1975,7 @@ class Mission
 			id=1262;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item136
+		class Item135
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5883,7 +1991,7 @@ class Mission
 			id=1264;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item137
+		class Item136
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5899,7 +2007,7 @@ class Mission
 			id=1265;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item138
+		class Item137
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5915,7 +2023,7 @@ class Mission
 			id=1271;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item139
+		class Item138
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5931,7 +2039,7 @@ class Mission
 			id=1273;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item140
+		class Item139
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5948,7 +2056,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item141
+		class Item140
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5965,7 +2073,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=2.0980835e-005;
 		};
-		class Item142
+		class Item141
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5981,7 +2089,7 @@ class Mission
 			type="Land_Cargo_Tower_V1_F";
 			atlOffset=-0.0099000931;
 		};
-		class Item143
+		class Item142
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5998,7 +2106,7 @@ class Mission
 			type="Land_Cargo_Tower_V1_F";
 			atlOffset=-0.017017365;
 		};
-		class Item144
+		class Item143
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6015,7 +2123,7 @@ class Mission
 			type="Land_Cargo_Tower_V1_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item145
+		class Item144
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6032,7 +2140,7 @@ class Mission
 			type="Land_Cargo_Tower_V1_F";
 			atlOffset=-1.011385;
 		};
-		class Item146
+		class Item145
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6048,7 +2156,7 @@ class Mission
 			type="Land_Cargo_Tower_V1_F";
 			atlOffset=-1.9073486e-006;
 		};
-		class Item147
+		class Item146
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6065,7 +2173,7 @@ class Mission
 			type="Land_TentHangar_V1_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item148
+		class Item147
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6082,7 +2190,7 @@ class Mission
 			type="Land_TentHangar_V1_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item149
+		class Item148
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6099,7 +2207,7 @@ class Mission
 			type="Land_TentHangar_V1_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item150
+		class Item149
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6115,7 +2223,7 @@ class Mission
 			id=1332;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item151
+		class Item150
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6131,7 +2239,7 @@ class Mission
 			id=1336;
 			type="Land_Airport_01_hangar_F";
 		};
-		class Item152
+		class Item151
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6147,7 +2255,7 @@ class Mission
 			id=1337;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item153
+		class Item152
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6163,7 +2271,7 @@ class Mission
 			id=1338;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item154
+		class Item153
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6180,7 +2288,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=1.4176254;
 		};
-		class Item155
+		class Item154
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6197,7 +2305,7 @@ class Mission
 			type="Land_Airport_Tower_F";
 			atlOffset=0.48480988;
 		};
-		class Item156
+		class Item155
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6213,7 +2321,7 @@ class Mission
 			id=1343;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item157
+		class Item156
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6229,7 +2337,7 @@ class Mission
 			id=1344;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item158
+		class Item157
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6245,7 +2353,7 @@ class Mission
 			id=1345;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item159
+		class Item158
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6261,7 +2369,7 @@ class Mission
 			id=1346;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item160
+		class Item159
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6277,7 +2385,7 @@ class Mission
 			id=1347;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item161
+		class Item160
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6293,7 +2401,7 @@ class Mission
 			id=1350;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item162
+		class Item161
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6309,7 +2417,7 @@ class Mission
 			id=1351;
 			type="Land_Cargo_Tower_V1_F";
 		};
-		class Item163
+		class Item162
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6325,7 +2433,7 @@ class Mission
 			id=1357;
 			type="Land_Cargo_HQ_V1_F";
 		};
-		class Item164
+		class Item163
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6341,7 +2449,7 @@ class Mission
 			id=1358;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item165
+		class Item164
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6382,7 +2490,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item166
+		class Item165
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6399,7 +2507,7 @@ class Mission
 			type="Flag_NATO_F";
 			atlOffset=-0.6429987;
 		};
-		class Item167
+		class Item166
 		{
 			dataType="Marker";
 			position[]={13537.383,17.984203,12063.334};
@@ -6408,7 +2516,7 @@ class Mission
 			id=1390;
 			atlOffset=4.0483103;
 		};
-		class Item168
+		class Item167
 		{
 			dataType="Group";
 			side="West";
@@ -6791,7 +2899,7 @@ class Mission
 			};
 			id=1406;
 		};
-		class Item169
+		class Item168
 		{
 			dataType="Marker";
 			position[]={10027.582,17.59524,12814.658};
@@ -6800,7 +2908,7 @@ class Mission
 			angle=227.508;
 			id=1440;
 		};
-		class Item170
+		class Item169
 		{
 			dataType="Marker";
 			position[]={8780.8975,35.592316,12043.754};
@@ -6809,7 +2917,7 @@ class Mission
 			angle=223.50795;
 			id=1441;
 		};
-		class Item171
+		class Item170
 		{
 			dataType="Marker";
 			position[]={7336.4771,16.04541,11418.288};
@@ -6819,7 +2927,7 @@ class Mission
 			id=1442;
 			atlOffset=3.2962132;
 		};
-		class Item172
+		class Item171
 		{
 			dataType="Marker";
 			position[]={10432.575,14.689998,11982.5};
@@ -6828,7 +2936,7 @@ class Mission
 			angle=227.508;
 			id=1445;
 		};
-		class Item173
+		class Item172
 		{
 			dataType="Marker";
 			position[]={9615.0332,12.606598,11695.909};
@@ -6838,7 +2946,7 @@ class Mission
 			id=1446;
 			atlOffset=0.63069153;
 		};
-		class Item174
+		class Item173
 		{
 			dataType="Marker";
 			position[]={11034.368,63.11581,12973.104};
@@ -6848,7 +2956,7 @@ class Mission
 			id=1443;
 			atlOffset=43.66288;
 		};
-		class Item175
+		class Item174
 		{
 			dataType="Marker";
 			position[]={11738.429,13.323238,13913.249};
@@ -6857,7 +2965,7 @@ class Mission
 			angle=26.564579;
 			id=1447;
 		};
-		class Item176
+		class Item175
 		{
 			dataType="Marker";
 			position[]={13483.127,15.282019,16028.804};
@@ -6866,7 +2974,7 @@ class Mission
 			angle=254.67212;
 			id=1448;
 		};
-		class Item177
+		class Item176
 		{
 			dataType="Marker";
 			position[]={12479.82,32.146729,15886.568};
@@ -6876,7 +2984,7 @@ class Mission
 			id=1450;
 			atlOffset=12.854931;
 		};
-		class Item178
+		class Item177
 		{
 			dataType="Marker";
 			position[]={14286.374,17.269678,18161.129};
@@ -6885,7 +2993,7 @@ class Mission
 			angle=333.82483;
 			id=1451;
 		};
-		class Item179
+		class Item178
 		{
 			dataType="Marker";
 			position[]={14310.426,26.728813,19600.521};
@@ -6894,7 +3002,7 @@ class Mission
 			angle=14.435917;
 			id=1452;
 		};
-		class Item180
+		class Item179
 		{
 			dataType="Marker";
 			position[]={14772.154,14.778986,17175.191};
@@ -6903,7 +3011,7 @@ class Mission
 			angle=53.226994;
 			id=1453;
 		};
-		class Item181
+		class Item180
 		{
 			dataType="Marker";
 			position[]={16953.045,16.280811,17813.107};
@@ -6912,7 +3020,7 @@ class Mission
 			angle=64.545609;
 			id=1454;
 		};
-		class Item182
+		class Item181
 		{
 			dataType="Marker";
 			position[]={15896.649,11.202651,16178.266};
@@ -6921,7 +3029,7 @@ class Mission
 			angle=120.79032;
 			id=1455;
 		};
-		class Item183
+		class Item182
 		{
 			dataType="Marker";
 			position[]={17469.98,4.3621092,14443.852};
@@ -6930,7 +3038,7 @@ class Mission
 			angle=148.54735;
 			id=1456;
 		};
-		class Item184
+		class Item183
 		{
 			dataType="Marker";
 			position[]={17045.52,15.683575,12893.139};
@@ -6939,7 +3047,7 @@ class Mission
 			angle=227.508;
 			id=1457;
 		};
-		class Item185
+		class Item184
 		{
 			dataType="Marker";
 			position[]={9380.7666,47.546509,21152.375};
@@ -6948,7 +3056,7 @@ class Mission
 			angle=155.2245;
 			id=1458;
 		};
-		class Item186
+		class Item185
 		{
 			dataType="Marker";
 			position[]={9718.4492,183.56577,19929.207};
@@ -6957,7 +3065,7 @@ class Mission
 			angle=117.23835;
 			id=1459;
 		};
-		class Item187
+		class Item186
 		{
 			dataType="Marker";
 			position[]={9819.0234,94.69236,18539.961};
@@ -6966,7 +3074,7 @@ class Mission
 			angle=227.508;
 			id=1460;
 		};
-		class Item188
+		class Item187
 		{
 			dataType="Marker";
 			position[]={7528.1772,171.76268,17280.842};
@@ -6975,7 +3083,7 @@ class Mission
 			angle=227.508;
 			id=1462;
 		};
-		class Item189
+		class Item188
 		{
 			dataType="Marker";
 			position[]={6922.4834,188.9752,19240.162};
@@ -6984,7 +3092,7 @@ class Mission
 			angle=1.5074006;
 			id=1463;
 		};
-		class Item190
+		class Item189
 		{
 			dataType="Marker";
 			position[]={5246.1899,230.57468,20359.127};
@@ -6993,7 +3101,7 @@ class Mission
 			angle=284.62128;
 			id=1464;
 		};
-		class Item191
+		class Item190
 		{
 			dataType="Marker";
 			position[]={21951.461,14.131549,7363.1597};
@@ -7002,7 +3110,7 @@ class Mission
 			angle=128.61185;
 			id=1465;
 		};
-		class Item192
+		class Item191
 		{
 			dataType="Marker";
 			position[]={21274.943,15.456692,8186.6035};
@@ -7011,7 +3119,7 @@ class Mission
 			angle=317.16461;
 			id=1466;
 		};
-		class Item193
+		class Item192
 		{
 			dataType="Marker";
 			position[]={20046.328,55.846924,8865.0693};
@@ -7020,7 +3128,7 @@ class Mission
 			angle=290.07159;
 			id=1467;
 		};
-		class Item194
+		class Item193
 		{
 			dataType="Marker";
 			position[]={20573.68,19.865625,10695.808};
@@ -7029,7 +3137,7 @@ class Mission
 			angle=354.21683;
 			id=1468;
 		};
-		class Item195
+		class Item194
 		{
 			dataType="Marker";
 			position[]={22282.488,15.448867,18421.662};
@@ -7038,7 +3146,7 @@ class Mission
 			angle=227.508;
 			id=1469;
 		};
-		class Item196
+		class Item195
 		{
 			dataType="Marker";
 			position[]={21706.1,22.576994,17678.889};
@@ -7047,7 +3155,7 @@ class Mission
 			angle=213.26985;
 			id=1470;
 		};
-		class Item197
+		class Item196
 		{
 			dataType="Marker";
 			position[]={21005.709,35.480789,17676.527};
@@ -7056,7 +3164,7 @@ class Mission
 			angle=2.0592506;
 			id=1471;
 		};
-		class Item198
+		class Item197
 		{
 			dataType="Marker";
 			position[]={20651.492,34.118702,18726.168};
@@ -7065,7 +3173,7 @@ class Mission
 			angle=353.88327;
 			id=1472;
 		};
-		class Item199
+		class Item198
 		{
 			dataType="Marker";
 			position[]={20633.316,30.614683,16457.666};
@@ -7074,7 +3182,7 @@ class Mission
 			angle=227.508;
 			id=1473;
 		};
-		class Item200
+		class Item199
 		{
 			dataType="Marker";
 			position[]={19814.211,16.058229,15687.382};
@@ -7083,7 +3191,7 @@ class Mission
 			angle=227.508;
 			id=1474;
 		};
-		class Item201
+		class Item200
 		{
 			dataType="Marker";
 			position[]={23162.15,14.283377,19607.332};
@@ -7092,7 +3200,7 @@ class Mission
 			angle=34.257725;
 			id=1475;
 		};
-		class Item202
+		class Item201
 		{
 			dataType="Marker";
 			position[]={22555.17,27.099434,20589.469};
@@ -7101,7 +3209,7 @@ class Mission
 			angle=335.03088;
 			id=1476;
 		};
-		class Item203
+		class Item202
 		{
 			dataType="Marker";
 			position[]={23029.904,51.844334,21113.5};
@@ -7110,7 +3218,7 @@ class Mission
 			angle=63.785625;
 			id=1477;
 		};
-		class Item204
+		class Item203
 		{
 			dataType="Marker";
 			position[]={24637.473,21.285206,20648.904};
@@ -7119,7 +3227,7 @@ class Mission
 			angle=57.619133;
 			id=1478;
 		};
-		class Item205
+		class Item204
 		{
 			dataType="Marker";
 			position[]={25174.367,14.661154,20623.25};
@@ -7128,7 +3236,7 @@ class Mission
 			angle=127.69429;
 			id=1479;
 		};
-		class Item206
+		class Item205
 		{
 			dataType="Marker";
 			position[]={25325.771,17.582952,21110.881};
@@ -7137,7 +3245,7 @@ class Mission
 			angle=334.7471;
 			id=1480;
 		};
-		class Item207
+		class Item206
 		{
 			dataType="Marker";
 			position[]={24739.473,75.226112,21810.691};
@@ -7146,7 +3254,7 @@ class Mission
 			angle=69.393608;
 			id=1481;
 		};
-		class Item208
+		class Item207
 		{
 			dataType="Marker";
 			position[]={26280.432,40.25845,21788.68};
@@ -7155,7 +3263,7 @@ class Mission
 			angle=52.54501;
 			id=1482;
 		};
-		class Item209
+		class Item208
 		{
 			dataType="Marker";
 			position[]={26493.066,20.179955,21324.83};
@@ -7164,7 +3272,7 @@ class Mission
 			angle=113.11586;
 			id=1483;
 		};
-		class Item210
+		class Item209
 		{
 			dataType="Marker";
 			position[]={27080.533,11.835176,24018.773};
@@ -7174,7 +3282,7 @@ class Mission
 			id=1484;
 			atlOffset=9.5367432e-007;
 		};
-		class Item211
+		class Item210
 		{
 			dataType="Marker";
 			position[]={26716.645,23.527546,22928.643};
@@ -7183,7 +3291,7 @@ class Mission
 			angle=227.508;
 			id=1485;
 		};
-		class Item212
+		class Item211
 		{
 			dataType="Marker";
 			position[]={8431.4795,115.94597,25108.053};
@@ -7192,7 +3300,7 @@ class Mission
 			id=1486;
 			atlOffset=5.421051;
 		};
-		class Item213
+		class Item212
 		{
 			dataType="Group";
 			side="East";
@@ -7569,7 +3677,7 @@ class Mission
 			id=1487;
 			atlOffset=7.6293945e-006;
 		};
-		class Item214
+		class Item213
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7586,7 +3694,7 @@ class Mission
 			id=1496;
 			type="Flag_Viper_F";
 		};
-		class Item215
+		class Item214
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -7600,7 +3708,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=1.1444092e-005;
 		};
-		class Item216
+		class Item215
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -7614,7 +3722,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item217
+		class Item216
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -7704,7 +3812,7 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item218
+		class Item217
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7745,7 +3853,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item219
+		class Item218
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -7757,7 +3865,7 @@ class Mission
 			type="Logic";
 			atlOffset=9.5367432e-007;
 		};
-		class Item220
+		class Item219
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7769,11 +3877,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1563;
 			type="Land_HelipadCircle_F";
+			atlOffset=-1.9073486e-006;
 		};
-		class Item221
+		class Item220
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7785,11 +3895,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1564;
 			type="Land_HelipadCircle_F";
 		};
-		class Item222
+		class Item221
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7801,12 +3912,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1565;
 			type="Land_HelipadCircle_F";
 			atlOffset=3.2424927e-005;
 		};
-		class Item223
+		class Item222
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7822,7 +3934,7 @@ class Mission
 			id=1567;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item224
+		class Item223
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7838,7 +3950,7 @@ class Mission
 			id=1568;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item225
+		class Item224
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7850,11 +3962,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1575;
 			type="Land_HelipadCircle_F";
 		};
-		class Item226
+		class Item225
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7866,11 +3979,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1576;
 			type="Land_HelipadCircle_F";
 		};
-		class Item227
+		class Item226
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7882,12 +3996,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1577;
 			type="Land_HelipadCircle_F";
 			atlOffset=5.7220459e-006;
 		};
-		class Item228
+		class Item227
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7899,11 +4014,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1578;
 			type="Land_HelipadCircle_F";
 		};
-		class Item229
+		class Item228
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7919,7 +4035,7 @@ class Mission
 			id=1585;
 			type="Land_Hangar_F";
 		};
-		class Item230
+		class Item229
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7931,11 +4047,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1587;
 			type="Land_HelipadCircle_F";
 		};
-		class Item231
+		class Item230
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7947,11 +4064,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1588;
 			type="Land_HelipadCircle_F";
 		};
-		class Item232
+		class Item231
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7963,11 +4081,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1589;
 			type="Land_HelipadCircle_F";
 		};
-		class Item233
+		class Item232
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7979,11 +4098,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1590;
 			type="Land_HelipadCircle_F";
 		};
-		class Item234
+		class Item233
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7995,11 +4115,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1591;
 			type="Land_HelipadCircle_F";
 		};
-		class Item235
+		class Item234
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8015,7 +4136,7 @@ class Mission
 			id=1592;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item236
+		class Item235
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8032,7 +4153,7 @@ class Mission
 			type="Land_TentHangar_V1_F";
 			atlOffset=-0.41318321;
 		};
-		class Item237
+		class Item236
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8049,7 +4170,7 @@ class Mission
 			type="Land_TentHangar_V1_F";
 			atlOffset=1.1444092e-005;
 		};
-		class Item238
+		class Item237
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8061,12 +4182,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1599;
 			type="Land_HelipadCircle_F";
 			atlOffset=6.4849854e-005;
 		};
-		class Item239
+		class Item238
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8078,11 +4200,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1600;
 			type="Land_HelipadCircle_F";
+			atlOffset=-1.9073486e-005;
 		};
-		class Item240
+		class Item239
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8094,11 +4218,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1606;
 			type="Land_HelipadSquare_F";
 		};
-		class Item241
+		class Item240
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8110,11 +4235,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1610;
 			type="Land_HelipadSquare_F";
+			atlOffset=-0.00021743774;
 		};
-		class Item242
+		class Item241
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8126,11 +4253,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1611;
 			type="Land_HelipadSquare_F";
 		};
-		class Item243
+		class Item242
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8142,11 +4270,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1617;
 			type="Land_HelipadCircle_F";
 		};
-		class Item244
+		class Item243
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8158,11 +4287,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1618;
 			type="Land_HelipadCircle_F";
 		};
-		class Item245
+		class Item244
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8174,11 +4304,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1619;
 			type="Land_HelipadCircle_F";
 		};
-		class Item246
+		class Item245
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8190,11 +4321,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1620;
 			type="Land_HelipadCircle_F";
 		};
-		class Item247
+		class Item246
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8206,11 +4338,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1621;
 			type="Land_HelipadCircle_F";
 		};
-		class Item248
+		class Item247
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8222,12 +4355,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1622;
 			type="Land_HelipadCircle_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item249
+		class Item248
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8239,11 +4373,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1623;
 			type="Land_HelipadSquare_F";
 		};
-		class Item250
+		class Item249
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8255,11 +4390,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1624;
 			type="Land_HelipadSquare_F";
 		};
-		class Item251
+		class Item250
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8271,11 +4407,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1625;
 			type="Land_HelipadSquare_F";
 		};
-		class Item252
+		class Item251
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8287,11 +4424,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1631;
 			type="Land_HelipadCircle_F";
 		};
-		class Item253
+		class Item252
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8302,12 +4440,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1632;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.27338982;
 		};
-		class Item254
+		class Item253
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8319,11 +4458,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1633;
 			type="Land_HelipadCircle_F";
+			atlOffset=-1.9073486e-006;
 		};
-		class Item255
+		class Item254
 		{
 			dataType="Layer";
 			name="Airports";
@@ -8472,7 +4613,7 @@ class Mission
 					colorName="ColorGreen";
 					a=35.460999;
 					b=6;
-					angle=225.25763;
+					angle=225.25757;
 					id=1626;
 				};
 				class Item11
@@ -8646,7 +4787,7 @@ class Mission
 			id=1636;
 			atlOffset=-25.965174;
 		};
-		class Item256
+		class Item255
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8658,12 +4799,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1648;
 			type="Land_HelipadCircle_F";
 			atlOffset=2.2888184e-005;
 		};
-		class Item257
+		class Item256
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8675,11 +4817,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1652;
 			type="Land_HelipadCircle_F";
+			atlOffset=-3.0517578e-005;
 		};
-		class Item258
+		class Item257
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8690,12 +4834,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1656;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.64629745;
 		};
-		class Item259
+		class Item258
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8707,11 +4852,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1657;
 			type="Land_HelipadCircle_F";
 		};
-		class Item260
+		class Item259
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8723,11 +4869,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1660;
 			type="Land_HelipadCircle_F";
 		};
-		class Item261
+		class Item260
 		{
 			dataType="Layer";
 			name="Factories";
@@ -8880,7 +5027,7 @@ class Mission
 					colorName="ColorGreen";
 					a=15.529018;
 					b=5.5;
-					angle=56.9062;
+					angle=56.906185;
 					id=1646;
 					atlOffset=-0.15297318;
 				};
@@ -9163,7 +5310,7 @@ class Mission
 			id=1662;
 			atlOffset=-46.166866;
 		};
-		class Item262
+		class Item261
 		{
 			dataType="Layer";
 			name="Resources";
@@ -9234,7 +5381,7 @@ class Mission
 					colorName="ColorGreen";
 					a=19.902;
 					b=5.5;
-					angle=56.794914;
+					angle=56.794899;
 					id=1668;
 					atlOffset=-0.00017929077;
 				};
@@ -9406,7 +5553,7 @@ class Mission
 			id=1672;
 			atlOffset=-116.46241;
 		};
-		class Item263
+		class Item262
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9418,11 +5565,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1674;
 			type="Land_HelipadCircle_F";
 		};
-		class Item264
+		class Item263
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9434,11 +5582,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1677;
 			type="Land_HelipadCircle_F";
+			atlOffset=-0.66293097;
 		};
-		class Item265
+		class Item264
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9450,11 +5600,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1680;
 			type="Land_HelipadCircle_F";
 		};
-		class Item266
+		class Item265
 		{
 			dataType="Layer";
 			name="Seaports";
@@ -9605,7 +5756,7 @@ class Mission
 			id=1683;
 			atlOffset=39.728893;
 		};
-		class Item267
+		class Item266
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9617,11 +5768,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1685;
 			type="Land_HelipadCircle_F";
+			atlOffset=-1.9073486e-005;
 		};
-		class Item268
+		class Item267
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9633,11 +5786,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1686;
 			type="Land_HelipadCircle_F";
 		};
-		class Item269
+		class Item268
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9648,12 +5802,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1688;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.73409367;
 		};
-		class Item270
+		class Item269
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9665,11 +5820,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1689;
 			type="Land_HelipadCircle_F";
 		};
-		class Item271
+		class Item270
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9681,12 +5837,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1691;
 			type="Land_HelipadCircle_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item272
+		class Item271
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9698,11 +5855,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1692;
 			type="Land_HelipadCircle_F";
+			atlOffset=-1.1444092e-005;
 		};
-		class Item273
+		class Item272
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9713,12 +5872,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1695;
 			type="Land_HelipadSquare_F";
 			atlOffset=1.3027191;
 		};
-		class Item274
+		class Item273
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9730,11 +5890,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1698;
 			type="Land_HelipadCircle_F";
+			atlOffset=-3.0517578e-005;
 		};
-		class Item275
+		class Item274
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9746,11 +5908,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1699;
 			type="Land_HelipadCircle_F";
 		};
-		class Item276
+		class Item275
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9762,11 +5925,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1703;
 			type="Land_HelipadCircle_F";
 		};
-		class Item277
+		class Item276
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9777,12 +5941,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1705;
 			type="Land_HelipadCircle_F";
 			atlOffset=2.0363579;
 		};
-		class Item278
+		class Item277
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9794,12 +5959,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1707;
 			type="Land_HelipadCircle_F";
 			atlOffset=1.7166138e-005;
 		};
-		class Item279
+		class Item278
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9811,12 +5977,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1708;
 			type="Land_HelipadCircle_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item280
+		class Item279
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9828,11 +5995,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1710;
 			type="Land_HelipadCircle_F";
 		};
-		class Item281
+		class Item280
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9844,11 +6012,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1715;
 			type="Land_HelipadCircle_F";
+			atlOffset=-1.5258789e-005;
 		};
-		class Item282
+		class Item281
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9860,11 +6030,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1716;
 			type="Land_HelipadCircle_F";
+			atlOffset=-1.5258789e-005;
 		};
-		class Item283
+		class Item282
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9875,12 +6047,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1718;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.56990051;
 		};
-		class Item284
+		class Item283
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9892,12 +6065,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1719;
 			type="Land_HelipadCircle_F";
 			atlOffset=9.1552734e-005;
 		};
-		class Item285
+		class Item284
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9909,11 +6083,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1721;
 			type="Land_HelipadCircle_F";
+			atlOffset=-3.8146973e-005;
 		};
-		class Item286
+		class Item285
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9925,11 +6101,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1722;
 			type="Land_HelipadCircle_F";
+			atlOffset=-7.6293945e-006;
 		};
-		class Item287
+		class Item286
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9941,11 +6119,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1724;
 			type="Land_HelipadCircle_F";
+			atlOffset=-0.00043487549;
 		};
-		class Item288
+		class Item287
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9957,12 +6137,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1727;
 			type="Land_HelipadCircle_F";
 			atlOffset=1.6212463e-005;
 		};
-		class Item289
+		class Item288
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9974,11 +6155,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1728;
 			type="Land_HelipadCircle_F";
+			atlOffset=-2.8610229e-005;
 		};
-		class Item290
+		class Item289
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9990,11 +6173,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1729;
 			type="Land_HelipadCircle_F";
 		};
-		class Item291
+		class Item290
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10006,11 +6190,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1730;
 			type="Land_HelipadCircle_F";
 		};
-		class Item292
+		class Item291
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10022,12 +6207,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1734;
 			type="Land_HelipadSquare_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item293
+		class Item292
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10038,12 +6224,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1735;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.37651825;
 		};
-		class Item294
+		class Item293
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10054,12 +6241,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1736;
 			type="Land_HelipadSquare_F";
 			atlOffset=1.1153603;
 		};
-		class Item295
+		class Item294
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10070,12 +6258,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1737;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.3127594;
 		};
-		class Item296
+		class Item295
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10087,11 +6276,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1742;
 			type="Land_HelipadCircle_F";
 		};
-		class Item297
+		class Item296
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10103,11 +6293,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1744;
 			type="Land_HelipadSquare_F";
 		};
-		class Item298
+		class Item297
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10119,11 +6310,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1747;
 			type="Land_HelipadCircle_F";
 		};
-		class Item299
+		class Item298
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10135,11 +6327,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1748;
 			type="Land_HelipadCircle_F";
 		};
-		class Item300
+		class Item299
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10151,11 +6344,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1752;
 			type="Land_HelipadCircle_F";
 		};
-		class Item301
+		class Item300
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10167,11 +6361,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1753;
 			type="Land_HelipadCircle_F";
+			atlOffset=-3.8146973e-006;
 		};
-		class Item302
+		class Item301
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10183,11 +6379,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1759;
 			type="Land_HelipadSquare_F";
 		};
-		class Item303
+		class Item302
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10199,11 +6396,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1760;
 			type="Land_HelipadSquare_F";
+			atlOffset=-1.3689947;
 		};
-		class Item304
+		class Item303
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10215,11 +6414,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1761;
 			type="Land_HelipadSquare_F";
 		};
-		class Item305
+		class Item304
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10231,11 +6431,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1766;
 			type="Land_HelipadCircle_F";
 		};
-		class Item306
+		class Item305
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10247,12 +6448,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1767;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.00032043457;
 		};
-		class Item307
+		class Item306
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10264,11 +6466,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1768;
 			type="Land_HelipadSquare_F";
 		};
-		class Item308
+		class Item307
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10279,12 +6482,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1772;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.7975235;
 		};
-		class Item309
+		class Item308
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10295,12 +6499,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1773;
 			type="Land_HelipadCircle_F";
 			atlOffset=2.1677933;
 		};
-		class Item310
+		class Item309
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10312,11 +6517,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1776;
 			type="Land_HelipadCircle_F";
 		};
-		class Item311
+		class Item310
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10328,11 +6534,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1777;
 			type="Land_HelipadCircle_F";
 		};
-		class Item312
+		class Item311
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10344,11 +6551,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1778;
 			type="Land_HelipadCircle_F";
 		};
-		class Item313
+		class Item312
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10360,11 +6568,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1779;
 			type="Land_HelipadSquare_F";
 		};
-		class Item314
+		class Item313
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10376,11 +6585,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1782;
 			type="Land_HelipadCircle_F";
 		};
-		class Item315
+		class Item314
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10392,11 +6602,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1787;
 			type="Land_HelipadSquare_F";
+			atlOffset=-3.8146973e-005;
 		};
-		class Item316
+		class Item315
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10408,11 +6620,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1788;
 			type="Land_HelipadSquare_F";
 		};
-		class Item317
+		class Item316
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10424,11 +6637,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1789;
 			type="Land_HelipadCircle_F";
+			atlOffset=-1.5258789e-005;
 		};
-		class Item318
+		class Item317
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10440,12 +6655,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1790;
 			type="Land_HelipadCircle_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item319
+		class Item318
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10457,11 +6673,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1794;
 			type="Land_HelipadCircle_F";
 		};
-		class Item320
+		class Item319
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10473,11 +6690,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1795;
 			type="Land_HelipadCircle_F";
 		};
-		class Item321
+		class Item320
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10489,11 +6707,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1797;
 			type="Land_HelipadCircle_F";
 		};
-		class Item322
+		class Item321
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10505,11 +6724,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1798;
 			type="Land_HelipadCircle_F";
 		};
-		class Item323
+		class Item322
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10521,11 +6741,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1799;
 			type="Land_HelipadSquare_F";
 		};
-		class Item324
+		class Item323
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10537,12 +6758,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1801;
 			type="Land_HelipadCircle_F";
 			atlOffset=1.335144e-005;
 		};
-		class Item325
+		class Item324
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10554,11 +6776,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1802;
 			type="Land_HelipadCircle_F";
+			atlOffset=-5.7220459e-006;
 		};
-		class Item326
+		class Item325
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10570,11 +6794,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1803;
 			type="Land_HelipadCircle_F";
+			atlOffset=-5.7220459e-006;
 		};
-		class Item327
+		class Item326
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10586,11 +6812,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1809;
 			type="Land_HelipadCircle_F";
+			atlOffset=-3.4332275e-005;
 		};
-		class Item328
+		class Item327
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10602,11 +6830,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1810;
 			type="Land_HelipadCircle_F";
+			atlOffset=-0.58641291;
 		};
-		class Item329
+		class Item328
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10618,12 +6848,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1811;
 			type="Land_HelipadCircle_F";
 			atlOffset=4.0769577e-005;
 		};
-		class Item330
+		class Item329
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10635,11 +6866,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1813;
 			type="Land_HelipadCircle_F";
+			atlOffset=-1.5258789e-005;
 		};
-		class Item331
+		class Item330
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10651,11 +6884,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1814;
 			type="Land_HelipadCircle_F";
 		};
-		class Item332
+		class Item331
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10667,12 +6901,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1815;
 			type="Land_HelipadCircle_F";
 			atlOffset=2.2888184e-005;
 		};
-		class Item333
+		class Item332
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10684,11 +6919,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1818;
 			type="Land_HelipadCircle_F";
 		};
-		class Item334
+		class Item333
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10700,11 +6936,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1819;
 			type="Land_HelipadSquare_F";
+			atlOffset=-7.6293945e-006;
 		};
-		class Item335
+		class Item334
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10716,11 +6954,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1821;
 			type="Land_HelipadCircle_F";
+			atlOffset=-1.7666759;
 		};
-		class Item336
+		class Item335
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10732,11 +6972,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1822;
 			type="Land_HelipadCircle_F";
 		};
-		class Item337
+		class Item336
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10747,12 +6988,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1825;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.96735001;
 		};
-		class Item338
+		class Item337
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10763,12 +7005,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1826;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.80735016;
 		};
-		class Item339
+		class Item338
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10780,11 +7023,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1827;
 			type="Land_HelipadCircle_F";
 		};
-		class Item340
+		class Item339
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10796,11 +7040,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1828;
 			type="Land_HelipadCircle_F";
+			atlOffset=-0.00016021729;
 		};
-		class Item341
+		class Item340
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10811,12 +7057,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1829;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.25952148;
 		};
-		class Item342
+		class Item341
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10828,12 +7075,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1833;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.00011825562;
 		};
-		class Item343
+		class Item342
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10844,12 +7092,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1835;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.55281067;
 		};
-		class Item344
+		class Item343
 		{
 			dataType="Layer";
 			name="Outposts";
@@ -12388,7 +8637,7 @@ class Mission
 					colorName="ColorGreen";
 					a=15.285;
 					b=6;
-					angle=312.75592;
+					angle=312.75589;
 					id=2067;
 					atlOffset=-0.0001335144;
 				};
@@ -12396,7 +8645,7 @@ class Mission
 			id=1838;
 			atlOffset=77.531845;
 		};
-		class Item345
+		class Item344
 		{
 			dataType="Marker";
 			position[]={14253.315,17.788271,15837.864};
@@ -12409,7 +8658,7 @@ class Mission
 			id=1842;
 			atlOffset=-0.11751556;
 		};
-		class Item346
+		class Item345
 		{
 			dataType="Marker";
 			position[]={15347.249,17.269489,17057.338};
@@ -12422,7 +8671,7 @@ class Mission
 			id=1843;
 			atlOffset=-0.64051056;
 		};
-		class Item347
+		class Item346
 		{
 			dataType="Marker";
 			position[]={14630.354,16.922852,16663.969};
@@ -12435,7 +8684,7 @@ class Mission
 			id=1844;
 			atlOffset=-0.98714828;
 		};
-		class Item348
+		class Item347
 		{
 			dataType="Marker";
 			position[]={21150.047,21.595703,7171.021};
@@ -12448,7 +8697,7 @@ class Mission
 			id=1845;
 			atlOffset=-1.137167;
 		};
-		class Item349
+		class Item348
 		{
 			dataType="Marker";
 			position[]={21180.377,18.380419,7536.7598};
@@ -12461,7 +8710,7 @@ class Mission
 			id=1846;
 			atlOffset=-0.41155434;
 		};
-		class Item350
+		class Item349
 		{
 			dataType="Marker";
 			position[]={26809.674,20.055626,24839.627};
@@ -12474,7 +8723,7 @@ class Mission
 			id=1847;
 			atlOffset=-1.4739056;
 		};
-		class Item351
+		class Item350
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12486,11 +8735,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2018;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item352
+		class Item351
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12502,11 +8752,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2019;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item353
+		class Item352
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12518,11 +8769,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2020;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item354
+		class Item353
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12534,11 +8786,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2021;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item355
+		class Item354
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12550,11 +8803,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2022;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item356
+		class Item355
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12566,11 +8820,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2023;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item357
+		class Item356
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12582,11 +8837,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2024;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item358
+		class Item357
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12598,11 +8854,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2025;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item359
+		class Item358
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12614,11 +8871,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2026;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item360
+		class Item359
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12630,11 +8888,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2027;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item361
+		class Item360
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12646,11 +8905,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2028;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item362
+		class Item361
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12662,11 +8922,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2029;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item363
+		class Item362
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12678,12 +8939,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2030;
 			type="Land_HBarrier_Big_F";
 			atlOffset=6.4849854e-005;
 		};
-		class Item364
+		class Item363
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12695,11 +8957,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2031;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item365
+		class Item364
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12711,11 +8974,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2032;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item366
+		class Item365
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12727,11 +8991,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2033;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item367
+		class Item366
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12743,11 +9008,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2034;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item368
+		class Item367
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12759,11 +9025,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2035;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item369
+		class Item368
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12775,11 +9042,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2036;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item370
+		class Item369
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12791,11 +9059,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2037;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item371
+		class Item370
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12807,11 +9076,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2038;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item372
+		class Item371
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12823,11 +9093,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2039;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item373
+		class Item372
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12839,11 +9110,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2040;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item374
+		class Item373
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12855,11 +9127,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2041;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item375
+		class Item374
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12871,11 +9144,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2042;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item376
+		class Item375
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12887,11 +9161,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2043;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item377
+		class Item376
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12903,11 +9178,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2044;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item378
+		class Item377
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12923,7 +9199,7 @@ class Mission
 			id=2045;
 			type="Land_BarGate_F";
 		};
-		class Item379
+		class Item378
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12939,7 +9215,7 @@ class Mission
 			id=2046;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item380
+		class Item379
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12951,11 +9227,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2047;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item381
+		class Item380
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12967,11 +9244,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2048;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item382
+		class Item381
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12983,11 +9261,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2049;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item383
+		class Item382
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12999,11 +9278,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2050;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item384
+		class Item383
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13015,11 +9295,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2051;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item385
+		class Item384
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13031,11 +9312,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2052;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item386
+		class Item385
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13047,11 +9329,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2053;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item387
+		class Item386
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13067,7 +9350,7 @@ class Mission
 			id=2054;
 			type="Land_BarGate_F";
 		};
-		class Item388
+		class Item387
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13083,7 +9366,7 @@ class Mission
 			id=2055;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item389
+		class Item388
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13099,7 +9382,7 @@ class Mission
 			id=2056;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item390
+		class Item389
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13115,7 +9398,7 @@ class Mission
 			id=2057;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item391
+		class Item390
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13131,7 +9414,7 @@ class Mission
 			id=2058;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item392
+		class Item391
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13147,7 +9430,7 @@ class Mission
 			id=2059;
 			type="Land_TTowerSmall_1_F";
 		};
-		class Item393
+		class Item392
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13163,7 +9446,7 @@ class Mission
 			id=2060;
 			type="Land_TTowerSmall_2_F";
 		};
-		class Item394
+		class Item393
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13179,57 +9462,63 @@ class Mission
 			id=2061;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item395
+		class Item394
 		{
 			dataType="Object";
 			class PositionInfo
 			{
 				position[]={14079.237,36.143406,22969.693};
-				angles[]={0,0.8457005,0};
+				angles[]={0,0.84569931,0};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=2062;
 			type="Land_Cargo40_military_green_F";
 			atlOffset=-0.0017242432;
+		};
+		class Item395
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={14077.167,36.137745,22967.902};
+				angles[]={0,0.84569931,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
+			};
+			id=2063;
+			type="Land_Cargo40_military_green_F";
+			atlOffset=-0.0065155029;
 		};
 		class Item396
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={14077.167,36.137745,22967.902};
-				angles[]={0,0.8457005,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=2063;
-			type="Land_Cargo40_military_green_F";
-			atlOffset=-0.0065155029;
-		};
-		class Item397
-		{
-			dataType="Object";
-			class PositionInfo
-			{
 				position[]={14078.302,38.766918,22968.865};
-				angles[]={0,0.8457005,0};
+				angles[]={0,0.84569931,0};
 			};
 			side="Empty";
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=2064;
 			type="Land_Cargo40_military_green_F";
 			atlOffset=2.6157455;
 		};
-		class Item398
+		class Item397
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13245,7 +9534,7 @@ class Mission
 			id=2065;
 			type="Land_Medevac_house_V1_F";
 		};
-		class Item399
+		class Item398
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13257,11 +9546,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2068;
 			type="Land_HelipadCircle_F";
+			atlOffset=-1.4862022;
 		};
-		class Item400
+		class Item399
 		{
 			dataType="Marker";
 			position[]={23151.998,3.1900001,18710.371};
@@ -13273,7 +9564,7 @@ class Mission
 			angle=35.229828;
 			id=2069;
 		};
-		class Item401
+		class Item400
 		{
 			dataType="Marker";
 			position[]={26907.941,19.783936,24787.373};
@@ -13286,7 +9577,7 @@ class Mission
 			id=2070;
 			atlOffset=-0.27813339;
 		};
-		class Item402
+		class Item401
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13303,7 +9594,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item403
+		class Item402
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13320,7 +9611,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=5.531311e-005;
 		};
-		class Item404
+		class Item403
 		{
 			dataType="Marker";
 			position[]={9100.9619,16.686979,21505.963};
@@ -13333,7 +9624,7 @@ class Mission
 			id=2073;
 			atlOffset=0.051624298;
 		};
-		class Item405
+		class Item404
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -13345,7 +9636,7 @@ class Mission
 			type="HighCommand";
 			atlOffset=-0.25428963;
 		};
-		class Item406
+		class Item405
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -13356,16 +9647,873 @@ class Mission
 			type="HighCommandSubordinate";
 			atlOffset=0.22619057;
 		};
+		class Item406
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=38;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3611.1216,14.951613,10278.536};
+					};
+					side="Independent";
+					flags=7;
+					class Attributes
+					{
+						name="commanderX";
+						description="Default Commaner";
+						isPlayer=1;
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2077;
+					type="I_G_officer_F";
+					atlOffset=-0.44756603;
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male04GRE";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1;
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3615.9165,15.390531,10275.833};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2078;
+					type="I_G_officer_F";
+					atlOffset=0.23984337;
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3616.0552,15.394004,10278.069};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2079;
+					type="I_G_officer_F";
+					atlOffset=0.22537708;
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3615.9976,15.357925,10280.403};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2080;
+					type="I_G_officer_F";
+					atlOffset=0.16194534;
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3615.8345,15.26186,10282.716};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2081;
+					type="I_G_officer_F";
+					atlOffset=0.045625687;
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3615.7935,15.171802,10285.171};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2082;
+					type="I_G_officer_F";
+					atlOffset=-0.18462944;
+				};
+				class Item6
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3615.6079,15.052153,10287.486};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2083;
+					type="I_G_officer_F";
+					atlOffset=-0.4460516;
+				};
+				class Item7
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3615.4009,14.924973,10289.382};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2084;
+					type="I_G_officer_F";
+					atlOffset=-0.69289207;
+				};
+				class Item8
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3618.2759,15.601477,10275.957};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2085;
+					type="I_G_Soldier_F";
+					atlOffset=0.55012512;
+				};
+				class Item9
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3618.2749,15.592041,10278.296};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2086;
+					type="I_G_Soldier_F";
+					atlOffset=0.51570892;
+				};
+				class Item10
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3618.1685,15.543119,10280.67};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2087;
+					type="I_G_Soldier_F";
+					atlOffset=0.46614361;
+				};
+				class Item11
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3618.1099,15.460299,10282.87};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2088;
+					type="I_G_Soldier_F";
+					atlOffset=0.38410473;
+				};
+				class Item12
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3617.9067,15.332737,10285.292};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2089;
+					type="I_G_Soldier_F";
+					atlOffset=0.10762024;
+				};
+				class Item13
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3617.7192,15.18074,10287.623};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2090;
+					type="I_G_Soldier_F";
+					atlOffset=-0.17505169;
+				};
+				class Item14
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3620.3843,15.790287,10275.993};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2091;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.82851601;
+				};
+				class Item15
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3620.5464,15.795074,10278.433};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2092;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.84661198;
+				};
+				class Item16
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3620.146,15.713996,10280.849};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2093;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.76836109;
+				};
+				class Item17
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3620.1226,15.614005,10282.997};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2094;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.66218662;
+				};
+				class Item18
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3619.9224,15.466564,10285.238};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2095;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.38076019;
+				};
+				class Item19
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3619.8354,15.313412,10287.697};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2096;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.18226337;
+				};
+				class Item20
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3622.4731,15.977149,10276.073};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2097;
+					type="I_G_Soldier_GL_F";
+					atlOffset=1.1262426;
+				};
+				class Item21
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3622.3433,15.956235,10278.391};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2098;
+					type="I_G_Soldier_GL_F";
+					atlOffset=1.1246681;
+				};
+				class Item22
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3622.2192,15.861652,10281.135};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2099;
+					type="I_G_Soldier_GL_F";
+					atlOffset=1.0549059;
+				};
+				class Item23
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3622.0454,15.729821,10283.144};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2100;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.90120506;
+				};
+				class Item24
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3621.9761,15.594293,10285.328};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2101;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.72624016;
+				};
+				class Item25
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3621.8706,15.43797,10287.819};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2102;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.52212715;
+				};
+				class Item26
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3624.0005,15.978456,10276.15};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2103;
+					type="I_G_medic_F";
+					atlOffset=1.1882639;
+				};
+				class Item27
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3623.8247,15.96973,10278.431};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2104;
+					type="I_G_medic_F";
+					atlOffset=1.2000971;
+				};
+				class Item28
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3623.7827,15.874046,10281.302};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2105;
+					type="I_G_medic_F";
+					atlOffset=1.1367235;
+				};
+				class Item29
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3623.6948,15.765423,10283.108};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2106;
+					type="I_G_medic_F";
+					atlOffset=1.0144587;
+				};
+				class Item30
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3623.5112,15.6234,10285.468};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2107;
+					type="I_G_medic_F";
+					atlOffset=0.83342648;
+				};
+				class Item31
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3623.522,15.478828,10287.878};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2108;
+					type="I_G_medic_F";
+					atlOffset=0.65377235;
+				};
+				class Item32
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3625.8022,15.974913,10276.315};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2109;
+					type="I_G_engineer_F";
+					atlOffset=1.2563658;
+				};
+				class Item33
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3625.8257,15.974535,10278.616};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2110;
+					type="I_G_engineer_F";
+					atlOffset=1.2845001;
+				};
+				class Item34
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3625.5835,15.872133,10281.405};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2111;
+					type="I_G_engineer_F";
+					atlOffset=1.1777554;
+				};
+				class Item35
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3625.3286,15.754671,10283.354};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2112;
+					type="I_G_engineer_F";
+					atlOffset=1.0393324;
+				};
+				class Item36
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3625.1333,15.620001,10285.59};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2113;
+					type="I_G_engineer_F";
+					atlOffset=0.86717224;
+				};
+				class Item37
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3625.0288,15.471598,10288.06};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2114;
+					type="I_G_engineer_F";
+					atlOffset=0.68074989;
+				};
+			};
+			class Attributes
+			{
+			};
+			id=2076;
+			atlOffset=-0.44756603;
+		};
 	};
 	class Connections
 	{
 		class LinkIDProvider
 		{
-			nextID=61;
+			nextID=39;
 		};
 		class Links
 		{
-			items=61;
+			items=39;
 			class Item0
 			{
 				linkID=0;
@@ -13379,7 +10527,7 @@ class Mission
 			class Item1
 			{
 				linkID=1;
-				item0=1013;
+				item0=2077;
 				item1=2074;
 				class CustomData
 				{
@@ -13389,7 +10537,7 @@ class Mission
 			class Item2
 			{
 				linkID=2;
-				item0=1014;
+				item0=2078;
 				item1=2074;
 				class CustomData
 				{
@@ -13399,7 +10547,7 @@ class Mission
 			class Item3
 			{
 				linkID=3;
-				item0=1020;
+				item0=2079;
 				item1=2074;
 				class CustomData
 				{
@@ -13409,7 +10557,7 @@ class Mission
 			class Item4
 			{
 				linkID=4;
-				item0=1022;
+				item0=2080;
 				item1=2074;
 				class CustomData
 				{
@@ -13419,7 +10567,7 @@ class Mission
 			class Item5
 			{
 				linkID=5;
-				item0=1024;
+				item0=2081;
 				item1=2074;
 				class CustomData
 				{
@@ -13429,7 +10577,7 @@ class Mission
 			class Item6
 			{
 				linkID=6;
-				item0=1026;
+				item0=2082;
 				item1=2074;
 				class CustomData
 				{
@@ -13439,7 +10587,7 @@ class Mission
 			class Item7
 			{
 				linkID=7;
-				item0=1028;
+				item0=2083;
 				item1=2074;
 				class CustomData
 				{
@@ -13449,7 +10597,7 @@ class Mission
 			class Item8
 			{
 				linkID=8;
-				item0=1030;
+				item0=2084;
 				item1=2074;
 				class CustomData
 				{
@@ -13459,7 +10607,7 @@ class Mission
 			class Item9
 			{
 				linkID=9;
-				item0=1032;
+				item0=2085;
 				item1=2074;
 				class CustomData
 				{
@@ -13469,7 +10617,7 @@ class Mission
 			class Item10
 			{
 				linkID=10;
-				item0=1034;
+				item0=2086;
 				item1=2074;
 				class CustomData
 				{
@@ -13479,7 +10627,7 @@ class Mission
 			class Item11
 			{
 				linkID=11;
-				item0=1036;
+				item0=2087;
 				item1=2074;
 				class CustomData
 				{
@@ -13489,7 +10637,7 @@ class Mission
 			class Item12
 			{
 				linkID=12;
-				item0=1038;
+				item0=2088;
 				item1=2074;
 				class CustomData
 				{
@@ -13499,7 +10647,7 @@ class Mission
 			class Item13
 			{
 				linkID=13;
-				item0=1040;
+				item0=2089;
 				item1=2074;
 				class CustomData
 				{
@@ -13509,7 +10657,7 @@ class Mission
 			class Item14
 			{
 				linkID=14;
-				item0=1042;
+				item0=2090;
 				item1=2074;
 				class CustomData
 				{
@@ -13519,7 +10667,7 @@ class Mission
 			class Item15
 			{
 				linkID=15;
-				item0=1046;
+				item0=2091;
 				item1=2074;
 				class CustomData
 				{
@@ -13529,7 +10677,7 @@ class Mission
 			class Item16
 			{
 				linkID=16;
-				item0=1048;
+				item0=2092;
 				item1=2074;
 				class CustomData
 				{
@@ -13539,7 +10687,7 @@ class Mission
 			class Item17
 			{
 				linkID=17;
-				item0=1050;
+				item0=2093;
 				item1=2074;
 				class CustomData
 				{
@@ -13549,7 +10697,7 @@ class Mission
 			class Item18
 			{
 				linkID=18;
-				item0=1052;
+				item0=2094;
 				item1=2074;
 				class CustomData
 				{
@@ -13559,7 +10707,7 @@ class Mission
 			class Item19
 			{
 				linkID=19;
-				item0=1054;
+				item0=2095;
 				item1=2074;
 				class CustomData
 				{
@@ -13569,7 +10717,7 @@ class Mission
 			class Item20
 			{
 				linkID=20;
-				item0=1058;
+				item0=2096;
 				item1=2074;
 				class CustomData
 				{
@@ -13579,7 +10727,7 @@ class Mission
 			class Item21
 			{
 				linkID=21;
-				item0=1060;
+				item0=2097;
 				item1=2074;
 				class CustomData
 				{
@@ -13589,7 +10737,7 @@ class Mission
 			class Item22
 			{
 				linkID=22;
-				item0=1062;
+				item0=2098;
 				item1=2074;
 				class CustomData
 				{
@@ -13599,7 +10747,7 @@ class Mission
 			class Item23
 			{
 				linkID=23;
-				item0=1064;
+				item0=2099;
 				item1=2074;
 				class CustomData
 				{
@@ -13609,7 +10757,7 @@ class Mission
 			class Item24
 			{
 				linkID=24;
-				item0=1066;
+				item0=2100;
 				item1=2074;
 				class CustomData
 				{
@@ -13619,7 +10767,7 @@ class Mission
 			class Item25
 			{
 				linkID=25;
-				item0=1044;
+				item0=2101;
 				item1=2074;
 				class CustomData
 				{
@@ -13629,7 +10777,7 @@ class Mission
 			class Item26
 			{
 				linkID=26;
-				item0=1056;
+				item0=2102;
 				item1=2074;
 				class CustomData
 				{
@@ -13639,7 +10787,7 @@ class Mission
 			class Item27
 			{
 				linkID=27;
-				item0=1417;
+				item0=2103;
 				item1=2074;
 				class CustomData
 				{
@@ -13649,7 +10797,7 @@ class Mission
 			class Item28
 			{
 				linkID=28;
-				item0=1419;
+				item0=2104;
 				item1=2074;
 				class CustomData
 				{
@@ -13659,7 +10807,7 @@ class Mission
 			class Item29
 			{
 				linkID=29;
-				item0=1421;
+				item0=2105;
 				item1=2074;
 				class CustomData
 				{
@@ -13669,7 +10817,7 @@ class Mission
 			class Item30
 			{
 				linkID=30;
-				item0=1423;
+				item0=2106;
 				item1=2074;
 				class CustomData
 				{
@@ -13679,7 +10827,7 @@ class Mission
 			class Item31
 			{
 				linkID=31;
-				item0=1425;
+				item0=2107;
 				item1=2074;
 				class CustomData
 				{
@@ -13689,7 +10837,7 @@ class Mission
 			class Item32
 			{
 				linkID=32;
-				item0=1427;
+				item0=2108;
 				item1=2074;
 				class CustomData
 				{
@@ -13699,7 +10847,7 @@ class Mission
 			class Item33
 			{
 				linkID=33;
-				item0=1429;
+				item0=2109;
 				item1=2074;
 				class CustomData
 				{
@@ -13709,7 +10857,7 @@ class Mission
 			class Item34
 			{
 				linkID=34;
-				item0=1431;
+				item0=2110;
 				item1=2074;
 				class CustomData
 				{
@@ -13719,7 +10867,7 @@ class Mission
 			class Item35
 			{
 				linkID=35;
-				item0=1433;
+				item0=2111;
 				item1=2074;
 				class CustomData
 				{
@@ -13729,7 +10877,7 @@ class Mission
 			class Item36
 			{
 				linkID=36;
-				item0=1435;
+				item0=2112;
 				item1=2074;
 				class CustomData
 				{
@@ -13739,7 +10887,7 @@ class Mission
 			class Item37
 			{
 				linkID=37;
-				item0=1437;
+				item0=2113;
 				item1=2074;
 				class CustomData
 				{
@@ -13749,227 +10897,7 @@ class Mission
 			class Item38
 			{
 				linkID=38;
-				item0=1439;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item39
-			{
-				linkID=39;
-				item0=1498;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item40
-			{
-				linkID=40;
-				item0=1500;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item41
-			{
-				linkID=41;
-				item0=1502;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item42
-			{
-				linkID=42;
-				item0=1504;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item43
-			{
-				linkID=43;
-				item0=1506;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item44
-			{
-				linkID=44;
-				item0=1508;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item45
-			{
-				linkID=45;
-				item0=1510;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item46
-			{
-				linkID=46;
-				item0=1512;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item47
-			{
-				linkID=47;
-				item0=1514;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item48
-			{
-				linkID=48;
-				item0=1516;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item49
-			{
-				linkID=49;
-				item0=1518;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item50
-			{
-				linkID=50;
-				item0=1520;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item51
-			{
-				linkID=51;
-				item0=1522;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item52
-			{
-				linkID=52;
-				item0=1524;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item53
-			{
-				linkID=53;
-				item0=1526;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item54
-			{
-				linkID=54;
-				item0=1528;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item55
-			{
-				linkID=55;
-				item0=1530;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item56
-			{
-				linkID=56;
-				item0=1532;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item57
-			{
-				linkID=57;
-				item0=1016;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item58
-			{
-				linkID=58;
-				item0=1017;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item59
-			{
-				linkID=59;
-				item0=1018;
-				item1=2074;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item60
-			{
-				linkID=60;
-				item0=1015;
+				item0=2114;
 				item1=2074;
 				class CustomData
 				{

--- a/Map-Templates/Antistasi-Anizay.tem_anizay/mission.sqm
+++ b/Map-Templates/Antistasi-Anizay.tem_anizay/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=1025;
 	class ItemIDProvider
 	{
-		nextID=2638;
+		nextID=2700;
 	};
 	class MarkerIDProvider
 	{
@@ -16,14 +16,14 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=163;
+		nextID=213;
 	};
 	class Camera
 	{
-		pos[]={4529.8794,285.65625,3572.1687};
-		dir[]={-0.559551,-0.75248569,0.34744111};
-		up[]={-0.63928288,0.65858829,0.39694855};
-		aside[]={0.52752161,-3.8635335e-008,0.84956974};
+		pos[]={4484.001,230.33473,3601.7454};
+		dir[]={-0.43830523,-0.87096131,0.22222641};
+		up[]={-0.77682322,0.49135727,0.39385739};
+		aside[]={0.45222646,-1.5030673e-007,0.89194578};
 	};
 };
 binarizationWanted=0;
@@ -34,7 +34,6 @@ addons[]=
 	"A3_Modules_F",
 	"A3_Characters_F",
 	"A3_Modules_F_Hc",
-	"A3_Weapons_F",
 	"A3_Structures_F_EPC_Civ_InfoBoards",
 	"A3_Structures_F_Mil_Flags",
 	"A3_Modules_F_Curator_Curator",
@@ -50,18 +49,15 @@ addons[]=
 	"A3_Structures_F_Heli_Furniture",
 	"A3_Structures_F_EPA_Civ_Constructions",
 	"A3_Structures_F_Walls",
-	"A3_Structures_F_Enoch_Military_Camps",
 	"A3_Structures_F_Civ_Lamps",
-	"A3_Structures_F_Orange_Humanitarian_Camps",
 	"A3_Structures_F_Heli_Ind_Machines",
-	"A3_Props_F_Orange_Humanitarian_Camps",
 	"A3_Structures_F_Enoch_Military_Radar",
-	"A3_Structures_F_Mil_Cargo",
 	"A3_Structures_F_Mil_Helipads",
 	"A3_Supplies_F_Heli_Bladders",
 	"A3_Ui_F_Exp",
 	"A3_Characters_F_Exp",
 	"A3_Structures_F_Exp_Military_Flags",
+	"A3_Structures_F_Mil_Cargo",
 	"A3_Structures_F_Ind_Transmitter_Tower",
 	"A3_Structures_F_Mil_BagBunker",
 	"A3_Structures_F_Civ_Camping",
@@ -77,13 +73,14 @@ addons[]=
 	"CUP_CAMisc",
 	"CUP_CAStructures_PMC_FuelStation",
 	"A3_Structures_F_Kart_Mil_Flags",
-	"CUP_CAStructuresHouse_A_FuelStation"
+	"CUP_CAStructuresHouse_A_FuelStation",
+	"A3_Weapons_F"
 };
 class AddonsMetaData
 {
 	class List
 	{
-		items=29;
+		items=27;
 		class Item0
 		{
 			className="A3_Ui_F";
@@ -177,96 +174,82 @@ class AddonsMetaData
 		};
 		class Item13
 		{
-			className="A3_Structures_F_Orange";
-			name="Arma 3 Orange - Buildings and Structures";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item14
-		{
-			className="A3_Props_F_Orange";
-			name="Arma 3 Orange - Decorative and Mission Objects";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item15
-		{
 			className="A3_Supplies_F_Heli";
 			name="Arma 3 Helicopters - Ammoboxes and Supplies";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item16
+		class Item14
 		{
 			className="A3_Ui_F_Exp";
 			name="Arma 3 Apex - User Interface";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item17
+		class Item15
 		{
 			className="A3_Characters_F_Exp";
 			name="Arma 3 Apex - Characters and Clothing";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item18
+		class Item16
 		{
 			className="A3_Structures_F_Exp";
 			name="Arma 3 Apex - Buildings and Structures";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item19
+		class Item17
 		{
 			className="CUP_CAStructures_E_Ind_Misc_PowerStation";
 			name="CUP_CAStructures_E_Ind_Misc_PowerStation";
 		};
-		class Item20
+		class Item18
 		{
 			className="CUP_CAStructures_E_HouseC";
 			name="CUP_CAStructures_E_HouseC";
 		};
-		class Item21
+		class Item19
 		{
 			className="CUP_CAStructures_E_Misc";
 			name="CUP_CAStructures_E_Misc";
 		};
-		class Item22
+		class Item20
 		{
 			className="CUP_CAStructures_E_Mil";
 			name="CUP_CAStructures_E_Mil";
 		};
-		class Item23
+		class Item21
 		{
 			className="CUP_CAStructures_E_Wall_Wall_L";
 			name="CUP_CAStructures_E_Wall_Wall_L";
 		};
-		class Item24
+		class Item22
 		{
 			className="A3_Signs_F";
 			name="Arma 3 - Signs";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item25
+		class Item23
 		{
 			className="CUP_CAMisc";
 			name="CUP_CAMisc";
 		};
-		class Item26
+		class Item24
 		{
 			className="CUP_CAStructures_PMC_FuelStation";
 			name="CUP_CAStructures_PMC_FuelStation";
 		};
-		class Item27
+		class Item25
 		{
 			className="A3_Structures_F_Kart";
 			name="Arma 3 Karts - Buildings and Structures";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item28
+		class Item26
 		{
 			className="CUP_CAStructuresHouse_A_FuelStation";
 			name="CUP_CAStructuresHouse_A_FuelStation";
@@ -281,24 +264,14 @@ class Mission
 	{
 		briefingName=$STR_antistasi_mission_info_anizay_mapname_text;
 		resistanceWest=0;
-		timeOfChanges=1800.0002;
-		startWeather=0;
-		startWind=0.10000001;
-		startWaves=0.1;
-		forecastWeather=0;
-		forecastWind=0.1;
-		forecastWaves=0.1;
-		forecastLightnings=0.1;
 		year=2018;
 		month=7;
 		day=2;
 		hour=12;
-		startFogDecay=0.014;
-		forecastFogDecay=0.014;
 	};
 	class Entities
 	{
-		items=870;
+		items=861;
 		class Item0
 		{
 			dataType="Layer";
@@ -602,7 +575,7 @@ class Mission
 					colorName="ColorGreen";
 					a=7.7494531;
 					b=12.772196;
-					angle=12.947085;
+					angle=12.947083;
 					id=801;
 					atlOffset=0.023376465;
 				};
@@ -657,7 +630,7 @@ class Mission
 					colorName="ColorGUER";
 					a=52.454731;
 					b=41.750999;
-					angle=13.567805;
+					angle=13.567803;
 					id=806;
 					atlOffset=-0.0062637329;
 				};
@@ -685,7 +658,7 @@ class Mission
 					colorName="ColorGUER";
 					a=54.500015;
 					b=56.263123;
-					angle=328.50308;
+					angle=328.50305;
 					id=810;
 					atlOffset=-3.7432404;
 				};
@@ -1158,7 +1131,7 @@ class Mission
 					colorName="ColorOrange";
 					a=59.402908;
 					b=60.699497;
-					angle=13.536361;
+					angle=13.536359;
 					id=890;
 					atlOffset=-1.8619385;
 				};
@@ -1172,7 +1145,7 @@ class Mission
 					colorName="ColorGreen";
 					a=10;
 					b=6;
-					angle=27.656986;
+					angle=27.656982;
 					id=897;
 					atlOffset=1.0401154;
 				};
@@ -1675,3983 +1648,6 @@ class Mission
 			side="Independent";
 			class Entities
 			{
-				items=60;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4448.9102,190.20132,3599.4604};
-						angles[]={6.2232571,0,6.2691903};
-					};
-					side="Independent";
-					flags=6;
-					class Attributes
-					{
-						skill=1;
-						name="commanderX";
-						description="Default Commander";
-						isPlayer=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=705;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item1
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4456.2725,189.97711,3595.896};
-						angles[]={6.2292376,6.2412972,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=706;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item2
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4467.7334,190.04243,3602.0483};
-						angles[]={6.2511988,6.2412972,6.2491965};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=707;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item3
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4466.9785,190.07692,3602.3237};
-						angles[]={6.2511988,0,6.2491965};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=708;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item4
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4469.9082,189.97354,3601.9761};
-						angles[]={6.2471995,0,6.2531958};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=709;
-					type="I_G_medic_F";
-					atlOffset=1.5258789e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item5
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4472.8066,189.84813,3602.1558};
-						angles[]={6.2471995,0,6.2372193};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=710;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item6
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4475.7949,189.67661,3602.3745};
-						angles[]={6.2372193,0,6.1558776};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=711;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item7
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4461.4434,190.20978,3602.0269};
-						angles[]={6.2491984,0,6.2631893};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=712;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item8
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4467.6299,190.14502,3604.8413};
-						angles[]={6.2471995,6.2412972,6.2531958};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=713;
-					type="I_G_Soldier_AR_F";
-					atlOffset=1.5258789e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item9
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4466.875,190.17688,3605.1206};
-						angles[]={6.2591896,0,6.2531958};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=714;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item10
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4469.8047,190.07719,3604.769};
-						angles[]={6.2471995,0,6.2531958};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=715;
-					type="I_G_medic_F";
-					atlOffset=1.5258789e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item11
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4472.7031,189.97946,3604.9487};
-						angles[]={6.2372193,0,6.2471995};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=716;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item12
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4475.6914,189.85979,3605.1675};
-						angles[]={6.2491965,0,6.2172837};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=717;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item13
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4461.3398,190.30472,3604.8237};
-						angles[]={6.2511969,0,6.261188};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=718;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item14
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4466.875,190.24889,3608.1206};
-						angles[]={6.2591896,0,6.2531958};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=719;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item15
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4469.8047,190.15263,3607.7729};
-						angles[]={6.259192,0,6.2531939};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=720;
-					type="I_G_medic_F";
-					atlOffset=-1.5258789e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item16
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4472.7031,190.05969,3607.9487};
-						angles[]={6.2491965,0,6.2571931};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=721;
-					type="I_G_engineer_F";
-					atlOffset=-1.5258789e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item17
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4475.6914,189.96193,3608.1714};
-						angles[]={6.2491965,0,6.2172837};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=722;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item18
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4461.3398,190.40071,3607.8237};
-						angles[]={6.251195,0,6.261188};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=723;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item19
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4466.7715,190.31404,3610.7065};
-						angles[]={6.259192,0,6.2531939};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=724;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item20
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4469.7012,190.21779,3610.3589};
-						angles[]={6.2591896,0,6.2531958};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=725;
-					type="I_G_medic_F";
-					atlOffset=-1.5258789e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item21
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4472.5996,190.14557,3610.5386};
-						angles[]={6.2591872,0,6.2571931};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=726;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item22
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4475.5879,190.07831,3610.7573};
-						angles[]={6.2551904,0,6.261188};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=727;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item23
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4461.2363,190.47729,3610.4097};
-						angles[]={6.2472029,0,6.2531958};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=728;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item24
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4467.7295,190.21935,3607.9585};
-						angles[]={6.259192,6.1574922,6.2531939};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=729;
-					type="I_G_Soldier_AR_F";
-					atlOffset=-1.5258789e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item25
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4467.8232,190.27861,3610.5444};
-						angles[]={6.259192,0,6.2531939};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=730;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item26
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4467.1035,190.36707,3613.3315};
-						angles[]={6.2591896,0,6.2531958};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=731;
-					type="I_G_Soldier_LAT_F";
-					atlOffset=-1.5258789e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item27
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4470.0332,190.27098,3612.9839};
-						angles[]={6.2591872,0,6.2571931};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=732;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item28
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4472.9316,190.20413,3613.1636};
-						angles[]={6.2551904,0,6.261188};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=733;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item29
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4475.9199,190.1445,3613.3823};
-						angles[]={6.2551904,0,6.261188};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=734;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item30
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4461.5684,190.56198,3613.0386};
-						angles[]={6.2472029,0,6.2531958};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=735;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item31
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4468.1553,190.33173,3613.1733};
-						angles[]={6.2591896,0,6.2531958};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=736;
-					type="I_G_Soldier_AR_F";
-					atlOffset=-1.5258789e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item32
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4467.1777,190.45493,3616.4058};
-						angles[]={6.2472029,0,6.2531958};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=737;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item33
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4470.1074,190.34932,3616.0581};
-						angles[]={6.2531958,0,6.261188};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=738;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item34
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4473.0059,190.29094,3616.2378};
-						angles[]={6.2531958,0,6.261188};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=739;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item35
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4475.9941,190.24368,3616.4565};
-						angles[]={6.2531977,0,6.2731905};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=740;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item36
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4461.6426,190.65919,3616.1128};
-						angles[]={6.2392135,0,6.2412114};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=741;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item37
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4468.2295,190.41765,3616.2476};
-						angles[]={6.2472029,0,6.2531958};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=742;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item38
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4464.209,190.66737,3619.394};
-						angles[]={6.2472029,0,6.2332263};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=743;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item39
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4467.1406,190.54425,3619.0464};
-						angles[]={6.2531958,0,6.2472029};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=744;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item40
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4470.0391,190.44574,3619.2222};
-						angles[]={6.2531958,0,6.261188};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=745;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item41
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4473.0273,190.38666,3619.4448};
-						angles[]={6.2531958,0,6.261188};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=746;
-					type="I_G_Soldier_GL_F";
-					atlOffset=-1.5258789e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item42
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4458.6758,190.9469,3619.0972};
-						angles[]={6.2392135,0,6.2172809};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=747;
-					type="I_G_officer_F";
-					atlOffset=-1.5258789e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item43
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4465.2627,190.61409,3619.2319};
-						angles[]={6.2472029,0,6.2531958};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=748;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item44
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4464.0605,190.8345,3622.6597};
-						angles[]={6.2332263,0,6.2272439};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=749;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item45
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4466.9922,190.69261,3622.3081};
-						angles[]={6.2332263,0,6.2472029};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=750;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item46
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4469.8906,190.57863,3622.4878};
-						angles[]={6.2412114,0,6.2392135};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=751;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item47
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4472.8789,190.51537,3622.7065};
-						angles[]={6.2491999,0,6.2531958};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=752;
-					type="I_G_Soldier_GL_F";
-					atlOffset=-1.5258789e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item48
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4458.5273,191.13992,3622.3628};
-						angles[]={6.2272439,0,6.2093177};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=753;
-					type="I_G_officer_F";
-					atlOffset=1.5258789e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item49
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4465.1143,190.76968,3622.4976};
-						angles[]={6.2332263,0,6.2472029};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=754;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item50
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4462.875,191.03943,3625.4019};
-						angles[]={6.2292366,0,6.2272449};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=755;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item51
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4465.8047,190.86621,3625.0542};
-						angles[]={6.2372155,0,6.2392135};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=756;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item52
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4468.7031,190.74695,3625.2339};
-						angles[]={6.2372155,0,6.2392135};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=757;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item53
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4468.8223,190.86305,3628.1187};
-						angles[]={6.2432051,0,6.2332263};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=758;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item54
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4457.3398,191.38159,3625.1089};
-						angles[]={6.2272439,0,6.2093177};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=759;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item55
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4463.9287,190.97188,3625.2437};
-						angles[]={6.2292366,0,6.2272449};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=760;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item56
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4458.4473,189.97321,3595.8237};
-						angles[]={6.2292376,0,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=761;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item57
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4461.4727,189.95149,3596.0815};
-						angles[]={6.2352209,0,6.2631893};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=762;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item58
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4464.0586,189.91928,3596.4878};
-						angles[]={6.2352209,0,6.2631893};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=763;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item59
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={4455.5176,189.99199,3596.1714};
-						angles[]={6.2292376,0,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-							compass="ItemCompass";
-							watch="ItemWatch";
-						};
-					};
-					id=764;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-			};
-			class Attributes
-			{
-			};
-			id=704;
-		};
-		class Item23
-		{
-			dataType="Group";
-			side="Independent";
-			class Entities
-			{
 				items=1;
 				class Item0
 				{
@@ -5739,7 +1735,7 @@ class Mission
 			id=765;
 			atlOffset=-1.5258789e-005;
 		};
-		class Item24
+		class Item23
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5780,7 +1776,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item25
+		class Item24
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5820,7 +1816,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item26
+		class Item25
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5834,7 +1830,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=0.099807739;
 		};
-		class Item27
+		class Item26
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5848,7 +1844,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item28
+		class Item27
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5939,7 +1935,7 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item29
+		class Item28
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5979,7 +1975,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item30
+		class Item29
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5991,7 +1987,7 @@ class Mission
 			id=773;
 			type="Logic";
 		};
-		class Item31
+		class Item30
 		{
 			dataType="Marker";
 			position[]={8385.1416,110.13867,6670.5601};
@@ -6000,7 +1996,7 @@ class Mission
 			id=774;
 			atlOffset=-0.59091949;
 		};
-		class Item32
+		class Item31
 		{
 			dataType="Marker";
 			position[]={719.8089,137.07715,4622.2583};
@@ -6010,7 +2006,7 @@ class Mission
 			id=780;
 			atlOffset=-7.109848;
 		};
-		class Item33
+		class Item32
 		{
 			dataType="Marker";
 			position[]={3189.446,143.52148,8383.582};
@@ -6019,7 +2015,7 @@ class Mission
 			id=786;
 			atlOffset=-1.2295227;
 		};
-		class Item34
+		class Item33
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -6075,7 +2071,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item35
+		class Item34
 		{
 			dataType="Layer";
 			name="Open Ammo Dump_4";
@@ -6164,6 +2160,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=946;
 					type="Land_HBarrier_5_F";
@@ -6377,6 +2374,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=958;
 					type="Land_HBarrier_5_F";
@@ -6430,6 +2428,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=961;
 					type="Land_HBarrier_5_F";
@@ -6448,6 +2447,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=962;
 					type="Land_HBarrier_5_F";
@@ -6465,6 +2465,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=963;
 					type="Land_HBarrier_5_F";
@@ -6483,6 +2484,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=964;
 					type="Land_HBarrier_5_F";
@@ -6492,23 +2494,23 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={931.25397,134.3576,4634.3525};
-						angles[]={0,2.769927,0};
+						position[]={931.25403,134.3576,4634.353};
+						angles[]={0,2.7699249,0};
 					};
 					side="Empty";
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=965;
-					type="CamoNet_BLUFOR_open_F";
-					atlOffset=1.0664825;
+					id=2678;
+					type="CamoNet_OPFOR_open_F";
+					atlOffset=1.0665131;
 				};
 			};
 			id=941;
-			atlOffset=1.22966;
+			atlOffset=0.46556091;
 		};
-		class Item36
+		class Item35
 		{
 			dataType="Layer";
 			name="Vehicle Repair_4";
@@ -6616,6 +2618,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=972;
 					type="Land_HBarrier_5_F";
@@ -6651,6 +2654,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=974;
 					type="Land_HBarrier_1_F";
@@ -6669,6 +2673,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=975;
 					type="Land_HBarrier_5_F";
@@ -6686,6 +2691,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=976;
 					type="Land_HBarrier_1_F";
@@ -6704,6 +2710,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=977;
 					type="Land_HBarrier_5_F";
@@ -6721,6 +2728,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=978;
 					type="Land_HBarrier_5_F";
@@ -6738,6 +2746,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=979;
 					type="Land_HBarrier_1_F";
@@ -6755,6 +2764,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=980;
 					type="Land_HBarrier_1_F";
@@ -6765,8 +2775,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={1014.5587,129.13179,4668.3569};
-						angles[]={6.2751918,2.9650755,6.2491984};
+						position[]={1014.559,129.13177,4668.3569};
+						angles[]={6.2751913,2.96507,6.2492037};
 					};
 					side="Empty";
 					flags=4;
@@ -6774,15 +2784,14 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=981;
-					type="CamoNet_BLUFOR_big_F";
-					atlOffset=-7.6293945e-006;
+					id=2680;
+					type="CamoNet_OPFOR_big_F";
 				};
 			};
 			id=966;
-			atlOffset=0.049041748;
+			atlOffset=0.032669067;
 		};
-		class Item37
+		class Item36
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6794,12 +2803,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=982;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item38
+		class Item37
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6811,11 +2821,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=983;
 			type="Land_HBarrier_5_F";
 		};
-		class Item39
+		class Item38
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6827,11 +2838,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=984;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item40
+		class Item39
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6843,11 +2855,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=985;
 			type="Land_HBarrier_5_F";
 		};
-		class Item41
+		class Item40
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6859,11 +2872,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=986;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item42
+		class Item41
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6875,11 +2889,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=987;
 			type="Land_HBarrier_5_F";
 		};
-		class Item43
+		class Item42
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6891,11 +2906,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=988;
 			type="Land_HBarrier_5_F";
 		};
-		class Item44
+		class Item43
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6907,11 +2923,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=989;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item45
+		class Item44
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6923,12 +2940,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=990;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item46
+		class Item45
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6940,11 +2958,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=991;
 			type="Land_HBarrier_5_F";
 		};
-		class Item47
+		class Item46
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6956,11 +2975,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=992;
 			type="Land_HBarrier_3_F";
 		};
-		class Item48
+		class Item47
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6972,12 +2992,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=993;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item49
+		class Item48
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6989,11 +3010,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=994;
 			type="Land_HBarrier_5_F";
 		};
-		class Item50
+		class Item49
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7005,11 +3027,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=995;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item51
+		class Item50
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7021,11 +3044,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=996;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item52
+		class Item51
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7037,11 +3061,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=997;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item53
+		class Item52
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7053,11 +3078,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=998;
 			type="Land_HBarrier_3_F";
 		};
-		class Item54
+		class Item53
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7069,11 +3095,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=999;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item55
+		class Item54
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7085,11 +3112,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1000;
 			type="Land_HBarrier_5_F";
 		};
-		class Item56
+		class Item55
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7101,11 +3129,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1001;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item57
+		class Item56
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7117,11 +3146,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1002;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item58
+		class Item57
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7133,12 +3163,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1003;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item59
+		class Item58
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7150,11 +3181,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1004;
 			type="Land_HBarrier_3_F";
 		};
-		class Item60
+		class Item59
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7166,12 +3198,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1005;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item61
+		class Item60
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7183,11 +3216,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1006;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item62
+		class Item61
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7199,12 +3233,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1007;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item63
+		class Item62
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7216,11 +3251,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1008;
 			type="Land_HBarrierWall6_F";
 		};
-		class Item64
+		class Item63
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7232,11 +3268,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1009;
 			type="Land_HBarrier_5_F";
 		};
-		class Item65
+		class Item64
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7252,7 +3289,7 @@ class Mission
 			id=1010;
 			type="Land_Mil_WiredFence_Gate_F";
 		};
-		class Item66
+		class Item65
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7264,11 +3301,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1011;
 			type="Land_HBarrier_5_F";
 		};
-		class Item67
+		class Item66
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7280,11 +3318,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1012;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item68
+		class Item67
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7296,11 +3335,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1013;
 			type="Land_HBarrier_5_F";
 		};
-		class Item69
+		class Item68
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7312,11 +3352,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1014;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item70
+		class Item69
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7328,11 +3369,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1015;
 			type="Land_HBarrier_5_F";
 		};
-		class Item71
+		class Item70
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7344,11 +3386,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1016;
 			type="Land_HBarrier_5_F";
 		};
-		class Item72
+		class Item71
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7360,12 +3403,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1017;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item73
+		class Item72
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7377,11 +3421,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1018;
 			type="Land_HBarrier_5_F";
 		};
-		class Item74
+		class Item73
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7393,11 +3438,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1019;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item75
+		class Item74
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7409,11 +3455,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1020;
 			type="Land_HBarrier_5_F";
 		};
-		class Item76
+		class Item75
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7425,12 +3472,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1021;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item77
+		class Item76
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7442,11 +3490,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1022;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item78
+		class Item77
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7458,11 +3507,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1023;
 			type="Land_HBarrier_5_F";
 		};
-		class Item79
+		class Item78
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7474,11 +3524,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1024;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item80
+		class Item79
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7490,11 +3541,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1025;
 			type="Land_HBarrier_5_F";
 		};
-		class Item81
+		class Item80
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7506,11 +3558,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1026;
 			type="Land_HBarrier_5_F";
 		};
-		class Item82
+		class Item81
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7522,11 +3575,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1027;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item83
+		class Item82
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7538,11 +3592,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1028;
 			type="Land_HBarrier_5_F";
 		};
-		class Item84
+		class Item83
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7554,11 +3609,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1029;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item85
+		class Item84
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7570,12 +3626,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1030;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item86
+		class Item85
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7587,11 +3644,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1031;
 			type="Land_HBarrier_5_F";
 		};
-		class Item87
+		class Item86
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7603,12 +3661,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1032;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item88
+		class Item87
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7620,12 +3679,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1033;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item89
+		class Item88
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7637,11 +3697,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1034;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item90
+		class Item89
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7653,52 +3714,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1035;
 			type="Land_HBarrier_3_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item91
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={992.21014,129.62624,4659.1143};
-				angles[]={0.049958061,5.930233,6.2232571};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1036;
-			type="Land_MedicalTent_01_NATO_generic_open_F";
-			atlOffset=1.5258789e-005;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item92
+		class Item90
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7714,7 +3736,7 @@ class Mission
 			id=1037;
 			type="Land_Razorwire_F";
 		};
-		class Item93
+		class Item91
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7730,7 +3752,7 @@ class Mission
 			id=1038;
 			type="Land_Razorwire_F";
 		};
-		class Item94
+		class Item92
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7746,7 +3768,7 @@ class Mission
 			id=1039;
 			type="Land_Razorwire_F";
 		};
-		class Item95
+		class Item93
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7762,7 +3784,7 @@ class Mission
 			id=1040;
 			type="Land_Razorwire_F";
 		};
-		class Item96
+		class Item94
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7778,7 +3800,7 @@ class Mission
 			id=1041;
 			type="Land_Razorwire_F";
 		};
-		class Item97
+		class Item95
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7794,7 +3816,7 @@ class Mission
 			id=1042;
 			type="Land_Razorwire_F";
 		};
-		class Item98
+		class Item96
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7806,11 +3828,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1043;
 			type="Land_HBarrier_3_F";
 		};
-		class Item99
+		class Item97
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7826,40 +3849,7 @@ class Mission
 			id=1044;
 			type="Land_LampSolar_F";
 		};
-		class Item100
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={1000.7253,159.74902,4663.478};
-				angles[]={0,2.78864,0};
-			};
-			side="Empty";
-			class Attributes
-			{
-			};
-			id=1045;
-			type="Land_MedicalTent_01_floor_dark_F";
-			atlOffset=28.810425;
-		};
-		class Item101
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={992.21014,131.5938,4659.1143};
-				angles[]={6.2072682,2.78864,0.27551216};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1046;
-			type="Land_MedicalTent_01_floor_dark_F";
-			atlOffset=0.1700592;
-		};
-		class Item102
+		class Item98
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7871,11 +3861,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1047;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item103
+		class Item99
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7892,116 +3883,7 @@ class Mission
 			type="Land_PressureWasher_01_F";
 			atlOffset=-0.00073242188;
 		};
-		class Item104
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={999.85266,128.59503,4655.1509};
-				angles[]={0.05394781,2.78864,6.2392149};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1049;
-			type="Land_AirConditioner_03_F";
-		};
-		class Item105
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={986.4043,129.20145,4657.5718};
-				angles[]={0.035987642,4.359437,6.2172809};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1050;
-			type="Land_AirConditioner_02_F";
-		};
-		class Item106
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={1001.5925,129.04027,4662.5708};
-				angles[]={0.033988956,5.930233,6.2412086};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1051;
-			type="Land_MedicalTent_01_NATO_generic_closed_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="MedSign_Hide";
-					expression="_this animateSource ['MedSign_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="Door_Hide";
-					expression="_this animateSource ['Door_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute2
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=3;
-			};
-		};
-		class Item107
+		class Item100
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8013,12 +3895,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1052;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item108
+		class Item101
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8030,11 +3913,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1053;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item109
+		class Item102
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8046,11 +3930,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1054;
 			type="Land_HBarrier_5_F";
 		};
-		class Item110
+		class Item103
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8062,11 +3947,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1055;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item111
+		class Item104
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8078,11 +3964,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1056;
 			type="Land_HBarrier_5_F";
 		};
-		class Item112
+		class Item105
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8094,11 +3981,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1057;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item113
+		class Item106
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8110,11 +3998,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1058;
 			type="Land_HBarrier_5_F";
 		};
-		class Item114
+		class Item107
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8126,11 +4015,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1059;
 			type="Land_HBarrier_3_F";
 		};
-		class Item115
+		class Item108
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8142,12 +4032,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1060;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item116
+		class Item109
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8159,11 +4050,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1061;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item117
+		class Item110
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8175,12 +4067,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1062;
 			type="Land_HBarrier_3_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item118
+		class Item111
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8192,11 +4085,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1063;
 			type="Land_HBarrier_5_F";
 		};
-		class Item119
+		class Item112
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8208,11 +4102,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1064;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item120
+		class Item113
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8224,11 +4119,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1065;
 			type="Land_HBarrier_3_F";
 		};
-		class Item121
+		class Item114
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8240,11 +4136,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1066;
 			type="Land_HBarrier_5_F";
 		};
-		class Item122
+		class Item115
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8256,11 +4153,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1067;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item123
+		class Item116
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8272,11 +4170,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1068;
 			type="Land_HBarrier_3_F";
 		};
-		class Item124
+		class Item117
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8288,11 +4187,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1069;
 			type="Land_HBarrier_5_F";
 		};
-		class Item125
+		class Item118
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8304,11 +4204,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1070;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item126
+		class Item119
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8320,11 +4221,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1071;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item127
+		class Item120
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8336,11 +4238,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1072;
 			type="Land_HBarrier_5_F";
 		};
-		class Item128
+		class Item121
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8352,12 +4255,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1073;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item129
+		class Item122
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8369,12 +4273,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1074;
 			type="Land_HBarrier_5_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item130
+		class Item123
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8386,12 +4291,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1075;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item131
+		class Item124
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8403,11 +4309,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1076;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item132
+		class Item125
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8419,11 +4326,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1077;
 			type="Land_HBarrier_5_F";
 		};
-		class Item133
+		class Item126
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8435,11 +4343,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1078;
 			type="Land_HBarrier_5_F";
 		};
-		class Item134
+		class Item127
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8451,12 +4360,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1079;
 			type="Land_HBarrier_5_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item135
+		class Item128
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8468,11 +4378,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1080;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item136
+		class Item129
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8484,11 +4395,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1081;
 			type="Land_HBarrier_5_F";
 		};
-		class Item137
+		class Item130
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8500,12 +4412,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1082;
 			type="Land_HBarrier_5_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item138
+		class Item131
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8517,12 +4430,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1083;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item139
+		class Item132
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8534,11 +4448,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1084;
 			type="Land_HBarrier_5_F";
 		};
-		class Item140
+		class Item133
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8550,11 +4465,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1085;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item141
+		class Item134
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8566,12 +4482,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1086;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item142
+		class Item135
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8583,12 +4500,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1087;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item143
+		class Item136
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8600,11 +4518,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1088;
 			type="Land_HBarrier_5_F";
 		};
-		class Item144
+		class Item137
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8616,11 +4535,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1089;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item145
+		class Item138
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8632,11 +4552,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1090;
 			type="Land_HBarrier_5_F";
 		};
-		class Item146
+		class Item139
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8648,11 +4569,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1091;
 			type="Land_HBarrier_5_F";
 		};
-		class Item147
+		class Item140
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8664,12 +4586,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1092;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item148
+		class Item141
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8681,11 +4604,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1093;
 			type="Land_HBarrier_5_F";
 		};
-		class Item149
+		class Item142
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8697,12 +4621,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1094;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item150
+		class Item143
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8714,11 +4639,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1095;
 			type="Land_HBarrier_5_F";
 		};
-		class Item151
+		class Item144
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8730,12 +4656,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1096;
 			type="Land_HBarrier_3_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item152
+		class Item145
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8747,12 +4674,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1097;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item153
+		class Item146
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8764,12 +4692,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1098;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item154
+		class Item147
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8781,11 +4710,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1099;
 			type="Land_HBarrier_5_F";
 		};
-		class Item155
+		class Item148
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8796,12 +4726,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1100;
 			type="Land_HBarrier_1_F";
 			atlOffset=0.4875946;
 		};
-		class Item156
+		class Item149
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8813,11 +4744,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1101;
 			type="Land_HBarrier_1_F";
 		};
-		class Item157
+		class Item150
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8829,11 +4761,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1102;
 			type="Land_HBarrier_5_F";
 		};
-		class Item158
+		class Item151
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8845,12 +4778,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1103;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item159
+		class Item152
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8862,12 +4796,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1104;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item160
+		class Item153
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8879,11 +4814,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1105;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item161
+		class Item154
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8895,12 +4831,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1106;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item162
+		class Item155
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8912,11 +4849,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1107;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item163
+		class Item156
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8928,11 +4866,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1108;
 			type="Land_HBarrier_5_F";
 		};
-		class Item164
+		class Item157
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8944,11 +4883,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1109;
 			type="Land_HBarrier_3_F";
 		};
-		class Item165
+		class Item158
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8960,11 +4900,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1110;
 			type="Land_HBarrier_5_F";
 		};
-		class Item166
+		class Item159
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8976,12 +4917,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1111;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item167
+		class Item160
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8993,12 +4935,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1112;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item168
+		class Item161
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9010,11 +4953,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1113;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item169
+		class Item162
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9026,11 +4970,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1114;
 			type="Land_HBarrier_5_F";
 		};
-		class Item170
+		class Item163
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9042,12 +4987,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1115;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item171
+		class Item164
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9063,7 +5009,7 @@ class Mission
 			id=1116;
 			type="Land_MobileRadar_01_radar_F";
 		};
-		class Item172
+		class Item165
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9080,88 +5026,7 @@ class Mission
 			type="Land_MobileRadar_01_generator_F";
 			atlOffset=0.058380127;
 		};
-		class Item173
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={1017.463,134.37215,4625.4282};
-				angles[]={0,5.9451499,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1118;
-			type="Land_Cargo_HQ_V1_F";
-		};
-		class Item174
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={1046.853,136.04626,4710.2808};
-				angles[]={0,4.3811255,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1119;
-			type="Land_Cargo_Patrol_V1_F";
-		};
-		class Item175
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={1038.592,136.98091,4714.313};
-				angles[]={0,2.8103292,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1120;
-			type="Land_Cargo_Patrol_V1_F";
-			atlOffset=-1.5258789e-005;
-		};
-		class Item176
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={1067.6801,136.46126,4632.0508};
-				angles[]={0,5.9519215,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1121;
-			type="Land_Cargo_Patrol_V1_F";
-		};
-		class Item177
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={1071.738,135.82742,4640.3452};
-				angles[]={0,4.3811255,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1122;
-			type="Land_Cargo_Patrol_V1_F";
-		};
-		class Item178
+		class Item166
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9173,12 +5038,13 @@ class Mission
 			class Attributes
 			{
 				init="call{this setVariable [""spawnableHelicopterTypes"", [""patrol"", ""transport"", ""attack""]];}";
+				disableSimulation=1;
 			};
 			id=1123;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.46276855;
 		};
-		class Item179
+		class Item167
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9190,11 +5056,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1124;
 			type="Land_HBarrier_5_F";
 		};
-		class Item180
+		class Item168
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9206,11 +5073,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1125;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item181
+		class Item169
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9222,11 +5090,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1126;
 			type="Land_HBarrier_5_F";
 		};
-		class Item182
+		class Item170
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9238,11 +5107,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1127;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item183
+		class Item171
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9254,11 +5124,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1128;
 			type="Land_HBarrier_5_F";
 		};
-		class Item184
+		class Item172
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9270,12 +5141,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1129;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item185
+		class Item173
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9287,11 +5159,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1130;
 			type="Land_HBarrier_5_F";
 		};
-		class Item186
+		class Item174
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9303,11 +5176,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1131;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item187
+		class Item175
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9319,12 +5193,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1132;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item188
+		class Item176
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9336,12 +5211,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1133;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item189
+		class Item177
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9353,11 +5229,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1134;
 			type="Land_HBarrier_5_F";
 		};
-		class Item190
+		class Item178
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9369,11 +5246,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1135;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item191
+		class Item179
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9385,11 +5263,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1136;
 			type="Land_HBarrier_5_F";
 		};
-		class Item192
+		class Item180
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9401,11 +5280,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1137;
 			type="Land_HBarrier_3_F";
 		};
-		class Item193
+		class Item181
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9417,11 +5297,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1138;
 			type="Land_HBarrier_5_F";
 		};
-		class Item194
+		class Item182
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9433,12 +5314,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1139;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item195
+		class Item183
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9450,11 +5332,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1140;
 			type="Land_HBarrier_5_F";
 		};
-		class Item196
+		class Item184
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9466,11 +5349,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1141;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item197
+		class Item185
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9482,11 +5366,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1142;
 			type="Land_HBarrier_5_F";
 		};
-		class Item198
+		class Item186
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9498,12 +5383,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1143;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item199
+		class Item187
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9515,11 +5401,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1144;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item200
+		class Item188
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9531,11 +5418,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1145;
 			type="Land_HBarrier_5_F";
 		};
-		class Item201
+		class Item189
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9547,11 +5435,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1146;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item202
+		class Item190
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9563,11 +5452,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1147;
 			type="Land_HBarrier_5_F";
 		};
-		class Item203
+		class Item191
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9579,11 +5469,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1148;
 			type="Land_HBarrier_5_F";
 		};
-		class Item204
+		class Item192
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9595,11 +5486,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1149;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item205
+		class Item193
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9611,11 +5503,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1150;
 			type="Land_HBarrier_5_F";
 		};
-		class Item206
+		class Item194
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9627,12 +5520,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1151;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item207
+		class Item195
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9644,11 +5538,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1152;
 			type="Land_HBarrier_3_F";
 		};
-		class Item208
+		class Item196
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9660,11 +5555,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1153;
 			type="Land_HBarrier_5_F";
 		};
-		class Item209
+		class Item197
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9676,11 +5572,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1154;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item210
+		class Item198
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9692,11 +5589,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1155;
 			type="Land_HBarrier_5_F";
 		};
-		class Item211
+		class Item199
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9708,11 +5606,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1156;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item212
+		class Item200
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9724,11 +5623,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1157;
 			type="Land_HBarrier_5_F";
 		};
-		class Item213
+		class Item201
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9740,12 +5640,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1158;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item214
+		class Item202
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9757,11 +5658,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1159;
 			type="Land_HBarrier_5_F";
 		};
-		class Item215
+		class Item203
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9773,12 +5675,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1160;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item216
+		class Item204
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9790,12 +5693,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1161;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item217
+		class Item205
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9807,11 +5711,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1162;
 			type="Land_HBarrier_3_F";
 		};
-		class Item218
+		class Item206
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9823,11 +5728,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1163;
 			type="Land_HBarrier_3_F";
 		};
-		class Item219
+		class Item207
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9839,11 +5745,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1164;
 			type="Land_HBarrier_3_F";
 		};
-		class Item220
+		class Item208
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9855,11 +5762,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1165;
 			type="Land_HBarrier_1_F";
 		};
-		class Item221
+		class Item209
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9871,12 +5779,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1166;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item222
+		class Item210
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9888,11 +5797,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1167;
 			type="Land_HBarrier_5_F";
 		};
-		class Item223
+		class Item211
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9904,12 +5814,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1168;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item224
+		class Item212
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9921,11 +5832,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1169;
 			type="Land_HBarrier_5_F";
 		};
-		class Item225
+		class Item213
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9937,11 +5849,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1170;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item226
+		class Item214
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9953,12 +5866,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1171;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item227
+		class Item215
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9970,11 +5884,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1172;
 			type="Land_HBarrier_5_F";
 		};
-		class Item228
+		class Item216
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9986,12 +5901,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1173;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item229
+		class Item217
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10003,11 +5919,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1174;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item230
+		class Item218
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10019,11 +5936,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1175;
 			type="Land_HBarrier_5_F";
 		};
-		class Item231
+		class Item219
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10035,11 +5953,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1176;
 			type="Land_HBarrier_5_F";
 		};
-		class Item232
+		class Item220
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10051,11 +5970,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1177;
 			type="Land_HBarrier_5_F";
 		};
-		class Item233
+		class Item221
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10067,11 +5987,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1178;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item234
+		class Item222
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10083,11 +6004,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1179;
 			type="Land_HBarrier_5_F";
 		};
-		class Item235
+		class Item223
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10099,59 +6021,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1180;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item236
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={870.38,146.99213,4640.979};
-				angles[]={0,4.3570051,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1181;
-			type="Land_Cargo_Tower_V1_F";
-		};
-		class Item237
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={892.763,146.93771,4577.4131};
-				angles[]={0,1.1974355,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1182;
-			type="Land_Cargo_Tower_V1_F";
-		};
-		class Item238
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={996.021,141.7713,4687.73};
-				angles[]={0,4.3570051,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1183;
-			type="Land_Cargo_Tower_V1_F";
-		};
-		class Item239
+		class Item224
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10163,12 +6038,13 @@ class Mission
 			class Attributes
 			{
 				init="call{this setVariable [""spawnableHelicopterTypes"", [""patrol"", ""transport"", ""attack""]];}";
+				disableSimulation=1;
 			};
 			id=1184;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.5135498;
 		};
-		class Item240
+		class Item225
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10180,12 +6056,13 @@ class Mission
 			class Attributes
 			{
 				init="call{this setVariable [""spawnableHelicopterTypes"", [""patrol"", ""transport"", ""attack""]];}";
+				disableSimulation=1;
 			};
 			id=1185;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.4744873;
 		};
-		class Item241
+		class Item226
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10197,12 +6074,13 @@ class Mission
 			class Attributes
 			{
 				init="call{this setVariable [""spawnableHelicopterTypes"", [""patrol"", ""transport"", ""attack""]];}";
+				disableSimulation=1;
 			};
 			id=1186;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.4243927;
 		};
-		class Item242
+		class Item227
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10218,7 +6096,7 @@ class Mission
 			id=1187;
 			type="Land_LampAirport_F";
 		};
-		class Item243
+		class Item228
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10234,134 +6112,7 @@ class Mission
 			id=1188;
 			type="Land_LampAirport_F";
 		};
-		class Item244
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={917.49121,132.4529,4629.8291};
-				angles[]={0.017997233,4.340723,6.2531958};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1189;
-			type="Land_MedicalTent_01_NATO_generic_open_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item245
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={917.49121,134.55528,4629.8291};
-				angles[]={5.9652162,4.340723,6.1195006};
-			};
-			side="Empty";
-			class Attributes
-			{
-			};
-			id=1190;
-			type="Land_MedicalTent_01_floor_dark_F";
-			atlOffset=0.26722717;
-		};
-		class Item246
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={904.797,133.15245,4624.8809};
-				angles[]={0.037981652,4.340723,6.2172809};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1191;
-			type="Land_MedicalTent_01_NATO_generic_open_F";
-			atlOffset=-1.5258789e-005;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item247
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={904.797,135.26018,4624.8809};
-				angles[]={5.9831305,4.340723,6.0850382};
-			};
-			side="Empty";
-			class Attributes
-			{
-			};
-			id=1192;
-			type="Land_MedicalTent_01_floor_dark_F";
-			atlOffset=0.27192688;
-		};
-		class Item248
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={899.25726,132.90315,4618.8491};
-				angles[]={0.055941612,3.5553255,6.2132974};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1193;
-			type="Land_AirConditioner_04_F";
-		};
-		class Item249
+		class Item229
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10378,7 +6129,7 @@ class Mission
 			type="StorageBladder_01_fuel_forest_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item250
+		class Item230
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10394,7 +6145,7 @@ class Mission
 			id=1195;
 			type="StorageBladder_01_fuel_forest_F";
 		};
-		class Item251
+		class Item231
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10406,11 +6157,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1196;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item252
+		class Item232
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10422,11 +6174,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1197;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item253
+		class Item233
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10438,11 +6191,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1198;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item254
+		class Item234
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10454,11 +6208,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1199;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item255
+		class Item235
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10470,11 +6225,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1200;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item256
+		class Item236
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10490,7 +6246,7 @@ class Mission
 			id=1201;
 			type="Land_LampAirport_F";
 		};
-		class Item257
+		class Item237
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10506,7 +6262,7 @@ class Mission
 			id=1202;
 			type="Land_LampAirport_F";
 		};
-		class Item258
+		class Item238
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10522,7 +6278,7 @@ class Mission
 			id=1203;
 			type="Land_LampSolar_F";
 		};
-		class Item259
+		class Item239
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10534,11 +6290,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1204;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item260
+		class Item240
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10550,44 +6307,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1205;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item261
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={880.71503,140.12596,4598.0791};
-				angles[]={0,1.2041899,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1206;
-			type="Land_Cargo_Patrol_V1_F";
-		};
-		class Item262
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={872.37097,138.91531,4619.894};
-				angles[]={0,1.2041899,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1207;
-			type="Land_Cargo_Patrol_V1_F";
-			atlOffset=-1.5258789e-005;
-		};
-		class Item263
+		class Item241
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10599,12 +6324,13 @@ class Mission
 			class Attributes
 			{
 				init="call{this setVariable [""spawnableHelicopterTypes"", [""patrol"", ""transport"", ""attack""]];}";
+				disableSimulation=1;
 			};
 			id=1208;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.45439148;
 		};
-		class Item264
+		class Item242
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10616,12 +6342,13 @@ class Mission
 			class Attributes
 			{
 				init="call{this setVariable [""spawnableHelicopterTypes"", [""patrol"", ""transport"", ""attack""]];}";
+				disableSimulation=1;
 			};
 			id=1209;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.45397949;
 		};
-		class Item265
+		class Item243
 		{
 			dataType="Marker";
 			position[]={10688.864,86.584534,5004.3037};
@@ -10632,7 +6359,7 @@ class Mission
 			id=1210;
 			atlOffset=33.583786;
 		};
-		class Item266
+		class Item244
 		{
 			dataType="Marker";
 			position[]={10683.529,150.57507,2139.2688};
@@ -10643,7 +6370,7 @@ class Mission
 			id=1211;
 			atlOffset=33.583809;
 		};
-		class Item267
+		class Item245
 		{
 			dataType="Marker";
 			position[]={8998.6348,96.559372,-224.72046};
@@ -10654,7 +6381,7 @@ class Mission
 			id=1212;
 			atlOffset=33.583797;
 		};
-		class Item268
+		class Item246
 		{
 			dataType="Marker";
 			position[]={5909.6606,190.36778,-321.87012};
@@ -10665,7 +6392,7 @@ class Mission
 			id=1213;
 			atlOffset=33.583801;
 		};
-		class Item269
+		class Item247
 		{
 			dataType="Marker";
 			position[]={2075.4426,211.8815,-332.66479};
@@ -10676,7 +6403,7 @@ class Mission
 			id=1214;
 			atlOffset=33.583801;
 		};
-		class Item270
+		class Item248
 		{
 			dataType="Marker";
 			position[]={-300.69156,217.39087,1448.4241};
@@ -10687,7 +6414,7 @@ class Mission
 			id=1215;
 			atlOffset=33.583801;
 		};
-		class Item271
+		class Item249
 		{
 			dataType="Marker";
 			position[]={-515.336,183.31531,4880.666};
@@ -10698,7 +6425,7 @@ class Mission
 			id=1216;
 			atlOffset=33.583847;
 		};
-		class Item272
+		class Item250
 		{
 			dataType="Marker";
 			position[]={-588.20789,182.28105,8076.2329};
@@ -10709,7 +6436,7 @@ class Mission
 			id=1217;
 			atlOffset=33.583801;
 		};
-		class Item273
+		class Item251
 		{
 			dataType="Marker";
 			position[]={2075.4431,189.1348,10645.318};
@@ -10720,7 +6447,7 @@ class Mission
 			id=1218;
 			atlOffset=33.583801;
 		};
-		class Item274
+		class Item252
 		{
 			dataType="Marker";
 			position[]={4916.0039,187.65778,10612.936};
@@ -10731,7 +6458,7 @@ class Mission
 			id=1219;
 			atlOffset=33.583801;
 		};
-		class Item275
+		class Item253
 		{
 			dataType="Marker";
 			position[]={8145.3857,200.84288,10548.168};
@@ -10742,7 +6469,7 @@ class Mission
 			id=1220;
 			atlOffset=33.583801;
 		};
-		class Item276
+		class Item254
 		{
 			dataType="Marker";
 			position[]={10586.324,111.18447,8194.9717};
@@ -10753,7 +6480,7 @@ class Mission
 			id=1221;
 			atlOffset=33.583801;
 		};
-		class Item277
+		class Item255
 		{
 			dataType="Marker";
 			position[]={2399.3965,179.49533,-123.15674};
@@ -10762,7 +6489,7 @@ class Mission
 			id=1222;
 			atlOffset=2.5770569;
 		};
-		class Item278
+		class Item256
 		{
 			dataType="Marker";
 			position[]={377.32193,156.50502,10260.37};
@@ -10770,7 +6497,7 @@ class Mission
 			type="flag_UN";
 			id=1223;
 		};
-		class Item279
+		class Item257
 		{
 			dataType="Marker";
 			position[]={10182.242,144.28058,10193.891};
@@ -10779,7 +6506,7 @@ class Mission
 			id=1233;
 			atlOffset=5.4211731;
 		};
-		class Item280
+		class Item258
 		{
 			dataType="Group";
 			side="East";
@@ -11153,7 +6880,7 @@ class Mission
 			};
 			id=1234;
 		};
-		class Item281
+		class Item259
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11171,7 +6898,7 @@ class Mission
 			type="Flag_Viper_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item282
+		class Item260
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11187,7 +6914,7 @@ class Mission
 			id=1242;
 			type="Flag_NATO_F";
 		};
-		class Item283
+		class Item261
 		{
 			dataType="Marker";
 			position[]={10203.88,32.664989,40.245483};
@@ -11196,7 +6923,7 @@ class Mission
 			id=1243;
 			atlOffset=4.0481567;
 		};
-		class Item284
+		class Item262
 		{
 			dataType="Group";
 			side="West";
@@ -11579,7 +7306,7 @@ class Mission
 			};
 			id=1244;
 		};
-		class Item285
+		class Item263
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11595,7 +7322,7 @@ class Mission
 			id=1253;
 			type="Land_Cargo_Tower_V3_F";
 		};
-		class Item286
+		class Item264
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11611,7 +7338,7 @@ class Mission
 			id=1254;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item287
+		class Item265
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -11666,7 +7393,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item288
+		class Item266
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -11722,7 +7449,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item289
+		class Item267
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11738,7 +7465,7 @@ class Mission
 			id=1257;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item290
+		class Item268
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -11793,7 +7520,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item291
+		class Item269
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11809,7 +7536,7 @@ class Mission
 			id=1259;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item292
+		class Item270
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -11865,7 +7592,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item293
+		class Item271
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11881,7 +7608,7 @@ class Mission
 			id=1261;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item294
+		class Item272
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -11936,7 +7663,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item295
+		class Item273
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11952,7 +7679,7 @@ class Mission
 			id=1263;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item296
+		class Item274
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -12008,7 +7735,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item297
+		class Item275
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -12064,7 +7791,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item298
+		class Item276
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12076,11 +7803,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1266;
 			type="Land_HelipadSquare_F";
 		};
-		class Item299
+		class Item277
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12092,11 +7820,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1267;
 			type="Land_HelipadSquare_F";
 		};
-		class Item300
+		class Item278
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12108,11 +7837,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1268;
 			type="Land_HelipadSquare_F";
 		};
-		class Item301
+		class Item279
 		{
 			dataType="Marker";
 			position[]={8559.5391,111.54,7591.9707};
@@ -12124,7 +7854,7 @@ class Mission
 			id=1269;
 			atlOffset=0.010665894;
 		};
-		class Item302
+		class Item280
 		{
 			dataType="Marker";
 			position[]={8577.7803,109.53027,6442.6914};
@@ -12136,7 +7866,7 @@ class Mission
 			id=1270;
 			atlOffset=-2.0097275;
 		};
-		class Item303
+		class Item281
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -12190,7 +7920,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item304
+		class Item282
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -12244,7 +7974,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item305
+		class Item283
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -12298,7 +8028,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item306
+		class Item284
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -12352,7 +8082,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item307
+		class Item285
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -12406,7 +8136,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item308
+		class Item286
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12418,11 +8148,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1276;
 			type="Land_HelipadSquare_F";
 		};
-		class Item309
+		class Item287
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12434,11 +8165,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1277;
 			type="Land_HelipadSquare_F";
 		};
-		class Item310
+		class Item288
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12450,11 +8182,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1278;
 			type="Land_HelipadSquare_F";
 		};
-		class Item311
+		class Item289
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12466,11 +8199,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1279;
 			type="Land_HelipadSquare_F";
 		};
-		class Item312
+		class Item290
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12482,11 +8216,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1280;
 			type="Land_HelipadSquare_F";
 		};
-		class Item313
+		class Item291
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12501,7 +8236,7 @@ class Mission
 			id=1287;
 			type="Land_Cargo_Tower_V3_F";
 		};
-		class Item314
+		class Item292
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12516,7 +8251,7 @@ class Mission
 			id=1288;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item315
+		class Item293
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12532,7 +8267,7 @@ class Mission
 			id=1289;
 			type="Land_Cargo_Tower_V3_F";
 		};
-		class Item316
+		class Item294
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12548,7 +8283,7 @@ class Mission
 			id=1290;
 			type="Land_Cargo_Tower_V3_F";
 		};
-		class Item317
+		class Item295
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -12602,7 +8337,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item318
+		class Item296
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12618,7 +8353,7 @@ class Mission
 			id=1292;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item319
+		class Item297
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12634,7 +8369,7 @@ class Mission
 			id=1293;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item320
+		class Item298
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12650,7 +8385,7 @@ class Mission
 			id=1294;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item321
+		class Item299
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -12705,7 +8440,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item322
+		class Item300
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -12761,7 +8496,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item323
+		class Item301
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12777,7 +8512,7 @@ class Mission
 			id=1297;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item324
+		class Item302
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -12833,7 +8568,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item325
+		class Item303
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12850,7 +8585,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=0.026832581;
 		};
-		class Item326
+		class Item304
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12866,7 +8601,7 @@ class Mission
 			id=1300;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item327
+		class Item305
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12882,7 +8617,7 @@ class Mission
 			id=1301;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item328
+		class Item306
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12898,7 +8633,7 @@ class Mission
 			id=1302;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item329
+		class Item307
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12914,7 +8649,7 @@ class Mission
 			id=1303;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item330
+		class Item308
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -12969,7 +8704,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item331
+		class Item309
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12985,7 +8720,7 @@ class Mission
 			id=1305;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item332
+		class Item310
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -13040,7 +8775,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item333
+		class Item311
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13056,7 +8791,7 @@ class Mission
 			id=1307;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item334
+		class Item312
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -13111,7 +8846,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item335
+		class Item313
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -13166,7 +8901,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item336
+		class Item314
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13178,12 +8913,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1310;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.0090103149;
 		};
-		class Item337
+		class Item315
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13195,11 +8931,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1311;
 			type="Land_HBarrier_5_F";
 		};
-		class Item338
+		class Item316
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13211,11 +8948,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1312;
 			type="Land_HBarrier_5_F";
 		};
-		class Item339
+		class Item317
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13227,12 +8965,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1313;
 			type="Land_HBarrier_5_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item340
+		class Item318
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13244,11 +8983,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1314;
 			type="Land_HBarrier_5_F";
 		};
-		class Item341
+		class Item319
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13260,12 +9000,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1315;
 			type="Land_HBarrier_5_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item342
+		class Item320
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13277,11 +9018,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1316;
 			type="Land_HBarrier_5_F";
 		};
-		class Item343
+		class Item321
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13293,12 +9035,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1317;
 			type="Land_HBarrier_5_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item344
+		class Item322
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13310,12 +9053,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1318;
 			type="Land_HBarrier_5_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item345
+		class Item323
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13327,12 +9071,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1319;
 			type="Land_HBarrier_5_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item346
+		class Item324
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13344,11 +9089,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1320;
 			type="Land_HBarrier_5_F";
 		};
-		class Item347
+		class Item325
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13360,12 +9106,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1321;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item348
+		class Item326
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13377,12 +9124,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1322;
 			type="Land_HBarrier_5_F";
 			atlOffset=6.1035156e-005;
 		};
-		class Item349
+		class Item327
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13394,12 +9142,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1323;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.0090026855;
 		};
-		class Item350
+		class Item328
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13411,12 +9160,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1324;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item351
+		class Item329
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13428,12 +9178,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1325;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.8146973e-005;
 		};
-		class Item352
+		class Item330
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13445,12 +9196,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1326;
 			type="Land_HBarrier_5_F";
 			atlOffset=5.3405762e-005;
 		};
-		class Item353
+		class Item331
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13462,12 +9214,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1327;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item354
+		class Item332
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13479,12 +9232,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1328;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item355
+		class Item333
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13496,12 +9250,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1329;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.8146973e-005;
 		};
-		class Item356
+		class Item334
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13513,12 +9268,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1330;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.008972168;
 		};
-		class Item357
+		class Item335
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13530,12 +9286,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1331;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item358
+		class Item336
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13547,12 +9304,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1332;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item359
+		class Item337
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13564,12 +9322,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1333;
 			type="Land_HBarrier_5_F";
 			atlOffset=6.8664551e-005;
 		};
-		class Item360
+		class Item338
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13581,12 +9340,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1334;
 			type="Land_HBarrier_5_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item361
+		class Item339
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13598,12 +9358,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1335;
 			type="Land_HBarrier_5_F";
 			atlOffset=2.2888184e-005;
 		};
-		class Item362
+		class Item340
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13615,12 +9376,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1336;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.8146973e-005;
 		};
-		class Item363
+		class Item341
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13632,12 +9394,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1337;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item364
+		class Item342
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13649,11 +9412,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1338;
 			type="Land_HBarrier_5_F";
 		};
-		class Item365
+		class Item343
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13665,12 +9429,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1339;
 			type="Land_HBarrier_3_F";
 			atlOffset=8.392334e-005;
 		};
-		class Item366
+		class Item344
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13682,12 +9447,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1340;
 			type="Land_HBarrier_3_F";
 			atlOffset=8.392334e-005;
 		};
-		class Item367
+		class Item345
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13699,12 +9465,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1341;
 			type="Land_HBarrier_3_F";
 			atlOffset=9.1552734e-005;
 		};
-		class Item368
+		class Item346
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13716,12 +9483,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1342;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.00010681152;
 		};
-		class Item369
+		class Item347
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13737,7 +9505,7 @@ class Mission
 			id=1343;
 			type="Land_Mil_WallBig_Corner_F";
 		};
-		class Item370
+		class Item348
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13753,7 +9521,7 @@ class Mission
 			id=1344;
 			type="Land_Mil_WallBig_Corner_F";
 		};
-		class Item371
+		class Item349
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13770,7 +9538,7 @@ class Mission
 			type="Land_Mil_WallBig_4m_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item372
+		class Item350
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13787,7 +9555,7 @@ class Mission
 			type="Land_Mil_WallBig_4m_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item373
+		class Item351
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13804,7 +9572,7 @@ class Mission
 			type="Land_Mil_WallBig_4m_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item374
+		class Item352
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13820,7 +9588,7 @@ class Mission
 			id=1348;
 			type="Land_Mil_WallBig_Corner_F";
 		};
-		class Item375
+		class Item353
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13836,7 +9604,7 @@ class Mission
 			id=1349;
 			type="Land_Mil_WallBig_Corner_F";
 		};
-		class Item376
+		class Item354
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13853,71 +9621,7 @@ class Mission
 			type="Land_Mil_WallBig_4m_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item377
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={6824.8901,116.30996,7145.5903};
-				angles[]={0,1.3538646,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-			};
-			id=1351;
-			type="Land_Cargo_Tower_V1_F";
-		};
-		class Item378
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={6834.6157,104.85357,7146.0933};
-				angles[]={0,2.9246607,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-			};
-			id=1352;
-			type="Land_Cargo_House_V1_F";
-		};
-		class Item379
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={6843.5767,105.31248,7147.8022};
-				angles[]={0,2.9246607,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-			};
-			id=1353;
-			type="Land_Cargo_House_V1_F";
-		};
-		class Item380
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={6858.7598,109.70748,7149.2754};
-				angles[]={0,6.0662537,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-			};
-			id=1354;
-			type="Land_Cargo_Patrol_V1_F";
-		};
-		class Item381
+		class Item355
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13929,11 +9633,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1355;
 			type="Land_HBarrier_5_F";
 		};
-		class Item382
+		class Item356
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13945,11 +9650,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1356;
 			type="Land_HBarrier_5_F";
 		};
-		class Item383
+		class Item357
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13961,11 +9667,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1357;
 			type="Land_HBarrier_5_F";
 		};
-		class Item384
+		class Item358
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13977,12 +9684,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1358;
 			type="Land_HBarrier_5_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item385
+		class Item359
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13994,11 +9702,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1359;
 			type="Land_HBarrier_5_F";
 		};
-		class Item386
+		class Item360
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14010,60 +9719,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1360;
 			type="Land_HBarrier_5_F";
 		};
-		class Item387
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={6815.0869,108.41675,7174.8335};
-				angles[]={0,1.3538646,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-			};
-			id=1361;
-			type="Land_Cargo_Patrol_V1_F";
-		};
-		class Item388
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={6869.7754,109.02059,7187.4868};
-				angles[]={0,2.9246607,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-			};
-			id=1362;
-			type="Land_Cargo_Patrol_V1_F";
-			atlOffset=-7.6293945e-006;
-		};
-		class Item389
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={6877.6558,109.47288,7155.0078};
-				angles[]={0,6.0662584,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-			};
-			id=1363;
-			type="Land_Cargo_Patrol_V1_F";
-		};
-		class Item390
+		class Item361
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14075,11 +9736,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1364;
 			type="Land_HBarrier_5_F";
 		};
-		class Item391
+		class Item362
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14091,12 +9753,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1365;
 			type="Land_HBarrier_5_F";
 			atlOffset=2.2888184e-005;
 		};
-		class Item392
+		class Item363
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14108,12 +9771,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1366;
 			type="Land_HBarrier_5_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item393
+		class Item364
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14125,44 +9789,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1367;
 			type="Land_HBarrier_5_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item394
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={6847.6445,105.27355,7181.7319};
-				angles[]={0,6.0478468,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-			};
-			id=1368;
-			type="Land_Cargo_House_V1_F";
-		};
-		class Item395
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={6856.5728,105.14413,7183.6055};
-				angles[]={0,6.0478468,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-			};
-			id=1369;
-			type="Land_Cargo_House_V1_F";
-		};
-		class Item396
+		class Item365
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -14218,7 +9851,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item397
+		class Item366
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14230,11 +9863,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1371;
 			type="Land_HelipadSquare_F";
 		};
-		class Item398
+		class Item367
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -14289,7 +9923,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item399
+		class Item368
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14305,7 +9939,7 @@ class Mission
 			id=1373;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item400
+		class Item369
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14321,7 +9955,7 @@ class Mission
 			id=1374;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item401
+		class Item370
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14333,12 +9967,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1375;
 			type="Land_HBarrier_Big_F";
 			atlOffset=0.014328003;
 		};
-		class Item402
+		class Item371
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14350,12 +9985,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1376;
 			type="Land_HBarrier_Big_F";
 			atlOffset=0.014328003;
 		};
-		class Item403
+		class Item372
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14367,12 +10003,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1377;
 			type="Land_HBarrier_Big_F";
 			atlOffset=0.014328003;
 		};
-		class Item404
+		class Item373
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14384,11 +10021,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1378;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item405
+		class Item374
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14400,11 +10038,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1379;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item406
+		class Item375
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14416,11 +10055,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1380;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item407
+		class Item376
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14432,11 +10072,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1381;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item408
+		class Item377
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -14493,7 +10134,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item409
+		class Item378
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14509,7 +10150,7 @@ class Mission
 			id=1383;
 			type="Land_Cargo_Tower_V3_F";
 		};
-		class Item410
+		class Item379
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14525,7 +10166,7 @@ class Mission
 			id=1384;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item411
+		class Item380
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14541,7 +10182,7 @@ class Mission
 			id=1386;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item412
+		class Item381
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14553,11 +10194,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1387;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item413
+		class Item382
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -14614,7 +10256,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item414
+		class Item383
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14626,11 +10268,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1392;
 			type="Land_HelipadSquare_F";
 		};
-		class Item415
+		class Item384
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14646,7 +10289,7 @@ class Mission
 			id=1393;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item416
+		class Item385
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14661,7 +10304,7 @@ class Mission
 			id=1394;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item417
+		class Item386
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14677,7 +10320,7 @@ class Mission
 			id=1395;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item418
+		class Item387
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14689,12 +10332,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1396;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item419
+		class Item388
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14706,12 +10350,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1397;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item420
+		class Item389
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14723,12 +10368,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1398;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item421
+		class Item390
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14740,12 +10386,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1399;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item422
+		class Item391
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14757,12 +10404,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1400;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.5776367e-005;
 		};
-		class Item423
+		class Item392
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14774,12 +10422,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1401;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item424
+		class Item393
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14791,12 +10440,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1402;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.5776367e-005;
 		};
-		class Item425
+		class Item394
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14808,12 +10458,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1403;
 			type="Land_HBarrier_Big_F";
 			atlOffset=6.1035156e-005;
 		};
-		class Item426
+		class Item395
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14825,12 +10476,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1404;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item427
+		class Item396
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14842,12 +10494,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1405;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.5776367e-005;
 		};
-		class Item428
+		class Item397
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14859,12 +10512,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1406;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item429
+		class Item398
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14876,12 +10530,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1407;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item430
+		class Item399
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14893,12 +10548,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1408;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item431
+		class Item400
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14910,12 +10566,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1409;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item432
+		class Item401
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14927,12 +10584,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1410;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item433
+		class Item402
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14944,12 +10602,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1411;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.5776367e-005;
 		};
-		class Item434
+		class Item403
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14961,12 +10620,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1412;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item435
+		class Item404
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14978,12 +10638,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1413;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item436
+		class Item405
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14995,12 +10656,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1414;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item437
+		class Item406
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15012,12 +10674,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1415;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item438
+		class Item407
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15029,12 +10692,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1416;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item439
+		class Item408
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15046,12 +10710,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1417;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item440
+		class Item409
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15063,12 +10728,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1418;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item441
+		class Item410
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15080,12 +10746,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1419;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item442
+		class Item411
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15097,12 +10764,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1420;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item443
+		class Item412
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15114,12 +10782,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1421;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item444
+		class Item413
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15131,11 +10800,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1422;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item445
+		class Item414
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15151,7 +10821,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.25006104;
 		};
-		class Item446
+		class Item415
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15163,12 +10833,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1424;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item447
+		class Item416
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15180,12 +10851,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1425;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item448
+		class Item417
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15197,12 +10869,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1426;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item449
+		class Item418
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15214,12 +10887,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1427;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item450
+		class Item419
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15231,12 +10905,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1428;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.5776367e-005;
 		};
-		class Item451
+		class Item420
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15248,12 +10923,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1429;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.5776367e-005;
 		};
-		class Item452
+		class Item421
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15265,12 +10941,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1430;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.5776367e-005;
 		};
-		class Item453
+		class Item422
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15286,7 +10963,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.25003052;
 		};
-		class Item454
+		class Item423
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15303,7 +10980,7 @@ class Mission
 			type="Land_TTowerSmall_1_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item455
+		class Item424
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15320,7 +10997,7 @@ class Mission
 			type="Land_TTowerSmall_2_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item456
+		class Item425
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15336,7 +11013,7 @@ class Mission
 			id=1434;
 			type="Land_Medevac_house_V1_F";
 		};
-		class Item457
+		class Item426
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15352,7 +11029,7 @@ class Mission
 			id=1435;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item458
+		class Item427
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15368,7 +11045,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item459
+		class Item428
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15385,7 +11062,7 @@ class Mission
 			type="Land_Cargo_House_V3_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item460
+		class Item429
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15400,7 +11077,7 @@ class Mission
 			id=1438;
 			type="Land_Cargo_House_V3_F";
 		};
-		class Item461
+		class Item430
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15416,7 +11093,7 @@ class Mission
 			id=1439;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item462
+		class Item431
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15433,7 +11110,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item463
+		class Item432
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15445,12 +11122,14 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=1441;
 			type="Land_Cargo40_sand_F";
 			atlOffset=-0.0128479;
 		};
-		class Item464
+		class Item433
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15462,12 +11141,14 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=1442;
 			type="Land_Cargo40_sand_F";
 			atlOffset=-0.011413574;
 		};
-		class Item465
+		class Item434
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15478,12 +11159,14 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=1443;
 			type="Land_Cargo40_sand_F";
 			atlOffset=2.6040955;
 		};
-		class Item466
+		class Item435
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15495,12 +11178,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1444;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.0089874268;
 		};
-		class Item467
+		class Item436
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15512,12 +11196,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1445;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item468
+		class Item437
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15529,12 +11214,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1446;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item469
+		class Item438
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15546,12 +11232,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1447;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item470
+		class Item439
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15563,12 +11250,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1455;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item471
+		class Item440
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15580,12 +11268,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1456;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item472
+		class Item441
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15597,11 +11286,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1457;
 			type="Land_HBarrier_5_F";
 		};
-		class Item473
+		class Item442
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15613,12 +11303,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1458;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item474
+		class Item443
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15630,11 +11321,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1459;
 			type="Land_HBarrier_5_F";
 		};
-		class Item475
+		class Item444
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15646,11 +11338,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1462;
 			type="Land_HBarrier_5_F";
 		};
-		class Item476
+		class Item445
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15662,11 +11355,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1463;
 			type="Land_HBarrier_5_F";
 		};
-		class Item477
+		class Item446
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15678,11 +11372,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1465;
 			type="Land_HBarrier_5_F";
 		};
-		class Item478
+		class Item447
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15694,11 +11389,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1466;
 			type="Land_HBarrier_5_F";
 		};
-		class Item479
+		class Item448
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15710,11 +11406,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1467;
 			type="Land_HBarrier_5_F";
 		};
-		class Item480
+		class Item449
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15726,11 +11423,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1468;
 			type="Land_HBarrier_5_F";
 		};
-		class Item481
+		class Item450
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15742,11 +11440,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1469;
 			type="Land_HBarrier_5_F";
 		};
-		class Item482
+		class Item451
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15758,12 +11457,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1470;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item483
+		class Item452
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15775,12 +11475,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1473;
 			type="Land_HBarrier_3_F";
 			atlOffset=6.1035156e-005;
 		};
-		class Item484
+		class Item453
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15792,11 +11493,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1490;
 			type="Land_HBarrier_5_F";
 		};
-		class Item485
+		class Item454
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15808,11 +11510,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1491;
 			type="Land_HBarrier_5_F";
 		};
-		class Item486
+		class Item455
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15824,11 +11527,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1494;
 			type="Land_HBarrier_5_F";
 		};
-		class Item487
+		class Item456
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15840,12 +11544,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1498;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item488
+		class Item457
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15857,12 +11562,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1499;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item489
+		class Item458
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15874,12 +11580,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1500;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item490
+		class Item459
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15891,12 +11598,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1501;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item491
+		class Item460
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15913,7 +11621,7 @@ class Mission
 			type="Land_Cargo_House_V3_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item492
+		class Item461
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15929,7 +11637,7 @@ class Mission
 			id=1505;
 			type="Land_Cargo_House_V3_F";
 		};
-		class Item493
+		class Item462
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15946,7 +11654,7 @@ class Mission
 			type="Land_Cargo_House_V3_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item494
+		class Item463
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15962,7 +11670,7 @@ class Mission
 			id=1507;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item495
+		class Item464
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15978,7 +11686,7 @@ class Mission
 			id=1510;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item496
+		class Item465
 		{
 			dataType="Layer";
 			name="Camp Audacity";
@@ -15998,6 +11706,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1511;
 					type="Land_HBarrierBig_F";
@@ -16085,6 +11794,8 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						createAsSimpleObject=1;
+						disableSimulation=1;
 					};
 					id=1516;
 					type="Land_Cargo20_military_green_F";
@@ -16103,6 +11814,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1517;
 					type="Land_HBarrierBig_F";
@@ -16121,6 +11833,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1518;
 					type="Land_HBarrierBig_F";
@@ -16138,6 +11851,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1519;
 					type="Land_HBarrier_5_F";
@@ -16155,6 +11869,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1520;
 					type="Land_HBarrier_5_F";
@@ -16173,6 +11888,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1521;
 					type="Land_HBarrier_5_F";
@@ -16191,6 +11907,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1522;
 					type="Land_HBarrierBig_F";
@@ -16209,6 +11926,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1523;
 					type="Land_HBarrierBig_F";
@@ -16226,6 +11944,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1524;
 					type="Land_HBarrierBig_F";
@@ -16244,6 +11963,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1525;
 					type="Land_HBarrier_5_F";
@@ -16262,6 +11982,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1526;
 					type="Land_HBarrierBig_F";
@@ -16280,6 +12001,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1527;
 					type="Land_HBarrier_5_F";
@@ -16298,6 +12020,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1528;
 					type="Land_HBarrier_5_F";
@@ -16315,6 +12038,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1529;
 					type="Land_HBarrierBig_F";
@@ -16367,6 +12091,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1532;
 					type="Land_HBarrierBig_F";
@@ -16384,6 +12109,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1533;
 					type="Land_HBarrierBig_F";
@@ -16401,6 +12127,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1534;
 					type="Land_HBarrier_5_F";
@@ -16419,6 +12146,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1535;
 					type="Land_HBarrier_5_F";
@@ -16437,6 +12165,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1536;
 					type="Land_HBarrier_5_F";
@@ -16455,6 +12184,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1537;
 					type="Land_HBarrierBig_F";
@@ -16473,6 +12203,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1538;
 					type="Land_HBarrierBig_F";
@@ -16490,6 +12221,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1539;
 					type="Land_HBarrierBig_F";
@@ -16507,6 +12239,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1540;
 					type="Land_HBarrier_5_F";
@@ -16524,6 +12257,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1541;
 					type="Land_HBarrierBig_F";
@@ -16541,6 +12275,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1542;
 					type="Land_HBarrier_5_F";
@@ -16558,6 +12293,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1543;
 					type="Land_HBarrier_5_F";
@@ -16575,6 +12311,8 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						createAsSimpleObject=1;
+						disableSimulation=1;
 					};
 					id=1544;
 					type="Land_Cargo20_military_green_F";
@@ -16593,6 +12331,8 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						createAsSimpleObject=1;
+						disableSimulation=1;
 					};
 					id=1545;
 					type="Land_Cargo20_military_green_F";
@@ -16611,6 +12351,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1546;
 					type="Land_HBarrier_5_F";
@@ -16628,6 +12369,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1547;
 					type="Land_HBarrier_5_F";
@@ -16645,6 +12387,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1548;
 					type="Land_HBarrier_5_F";
@@ -16662,6 +12405,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1549;
 					type="Land_HBarrier_5_F";
@@ -16680,6 +12424,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1550;
 					type="Land_HBarrier_5_F";
@@ -16697,6 +12442,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1551;
 					type="Land_HBarrier_5_F";
@@ -16784,6 +12530,8 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						createAsSimpleObject=1;
+						disableSimulation=1;
 					};
 					id=1557;
 					type="Land_Cargo20_military_green_F";
@@ -16923,6 +12671,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1572;
 					type="Land_HBarrier_5_F";
@@ -16940,6 +12689,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1573;
 					type="Land_HBarrier_5_F";
@@ -16957,6 +12707,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1574;
 					type="Land_HBarrier_5_F";
@@ -16975,6 +12726,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1575;
 					type="Land_HBarrierBig_F";
@@ -17026,6 +12778,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1578;
 					type="Land_HBarrier_5_F";
@@ -17043,6 +12796,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1579;
 					type="Land_HBarrier_5_F";
@@ -17060,6 +12814,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1580;
 					type="Land_HBarrier_5_F";
@@ -17078,6 +12833,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1581;
 					type="Land_HBarrierBig_F";
@@ -17131,6 +12887,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1677;
 					type="Land_HBarrier_5_F";
@@ -17149,6 +12906,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1678;
 					type="Land_HBarrier_5_F";
@@ -17166,6 +12924,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1679;
 					type="Land_HBarrier_5_F";
@@ -17218,6 +12977,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1683;
 					type="Land_HBarrier_5_F";
@@ -17236,6 +12996,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1684;
 					type="Land_HBarrier_5_F";
@@ -17254,6 +13015,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1685;
 					type="Land_HBarrier_5_F";
@@ -17272,6 +13034,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1686;
 					type="Land_HBarrierBig_F";
@@ -17341,6 +13104,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1694;
 					type="Land_HBarrierBig_F";
@@ -17358,6 +13122,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1695;
 					type="Land_HBarrierBig_F";
@@ -17376,6 +13141,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1754;
 					type="Land_HBarrierBig_F";
@@ -17428,6 +13194,8 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						createAsSimpleObject=1;
+						disableSimulation=1;
 					};
 					id=1759;
 					type="Land_Cargo20_military_green_F";
@@ -17446,6 +13214,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1760;
 					type="Land_HBarrierBig_F";
@@ -17463,6 +13232,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1761;
 					type="Land_HBarrierBig_F";
@@ -17481,6 +13251,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1762;
 					type="Land_HBarrier_5_F";
@@ -17498,6 +13269,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1763;
 					type="Land_HBarrier_5_F";
@@ -17515,6 +13287,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1764;
 					type="Land_HBarrier_5_F";
@@ -17533,6 +13306,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1765;
 					type="Land_HBarrierBig_F";
@@ -17551,6 +13325,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1766;
 					type="Land_HBarrierBig_F";
@@ -17568,6 +13343,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1768;
 					type="Land_HBarrier_5_F";
@@ -17585,6 +13361,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1770;
 					type="Land_HBarrier_5_F";
@@ -17602,6 +13379,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1771;
 					type="Land_HBarrier_5_F";
@@ -17619,6 +13397,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1772;
 					type="Land_HBarrierBig_F";
@@ -17654,6 +13433,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1775;
 					type="Land_HBarrierBig_F";
@@ -17670,6 +13450,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1776;
 					type="Land_HBarrierBig_F";
@@ -17688,6 +13469,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1777;
 					type="Land_HBarrier_5_F";
@@ -17706,6 +13488,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1778;
 					type="Land_HBarrier_5_F";
@@ -17723,6 +13506,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1779;
 					type="Land_HBarrier_5_F";
@@ -17741,6 +13525,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1780;
 					type="Land_HBarrierBig_F";
@@ -17759,6 +13544,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1781;
 					type="Land_HBarrierBig_F";
@@ -17776,6 +13562,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1782;
 					type="Land_HBarrierBig_F";
@@ -17793,6 +13580,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1783;
 					type="Land_HBarrier_5_F";
@@ -17810,6 +13598,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1784;
 					type="Land_HBarrierBig_F";
@@ -17827,6 +13616,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1785;
 					type="Land_HBarrier_5_F";
@@ -17844,6 +13634,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1786;
 					type="Land_HBarrier_5_F";
@@ -17861,6 +13652,8 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						createAsSimpleObject=1;
+						disableSimulation=1;
 					};
 					id=1787;
 					type="Land_Cargo20_military_green_F";
@@ -17879,6 +13672,8 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						createAsSimpleObject=1;
+						disableSimulation=1;
 					};
 					id=1788;
 					type="Land_Cargo20_military_green_F";
@@ -17897,6 +13692,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1789;
 					type="Land_HBarrier_5_F";
@@ -17914,6 +13710,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1790;
 					type="Land_HBarrier_5_F";
@@ -17931,6 +13728,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1791;
 					type="Land_HBarrier_5_F";
@@ -17948,6 +13746,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1792;
 					type="Land_HBarrier_5_F";
@@ -17965,6 +13764,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1794;
 					type="Land_HBarrier_5_F";
@@ -18018,6 +13818,8 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						createAsSimpleObject=1;
+						disableSimulation=1;
 					};
 					id=1799;
 					type="Land_Cargo20_military_green_F";
@@ -18140,6 +13942,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1808;
 					type="Land_HBarrierBig_F";
@@ -18158,6 +13961,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1809;
 					type="Land_HBarrierBig_F";
@@ -18175,6 +13979,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1810;
 					type="Land_HBarrierBig_F";
@@ -18193,6 +13998,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1811;
 					type="Land_HBarrier_5_F";
@@ -18201,7 +14007,7 @@ class Mission
 			id=1567;
 			atlOffset=0.13801575;
 		};
-		class Item497
+		class Item466
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -18255,7 +14061,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item498
+		class Item467
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -18311,7 +14117,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item499
+		class Item468
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -18368,7 +14174,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item500
+		class Item469
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -18424,7 +14230,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item501
+		class Item470
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18436,11 +14242,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1586;
 			type="Land_HelipadSquare_F";
 		};
-		class Item502
+		class Item471
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -18496,7 +14303,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item503
+		class Item472
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -18553,7 +14360,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item504
+		class Item473
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18569,7 +14376,7 @@ class Mission
 			id=1589;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item505
+		class Item474
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18585,7 +14392,7 @@ class Mission
 			id=1590;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item506
+		class Item475
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18597,12 +14404,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1594;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item507
+		class Item476
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18614,11 +14422,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1598;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item508
+		class Item477
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18630,12 +14439,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1600;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item509
+		class Item478
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18647,12 +14457,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1601;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item510
+		class Item479
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18664,12 +14475,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1602;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item511
+		class Item480
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18681,12 +14493,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1603;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item512
+		class Item481
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18698,11 +14511,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1604;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item513
+		class Item482
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18714,12 +14528,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1605;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item514
+		class Item483
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18731,12 +14546,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1606;
 			type="Land_HBarrier_Big_F";
 			atlOffset=2.2888184e-005;
 		};
-		class Item515
+		class Item484
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18748,12 +14564,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1607;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item516
+		class Item485
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18765,12 +14582,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1608;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item517
+		class Item486
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18782,12 +14600,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1609;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item518
+		class Item487
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18799,12 +14618,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1610;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item519
+		class Item488
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18816,12 +14636,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1611;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item520
+		class Item489
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18833,11 +14654,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1612;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item521
+		class Item490
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18849,12 +14671,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1613;
 			type="Land_HBarrier_Big_F";
 			atlOffset=2.2888184e-005;
 		};
-		class Item522
+		class Item491
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18866,12 +14689,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1614;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item523
+		class Item492
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18883,12 +14707,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1615;
 			type="Land_HBarrier_Big_F";
 			atlOffset=2.2888184e-005;
 		};
-		class Item524
+		class Item493
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18900,11 +14725,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1616;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item525
+		class Item494
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18916,11 +14742,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1617;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item526
+		class Item495
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18932,12 +14759,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1618;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item527
+		class Item496
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18949,12 +14777,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1620;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item528
+		class Item497
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18966,12 +14795,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1621;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item529
+		class Item498
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18983,12 +14813,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1622;
 			type="Land_HBarrier_Big_F";
 			atlOffset=2.2888184e-005;
 		};
-		class Item530
+		class Item499
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19000,12 +14831,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1623;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item531
+		class Item500
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19017,12 +14849,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1624;
 			type="Land_HBarrier_Big_F";
 			atlOffset=2.2888184e-005;
 		};
-		class Item532
+		class Item501
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19034,12 +14867,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1625;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item533
+		class Item502
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19051,12 +14885,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1626;
 			type="Land_HBarrier_Big_F";
 			atlOffset=2.2888184e-005;
 		};
-		class Item534
+		class Item503
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19072,7 +14907,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.25001526;
 		};
-		class Item535
+		class Item504
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19089,7 +14924,7 @@ class Mission
 			type="Land_TTowerSmall_1_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item536
+		class Item505
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19106,7 +14941,7 @@ class Mission
 			type="Land_TTowerSmall_2_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item537
+		class Item506
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19122,7 +14957,7 @@ class Mission
 			id=1630;
 			type="Land_Medevac_house_V1_F";
 		};
-		class Item538
+		class Item507
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19138,7 +14973,7 @@ class Mission
 			id=1631;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item539
+		class Item508
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19155,7 +14990,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item540
+		class Item509
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19171,7 +15006,7 @@ class Mission
 			id=1633;
 			type="Land_Cargo_House_V3_F";
 		};
-		class Item541
+		class Item510
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19187,7 +15022,7 @@ class Mission
 			id=1634;
 			type="Land_Cargo_House_V3_F";
 		};
-		class Item542
+		class Item511
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19204,7 +15039,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item543
+		class Item512
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19220,7 +15055,7 @@ class Mission
 			id=1636;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item544
+		class Item513
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19232,12 +15067,14 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=1637;
 			type="Land_Cargo40_sand_F";
 			atlOffset=-0.0092849731;
 		};
-		class Item545
+		class Item514
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19249,12 +15086,14 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=1638;
 			type="Land_Cargo40_sand_F";
 			atlOffset=-0.016242981;
 		};
-		class Item546
+		class Item515
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19265,12 +15104,14 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=1639;
 			type="Land_Cargo40_sand_F";
 			atlOffset=2.6031113;
 		};
-		class Item547
+		class Item516
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19282,11 +15123,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1641;
 			type="Land_HelipadSquare_F";
 		};
-		class Item548
+		class Item517
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19302,7 +15144,7 @@ class Mission
 			id=1642;
 			type="Land_Cargo_Tower_V3_F";
 		};
-		class Item549
+		class Item518
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19318,7 +15160,7 @@ class Mission
 			id=1643;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item550
+		class Item519
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19330,11 +15172,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1644;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item551
+		class Item520
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19346,11 +15189,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1645;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item552
+		class Item521
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19362,11 +15206,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1646;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item553
+		class Item522
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19378,12 +15223,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1647;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item554
+		class Item523
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19395,11 +15241,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1648;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item555
+		class Item524
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19411,11 +15258,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1649;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item556
+		class Item525
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19431,7 +15279,7 @@ class Mission
 			id=1650;
 			type="Land_Medevac_house_V1_F";
 		};
-		class Item557
+		class Item526
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19447,7 +15295,7 @@ class Mission
 			id=1651;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item558
+		class Item527
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19463,7 +15311,7 @@ class Mission
 			id=1652;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item559
+		class Item528
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -19519,7 +15367,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item560
+		class Item529
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -19575,7 +15423,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item561
+		class Item530
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19587,11 +15435,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1655;
 			type="Land_HelipadSquare_F";
 		};
-		class Item562
+		class Item531
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19608,7 +15457,7 @@ class Mission
 			type="Land_Cargo_Tower_V3_F";
 			atlOffset=-0.026695251;
 		};
-		class Item563
+		class Item532
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -19663,7 +15512,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item564
+		class Item533
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19679,7 +15528,7 @@ class Mission
 			id=1658;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item565
+		class Item534
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19695,7 +15544,7 @@ class Mission
 			id=1659;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item566
+		class Item535
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19711,7 +15560,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.25002289;
 		};
-		class Item567
+		class Item536
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -19765,7 +15614,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item568
+		class Item537
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -19819,7 +15668,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item569
+		class Item538
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -19874,7 +15723,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item570
+		class Item539
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -19928,7 +15777,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item571
+		class Item540
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -19982,7 +15831,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item572
+		class Item541
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19999,7 +15848,7 @@ class Mission
 			type="Land_Cargo_Tower_V3_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item573
+		class Item542
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20054,7 +15903,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item574
+		class Item543
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20070,7 +15919,7 @@ class Mission
 			id=1668;
 			type="Land_Cargo_Tower_V3_F";
 		};
-		class Item575
+		class Item544
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20086,7 +15935,7 @@ class Mission
 			id=1669;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item576
+		class Item545
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20102,7 +15951,7 @@ class Mission
 			id=1670;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item577
+		class Item546
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20118,7 +15967,7 @@ class Mission
 			id=1671;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item578
+		class Item547
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20134,7 +15983,7 @@ class Mission
 			id=1672;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item579
+		class Item548
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20146,11 +15995,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1673;
 			type="Land_HelipadSquare_F";
 		};
-		class Item580
+		class Item549
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20161,11 +16011,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1674;
 			type="Land_HelipadSquare_F";
 		};
-		class Item581
+		class Item550
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20220,7 +16071,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item582
+		class Item551
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20277,7 +16128,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item583
+		class Item552
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20289,12 +16140,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1697;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item584
+		class Item553
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20306,12 +16158,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1698;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item585
+		class Item554
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20323,12 +16176,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1699;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item586
+		class Item555
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20340,12 +16194,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1700;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item587
+		class Item556
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20357,11 +16212,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1701;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item588
+		class Item557
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20373,12 +16229,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1702;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item589
+		class Item558
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20390,11 +16247,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1703;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item590
+		class Item559
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20406,12 +16264,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1704;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item591
+		class Item560
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20423,12 +16282,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1705;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item592
+		class Item561
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20440,12 +16300,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1706;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item593
+		class Item562
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20457,11 +16318,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1707;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item594
+		class Item563
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20473,11 +16335,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1708;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item595
+		class Item564
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20489,12 +16352,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1709;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item596
+		class Item565
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20506,12 +16370,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1710;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item597
+		class Item566
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20523,12 +16388,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1711;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item598
+		class Item567
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20540,12 +16406,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1712;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item599
+		class Item568
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20557,12 +16424,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1713;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item600
+		class Item569
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20574,12 +16442,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1714;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.5776367e-005;
 		};
-		class Item601
+		class Item570
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20591,11 +16460,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1715;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item602
+		class Item571
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20607,12 +16477,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1716;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item603
+		class Item572
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20624,11 +16495,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1717;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item604
+		class Item573
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20640,12 +16512,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1718;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item605
+		class Item574
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20657,12 +16530,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1719;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item606
+		class Item575
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20674,12 +16548,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1720;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item607
+		class Item576
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20691,12 +16566,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1721;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item608
+		class Item577
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20708,12 +16584,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1722;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item609
+		class Item578
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20725,12 +16602,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1723;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item610
+		class Item579
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20742,12 +16620,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1724;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item611
+		class Item580
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20763,7 +16642,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.25001526;
 		};
-		class Item612
+		class Item581
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20780,7 +16659,7 @@ class Mission
 			type="Land_TTowerSmall_1_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item613
+		class Item582
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20797,7 +16676,7 @@ class Mission
 			type="Land_TTowerSmall_2_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item614
+		class Item583
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20813,7 +16692,7 @@ class Mission
 			id=1728;
 			type="Land_Medevac_house_V1_F";
 		};
-		class Item615
+		class Item584
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20829,7 +16708,7 @@ class Mission
 			id=1729;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item616
+		class Item585
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20846,7 +16725,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item617
+		class Item586
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20863,7 +16742,7 @@ class Mission
 			type="Land_Cargo_House_V3_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item618
+		class Item587
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20879,7 +16758,7 @@ class Mission
 			id=1732;
 			type="Land_Cargo_House_V3_F";
 		};
-		class Item619
+		class Item588
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20895,7 +16774,7 @@ class Mission
 			id=1733;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item620
+		class Item589
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20911,7 +16790,7 @@ class Mission
 			id=1734;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item621
+		class Item590
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20923,12 +16802,14 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=1735;
 			type="Land_Cargo40_sand_F";
 			atlOffset=-0.0090789795;
 		};
-		class Item622
+		class Item591
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20940,12 +16821,14 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=1736;
 			type="Land_Cargo40_sand_F";
 			atlOffset=-0.010482788;
 		};
-		class Item623
+		class Item592
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20957,11 +16840,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1738;
 			type="Land_HelipadSquare_F";
 		};
-		class Item624
+		class Item593
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -21017,7 +16901,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item625
+		class Item594
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21033,7 +16917,7 @@ class Mission
 			id=1740;
 			type="Land_Ind_PowerStation_EP1";
 		};
-		class Item626
+		class Item595
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21049,7 +16933,7 @@ class Mission
 			id=1741;
 			type="Land_House_C_2_EP1";
 		};
-		class Item627
+		class Item596
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21065,7 +16949,7 @@ class Mission
 			id=1742;
 			type="Land_House_C_12_EP1";
 		};
-		class Item628
+		class Item597
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21081,7 +16965,7 @@ class Mission
 			id=1743;
 			type="Land_Shed_M01_EP1";
 		};
-		class Item629
+		class Item598
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21097,7 +16981,7 @@ class Mission
 			id=1744;
 			type="Land_Shed_W02_EP1";
 		};
-		class Item630
+		class Item599
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21113,7 +16997,7 @@ class Mission
 			id=1745;
 			type="Land_Mil_Guardhouse_EP1";
 		};
-		class Item631
+		class Item600
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21129,7 +17013,7 @@ class Mission
 			id=1748;
 			type="Wall_L1_2m5_EP1";
 		};
-		class Item632
+		class Item601
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21145,7 +17029,7 @@ class Mission
 			id=1752;
 			type="Wall_L1_2m5_EP1";
 		};
-		class Item633
+		class Item602
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21161,7 +17045,7 @@ class Mission
 			id=1753;
 			type="Land_House_C_2_EP1";
 		};
-		class Item634
+		class Item603
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -21216,7 +17100,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item635
+		class Item604
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21233,7 +17117,7 @@ class Mission
 			type="Land_Cargo_Tower_V3_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item636
+		class Item605
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -21290,7 +17174,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item637
+		class Item606
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -21345,7 +17229,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item638
+		class Item607
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21357,11 +17241,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1814;
 			type="Land_HelipadSquare_F";
 		};
-		class Item639
+		class Item608
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21377,7 +17262,7 @@ class Mission
 			id=1815;
 			type="Land_Cargo_Tower_V3_F";
 		};
-		class Item640
+		class Item609
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21393,7 +17278,7 @@ class Mission
 			id=1816;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item641
+		class Item610
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21409,7 +17294,7 @@ class Mission
 			id=1817;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item642
+		class Item611
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21425,7 +17310,7 @@ class Mission
 			id=1818;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item643
+		class Item612
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21441,7 +17326,7 @@ class Mission
 			id=1819;
 			type="Land_Cargo_House_V3_F";
 		};
-		class Item644
+		class Item613
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21457,7 +17342,7 @@ class Mission
 			id=1822;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item645
+		class Item614
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21473,7 +17358,7 @@ class Mission
 			id=1823;
 			type="Land_Medevac_house_V1_F";
 		};
-		class Item646
+		class Item615
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21489,7 +17374,7 @@ class Mission
 			id=1824;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item647
+		class Item616
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21505,7 +17390,7 @@ class Mission
 			id=1825;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item648
+		class Item617
 		{
 			dataType="Layer";
 			name="Roadblock";
@@ -22221,77 +18106,77 @@ class Mission
 			id=1843;
 			atlOffset=0.15333557;
 		};
-		class Item649
+		class Item618
 		{
 			dataType="Layer";
 			name="Hasty Roadblock";
 			id=1851;
 			atlOffset=-182.61;
 		};
-		class Item650
+		class Item619
 		{
 			dataType="Layer";
 			name="Check Point (Large)";
 			id=1869;
 			atlOffset=-182.61;
 		};
-		class Item651
+		class Item620
 		{
 			dataType="Layer";
 			name="Check Point (Medium)";
 			id=1874;
 			atlOffset=-182.61;
 		};
-		class Item652
+		class Item621
 		{
 			dataType="Layer";
 			name="Check Point (Small)";
 			id=1879;
 			atlOffset=-182.61;
 		};
-		class Item653
+		class Item622
 		{
 			dataType="Layer";
 			name="Camp Fortitude";
 			id=1930;
 			atlOffset=-182.61;
 		};
-		class Item654
+		class Item623
 		{
 			dataType="Layer";
 			name="Camp Endurance";
 			id=1981;
 			atlOffset=-182.61;
 		};
-		class Item655
+		class Item624
 		{
 			dataType="Layer";
 			name="Camp Defiance";
 			id=2031;
 			atlOffset=-182.61;
 		};
-		class Item656
+		class Item625
 		{
 			dataType="Layer";
 			name="Camp Courage";
 			id=2084;
 			atlOffset=-182.61;
 		};
-		class Item657
+		class Item626
 		{
 			dataType="Layer";
 			name="Camp Bravery";
 			id=2134;
 			atlOffset=-182.61;
 		};
-		class Item658
+		class Item627
 		{
 			dataType="Layer";
 			name="Camp Audacity";
 			id=2191;
 			atlOffset=-182.61;
 		};
-		class Item659
+		class Item628
 		{
 			dataType="Layer";
 			name="Camp Endurance";
@@ -22311,6 +18196,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2192;
 					type="Land_HBarrier_5_F";
@@ -22329,6 +18215,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2193;
 					type="Land_HBarrier_5_F";
@@ -22346,6 +18233,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2194;
 					type="Land_HBarrier_5_F";
@@ -22363,6 +18251,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2195;
 					type="Land_HBarrier_5_F";
@@ -22380,6 +18269,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2196;
 					type="Land_HBarrier_5_F";
@@ -22397,6 +18287,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2197;
 					type="Land_HBarrier_5_F";
@@ -22415,6 +18306,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2198;
 					type="Land_HBarrier_5_F";
@@ -22433,6 +18325,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2199;
 					type="Land_HBarrier_5_F";
@@ -22450,6 +18343,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2200;
 					type="Land_HBarrier_5_F";
@@ -22468,6 +18362,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2204;
 					type="Land_HBarrier_5_F";
@@ -22485,6 +18380,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2205;
 					type="Land_HBarrier_5_F";
@@ -22503,6 +18399,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2206;
 					type="Land_HBarrier_5_F";
@@ -22521,6 +18418,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2207;
 					type="Land_HBarrier_5_F";
@@ -22539,6 +18437,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2208;
 					type="Land_HBarrier_5_F";
@@ -22664,6 +18563,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2235;
 					type="Land_HBarrier_1_F";
@@ -22682,6 +18582,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2236;
 					type="Land_HBarrier_1_F";
@@ -22754,6 +18655,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2243;
 					type="Land_HBarrier_5_F";
@@ -22772,6 +18674,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2244;
 					type="Land_HBarrier_5_F";
@@ -22790,6 +18693,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2245;
 					type="Land_HBarrier_5_F";
@@ -22807,6 +18711,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2246;
 					type="Land_HBarrier_5_F";
@@ -22825,6 +18730,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2247;
 					type="Land_HBarrier_5_F";
@@ -22842,6 +18748,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2248;
 					type="Land_HBarrier_5_F";
@@ -22860,6 +18767,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2249;
 					type="Land_HBarrier_5_F";
@@ -22878,6 +18786,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2250;
 					type="Land_HBarrier_5_F";
@@ -22895,6 +18804,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2251;
 					type="Land_HBarrier_5_F";
@@ -22913,6 +18823,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2257;
 					type="Land_HBarrier_5_F";
@@ -22931,6 +18842,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2258;
 					type="Land_HBarrier_5_F";
@@ -22949,6 +18861,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2259;
 					type="Land_HBarrier_5_F";
@@ -22967,6 +18880,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2271;
 					type="Land_HBarrier_5_F";
@@ -22984,6 +18898,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2272;
 					type="Land_HBarrier_5_F";
@@ -23088,6 +19003,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2299;
 					type="Land_HBarrier_5_F";
@@ -23105,6 +19021,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2300;
 					type="Land_HBarrier_5_F";
@@ -23123,6 +19040,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2301;
 					type="Land_HBarrier_5_F";
@@ -23141,6 +19059,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2302;
 					type="Land_HBarrier_5_F";
@@ -23158,6 +19077,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2303;
 					type="Land_HBarrier_5_F";
@@ -23175,6 +19095,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2304;
 					type="Land_HBarrier_5_F";
@@ -23193,6 +19114,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2305;
 					type="Land_HBarrier_5_F";
@@ -23211,6 +19133,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2306;
 					type="Land_HBarrier_5_F";
@@ -23228,6 +19151,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2307;
 					type="Land_HBarrier_5_F";
@@ -23245,6 +19169,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2308;
 					type="Land_HBarrier_5_F";
@@ -23262,6 +19187,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2309;
 					type="Land_HBarrier_5_F";
@@ -23279,6 +19205,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2310;
 					type="Land_HBarrier_5_F";
@@ -23296,6 +19223,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2311;
 					type="Land_HBarrier_5_F";
@@ -23313,6 +19241,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2312;
 					type="Land_HBarrier_5_F";
@@ -23434,6 +19363,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2319;
 					type="Land_HBarrier_1_F";
@@ -23451,6 +19381,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2320;
 					type="Land_HBarrier_1_F";
@@ -23522,6 +19453,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2324;
 					type="Land_HBarrier_5_F";
@@ -23539,6 +19471,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2325;
 					type="Land_HBarrier_5_F";
@@ -23557,6 +19490,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2326;
 					type="Land_HBarrier_5_F";
@@ -23574,6 +19508,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2327;
 					type="Land_HBarrier_5_F";
@@ -23591,6 +19526,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2328;
 					type="Land_HBarrier_5_F";
@@ -23608,6 +19544,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2329;
 					type="Land_HBarrier_5_F";
@@ -23625,6 +19562,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2330;
 					type="Land_HBarrier_5_F";
@@ -23642,6 +19580,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2331;
 					type="Land_HBarrier_5_F";
@@ -23659,6 +19598,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2332;
 					type="Land_HBarrier_5_F";
@@ -23676,6 +19616,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2333;
 					type="Land_HBarrier_5_F";
@@ -23693,6 +19634,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2334;
 					type="Land_HBarrier_5_F";
@@ -23710,6 +19652,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2335;
 					type="Land_HBarrier_5_F";
@@ -23727,6 +19670,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2336;
 					type="Land_HBarrier_5_F";
@@ -23744,6 +19688,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2337;
 					type="Land_HBarrier_5_F";
@@ -23839,7 +19784,7 @@ class Mission
 			id=2242;
 			atlOffset=-0.51138306;
 		};
-		class Item660
+		class Item629
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23851,11 +19796,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2278;
 			type="Land_HelipadSquare_F";
 		};
-		class Item661
+		class Item630
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23867,11 +19813,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2343;
 			type="Land_HelipadSquare_F";
 		};
-		class Item662
+		class Item631
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -23928,7 +19875,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item663
+		class Item632
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -23985,7 +19932,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item664
+		class Item633
 		{
 			dataType="Object";
 			class PositionInfo
@@ -24001,7 +19948,7 @@ class Mission
 			type="Land_Ind_PowerStation_EP1";
 			atlOffset=0.77583313;
 		};
-		class Item665
+		class Item634
 		{
 			dataType="Object";
 			class PositionInfo
@@ -24017,7 +19964,7 @@ class Mission
 			type="Land_House_C_2_EP1";
 			atlOffset=0.71500397;
 		};
-		class Item666
+		class Item635
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -24072,7 +20019,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item667
+		class Item636
 		{
 			dataType="Object";
 			class PositionInfo
@@ -24088,7 +20035,7 @@ class Mission
 			id=2349;
 			type="Land_House_C_3_dam_EP1";
 		};
-		class Item668
+		class Item637
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -24143,7 +20090,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item669
+		class Item638
 		{
 			dataType="Object";
 			class PositionInfo
@@ -24159,7 +20106,7 @@ class Mission
 			type="Land_House_C_1_v2_EP1";
 			atlOffset=0.34170532;
 		};
-		class Item670
+		class Item639
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -24214,7 +20161,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item671
+		class Item640
 		{
 			dataType="Marker";
 			position[]={4456.8687,190.47711,3606.6189};
@@ -24226,7 +20173,7 @@ class Mission
 			b=50;
 			id=2353;
 		};
-		class Item672
+		class Item641
 		{
 			dataType="Marker";
 			position[]={4463.71,2.7037606e+012,3610.7322};
@@ -24237,7 +20184,7 @@ class Mission
 			id=2354;
 			atlOffset=2.7037606e+012;
 		};
-		class Item673
+		class Item642
 		{
 			dataType="Marker";
 			position[]={5205.9829,154.868,5194.752};
@@ -24251,7 +20198,7 @@ class Mission
 			id=2440;
 			atlOffset=-0.71340942;
 		};
-		class Item674
+		class Item643
 		{
 			dataType="Marker";
 			position[]={7903.9082,112.85633,6730.4644};
@@ -24260,7 +20207,7 @@ class Mission
 			angle=227.508;
 			id=2442;
 		};
-		class Item675
+		class Item644
 		{
 			dataType="Marker";
 			position[]={7323.8711,86.567894,6915.7256};
@@ -24269,7 +20216,7 @@ class Mission
 			angle=227.508;
 			id=2443;
 		};
-		class Item676
+		class Item645
 		{
 			dataType="Marker";
 			position[]={6799.0586,100.56138,7111.6851};
@@ -24278,7 +20225,7 @@ class Mission
 			angle=227.508;
 			id=2444;
 		};
-		class Item677
+		class Item646
 		{
 			dataType="Marker";
 			position[]={5934.9629,113.91276,7145.8306};
@@ -24287,7 +20234,7 @@ class Mission
 			angle=227.508;
 			id=2445;
 		};
-		class Item678
+		class Item647
 		{
 			dataType="Marker";
 			position[]={5257.1509,115.4539,7035.2681};
@@ -24296,7 +20243,7 @@ class Mission
 			angle=227.508;
 			id=2446;
 		};
-		class Item679
+		class Item648
 		{
 			dataType="Marker";
 			position[]={4598.3291,136.91579,6981.1094};
@@ -24305,7 +20252,7 @@ class Mission
 			angle=227.508;
 			id=2447;
 		};
-		class Item680
+		class Item649
 		{
 			dataType="Marker";
 			position[]={4050.3445,136.64241,6907.9141};
@@ -24314,7 +20261,7 @@ class Mission
 			angle=227.508;
 			id=2448;
 		};
-		class Item681
+		class Item650
 		{
 			dataType="Marker";
 			position[]={4166.0698,136.03134,6484.4424};
@@ -24323,7 +20270,7 @@ class Mission
 			angle=227.508;
 			id=2449;
 		};
-		class Item682
+		class Item651
 		{
 			dataType="Marker";
 			position[]={4293.9258,137.30052,6021.228};
@@ -24332,7 +20279,7 @@ class Mission
 			angle=227.508;
 			id=2450;
 		};
-		class Item683
+		class Item652
 		{
 			dataType="Marker";
 			position[]={4311.5908,133.75879,5660.5771};
@@ -24341,7 +20288,7 @@ class Mission
 			angle=227.508;
 			id=2451;
 		};
-		class Item684
+		class Item653
 		{
 			dataType="Marker";
 			position[]={3989.1768,127.41193,5219.5762};
@@ -24351,7 +20298,7 @@ class Mission
 			id=2452;
 			atlOffset=-7.6293945e-006;
 		};
-		class Item685
+		class Item654
 		{
 			dataType="Marker";
 			position[]={3498.0703,156.86731,4549.0088};
@@ -24360,7 +20307,7 @@ class Mission
 			angle=227.508;
 			id=2453;
 		};
-		class Item686
+		class Item655
 		{
 			dataType="Marker";
 			position[]={4105.0332,156.6432,4759.7324};
@@ -24369,7 +20316,7 @@ class Mission
 			angle=227.508;
 			id=2454;
 		};
-		class Item687
+		class Item656
 		{
 			dataType="Marker";
 			position[]={5184.0425,165.94556,5099.5479};
@@ -24378,7 +20325,7 @@ class Mission
 			angle=227.508;
 			id=2455;
 		};
-		class Item688
+		class Item657
 		{
 			dataType="Marker";
 			position[]={6080.3027,192.04518,3845.8979};
@@ -24387,7 +20334,7 @@ class Mission
 			angle=227.508;
 			id=2456;
 		};
-		class Item689
+		class Item658
 		{
 			dataType="Marker";
 			position[]={7111.9653,297.34232,3385.6274};
@@ -24396,7 +20343,7 @@ class Mission
 			angle=227.508;
 			id=2457;
 		};
-		class Item690
+		class Item659
 		{
 			dataType="Marker";
 			position[]={8513.8281,171.41595,3848.6235};
@@ -24405,7 +20352,7 @@ class Mission
 			angle=227.508;
 			id=2458;
 		};
-		class Item691
+		class Item660
 		{
 			dataType="Marker";
 			position[]={8164.748,123.16555,4348.8281};
@@ -24414,7 +20361,7 @@ class Mission
 			angle=227.508;
 			id=2459;
 		};
-		class Item692
+		class Item661
 		{
 			dataType="Marker";
 			position[]={8437.4014,77.830002,5358.4033};
@@ -24423,7 +20370,7 @@ class Mission
 			angle=227.508;
 			id=2460;
 		};
-		class Item693
+		class Item662
 		{
 			dataType="Marker";
 			position[]={6869.1094,119.71,5586.9019};
@@ -24432,7 +20379,7 @@ class Mission
 			angle=227.508;
 			id=2461;
 		};
-		class Item694
+		class Item663
 		{
 			dataType="Marker";
 			position[]={7109.1108,103.3672,6243.3799};
@@ -24442,7 +20389,7 @@ class Mission
 			id=2462;
 			atlOffset=7.6293945e-006;
 		};
-		class Item695
+		class Item664
 		{
 			dataType="Marker";
 			position[]={7198.2852,84.688133,6676.1284};
@@ -24451,7 +20398,7 @@ class Mission
 			angle=227.508;
 			id=2463;
 		};
-		class Item696
+		class Item665
 		{
 			dataType="Marker";
 			position[]={5471.2114,117.53523,6318.8008};
@@ -24460,7 +20407,7 @@ class Mission
 			angle=227.508;
 			id=2464;
 		};
-		class Item697
+		class Item666
 		{
 			dataType="Marker";
 			position[]={1387.6671,149.92709,9917.2793};
@@ -24469,7 +20416,7 @@ class Mission
 			angle=227.508;
 			id=2465;
 		};
-		class Item698
+		class Item667
 		{
 			dataType="Marker";
 			position[]={1334.3232,148.04881,9595.8418};
@@ -24478,7 +20425,7 @@ class Mission
 			angle=227.508;
 			id=2466;
 		};
-		class Item699
+		class Item668
 		{
 			dataType="Marker";
 			position[]={1330.6385,143.92969,9004.543};
@@ -24487,7 +20434,7 @@ class Mission
 			angle=227.508;
 			id=2467;
 		};
-		class Item700
+		class Item669
 		{
 			dataType="Marker";
 			position[]={1301.5686,139.1483,8400.9688};
@@ -24496,7 +20443,7 @@ class Mission
 			angle=227.508;
 			id=2468;
 		};
-		class Item701
+		class Item670
 		{
 			dataType="Marker";
 			position[]={1310.5763,142.33211,8129.2568};
@@ -24505,7 +20452,7 @@ class Mission
 			angle=227.508;
 			id=2469;
 		};
-		class Item702
+		class Item671
 		{
 			dataType="Marker";
 			position[]={1249.5706,140.64145,7850.9985};
@@ -24514,7 +20461,7 @@ class Mission
 			angle=227.508;
 			id=2470;
 		};
-		class Item703
+		class Item672
 		{
 			dataType="Marker";
 			position[]={1224.595,138.6162,7469.2114};
@@ -24523,7 +20470,7 @@ class Mission
 			angle=227.508;
 			id=2471;
 		};
-		class Item704
+		class Item673
 		{
 			dataType="Marker";
 			position[]={1366.6693,138.04636,7224.0986};
@@ -24532,7 +20479,7 @@ class Mission
 			angle=227.508;
 			id=2472;
 		};
-		class Item705
+		class Item674
 		{
 			dataType="Marker";
 			position[]={1007.8506,137.33551,7154.0308};
@@ -24541,7 +20488,7 @@ class Mission
 			angle=227.508;
 			id=2473;
 		};
-		class Item706
+		class Item675
 		{
 			dataType="Marker";
 			position[]={1032.4167,134.16518,6830.2832};
@@ -24550,7 +20497,7 @@ class Mission
 			angle=227.508;
 			id=2474;
 		};
-		class Item707
+		class Item676
 		{
 			dataType="Marker";
 			position[]={1018.4197,133.41061,6320.6797};
@@ -24559,7 +20506,7 @@ class Mission
 			angle=227.508;
 			id=2475;
 		};
-		class Item708
+		class Item677
 		{
 			dataType="Marker";
 			position[]={1088.1899,138.78212,7986.2041};
@@ -24568,7 +20515,7 @@ class Mission
 			angle=227.508;
 			id=2476;
 		};
-		class Item709
+		class Item678
 		{
 			dataType="Marker";
 			position[]={632.86353,140.09219,7682.8276};
@@ -24577,7 +20524,7 @@ class Mission
 			angle=227.508;
 			id=2477;
 		};
-		class Item710
+		class Item679
 		{
 			dataType="Marker";
 			position[]={607.58344,129.61633,5654.9023};
@@ -24586,7 +20533,7 @@ class Mission
 			angle=227.508;
 			id=2478;
 		};
-		class Item711
+		class Item680
 		{
 			dataType="Marker";
 			position[]={493.11285,131.63519,5653.5801};
@@ -24595,7 +20542,7 @@ class Mission
 			angle=227.508;
 			id=2479;
 		};
-		class Item712
+		class Item681
 		{
 			dataType="Marker";
 			position[]={497.08289,130.13283,6095.3311};
@@ -24604,7 +20551,7 @@ class Mission
 			angle=227.508;
 			id=2480;
 		};
-		class Item713
+		class Item682
 		{
 			dataType="Marker";
 			position[]={497.08289,134.84021,6626.3579};
@@ -24613,7 +20560,7 @@ class Mission
 			angle=227.508;
 			id=2481;
 		};
-		class Item714
+		class Item683
 		{
 			dataType="Marker";
 			position[]={2234.9827,131.32094,6249.5107};
@@ -24622,7 +20569,7 @@ class Mission
 			angle=227.508;
 			id=2482;
 		};
-		class Item715
+		class Item684
 		{
 			dataType="Marker";
 			position[]={2001.4194,134.0605,5873.085};
@@ -24631,7 +20578,7 @@ class Mission
 			angle=227.508;
 			id=2483;
 		};
-		class Item716
+		class Item685
 		{
 			dataType="Marker";
 			position[]={1667.4977,127.30618,5458.4121};
@@ -24640,7 +20587,7 @@ class Mission
 			angle=227.508;
 			id=2484;
 		};
-		class Item717
+		class Item686
 		{
 			dataType="Marker";
 			position[]={1269.6084,128.23842,5377.4717};
@@ -24649,7 +20596,7 @@ class Mission
 			angle=227.508;
 			id=2485;
 		};
-		class Item718
+		class Item687
 		{
 			dataType="Marker";
 			position[]={1195.0776,129.06998,5669.5605};
@@ -24658,7 +20605,7 @@ class Mission
 			angle=227.508;
 			id=2486;
 		};
-		class Item719
+		class Item688
 		{
 			dataType="Marker";
 			position[]={1296.5265,119.59484,4615.2046};
@@ -24667,7 +20614,7 @@ class Mission
 			angle=227.508;
 			id=2487;
 		};
-		class Item720
+		class Item689
 		{
 			dataType="Marker";
 			position[]={670.37024,129.51768,5245.6885};
@@ -24676,7 +20623,7 @@ class Mission
 			angle=227.508;
 			id=2488;
 		};
-		class Item721
+		class Item690
 		{
 			dataType="Marker";
 			position[]={718.25586,136.47786,4840.4531};
@@ -24685,7 +20632,7 @@ class Mission
 			angle=227.508;
 			id=2489;
 		};
-		class Item722
+		class Item691
 		{
 			dataType="Marker";
 			position[]={625.70154,146.29971,4320.8936};
@@ -24694,7 +20641,7 @@ class Mission
 			angle=227.508;
 			id=2490;
 		};
-		class Item723
+		class Item692
 		{
 			dataType="Marker";
 			position[]={1003.7279,140.34142,4226.8945};
@@ -24703,7 +20650,7 @@ class Mission
 			angle=227.508;
 			id=2491;
 		};
-		class Item724
+		class Item693
 		{
 			dataType="Marker";
 			position[]={1690.7842,138.47931,4250.4858};
@@ -24712,7 +20659,7 @@ class Mission
 			angle=227.508;
 			id=2492;
 		};
-		class Item725
+		class Item694
 		{
 			dataType="Marker";
 			position[]={1711.3572,140.07838,3499.3176};
@@ -24721,7 +20668,7 @@ class Mission
 			angle=227.508;
 			id=2493;
 		};
-		class Item726
+		class Item695
 		{
 			dataType="Marker";
 			position[]={2396.4524,150.98032,2909.439};
@@ -24730,7 +20677,7 @@ class Mission
 			angle=227.508;
 			id=2494;
 		};
-		class Item727
+		class Item696
 		{
 			dataType="Marker";
 			position[]={2532.7585,147.06201,2408.1714};
@@ -24739,7 +20686,7 @@ class Mission
 			angle=227.508;
 			id=2495;
 		};
-		class Item728
+		class Item697
 		{
 			dataType="Marker";
 			position[]={1828.1792,146.1882,2670.2324};
@@ -24748,7 +20695,7 @@ class Mission
 			angle=227.508;
 			id=2496;
 		};
-		class Item729
+		class Item698
 		{
 			dataType="Marker";
 			position[]={2023.8654,146.48511,3105.2002};
@@ -24757,7 +20704,7 @@ class Mission
 			angle=227.508;
 			id=2497;
 		};
-		class Item730
+		class Item699
 		{
 			dataType="Marker";
 			position[]={1815.3469,145.25621,3061.3831};
@@ -24766,7 +20713,7 @@ class Mission
 			angle=227.508;
 			id=2498;
 		};
-		class Item731
+		class Item700
 		{
 			dataType="Marker";
 			position[]={1703.0679,147.32896,2496.0315};
@@ -24775,7 +20722,7 @@ class Mission
 			angle=227.508;
 			id=2499;
 		};
-		class Item732
+		class Item701
 		{
 			dataType="Marker";
 			position[]={1220.1426,135.45865,2249.2852};
@@ -24784,7 +20731,7 @@ class Mission
 			angle=227.508;
 			id=2500;
 		};
-		class Item733
+		class Item702
 		{
 			dataType="Marker";
 			position[]={1980.1057,159.39584,1481.7572};
@@ -24793,7 +20740,7 @@ class Mission
 			angle=227.508;
 			id=2501;
 		};
-		class Item734
+		class Item703
 		{
 			dataType="Marker";
 			position[]={2259.644,167.59979,975.36682};
@@ -24802,7 +20749,7 @@ class Mission
 			angle=227.508;
 			id=2502;
 		};
-		class Item735
+		class Item704
 		{
 			dataType="Marker";
 			position[]={2965.1685,175.48628,944.91028};
@@ -24811,7 +20758,7 @@ class Mission
 			angle=227.508;
 			id=2503;
 		};
-		class Item736
+		class Item705
 		{
 			dataType="Marker";
 			position[]={3706.5171,211.99948,678.42163};
@@ -24820,7 +20767,7 @@ class Mission
 			angle=227.508;
 			id=2504;
 		};
-		class Item737
+		class Item706
 		{
 			dataType="Marker";
 			position[]={4384.8394,220.06963,1104.856};
@@ -24829,7 +20776,7 @@ class Mission
 			angle=227.508;
 			id=2505;
 		};
-		class Item738
+		class Item707
 		{
 			dataType="Marker";
 			position[]={5227.6973,213.57674,1423.5925};
@@ -24838,7 +20785,7 @@ class Mission
 			angle=227.508;
 			id=2506;
 		};
-		class Item739
+		class Item708
 		{
 			dataType="Marker";
 			position[]={5238.0396,232.59465,1016.2347};
@@ -24848,7 +20795,7 @@ class Mission
 			id=2507;
 			atlOffset=-1.5258789e-005;
 		};
-		class Item740
+		class Item709
 		{
 			dataType="Marker";
 			position[]={5704.7266,255.02541,1012.2681};
@@ -24858,7 +20805,7 @@ class Mission
 			id=2508;
 			atlOffset=1.5258789e-005;
 		};
-		class Item741
+		class Item710
 		{
 			dataType="Marker";
 			position[]={5837.0576,199.00586,1784.3237};
@@ -24867,7 +20814,7 @@ class Mission
 			angle=227.508;
 			id=2509;
 		};
-		class Item742
+		class Item711
 		{
 			dataType="Marker";
 			position[]={6457.5757,213.05002,2384.4951};
@@ -24876,7 +20823,7 @@ class Mission
 			angle=227.508;
 			id=2510;
 		};
-		class Item743
+		class Item712
 		{
 			dataType="Marker";
 			position[]={6962.1753,214.38515,2260.9766};
@@ -24885,7 +20832,7 @@ class Mission
 			angle=227.508;
 			id=2511;
 		};
-		class Item744
+		class Item713
 		{
 			dataType="Marker";
 			position[]={7602.582,140.57263,1809.7522};
@@ -24894,7 +20841,7 @@ class Mission
 			angle=227.508;
 			id=2512;
 		};
-		class Item745
+		class Item714
 		{
 			dataType="Marker";
 			position[]={8030.5215,107.27513,1645.9631};
@@ -24903,7 +20850,7 @@ class Mission
 			angle=227.508;
 			id=2513;
 		};
-		class Item746
+		class Item715
 		{
 			dataType="Marker";
 			position[]={8583.9082,102.97036,1955.4364};
@@ -24912,7 +20859,7 @@ class Mission
 			angle=227.508;
 			id=2514;
 		};
-		class Item747
+		class Item716
 		{
 			dataType="Marker";
 			position[]={8896.207,79.46431,2107.3359};
@@ -24921,7 +20868,7 @@ class Mission
 			angle=227.508;
 			id=2515;
 		};
-		class Item748
+		class Item717
 		{
 			dataType="Marker";
 			position[]={7926.4448,145.50204,3005.2192};
@@ -24930,7 +20877,7 @@ class Mission
 			angle=227.508;
 			id=2516;
 		};
-		class Item749
+		class Item718
 		{
 			dataType="Marker";
 			position[]={8723.748,96.189384,2329.0857};
@@ -24939,7 +20886,7 @@ class Mission
 			angle=227.508;
 			id=2517;
 		};
-		class Item750
+		class Item719
 		{
 			dataType="Marker";
 			position[]={8637.0049,126.93756,2855.2544};
@@ -24948,7 +20895,7 @@ class Mission
 			angle=227.508;
 			id=2518;
 		};
-		class Item751
+		class Item720
 		{
 			dataType="Marker";
 			position[]={8585.2715,170.22696,3297.0752};
@@ -24957,7 +20904,7 @@ class Mission
 			angle=227.508;
 			id=2519;
 		};
-		class Item752
+		class Item721
 		{
 			dataType="Marker";
 			position[]={7989.5586,179.58904,3757.5752};
@@ -24966,7 +20913,7 @@ class Mission
 			angle=227.508;
 			id=2520;
 		};
-		class Item753
+		class Item722
 		{
 			dataType="Marker";
 			position[]={9511.6738,67.452042,2194.2134};
@@ -24975,7 +20922,7 @@ class Mission
 			angle=227.508;
 			id=2521;
 		};
-		class Item754
+		class Item723
 		{
 			dataType="Marker";
 			position[]={9349.1367,93.910873,2729.6411};
@@ -24984,7 +20931,7 @@ class Mission
 			angle=227.508;
 			id=2522;
 		};
-		class Item755
+		class Item724
 		{
 			dataType="Marker";
 			position[]={9592.9443,126.63605,3093.0059};
@@ -24993,7 +20940,7 @@ class Mission
 			angle=227.508;
 			id=2523;
 		};
-		class Item756
+		class Item725
 		{
 			dataType="Marker";
 			position[]={9085.0156,196.46713,3459.5771};
@@ -25002,7 +20949,7 @@ class Mission
 			angle=227.508;
 			id=2524;
 		};
-		class Item757
+		class Item726
 		{
 			dataType="Marker";
 			position[]={8997.2793,142.84566,4040.981};
@@ -25011,7 +20958,7 @@ class Mission
 			angle=227.508;
 			id=2525;
 		};
-		class Item758
+		class Item727
 		{
 			dataType="Marker";
 			position[]={8866.8213,101.86787,4453.5083};
@@ -25021,7 +20968,7 @@ class Mission
 			id=2526;
 			atlOffset=-7.6293945e-006;
 		};
-		class Item759
+		class Item728
 		{
 			dataType="Marker";
 			position[]={9083.8955,69.852875,4807.2549};
@@ -25030,7 +20977,7 @@ class Mission
 			angle=227.508;
 			id=2527;
 		};
-		class Item760
+		class Item729
 		{
 			dataType="Marker";
 			position[]={8444.5234,64.285133,5793.0068};
@@ -25039,7 +20986,7 @@ class Mission
 			angle=227.508;
 			id=2528;
 		};
-		class Item761
+		class Item730
 		{
 			dataType="Marker";
 			position[]={8628.7813,58.664654,5953.749};
@@ -25048,7 +20995,7 @@ class Mission
 			angle=227.508;
 			id=2529;
 		};
-		class Item762
+		class Item731
 		{
 			dataType="Marker";
 			position[]={8071.8501,54.827595,6183.1582};
@@ -25057,7 +21004,7 @@ class Mission
 			angle=227.508;
 			id=2530;
 		};
-		class Item763
+		class Item732
 		{
 			dataType="Marker";
 			position[]={7310.3945,71.54364,6630.9873};
@@ -25066,7 +21013,7 @@ class Mission
 			angle=227.508;
 			id=2531;
 		};
-		class Item764
+		class Item733
 		{
 			dataType="Marker";
 			position[]={8470.6318,111.42742,7542.2656};
@@ -25075,7 +21022,7 @@ class Mission
 			angle=227.508;
 			id=2532;
 		};
-		class Item765
+		class Item734
 		{
 			dataType="Marker";
 			position[]={8473.1465,120.76546,8042.9487};
@@ -25084,7 +21031,7 @@ class Mission
 			angle=227.508;
 			id=2533;
 		};
-		class Item766
+		class Item735
 		{
 			dataType="Marker";
 			position[]={8254.2109,188.7316,8695.6621};
@@ -25093,7 +21040,7 @@ class Mission
 			angle=227.508;
 			id=2534;
 		};
-		class Item767
+		class Item736
 		{
 			dataType="Marker";
 			position[]={8953.625,142.82301,8649.25};
@@ -25102,7 +21049,7 @@ class Mission
 			angle=227.508;
 			id=2535;
 		};
-		class Item768
+		class Item737
 		{
 			dataType="Marker";
 			position[]={8958.3223,116.90911,9111.4336};
@@ -25111,7 +21058,7 @@ class Mission
 			angle=227.508;
 			id=2536;
 		};
-		class Item769
+		class Item738
 		{
 			dataType="Marker";
 			position[]={6623.98,101.63037,7527.3608};
@@ -25120,7 +21067,7 @@ class Mission
 			angle=227.508;
 			id=2537;
 		};
-		class Item770
+		class Item739
 		{
 			dataType="Marker";
 			position[]={6884.6924,118.5795,8236.1416};
@@ -25129,7 +21076,7 @@ class Mission
 			angle=227.508;
 			id=2538;
 		};
-		class Item771
+		class Item740
 		{
 			dataType="Marker";
 			position[]={5013.1992,137.68842,7333.9023};
@@ -25138,7 +21085,7 @@ class Mission
 			angle=227.508;
 			id=2539;
 		};
-		class Item772
+		class Item741
 		{
 			dataType="Marker";
 			position[]={4978.1353,140.01778,7744.7402};
@@ -25147,7 +21094,7 @@ class Mission
 			angle=227.508;
 			id=2540;
 		};
-		class Item773
+		class Item742
 		{
 			dataType="Marker";
 			position[]={4906.5142,142.00604,8240.5781};
@@ -25156,7 +21103,7 @@ class Mission
 			angle=227.508;
 			id=2541;
 		};
-		class Item774
+		class Item743
 		{
 			dataType="Marker";
 			position[]={5284.7588,131.18858,7913.9966};
@@ -25165,7 +21112,7 @@ class Mission
 			angle=227.508;
 			id=2542;
 		};
-		class Item775
+		class Item744
 		{
 			dataType="Marker";
 			position[]={5248.2036,125.82599,7363.728};
@@ -25174,7 +21121,7 @@ class Mission
 			angle=227.508;
 			id=2543;
 		};
-		class Item776
+		class Item745
 		{
 			dataType="Marker";
 			position[]={4310.8301,142.03046,8062.5415};
@@ -25183,7 +21130,7 @@ class Mission
 			angle=227.508;
 			id=2544;
 		};
-		class Item777
+		class Item746
 		{
 			dataType="Marker";
 			position[]={3903.2021,141.13139,7914.439};
@@ -25192,7 +21139,7 @@ class Mission
 			angle=227.508;
 			id=2545;
 		};
-		class Item778
+		class Item747
 		{
 			dataType="Marker";
 			position[]={3265.4355,142.57207,7920.3169};
@@ -25201,7 +21148,7 @@ class Mission
 			angle=227.508;
 			id=2546;
 		};
-		class Item779
+		class Item748
 		{
 			dataType="Marker";
 			position[]={2546.9724,145.02423,8245.2363};
@@ -25210,7 +21157,7 @@ class Mission
 			angle=227.508;
 			id=2547;
 		};
-		class Item780
+		class Item749
 		{
 			dataType="Marker";
 			position[]={1868.6412,141.50815,8167.7617};
@@ -25219,7 +21166,7 @@ class Mission
 			angle=227.508;
 			id=2548;
 		};
-		class Item781
+		class Item750
 		{
 			dataType="Marker";
 			position[]={3017.7266,161.14365,2942.4414};
@@ -25228,7 +21175,7 @@ class Mission
 			angle=227.508;
 			id=2549;
 		};
-		class Item782
+		class Item751
 		{
 			dataType="Marker";
 			position[]={3491.5525,164.97371,3112.3433};
@@ -25237,7 +21184,7 @@ class Mission
 			angle=227.508;
 			id=2550;
 		};
-		class Item783
+		class Item752
 		{
 			dataType="Marker";
 			position[]={3702.5442,166.89229,2797.8438};
@@ -25246,7 +21193,7 @@ class Mission
 			angle=227.508;
 			id=2551;
 		};
-		class Item784
+		class Item753
 		{
 			dataType="Marker";
 			position[]={4620.6328,179.69034,2554.7583};
@@ -25255,7 +21202,7 @@ class Mission
 			angle=227.508;
 			id=2552;
 		};
-		class Item785
+		class Item754
 		{
 			dataType="Marker";
 			position[]={3570.2244,195.11763,2018.5333};
@@ -25264,7 +21211,7 @@ class Mission
 			angle=227.508;
 			id=2553;
 		};
-		class Item786
+		class Item755
 		{
 			dataType="Marker";
 			position[]={2804.0042,172.26936,2197.4866};
@@ -25273,7 +21220,7 @@ class Mission
 			angle=227.508;
 			id=2554;
 		};
-		class Item787
+		class Item756
 		{
 			dataType="Marker";
 			position[]={1988.7231,152.67973,2221.4678};
@@ -25282,7 +21229,7 @@ class Mission
 			angle=227.508;
 			id=2555;
 		};
-		class Item788
+		class Item757
 		{
 			dataType="Marker";
 			position[]={2081.6938,155.96461,1850.1776};
@@ -25291,7 +21238,7 @@ class Mission
 			angle=227.508;
 			id=2556;
 		};
-		class Item789
+		class Item758
 		{
 			dataType="Marker";
 			position[]={1442.7388,157.71983,1234.903};
@@ -25300,7 +21247,7 @@ class Mission
 			angle=227.508;
 			id=2557;
 		};
-		class Item790
+		class Item759
 		{
 			dataType="Marker";
 			position[]={1082.1212,168.78,1180.0146};
@@ -25309,7 +21256,7 @@ class Mission
 			angle=227.508;
 			id=2558;
 		};
-		class Item791
+		class Item760
 		{
 			dataType="Marker";
 			position[]={925.96405,164.96494,1690.5438};
@@ -25318,7 +21265,7 @@ class Mission
 			angle=227.508;
 			id=2559;
 		};
-		class Item792
+		class Item761
 		{
 			dataType="Marker";
 			position[]={2652.9041,136.63206,6831.5679};
@@ -25327,7 +21274,7 @@ class Mission
 			angle=227.508;
 			id=2560;
 		};
-		class Item793
+		class Item762
 		{
 			dataType="Marker";
 			position[]={2915.7888,140.99557,7346.9736};
@@ -25336,7 +21283,7 @@ class Mission
 			angle=227.508;
 			id=2561;
 		};
-		class Item794
+		class Item763
 		{
 			dataType="Marker";
 			position[]={2994.5432,140.76611,7860.5781};
@@ -25345,7 +21292,7 @@ class Mission
 			angle=227.508;
 			id=2562;
 		};
-		class Item795
+		class Item764
 		{
 			dataType="Marker";
 			position[]={1737.095,144.80362,8864.8223};
@@ -25354,7 +21301,7 @@ class Mission
 			angle=227.508;
 			id=2563;
 		};
-		class Item796
+		class Item765
 		{
 			dataType="Marker";
 			position[]={2328.8125,146.04866,9046.1973};
@@ -25363,7 +21310,7 @@ class Mission
 			angle=227.508;
 			id=2564;
 		};
-		class Item797
+		class Item766
 		{
 			dataType="Marker";
 			position[]={2926.7905,145.43372,9160.2061};
@@ -25372,7 +21319,7 @@ class Mission
 			angle=227.508;
 			id=2565;
 		};
-		class Item798
+		class Item767
 		{
 			dataType="Marker";
 			position[]={3235.5251,143.73969,8581.6934};
@@ -25381,7 +21328,7 @@ class Mission
 			angle=227.508;
 			id=2566;
 		};
-		class Item799
+		class Item768
 		{
 			dataType="Marker";
 			position[]={3783.4998,141.88722,8713.3613};
@@ -25390,7 +21337,7 @@ class Mission
 			angle=227.508;
 			id=2567;
 		};
-		class Item800
+		class Item769
 		{
 			dataType="Marker";
 			position[]={4362.124,143.29799,8761.4316};
@@ -25399,7 +21346,7 @@ class Mission
 			angle=227.508;
 			id=2568;
 		};
-		class Item801
+		class Item770
 		{
 			dataType="Marker";
 			position[]={4895.7207,149.30823,8789.2178};
@@ -25408,7 +21355,7 @@ class Mission
 			angle=227.508;
 			id=2569;
 		};
-		class Item802
+		class Item771
 		{
 			dataType="Object";
 			class PositionInfo
@@ -25424,7 +21371,7 @@ class Mission
 			type="Land_dp_smallTank_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item803
+		class Item772
 		{
 			dataType="Object";
 			class PositionInfo
@@ -25440,7 +21387,7 @@ class Mission
 			type="Land_dp_smallTank_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item804
+		class Item773
 		{
 			dataType="Object";
 			class PositionInfo
@@ -25455,7 +21402,7 @@ class Mission
 			id=2572;
 			type="Land_dp_smallTank_F";
 		};
-		class Item805
+		class Item774
 		{
 			dataType="Object";
 			class PositionInfo
@@ -25471,7 +21418,7 @@ class Mission
 			type="Land_dp_bigTank_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item806
+		class Item775
 		{
 			dataType="Object";
 			class PositionInfo
@@ -25487,7 +21434,7 @@ class Mission
 			id=2574;
 			type="Land_Fuel_tank_stairs";
 		};
-		class Item807
+		class Item776
 		{
 			dataType="Object";
 			class PositionInfo
@@ -25503,7 +21450,7 @@ class Mission
 			id=2575;
 			type="Land_FuelStation_Shed_PMC";
 		};
-		class Item808
+		class Item777
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -25558,7 +21505,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item809
+		class Item778
 		{
 			dataType="Object";
 			class PositionInfo
@@ -25574,7 +21521,7 @@ class Mission
 			type="Flag_Fuel_F";
 			atlOffset=-0.046134949;
 		};
-		class Item810
+		class Item779
 		{
 			dataType="Object";
 			class PositionInfo
@@ -25591,7 +21538,7 @@ class Mission
 			type="Land_A_FuelStation_Feed";
 			atlOffset=0.00086212158;
 		};
-		class Item811
+		class Item780
 		{
 			dataType="Object";
 			class PositionInfo
@@ -25608,7 +21555,7 @@ class Mission
 			type="Land_A_FuelStation_Feed";
 			atlOffset=0.00085449219;
 		};
-		class Item812
+		class Item781
 		{
 			dataType="Marker";
 			position[]={2596.3071,118.60456,5233.71};
@@ -25617,7 +21564,7 @@ class Mission
 			angle=227.508;
 			id=2580;
 		};
-		class Item813
+		class Item782
 		{
 			dataType="Marker";
 			position[]={2391.7888,125.01167,5041.915};
@@ -25626,7 +21573,7 @@ class Mission
 			angle=227.508;
 			id=2581;
 		};
-		class Item814
+		class Item783
 		{
 			dataType="Marker";
 			position[]={2339.4814,133.09361,6072.5952};
@@ -25635,7 +21582,7 @@ class Mission
 			angle=227.508;
 			id=2582;
 		};
-		class Item815
+		class Item784
 		{
 			dataType="Marker";
 			position[]={2899.4629,133.35263,6536.3721};
@@ -25644,7 +21591,7 @@ class Mission
 			angle=227.508;
 			id=2583;
 		};
-		class Item816
+		class Item785
 		{
 			dataType="Marker";
 			position[]={1751.1658,118.01345,4948.9502};
@@ -25653,7 +21600,7 @@ class Mission
 			angle=227.508;
 			id=2584;
 		};
-		class Item817
+		class Item786
 		{
 			dataType="Marker";
 			position[]={5544.3071,174.20535,4510.8086};
@@ -25662,7 +21609,7 @@ class Mission
 			angle=227.508;
 			id=2585;
 		};
-		class Item818
+		class Item787
 		{
 			dataType="Marker";
 			position[]={8016.9131,113.62109,6743.106};
@@ -25674,7 +21621,7 @@ class Mission
 			id=2586;
 			atlOffset=-6.4071274;
 		};
-		class Item819
+		class Item788
 		{
 			dataType="Marker";
 			position[]={5596.3457,222.30594,3685.8198};
@@ -25686,7 +21633,7 @@ class Mission
 			id=2587;
 			atlOffset=-6.4071198;
 		};
-		class Item820
+		class Item789
 		{
 			dataType="Marker";
 			position[]={3494.6838,149.24261,3921.4941};
@@ -25698,7 +21645,7 @@ class Mission
 			id=2588;
 			atlOffset=-6.4071198;
 		};
-		class Item821
+		class Item790
 		{
 			dataType="Marker";
 			position[]={2295.3977,129.82422,4820.3481};
@@ -25710,7 +21657,7 @@ class Mission
 			id=2589;
 			atlOffset=-6.4325256;
 		};
-		class Item822
+		class Item791
 		{
 			dataType="Marker";
 			position[]={4113.8896,123.80766,5322.4473};
@@ -25722,7 +21669,7 @@ class Mission
 			id=2590;
 			atlOffset=-6.4071198;
 		};
-		class Item823
+		class Item792
 		{
 			dataType="Marker";
 			position[]={610.54071,123.32086,5213.7363};
@@ -25734,7 +21681,7 @@ class Mission
 			id=2591;
 			atlOffset=-6.4071198;
 		};
-		class Item824
+		class Item793
 		{
 			dataType="Marker";
 			position[]={1270.5529,121.79486,5376.6284};
@@ -25746,7 +21693,7 @@ class Mission
 			id=2592;
 			atlOffset=-6.4071198;
 		};
-		class Item825
+		class Item794
 		{
 			dataType="Marker";
 			position[]={2302.6797,130.12689,5492.1904};
@@ -25758,7 +21705,7 @@ class Mission
 			id=2593;
 			atlOffset=-6.4071198;
 		};
-		class Item826
+		class Item795
 		{
 			dataType="Marker";
 			position[]={4140.019,124.32593,6609.1626};
@@ -25770,7 +21717,7 @@ class Mission
 			id=2594;
 			atlOffset=-6.4071198;
 		};
-		class Item827
+		class Item796
 		{
 			dataType="Marker";
 			position[]={3446.3147,129.20721,6391.7681};
@@ -25782,7 +21729,7 @@ class Mission
 			id=2595;
 			atlOffset=-6.4071198;
 		};
-		class Item828
+		class Item797
 		{
 			dataType="Marker";
 			position[]={5095.0527,126.3951,6966.5879};
@@ -25794,7 +21741,7 @@ class Mission
 			id=2596;
 			atlOffset=-6.4071121;
 		};
-		class Item829
+		class Item798
 		{
 			dataType="Marker";
 			position[]={7982.0088,139.07753,9244.6699};
@@ -25806,7 +21753,7 @@ class Mission
 			id=2597;
 			atlOffset=-6.4071198;
 		};
-		class Item830
+		class Item799
 		{
 			dataType="Marker";
 			position[]={9020.9121,111.24505,9524.0615};
@@ -25818,7 +21765,7 @@ class Mission
 			id=2598;
 			atlOffset=-6.4071198;
 		};
-		class Item831
+		class Item800
 		{
 			dataType="Marker";
 			position[]={8433.0254,71.422882,5355.2437};
@@ -25830,7 +21777,7 @@ class Mission
 			id=2599;
 			atlOffset=-6.4071198;
 		};
-		class Item832
+		class Item801
 		{
 			dataType="Marker";
 			position[]={8335.6523,136.16066,4030.9729};
@@ -25842,7 +21789,7 @@ class Mission
 			id=2600;
 			atlOffset=-6.4071198;
 		};
-		class Item833
+		class Item802
 		{
 			dataType="Marker";
 			position[]={6531.3872,208.98811,2419.8816};
@@ -25854,7 +21801,7 @@ class Mission
 			id=2601;
 			atlOffset=-6.4071198;
 		};
-		class Item834
+		class Item803
 		{
 			dataType="Marker";
 			position[]={7734.438,120.4747,1705.9161};
@@ -25866,7 +21813,7 @@ class Mission
 			id=2602;
 			atlOffset=-6.4071198;
 		};
-		class Item835
+		class Item804
 		{
 			dataType="Marker";
 			position[]={5384.0156,227.12245,989.9408};
@@ -25878,7 +21825,7 @@ class Mission
 			id=2603;
 			atlOffset=-6.4071198;
 		};
-		class Item836
+		class Item805
 		{
 			dataType="Marker";
 			position[]={4532.0967,224.2269,911.18103};
@@ -25890,7 +21837,7 @@ class Mission
 			id=2604;
 			atlOffset=-6.4071198;
 		};
-		class Item837
+		class Item806
 		{
 			dataType="Marker";
 			position[]={2193.5515,158.67892,1119.8474};
@@ -25902,7 +21849,7 @@ class Mission
 			id=2605;
 			atlOffset=-6.4071198;
 		};
-		class Item838
+		class Item807
 		{
 			dataType="Marker";
 			position[]={1971.045,144.78444,2251.8958};
@@ -25914,7 +21861,7 @@ class Mission
 			id=2606;
 			atlOffset=-6.4071198;
 		};
-		class Item839
+		class Item808
 		{
 			dataType="Marker";
 			position[]={1713.1868,133.66725,3497.2058};
@@ -25926,7 +21873,7 @@ class Mission
 			id=2607;
 			atlOffset=-6.4071198;
 		};
-		class Item840
+		class Item809
 		{
 			dataType="Marker";
 			position[]={626.62299,139.91359,4320.8452};
@@ -25938,7 +21885,7 @@ class Mission
 			id=2608;
 			atlOffset=-6.4071198;
 		};
-		class Item841
+		class Item810
 		{
 			dataType="Marker";
 			position[]={4549.6333,137.57285,8083.3618};
@@ -25950,7 +21897,7 @@ class Mission
 			id=2609;
 			atlOffset=-6.4071198;
 		};
-		class Item842
+		class Item811
 		{
 			dataType="Marker";
 			position[]={3810.8997,141.93123,8562.3975};
@@ -25962,7 +21909,7 @@ class Mission
 			id=2610;
 			atlOffset=-6.4071198;
 		};
-		class Item843
+		class Item812
 		{
 			dataType="Marker";
 			position[]={2517.0425,139.00204,9073.377};
@@ -25974,7 +21921,7 @@ class Mission
 			id=2611;
 			atlOffset=-6.4071198;
 		};
-		class Item844
+		class Item813
 		{
 			dataType="Marker";
 			position[]={1327.5206,141.11029,8749.1475};
@@ -25986,7 +21933,7 @@ class Mission
 			id=2612;
 			atlOffset=-6.4071198;
 		};
-		class Item845
+		class Item814
 		{
 			dataType="Marker";
 			position[]={1339.541,139.94246,9657.1914};
@@ -25998,7 +21945,7 @@ class Mission
 			id=2613;
 			atlOffset=-6.4071198;
 		};
-		class Item846
+		class Item815
 		{
 			dataType="Marker";
 			position[]={785.97772,142.39632,9489.5684};
@@ -26010,7 +21957,7 @@ class Mission
 			id=2614;
 			atlOffset=-6.4071198;
 		};
-		class Item847
+		class Item816
 		{
 			dataType="Marker";
 			position[]={475.00439,137.72285,8850.0166};
@@ -26022,7 +21969,7 @@ class Mission
 			id=2615;
 			atlOffset=-6.4071198;
 		};
-		class Item848
+		class Item817
 		{
 			dataType="Marker";
 			position[]={255.57129,132.83481,8011.7241};
@@ -26034,7 +21981,7 @@ class Mission
 			id=2616;
 			atlOffset=-6.4071198;
 		};
-		class Item849
+		class Item818
 		{
 			dataType="Marker";
 			position[]={281.4068,131.06479,7478.0811};
@@ -26046,7 +21993,7 @@ class Mission
 			id=2617;
 			atlOffset=-6.4071198;
 		};
-		class Item850
+		class Item819
 		{
 			dataType="Marker";
 			position[]={1624.3846,133.25714,7259.5664};
@@ -26058,7 +22005,7 @@ class Mission
 			id=2618;
 			atlOffset=-6.4071198;
 		};
-		class Item851
+		class Item820
 		{
 			dataType="Marker";
 			position[]={2310.6577,128.34216,6689.7808};
@@ -26070,7 +22017,7 @@ class Mission
 			id=2619;
 			atlOffset=-6.4071198;
 		};
-		class Item852
+		class Item821
 		{
 			dataType="Marker";
 			position[]={1949.3798,129.72643,5827.3857};
@@ -26082,7 +22029,7 @@ class Mission
 			id=2620;
 			atlOffset=-6.4071198;
 		};
-		class Item853
+		class Item822
 		{
 			dataType="Marker";
 			position[]={2885.8752,130.69649,6852.6719};
@@ -26094,7 +22041,7 @@ class Mission
 			id=2621;
 			atlOffset=-6.4071198;
 		};
-		class Item854
+		class Item823
 		{
 			dataType="Marker";
 			position[]={4514.9604,136.74278,9351.3652};
@@ -26106,7 +22053,7 @@ class Mission
 			id=2622;
 			atlOffset=-6.4071198;
 		};
-		class Item855
+		class Item824
 		{
 			dataType="Marker";
 			position[]={5156.0737,141.71494,8982.7764};
@@ -26118,7 +22065,7 @@ class Mission
 			id=2623;
 			atlOffset=-6.4071198;
 		};
-		class Item856
+		class Item825
 		{
 			dataType="Marker";
 			position[]={6348.4966,127.63069,7860.4863};
@@ -26130,7 +22077,7 @@ class Mission
 			id=2624;
 			atlOffset=-6.4071198;
 		};
-		class Item857
+		class Item826
 		{
 			dataType="Marker";
 			position[]={6873.3398,114.06079,8259.9199};
@@ -26142,7 +22089,7 @@ class Mission
 			id=2625;
 			atlOffset=-6.4071198;
 		};
-		class Item858
+		class Item827
 		{
 			dataType="Marker";
 			position[]={7943.9229,141.41728,3031.7085};
@@ -26154,7 +22101,7 @@ class Mission
 			id=2626;
 			atlOffset=-6.4071198;
 		};
-		class Item859
+		class Item828
 		{
 			dataType="Marker";
 			position[]={8773.3848,183.80649,3504.0107};
@@ -26166,7 +22113,7 @@ class Mission
 			id=2627;
 			atlOffset=-6.4071198;
 		};
-		class Item860
+		class Item829
 		{
 			dataType="Marker";
 			position[]={7324.2373,117.02272,552.26624};
@@ -26178,7 +22125,7 @@ class Mission
 			id=2628;
 			atlOffset=-6.4071198;
 		};
-		class Item861
+		class Item830
 		{
 			dataType="Marker";
 			position[]={5590.9092,223.70375,221.37573};
@@ -26190,7 +22137,7 @@ class Mission
 			id=2629;
 			atlOffset=-6.4071198;
 		};
-		class Item862
+		class Item831
 		{
 			dataType="Marker";
 			position[]={2328.6221,166.40311,283.60901};
@@ -26202,7 +22149,7 @@ class Mission
 			id=2630;
 			atlOffset=-6.4071198;
 		};
-		class Item863
+		class Item832
 		{
 			dataType="Marker";
 			position[]={880.64941,167.31091,447.01843};
@@ -26214,7 +22161,7 @@ class Mission
 			id=2631;
 			atlOffset=-6.4071198;
 		};
-		class Item864
+		class Item833
 		{
 			dataType="Marker";
 			position[]={371.89377,176.20584,3180.4692};
@@ -26226,7 +22173,7 @@ class Mission
 			id=2632;
 			atlOffset=-6.4071198;
 		};
-		class Item865
+		class Item834
 		{
 			dataType="Marker";
 			position[]={583.41504,125.17369,6120.7432};
@@ -26238,7 +22185,7 @@ class Mission
 			id=2633;
 			atlOffset=-6.4071198;
 		};
-		class Item866
+		class Item835
 		{
 			dataType="Marker";
 			position[]={2108.5444,141.91605,9579.0801};
@@ -26250,7 +22197,7 @@ class Mission
 			id=2634;
 			atlOffset=-6.4071198;
 		};
-		class Item867
+		class Item836
 		{
 			dataType="Marker";
 			position[]={3409.7593,142.90096,9876.3193};
@@ -26262,7 +22209,7 @@ class Mission
 			id=2635;
 			atlOffset=-6.4071198;
 		};
-		class Item868
+		class Item837
 		{
 			dataType="Marker";
 			position[]={7140.8271,134.57773,5711.207};
@@ -26274,7 +22221,7 @@ class Mission
 			id=2636;
 			atlOffset=-6.4071198;
 		};
-		class Item869
+		class Item838
 		{
 			dataType="Marker";
 			position[]={7249.7808,176.22713,4233.6602};
@@ -26286,16 +22233,1235 @@ class Mission
 			id=2637;
 			atlOffset=-6.4071198;
 		};
+		class Item839
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=38;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4454.0747,192.65649,3604.7825};
+					};
+					side="Independent";
+					flags=3;
+					class Attributes
+					{
+						name="commanderX";
+						description="Default Commaner";
+						isPlayer=1;
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2639;
+					type="I_G_officer_F";
+					atlOffset=2.2093964;
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male04GRE";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1;
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4458.8696,191.82607,3602.0793};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2640;
+					type="I_G_officer_F";
+					atlOffset=1.5630188;
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4459.0083,191.83224,3604.3152};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2641;
+					type="I_G_officer_F";
+					atlOffset=1.4959564;
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4458.9507,191.83369,3606.6487};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2642;
+					type="I_G_officer_F";
+					atlOffset=1.405426;
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4458.7876,191.8157,3608.9622};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2643;
+					type="I_G_officer_F";
+					atlOffset=1.3078613;
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4458.7466,191.81754,3611.4163};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2644;
+					type="I_G_officer_F";
+					atlOffset=1.2042542;
+				};
+				class Item6
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4458.561,191.82071,3613.7322};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2645;
+					type="I_G_officer_F";
+					atlOffset=1.1147766;
+				};
+				class Item7
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4458.354,191.82779,3615.6277};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2646;
+					type="I_G_officer_F";
+					atlOffset=1.0294037;
+				};
+				class Item8
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4461.229,191.35509,3602.2029};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2647;
+					type="I_G_Soldier_F";
+					atlOffset=1.1350403;
+				};
+				class Item9
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4461.228,191.35278,3604.5422};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2648;
+					type="I_G_Soldier_F";
+					atlOffset=1.0546265;
+				};
+				class Item10
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4461.1216,191.34167,3606.9158};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2649;
+					type="I_G_Soldier_F";
+					atlOffset=0.96520996;
+				};
+				class Item11
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4461.063,191.32449,3609.1155};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2650;
+					type="I_G_Soldier_F";
+					atlOffset=0.87738037;
+				};
+				class Item12
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4460.8599,191.31165,3611.5378};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2651;
+					type="I_G_Soldier_F";
+					atlOffset=0.78245544;
+				};
+				class Item13
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4460.6724,191.29507,3613.8689};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2652;
+					type="I_G_Soldier_F";
+					atlOffset=0.67633057;
+				};
+				class Item14
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4463.3374,191.18707,3602.239};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2653;
+					type="I_G_Soldier_AR_F";
+					atlOffset=1.0090179;
+				};
+				class Item15
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4463.4995,191.16605,3604.679};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2654;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.91348267;
+				};
+				class Item16
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4463.0991,191.15504,3607.094};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2655;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.8175354;
+				};
+				class Item17
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4463.0757,191.09033,3609.2429};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2656;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.70054626;
+				};
+				class Item18
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4462.8755,191.02826,3611.4841};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2657;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.56147766;
+				};
+				class Item19
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4462.7886,190.96762,3613.9431};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2658;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.42988586;
+				};
+				class Item20
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4465.4263,191.01218,3602.3186};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2659;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.88264465;
+				};
+				class Item21
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4465.2964,191.00548,3604.6365};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2660;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.79734802;
+				};
+				class Item22
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4465.1724,190.92288,3607.3806};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2661;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.64068604;
+				};
+				class Item23
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4464.9985,190.85086,3609.3894};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2662;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.51522827;
+				};
+				class Item24
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4464.9292,190.75032,3611.574};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2663;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.35932922;
+				};
+				class Item25
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4464.8237,190.68732,3614.0647};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2664;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.23213196;
+				};
+				class Item26
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4466.9536,190.72488,3602.3962};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2665;
+					type="I_G_medic_F";
+					atlOffset=0.64480591;
+				};
+				class Item27
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4466.7778,190.74411,3604.676};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2666;
+					type="I_G_medic_F";
+					atlOffset=0.57946777;
+				};
+				class Item28
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4466.7358,190.64731,3607.5476};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2667;
+					type="I_G_medic_F";
+					atlOffset=0.40800476;
+				};
+				class Item29
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4466.6479,190.57272,3609.3542};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2668;
+					type="I_G_medic_F";
+					atlOffset=0.28741455;
+				};
+				class Item30
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4466.4644,190.48819,3611.7136};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2669;
+					type="I_G_medic_F";
+					atlOffset=0.14077759;
+				};
+				class Item31
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4466.4751,190.41156,3614.1243};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2670;
+					type="I_G_medic_F";
+					atlOffset=0.0065917969;
+				};
+				class Item32
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4468.7554,190.39514,3602.5613};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2671;
+					type="I_G_engineer_F";
+					atlOffset=0.3659668;
+				};
+				class Item33
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4468.7788,190.38878,3604.8616};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2672;
+					type="I_G_engineer_F";
+					atlOffset=0.27748108;
+				};
+				class Item34
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4468.5366,190.31808,3607.6516};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2673;
+					type="I_G_engineer_F";
+					atlOffset=0.13031006;
+				};
+				class Item35
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4468.2817,190.2645,3609.5994};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2674;
+					type="I_G_engineer_F";
+					atlOffset=0.022338867;
+				};
+				class Item36
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4468.0864,190.18588,3611.8357};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2675;
+					type="I_G_engineer_F";
+					atlOffset=-0.11579895;
+				};
+				class Item37
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={4467.9819,190.11296,3614.3049};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=2676;
+					type="I_G_engineer_F";
+					atlOffset=-0.25114441;
+				};
+			};
+			class Attributes
+			{
+			};
+			id=2638;
+			atlOffset=2.2093964;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="Guerillas";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item840
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={911.14166,132.55809,4626.4761};
+				angles[]={0.019999012,5.9639554,6.2392135};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=2677;
+			type="CamoNet_OPFOR_open_F";
+		};
+		class Item841
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={994.90662,129.23555,4659.5576};
+				angles[]={0.049958061,5.9639554,6.2232571};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=2679;
+			type="CamoNet_OPFOR_open_F";
+		};
+		class Item842
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1046.853,136.04626,4710.2808};
+				angles[]={0,4.3811255,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=2681;
+			type="Land_Cargo_Patrol_V3_F";
+		};
+		class Item843
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1038.592,136.98091,4714.313};
+				angles[]={0,2.8103292,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=2682;
+			type="Land_Cargo_Patrol_V3_F";
+			atlOffset=-1.5258789e-005;
+		};
+		class Item844
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1067.6801,136.46126,4632.0508};
+				angles[]={0,5.9519215,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=2683;
+			type="Land_Cargo_Patrol_V3_F";
+		};
+		class Item845
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1071.738,135.82742,4640.3452};
+				angles[]={0,4.3811255,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=2684;
+			type="Land_Cargo_Patrol_V3_F";
+		};
+		class Item846
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={880.71503,140.12596,4598.0791};
+				angles[]={0,1.2041899,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=2685;
+			type="Land_Cargo_Patrol_V3_F";
+		};
+		class Item847
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={872.37097,138.91531,4619.894};
+				angles[]={0,1.2041899,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=2686;
+			type="Land_Cargo_Patrol_V3_F";
+			atlOffset=-1.5258789e-005;
+		};
+		class Item848
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={6858.7598,109.70748,7149.2754};
+				angles[]={0,6.0662537,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=2687;
+			type="Land_Cargo_Patrol_V3_F";
+		};
+		class Item849
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={6815.0869,108.41675,7174.8335};
+				angles[]={0,1.3538646,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=2688;
+			type="Land_Cargo_Patrol_V3_F";
+		};
+		class Item850
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={6869.7754,109.02059,7187.4868};
+				angles[]={0,2.9246607,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=2689;
+			type="Land_Cargo_Patrol_V3_F";
+			atlOffset=-7.6293945e-006;
+		};
+		class Item851
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={6877.6558,109.47288,7155.0078};
+				angles[]={0,6.0662584,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=2690;
+			type="Land_Cargo_Patrol_V3_F";
+		};
+		class Item852
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={6834.6157,104.85357,7146.0933};
+				angles[]={0,2.9246607,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=2691;
+			type="Land_Cargo_House_V3_F";
+		};
+		class Item853
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={6843.5767,105.31248,7147.8022};
+				angles[]={0,2.9246607,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=2692;
+			type="Land_Cargo_House_V3_F";
+		};
+		class Item854
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={6847.6445,105.27355,7181.7319};
+				angles[]={0,6.0478468,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=2693;
+			type="Land_Cargo_House_V3_F";
+		};
+		class Item855
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={6856.5728,105.14413,7183.6055};
+				angles[]={0,6.0478468,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=2694;
+			type="Land_Cargo_House_V3_F";
+		};
+		class Item856
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={870.38,146.99213,4640.979};
+				angles[]={0,4.3570051,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=2695;
+			type="Land_Cargo_Tower_V3_F";
+		};
+		class Item857
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={892.763,146.93771,4577.4131};
+				angles[]={0,1.1974355,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=2696;
+			type="Land_Cargo_Tower_V3_F";
+		};
+		class Item858
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={996.021,141.7713,4687.73};
+				angles[]={0,4.3570051,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=2697;
+			type="Land_Cargo_Tower_V3_F";
+		};
+		class Item859
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={6824.8901,116.30996,7145.5903};
+				angles[]={0,1.3538646,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=2698;
+			type="Land_Cargo_Tower_V3_F";
+		};
+		class Item860
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1017.463,134.37215,4625.4282};
+				angles[]={0,5.9451499,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=2699;
+			type="Land_Cargo_HQ_V3_F";
+		};
 	};
 	class Connections
 	{
 		class LinkIDProvider
 		{
-			nextID=61;
+			nextID=39;
 		};
 		class Links
 		{
-			items=61;
+			items=39;
 			class Item0
 			{
 				linkID=0;
@@ -26309,7 +23475,7 @@ class Mission
 			class Item1
 			{
 				linkID=1;
-				item0=705;
+				item0=2639;
 				item1=698;
 				class CustomData
 				{
@@ -26319,7 +23485,7 @@ class Mission
 			class Item2
 			{
 				linkID=2;
-				item0=706;
+				item0=2640;
 				item1=698;
 				class CustomData
 				{
@@ -26329,7 +23495,7 @@ class Mission
 			class Item3
 			{
 				linkID=3;
-				item0=707;
+				item0=2641;
 				item1=698;
 				class CustomData
 				{
@@ -26339,7 +23505,7 @@ class Mission
 			class Item4
 			{
 				linkID=4;
-				item0=713;
+				item0=2642;
 				item1=698;
 				class CustomData
 				{
@@ -26349,7 +23515,7 @@ class Mission
 			class Item5
 			{
 				linkID=5;
-				item0=729;
+				item0=2643;
 				item1=698;
 				class CustomData
 				{
@@ -26359,7 +23525,7 @@ class Mission
 			class Item6
 			{
 				linkID=6;
-				item0=730;
+				item0=2644;
 				item1=698;
 				class CustomData
 				{
@@ -26369,7 +23535,7 @@ class Mission
 			class Item7
 			{
 				linkID=7;
-				item0=736;
+				item0=2645;
 				item1=698;
 				class CustomData
 				{
@@ -26379,7 +23545,7 @@ class Mission
 			class Item8
 			{
 				linkID=8;
-				item0=742;
+				item0=2646;
 				item1=698;
 				class CustomData
 				{
@@ -26389,7 +23555,7 @@ class Mission
 			class Item9
 			{
 				linkID=9;
-				item0=748;
+				item0=2647;
 				item1=698;
 				class CustomData
 				{
@@ -26399,7 +23565,7 @@ class Mission
 			class Item10
 			{
 				linkID=10;
-				item0=754;
+				item0=2648;
 				item1=698;
 				class CustomData
 				{
@@ -26409,7 +23575,7 @@ class Mission
 			class Item11
 			{
 				linkID=11;
-				item0=760;
+				item0=2649;
 				item1=698;
 				class CustomData
 				{
@@ -26419,7 +23585,7 @@ class Mission
 			class Item12
 			{
 				linkID=12;
-				item0=709;
+				item0=2650;
 				item1=698;
 				class CustomData
 				{
@@ -26429,7 +23595,7 @@ class Mission
 			class Item13
 			{
 				linkID=13;
-				item0=715;
+				item0=2651;
 				item1=698;
 				class CustomData
 				{
@@ -26439,7 +23605,7 @@ class Mission
 			class Item14
 			{
 				linkID=14;
-				item0=720;
+				item0=2652;
 				item1=698;
 				class CustomData
 				{
@@ -26449,7 +23615,7 @@ class Mission
 			class Item15
 			{
 				linkID=15;
-				item0=725;
+				item0=2653;
 				item1=698;
 				class CustomData
 				{
@@ -26459,7 +23625,7 @@ class Mission
 			class Item16
 			{
 				linkID=16;
-				item0=732;
+				item0=2654;
 				item1=698;
 				class CustomData
 				{
@@ -26469,7 +23635,7 @@ class Mission
 			class Item17
 			{
 				linkID=17;
-				item0=738;
+				item0=2655;
 				item1=698;
 				class CustomData
 				{
@@ -26479,7 +23645,7 @@ class Mission
 			class Item18
 			{
 				linkID=18;
-				item0=744;
+				item0=2656;
 				item1=698;
 				class CustomData
 				{
@@ -26489,7 +23655,7 @@ class Mission
 			class Item19
 			{
 				linkID=19;
-				item0=750;
+				item0=2657;
 				item1=698;
 				class CustomData
 				{
@@ -26499,7 +23665,7 @@ class Mission
 			class Item20
 			{
 				linkID=20;
-				item0=756;
+				item0=2658;
 				item1=698;
 				class CustomData
 				{
@@ -26509,7 +23675,7 @@ class Mission
 			class Item21
 			{
 				linkID=21;
-				item0=761;
+				item0=2659;
 				item1=698;
 				class CustomData
 				{
@@ -26519,7 +23685,7 @@ class Mission
 			class Item22
 			{
 				linkID=22;
-				item0=710;
+				item0=2660;
 				item1=698;
 				class CustomData
 				{
@@ -26529,7 +23695,7 @@ class Mission
 			class Item23
 			{
 				linkID=23;
-				item0=716;
+				item0=2661;
 				item1=698;
 				class CustomData
 				{
@@ -26539,7 +23705,7 @@ class Mission
 			class Item24
 			{
 				linkID=24;
-				item0=721;
+				item0=2662;
 				item1=698;
 				class CustomData
 				{
@@ -26549,7 +23715,7 @@ class Mission
 			class Item25
 			{
 				linkID=25;
-				item0=726;
+				item0=2663;
 				item1=698;
 				class CustomData
 				{
@@ -26559,7 +23725,7 @@ class Mission
 			class Item26
 			{
 				linkID=26;
-				item0=733;
+				item0=2664;
 				item1=698;
 				class CustomData
 				{
@@ -26569,7 +23735,7 @@ class Mission
 			class Item27
 			{
 				linkID=27;
-				item0=739;
+				item0=2665;
 				item1=698;
 				class CustomData
 				{
@@ -26579,7 +23745,7 @@ class Mission
 			class Item28
 			{
 				linkID=28;
-				item0=745;
+				item0=2666;
 				item1=698;
 				class CustomData
 				{
@@ -26589,7 +23755,7 @@ class Mission
 			class Item29
 			{
 				linkID=29;
-				item0=751;
+				item0=2667;
 				item1=698;
 				class CustomData
 				{
@@ -26599,7 +23765,7 @@ class Mission
 			class Item30
 			{
 				linkID=30;
-				item0=757;
+				item0=2668;
 				item1=698;
 				class CustomData
 				{
@@ -26609,7 +23775,7 @@ class Mission
 			class Item31
 			{
 				linkID=31;
-				item0=762;
+				item0=2669;
 				item1=698;
 				class CustomData
 				{
@@ -26619,7 +23785,7 @@ class Mission
 			class Item32
 			{
 				linkID=32;
-				item0=711;
+				item0=2670;
 				item1=698;
 				class CustomData
 				{
@@ -26629,7 +23795,7 @@ class Mission
 			class Item33
 			{
 				linkID=33;
-				item0=717;
+				item0=2671;
 				item1=698;
 				class CustomData
 				{
@@ -26639,7 +23805,7 @@ class Mission
 			class Item34
 			{
 				linkID=34;
-				item0=722;
+				item0=2672;
 				item1=698;
 				class CustomData
 				{
@@ -26649,7 +23815,7 @@ class Mission
 			class Item35
 			{
 				linkID=35;
-				item0=727;
+				item0=2673;
 				item1=698;
 				class CustomData
 				{
@@ -26659,7 +23825,7 @@ class Mission
 			class Item36
 			{
 				linkID=36;
-				item0=734;
+				item0=2674;
 				item1=698;
 				class CustomData
 				{
@@ -26669,7 +23835,7 @@ class Mission
 			class Item37
 			{
 				linkID=37;
-				item0=740;
+				item0=2675;
 				item1=698;
 				class CustomData
 				{
@@ -26679,227 +23845,7 @@ class Mission
 			class Item38
 			{
 				linkID=38;
-				item0=746;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item39
-			{
-				linkID=39;
-				item0=752;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item40
-			{
-				linkID=40;
-				item0=758;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item41
-			{
-				linkID=41;
-				item0=763;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item42
-			{
-				linkID=42;
-				item0=712;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item43
-			{
-				linkID=43;
-				item0=718;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item44
-			{
-				linkID=44;
-				item0=723;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item45
-			{
-				linkID=45;
-				item0=728;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item46
-			{
-				linkID=46;
-				item0=735;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item47
-			{
-				linkID=47;
-				item0=741;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item48
-			{
-				linkID=48;
-				item0=747;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item49
-			{
-				linkID=49;
-				item0=753;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item50
-			{
-				linkID=50;
-				item0=759;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item51
-			{
-				linkID=51;
-				item0=708;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item52
-			{
-				linkID=52;
-				item0=714;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item53
-			{
-				linkID=53;
-				item0=719;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item54
-			{
-				linkID=54;
-				item0=724;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item55
-			{
-				linkID=55;
-				item0=731;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item56
-			{
-				linkID=56;
-				item0=737;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item57
-			{
-				linkID=57;
-				item0=743;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item58
-			{
-				linkID=58;
-				item0=749;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item59
-			{
-				linkID=59;
-				item0=755;
-				item1=698;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item60
-			{
-				linkID=60;
-				item0=764;
+				item0=2676;
 				item1=698;
 				class CustomData
 				{

--- a/Map-Templates/Antistasi-Chernarus.chernarus_summer/mission.sqm
+++ b/Map-Templates/Antistasi-Chernarus.chernarus_summer/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=1025;
 	class ItemIDProvider
 	{
-		nextID=887;
+		nextID=926;
 	};
 	class MarkerIDProvider
 	{
@@ -16,14 +16,14 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=7;
+		nextID=21;
 	};
 	class Camera
 	{
-		pos[]={4160.0986,370.77472,8830.498};
-		dir[]={0.047367383,-0.47201225,0.88032174};
-		up[]={0.02536091,0.88159066,0.47133157};
-		aside[]={0.99855709,3.8953658e-009,-0.053729318};
+		pos[]={8402.0654,305.784,5986.9878};
+		dir[]={-0.21361355,-0.96107328,0.17543605};
+		up[]={-0.74268818,0.27635285,0.6099534};
+		aside[]={0.63468939,-1.701992e-007,0.77280718};
 	};
 };
 binarizationWanted=0;
@@ -34,8 +34,6 @@ addons[]=
 	"A3_Modules_F",
 	"A3_Characters_F",
 	"A3_Modules_F_Hc",
-	"A3_Weapons_F",
-	"A3_Characters_F_Tank",
 	"A3_Structures_F_EPC_Civ_InfoBoards",
 	"A3_Structures_F_Mil_Flags",
 	"A3_Modules_F_Curator_Curator",
@@ -44,13 +42,14 @@ addons[]=
 	"A3_Characters_F_Patrol",
 	"A3_Characters_F_Exp",
 	"A3_Structures_F_Exp_Military_Flags",
-	"A3_Structures_F_Mil_Helipads"
+	"A3_Structures_F_Mil_Helipads",
+	"A3_Weapons_F"
 };
 class AddonsMetaData
 {
 	class List
 	{
-		items=13;
+		items=12;
 		class Item0
 		{
 			className="A3_Ui_F";
@@ -81,61 +80,54 @@ class AddonsMetaData
 		};
 		class Item4
 		{
-			className="A3_Characters_F_Tank";
-			name="Arma 3 Tank - Characters and Clothing";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item5
-		{
 			className="A3_Structures_F_EPC";
 			name="Arma 3 Win Episode - Buildings and Structures";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item6
+		class Item5
 		{
 			className="A3_Structures_F_Mil";
 			name="Arma 3 - Military Buildings and Structures";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item7
+		class Item6
 		{
 			className="A3_Modules_F_Curator";
 			name="Arma 3 Zeus Update - Scripted Modules";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item8
+		class Item7
 		{
 			className="A3_Props_F_Enoch";
 			name="Arma 3 Enoch - Decorative and Mission Objects";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item9
+		class Item8
 		{
 			className="A3_Ui_F_Exp";
 			name="Arma 3 Apex - User Interface";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item10
+		class Item9
 		{
 			className="A3_Characters_F_Patrol";
 			name="Arma 3 Patrol - Characters and Clothing";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item11
+		class Item10
 		{
 			className="A3_Characters_F_Exp";
 			name="Arma 3 Apex - Characters and Clothing";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item12
+		class Item11
 		{
 			className="A3_Structures_F_Exp";
 			name="Arma 3 Apex - Buildings and Structures";
@@ -418,3893 +410,6 @@ class Mission
 			side="Independent";
 			class Entities
 			{
-				items=60;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8400.0264,292.05978,5995.3242};
-						angles[]={6.2405434,0,6.2818484};
-					};
-					side="Independent";
-					flags=6;
-					class Attributes
-					{
-						skill=1;
-						name="commanderX";
-						description="Default Commander";
-						isPlayer=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=725;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item1
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8403.5596,291.93668,5991.7998};
-						angles[]={0,6.2412972,6.2818937};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=729;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item2
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8415.0186,291.93146,5997.9521};
-						angles[]={0,6.2412972,0.0012918708};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=730;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item3
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8421.0225,291.93945,5997.8389};
-						angles[]={0,0,0.0012918708};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=732;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item4
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8423.9219,291.94333,5998.0176};
-						angles[]={0,0,0.0012918708};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=733;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item5
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8426.9092,291.94733,5998.2373};
-						angles[]={0,0,0.0012918708};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=734;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item6
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8412.5576,291.93143,5997.8916};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=735;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item7
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8414.916,292.0769,6000.7471};
-						angles[]={6.0768309,6.2412972,0.0066682254};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=736;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item8
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8420.9199,292.06161,6000.6338};
-						angles[]={6.0768313,0,0.0013372133};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=738;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item9
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8423.8193,292.09683,6000.8125};
-						angles[]={6.084507,0,0.0013372133};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=739;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item10
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8426.8066,292.14505,6001.0322};
-						angles[]={6.084507,0,0.0013372133};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=740;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item11
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8412.4551,292.06058,6000.6865};
-						angles[]={6.0832248,0,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=741;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item12
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8420.9199,292.6738,6003.6348};
-						angles[]={6.084507,0,6.276526};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=743;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item13
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8423.8193,292.70108,6003.8135};
-						angles[]={6.084507,0,0.0013372133};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=744;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item14
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8426.8066,292.73346,6004.0332};
-						angles[]={6.1038036,0,6.2645183};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=745;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item15
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8412.4551,292.67599,6003.6875};
-						angles[]={6.0768309,0,0.0066682254};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=746;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item16
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8420.8154,293.19531,6006.2217};
-						angles[]={6.084507,0,6.276526};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=748;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item17
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8423.7148,293.22043,6006.4004};
-						angles[]={6.1038036,0,6.2645183};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=749;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item18
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8426.7031,293.20447,6006.6201};
-						angles[]={6.1038036,0,6.2645183};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=750;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item19
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8412.3506,293.21692,6006.2744};
-						angles[]={6.0768309,0,0.0066682254};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=751;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item20
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8415.0146,292.72977,6003.8633};
-						angles[]={6.0768313,6.1574922,0.0013372133};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=752;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item21
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8415.1104,293.27151,6006.4502};
-						angles[]={6.0768313,0,0.0013372133};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=753;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item22
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8421.1484,293.80838,6008.8477};
-						angles[]={6.0213375,0,6.2765174};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=755;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item23
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8424.0479,293.81436,6009.0264};
-						angles[]={6.0238295,0,6.2645183};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=756;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item24
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8427.0352,293.81689,6009.2461};
-						angles[]={6.0238295,0,6.2645183};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=757;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item25
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8412.6836,293.83182,6008.9004};
-						angles[]={6.0325699,0,0.0066682254};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=758;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item26
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8415.4424,293.90762,6009.0762};
-						angles[]={6.0213375,0,6.2765174};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=759;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item27
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8421.2217,294.62357,6011.9219};
-						angles[]={6.0238295,0,6.2738504};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=761;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item28
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8424.1211,294.62872,6012.1006};
-						angles[]={6.0238295,0,6.2645183};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=762;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item29
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8427.1084,294.60117,6012.3203};
-						angles[]={6.038835,0,6.2485313};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=763;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item30
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8412.7568,294.64554,6011.9746};
-						angles[]={6.0213375,0,0.018670246};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=764;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item31
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8415.5156,294.73105,6012.1504};
-						angles[]={6.0213375,0,6.2765174};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=765;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item32
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8418.2549,295.44351,6014.9082};
-						angles[]={6.0238295,0,6.2738504};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=767;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item33
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8421.1543,295.46671,6015.0869};
-						angles[]={5.9566455,0,6.2738504};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=768;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item34
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8424.1416,295.47058,6015.3066};
-						angles[]={5.9602342,0,6.2485328};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=769;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item35
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8409.79,295.39053,6014.9609};
-						angles[]={6.0213375,0,0.018670246};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=770;
-					type="I_G_officer_F";
-					atlOffset=3.0517578e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item36
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8412.5488,295.49496,6015.1367};
-						angles[]={5.9602342,0,0.018667053};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=771;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item37
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8418.1064,296.54022,6018.1729};
-						angles[]={5.9566455,0,6.2738504};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=773;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item38
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8421.0059,296.56638,6018.3516};
-						angles[]={5.9602346,0,6.2698579};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=774;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item39
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8423.9932,296.56824,6018.5713};
-						angles[]={5.9602342,0,6.2485328};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=775;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item40
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8409.6416,296.47437,6018.2256};
-						angles[]={5.9602342,0,0.018667053};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=776;
-					type="I_G_officer_F";
-					atlOffset=3.0517578e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item41
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8412.4004,296.58765,6018.4014};
-						angles[]={5.9566455,0,0.022662206};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=777;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item42
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8416.9199,297.47983,6020.918};
-						angles[]={5.9602346,0,6.2698579};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=779;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item43
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8419.8193,297.50092,6021.0967};
-						angles[]={5.9602346,0,6.2698579};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=780;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item44
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8422.8066,297.52811,6021.3164};
-						angles[]={5.9602342,0,6.2485328};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=781;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item45
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8408.4551,297.37094,6020.9707};
-						angles[]={5.9602342,0,0.018667053};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=782;
-					type="I_G_officer_F";
-					atlOffset=3.0517578e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item46
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8411.2139,297.49045,6021.1465};
-						angles[]={5.9566455,0,0.022662206};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=783;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item47
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8409.5635,291.93143,5991.6865};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=784;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item48
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8412.5879,291.93143,5991.9453};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=785;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item49
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8415.1729,291.93167,5992.3516};
-						angles[]={0,0,0.0012918708};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=786;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item50
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8418.0928,291.93555,5998.1875};
-						angles[]={0,0,0.0012918708};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=815;
-					type="I_G_Soldier_LAT2_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item51
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8417.9893,292.13071,6000.9824};
-						angles[]={6.0768313,0,0.0013372133};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=816;
-					type="I_G_Soldier_LAT2_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item52
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8417.9893,292.75903,6003.9839};
-						angles[]={6.0768352,0,0.0013439035};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=817;
-					type="I_G_Soldier_LAT2_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item53
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8417.8857,293.28506,6006.5703};
-						angles[]={6.084507,0,6.276526};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=818;
-					type="I_G_Soldier_LAT2_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item54
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8418.2178,293.92126,6009.1963};
-						angles[]={6.0213375,0,6.2765174};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=819;
-					type="I_G_Soldier_LAT2_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item55
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8418.292,294.74335,6012.2705};
-						angles[]={6.0238295,0,6.2738504};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=820;
-					type="I_G_Soldier_LAT2_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item56
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8415.3252,295.57861,6015.2568};
-						angles[]={5.9566455,0,6.2738504};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=821;
-					type="I_G_Soldier_LAT2_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item57
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8415.1768,296.68567,6018.5215};
-						angles[]={5.9566455,0,6.2738504};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=822;
-					type="I_G_Soldier_LAT2_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item58
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8413.9893,297.59396,6021.2666};
-						angles[]={5.9566455,0,0.022662206};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=823;
-					type="I_G_Soldier_LAT2_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item59
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8406.6328,291.93259,5992.0352};
-						angles[]={0,0,6.2818937};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=824;
-					type="I_G_Soldier_LAT2_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-			};
-			class Attributes
-			{
-			};
-			id=724;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="groupID";
-					expression="_this setGroupID [_value];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"STRING"
-								};
-							};
-							value="Rebels";
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item19
-		{
-			dataType="Group";
-			side="Independent";
-			class Entities
-			{
 				items=1;
 				class Item0
 				{
@@ -4413,7 +518,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item20
+		class Item19
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4453,7 +558,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item21
+		class Item20
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4493,7 +598,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item22
+		class Item21
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -4506,7 +611,7 @@ class Mission
 			id=790;
 			type="HeadlessClient_F";
 		};
-		class Item23
+		class Item22
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -4519,7 +624,7 @@ class Mission
 			id=791;
 			type="HeadlessClient_F";
 		};
-		class Item24
+		class Item23
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -4610,7 +715,7 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item25
+		class Item24
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4650,7 +755,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item26
+		class Item25
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4667,7 +772,7 @@ class Mission
 			id=797;
 			type="Flag_NATO_F";
 		};
-		class Item27
+		class Item26
 		{
 			dataType="Marker";
 			position[]={-0.40327436,20.631073,1693.8477};
@@ -4676,7 +781,7 @@ class Mission
 			id=798;
 			atlOffset=-3.6200981;
 		};
-		class Item28
+		class Item27
 		{
 			dataType="Group";
 			side="West";
@@ -5066,7 +1171,7 @@ class Mission
 			id=799;
 			atlOffset=1.9073486e-006;
 		};
-		class Item29
+		class Item28
 		{
 			dataType="Group";
 			side="East";
@@ -5447,7 +1552,7 @@ class Mission
 			};
 			id=806;
 		};
-		class Item30
+		class Item29
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5464,7 +1569,7 @@ class Mission
 			id=813;
 			type="Flag_Viper_F";
 		};
-		class Item31
+		class Item30
 		{
 			dataType="Marker";
 			position[]={2220.9285,541.20178,15364.892};
@@ -5473,7 +1578,7 @@ class Mission
 			id=814;
 			atlOffset=18.488037;
 		};
-		class Item32
+		class Item31
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5532,7 +1637,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item33
+		class Item32
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5543,7 +1648,7 @@ class Mission
 			id=826;
 			type="Logic";
 		};
-		class Item34
+		class Item33
 		{
 			dataType="Layer";
 			name="Airports";
@@ -5587,7 +1692,7 @@ class Mission
 					colorName="ColorEAST";
 					a=249.14926;
 					b=109.36142;
-					angle=28.489843;
+					angle=28.48984;
 					id=6;
 					atlOffset=-0.20903301;
 				};
@@ -5713,7 +1818,7 @@ class Mission
 					colorName="ColorGreen";
 					a=43.498734;
 					b=23.140686;
-					angle=237.01164;
+					angle=237.01163;
 					id=860;
 				};
 				class Item13
@@ -5726,7 +1831,7 @@ class Mission
 					colorName="ColorGreen";
 					a=44.02475;
 					b=23.856892;
-					angle=236.65271;
+					angle=236.65265;
 					id=861;
 				};
 				class Item14
@@ -5739,7 +1844,7 @@ class Mission
 					colorName="ColorGreen";
 					a=32.455002;
 					b=20.924999;
-					angle=207.52599;
+					angle=207.52596;
 					id=874;
 				};
 				class Item15
@@ -5765,7 +1870,7 @@ class Mission
 					colorName="ColorGreen";
 					a=32.455002;
 					b=20.924999;
-					angle=195.99698;
+					angle=195.99695;
 					id=873;
 				};
 				class Item17
@@ -5777,7 +1882,7 @@ class Mission
 					type="rectangle";
 					a=739.97546;
 					b=253.8351;
-					angle=59.967663;
+					angle=59.967659;
 					id=834;
 				};
 				class Item18
@@ -5789,7 +1894,7 @@ class Mission
 					type="rectangle";
 					a=379.85837;
 					b=130.2925;
-					angle=29.909325;
+					angle=29.909319;
 					id=835;
 					atlOffset=0.03082943;
 				};
@@ -5802,7 +1907,7 @@ class Mission
 					type="rectangle";
 					a=467.86603;
 					b=197.88884;
-					angle=19.954424;
+					angle=19.95442;
 					id=836;
 					atlOffset=-0.67440796;
 				};
@@ -5810,7 +1915,7 @@ class Mission
 			id=827;
 			atlOffset=-156.77542;
 		};
-		class Item35
+		class Item34
 		{
 			dataType="Layer";
 			name="Outposts";
@@ -5936,7 +2041,7 @@ class Mission
 					colorName="ColorGreen";
 					a=55.869678;
 					b=48.883904;
-					angle=179.87865;
+					angle=179.87862;
 					id=39;
 					atlOffset=-3.3840942;
 				};
@@ -5976,7 +2081,7 @@ class Mission
 					colorName="ColorGreen";
 					a=70;
 					b=50;
-					angle=318.96817;
+					angle=318.96811;
 					id=52;
 				};
 				class Item12
@@ -6016,7 +2121,7 @@ class Mission
 					colorName="ColorGreen";
 					a=55.818733;
 					b=57.456215;
-					angle=121.37392;
+					angle=121.37389;
 					id=295;
 					atlOffset=-6.7468872;
 				};
@@ -6202,7 +2307,7 @@ class Mission
 					colorName="ColorGreen";
 					a=9.691;
 					b=18.506001;
-					angle=180.35098;
+					angle=180.35095;
 					id=881;
 					atlOffset=0.45897436;
 				};
@@ -6216,7 +2321,7 @@ class Mission
 					colorName="ColorGreen";
 					a=12.183;
 					b=5.744;
-					angle=207.52599;
+					angle=207.52596;
 					id=878;
 					atlOffset=0.072692871;
 				};
@@ -6230,7 +2335,7 @@ class Mission
 					colorName="ColorGreen";
 					a=12.214;
 					b=20.924999;
-					angle=225.60698;
+					angle=225.60695;
 					id=883;
 					atlOffset=-0.138937;
 				};
@@ -6244,14 +2349,14 @@ class Mission
 					colorName="ColorGreen";
 					a=32.455002;
 					b=20.924999;
-					angle=207.52599;
+					angle=207.52596;
 					id=876;
 				};
 			};
 			id=828;
 			atlOffset=-140.3578;
 		};
-		class Item36
+		class Item35
 		{
 			dataType="Layer";
 			name="Seaports";
@@ -6348,7 +2453,7 @@ class Mission
 					colorName="ColorGreen";
 					a=32.455002;
 					b=12.286;
-					angle=179.12999;
+					angle=179.12996;
 					id=879;
 					atlOffset=0.24533272;
 				};
@@ -6356,7 +2461,7 @@ class Mission
 			id=829;
 			atlOffset=-108.53817;
 		};
-		class Item37
+		class Item36
 		{
 			dataType="Layer";
 			name="Factories";
@@ -6448,7 +2553,7 @@ class Mission
 			id=830;
 			atlOffset=-167.34557;
 		};
-		class Item38
+		class Item37
 		{
 			dataType="Layer";
 			name="Resources";
@@ -6608,7 +2713,7 @@ class Mission
 			id=831;
 			atlOffset=-278.84216;
 		};
-		class Item39
+		class Item38
 		{
 			dataType="Layer";
 			name="Roadblocks";
@@ -7117,7 +3222,7 @@ class Mission
 			id=832;
 			atlOffset=7.5841923;
 		};
-		class Item40
+		class Item39
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -7171,7 +3276,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item41
+		class Item40
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7183,11 +3288,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=848;
 			type="Land_HelipadSquare_F";
 		};
-		class Item42
+		class Item41
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7199,11 +3305,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=849;
 			type="Land_HelipadSquare_F";
 		};
-		class Item43
+		class Item42
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7215,27 +3322,29 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=850;
 			type="Land_HelipadSquare_F";
 		};
-		class Item44
+		class Item43
 		{
 			dataType="Object";
 			class PositionInfo
 			{
 				position[]={5099.7905,9,2336.02};
-				angles[]={-0,2.0886309,0};
+				angles[]={0,2.0886309,0};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=851;
 			type="Land_HelipadSquare_F";
 		};
-		class Item45
+		class Item44
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7247,27 +3356,29 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=852;
 			type="Land_HelipadSquare_F";
 		};
-		class Item46
+		class Item45
 		{
 			dataType="Object";
 			class PositionInfo
 			{
 				position[]={4795.1753,9,2522.0068};
-				angles[]={-0,3.6794586,0};
+				angles[]={0,3.6794586,0};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=853;
 			type="Land_HelipadSquare_F";
 		};
-		class Item47
+		class Item46
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7279,11 +3390,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=855;
 			type="Land_HelipadSquare_F";
 		};
-		class Item48
+		class Item47
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7295,11 +3407,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=857;
 			type="Land_HelipadSquare_F";
 		};
-		class Item49
+		class Item48
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -7355,7 +3468,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item50
+		class Item49
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -7411,20 +3524,38 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item51
+		class Item50
 		{
 			dataType="Object";
 			class PositionInfo
 			{
 				position[]={4773.082,339,10120.783};
-				angles[]={-0,1.0440426,0};
+				angles[]={0,1.0440426,0};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=862;
+			type="Land_HelipadSquare_F";
+		};
+		class Item51
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={4793.561,339,10085.981};
+				angles[]={0,1.0440426,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=863;
 			type="Land_HelipadSquare_F";
 		};
 		class Item52
@@ -7432,15 +3563,16 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={4793.561,339,10085.981};
-				angles[]={-0,1.0440426,0};
+				position[]={4816.0903,339,10048.161};
+				angles[]={0,1.0440426,0};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
-			id=863;
+			id=864;
 			type="Land_HelipadSquare_F";
 		};
 		class Item53
@@ -7448,34 +3580,19 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={4816.0903,339,10048.161};
-				angles[]={-0,1.0440426,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=864;
-			type="Land_HelipadSquare_F";
-		};
-		class Item54
-		{
-			dataType="Object";
-			class PositionInfo
-			{
 				position[]={4841.4712,339,10004.922};
-				angles[]={-0,1.0440426,0};
+				angles[]={0,1.0440426,0};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=865;
 			type="Land_HelipadSquare_F";
 		};
-		class Item55
+		class Item54
 		{
 			dataType="Layer";
 			name="Roads";
@@ -7874,16 +3991,862 @@ class Mission
 			id=886;
 			atlOffset=29.723694;
 		};
+		class Item55
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=38;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8399.4902,292.33167,6000.6846};
+					};
+					side="Independent";
+					flags=7;
+					class Attributes
+					{
+						name="commanderX";
+						description="Default Commaner";
+						isPlayer=1;
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=888;
+					type="I_G_officer_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male04GRE";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1;
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8404.2852,292.07288,5997.9814};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=889;
+					type="I_G_officer_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8404.4238,292.08984,6000.2173};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=890;
+					type="I_G_officer_F";
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8404.3662,292.41278,6002.5508};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=891;
+					type="I_G_officer_F";
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8404.2031,292.83685,6004.8643};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=892;
+					type="I_G_officer_F";
+					atlOffset=-3.0517578e-005;
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8404.1621,293.33337,6007.3184};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=893;
+					type="I_G_officer_F";
+					atlOffset=-3.0517578e-005;
+				};
+				class Item6
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8403.9766,293.86826,6009.6343};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=894;
+					type="I_G_officer_F";
+				};
+				class Item7
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8403.7695,294.31622,6011.5298};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=895;
+					type="I_G_officer_F";
+				};
+				class Item8
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8406.6445,291.96906,5998.105};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=896;
+					type="I_G_Soldier_F";
+				};
+				class Item9
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8406.6436,292.02335,6000.4443};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=897;
+					type="I_G_Soldier_F";
+				};
+				class Item10
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8406.5371,292.47195,6002.8179};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=898;
+					type="I_G_Soldier_F";
+					atlOffset=-3.0517578e-005;
+				};
+				class Item11
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8406.4785,292.9165,6005.0176};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=899;
+					type="I_G_Soldier_F";
+					atlOffset=-3.0517578e-005;
+				};
+				class Item12
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8406.2754,293.40311,6007.4399};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=900;
+					type="I_G_Soldier_F";
+					atlOffset=-3.0517578e-005;
+				};
+				class Item13
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8406.0879,293.96179,6009.771};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=901;
+					type="I_G_Soldier_F";
+				};
+				class Item14
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8408.7529,291.93143,5998.1411};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=902;
+					type="I_G_Soldier_AR_F";
+				};
+				class Item15
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8408.915,292.03912,6000.5811};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=903;
+					type="I_G_Soldier_AR_F";
+				};
+				class Item16
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8408.5146,292.52863,6002.9961};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=904;
+					type="I_G_Soldier_AR_F";
+				};
+				class Item17
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8408.4912,292.96411,6005.145};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=905;
+					type="I_G_Soldier_AR_F";
+				};
+				class Item18
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8408.291,293.42252,6007.3862};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=906;
+					type="I_G_Soldier_AR_F";
+				};
+				class Item19
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8408.2041,294.04382,6009.8452};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=907;
+					type="I_G_Soldier_AR_F";
+				};
+				class Item20
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8410.8418,291.93143,5998.2207};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=908;
+					type="I_G_Soldier_GL_F";
+				};
+				class Item21
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8410.7119,292.03052,6000.5386};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=909;
+					type="I_G_Soldier_GL_F";
+				};
+				class Item22
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8410.5879,292.5867,6003.2827};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=910;
+					type="I_G_Soldier_GL_F";
+				};
+				class Item23
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8410.4141,292.99814,6005.2915};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=911;
+					type="I_G_Soldier_GL_F";
+				};
+				class Item24
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8410.3447,293.45508,6007.4761};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=912;
+					type="I_G_Soldier_GL_F";
+				};
+				class Item25
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8410.2393,294.08856,6009.9668};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=913;
+					type="I_G_Soldier_GL_F";
+				};
+				class Item26
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8412.3691,291.93143,5998.2983};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=914;
+					type="I_G_medic_F";
+				};
+				class Item27
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8412.1934,292.03857,6000.5781};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=915;
+					type="I_G_medic_F";
+				};
+				class Item28
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8412.1514,292.62424,6003.4497};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=916;
+					type="I_G_medic_F";
+				};
+				class Item29
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8412.0635,293.00189,6005.2563};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=917;
+					type="I_G_medic_F";
+				};
+				class Item30
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8411.8799,293.49765,6007.6157};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=918;
+					type="I_G_medic_F";
+				};
+				class Item31
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8411.8906,294.11481,6010.0264};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=919;
+					type="I_G_medic_F";
+				};
+				class Item32
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8414.1709,291.93143,5998.4634};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=920;
+					type="I_G_engineer_F";
+				};
+				class Item33
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8414.1943,292.07614,6000.7637};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=921;
+					type="I_G_engineer_F";
+				};
+				class Item34
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8413.9521,292.65799,6003.5537};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=922;
+					type="I_G_engineer_F";
+				};
+				class Item35
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8413.6973,293.06406,6005.5015};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=923;
+					type="I_G_engineer_F";
+				};
+				class Item36
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8413.502,293.53961,6007.7378};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=924;
+					type="I_G_engineer_F";
+				};
+				class Item37
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8413.3975,294.18369,6010.207};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=925;
+					type="I_G_engineer_F";
+				};
+			};
+			class Attributes
+			{
+			};
+			id=887;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="Guerillas";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
 	};
 	class Connections
 	{
 		class LinkIDProvider
 		{
-			nextID=61;
+			nextID=39;
 		};
 		class Links
 		{
-			items=61;
+			items=39;
 			class Item0
 			{
 				linkID=0;
@@ -7897,7 +4860,7 @@ class Mission
 			class Item1
 			{
 				linkID=1;
-				item0=725;
+				item0=888;
 				item1=718;
 				class CustomData
 				{
@@ -7907,7 +4870,7 @@ class Mission
 			class Item2
 			{
 				linkID=2;
-				item0=729;
+				item0=889;
 				item1=718;
 				class CustomData
 				{
@@ -7917,7 +4880,7 @@ class Mission
 			class Item3
 			{
 				linkID=3;
-				item0=730;
+				item0=890;
 				item1=718;
 				class CustomData
 				{
@@ -7927,7 +4890,7 @@ class Mission
 			class Item4
 			{
 				linkID=4;
-				item0=732;
+				item0=891;
 				item1=718;
 				class CustomData
 				{
@@ -7937,7 +4900,7 @@ class Mission
 			class Item5
 			{
 				linkID=5;
-				item0=733;
+				item0=892;
 				item1=718;
 				class CustomData
 				{
@@ -7947,7 +4910,7 @@ class Mission
 			class Item6
 			{
 				linkID=6;
-				item0=734;
+				item0=893;
 				item1=718;
 				class CustomData
 				{
@@ -7957,7 +4920,7 @@ class Mission
 			class Item7
 			{
 				linkID=7;
-				item0=735;
+				item0=894;
 				item1=718;
 				class CustomData
 				{
@@ -7967,7 +4930,7 @@ class Mission
 			class Item8
 			{
 				linkID=8;
-				item0=736;
+				item0=895;
 				item1=718;
 				class CustomData
 				{
@@ -7977,7 +4940,7 @@ class Mission
 			class Item9
 			{
 				linkID=9;
-				item0=738;
+				item0=896;
 				item1=718;
 				class CustomData
 				{
@@ -7987,7 +4950,7 @@ class Mission
 			class Item10
 			{
 				linkID=10;
-				item0=739;
+				item0=897;
 				item1=718;
 				class CustomData
 				{
@@ -7997,7 +4960,7 @@ class Mission
 			class Item11
 			{
 				linkID=11;
-				item0=740;
+				item0=898;
 				item1=718;
 				class CustomData
 				{
@@ -8007,7 +4970,7 @@ class Mission
 			class Item12
 			{
 				linkID=12;
-				item0=741;
+				item0=899;
 				item1=718;
 				class CustomData
 				{
@@ -8017,7 +4980,7 @@ class Mission
 			class Item13
 			{
 				linkID=13;
-				item0=743;
+				item0=900;
 				item1=718;
 				class CustomData
 				{
@@ -8027,7 +4990,7 @@ class Mission
 			class Item14
 			{
 				linkID=14;
-				item0=744;
+				item0=901;
 				item1=718;
 				class CustomData
 				{
@@ -8037,7 +5000,7 @@ class Mission
 			class Item15
 			{
 				linkID=15;
-				item0=745;
+				item0=902;
 				item1=718;
 				class CustomData
 				{
@@ -8047,7 +5010,7 @@ class Mission
 			class Item16
 			{
 				linkID=16;
-				item0=746;
+				item0=903;
 				item1=718;
 				class CustomData
 				{
@@ -8057,7 +5020,7 @@ class Mission
 			class Item17
 			{
 				linkID=17;
-				item0=748;
+				item0=904;
 				item1=718;
 				class CustomData
 				{
@@ -8067,7 +5030,7 @@ class Mission
 			class Item18
 			{
 				linkID=18;
-				item0=749;
+				item0=905;
 				item1=718;
 				class CustomData
 				{
@@ -8077,7 +5040,7 @@ class Mission
 			class Item19
 			{
 				linkID=19;
-				item0=750;
+				item0=906;
 				item1=718;
 				class CustomData
 				{
@@ -8087,7 +5050,7 @@ class Mission
 			class Item20
 			{
 				linkID=20;
-				item0=751;
+				item0=907;
 				item1=718;
 				class CustomData
 				{
@@ -8097,7 +5060,7 @@ class Mission
 			class Item21
 			{
 				linkID=21;
-				item0=752;
+				item0=908;
 				item1=718;
 				class CustomData
 				{
@@ -8107,7 +5070,7 @@ class Mission
 			class Item22
 			{
 				linkID=22;
-				item0=753;
+				item0=909;
 				item1=718;
 				class CustomData
 				{
@@ -8117,7 +5080,7 @@ class Mission
 			class Item23
 			{
 				linkID=23;
-				item0=755;
+				item0=910;
 				item1=718;
 				class CustomData
 				{
@@ -8127,7 +5090,7 @@ class Mission
 			class Item24
 			{
 				linkID=24;
-				item0=756;
+				item0=911;
 				item1=718;
 				class CustomData
 				{
@@ -8137,7 +5100,7 @@ class Mission
 			class Item25
 			{
 				linkID=25;
-				item0=757;
+				item0=912;
 				item1=718;
 				class CustomData
 				{
@@ -8147,7 +5110,7 @@ class Mission
 			class Item26
 			{
 				linkID=26;
-				item0=758;
+				item0=913;
 				item1=718;
 				class CustomData
 				{
@@ -8157,7 +5120,7 @@ class Mission
 			class Item27
 			{
 				linkID=27;
-				item0=759;
+				item0=914;
 				item1=718;
 				class CustomData
 				{
@@ -8167,7 +5130,7 @@ class Mission
 			class Item28
 			{
 				linkID=28;
-				item0=761;
+				item0=915;
 				item1=718;
 				class CustomData
 				{
@@ -8177,7 +5140,7 @@ class Mission
 			class Item29
 			{
 				linkID=29;
-				item0=762;
+				item0=916;
 				item1=718;
 				class CustomData
 				{
@@ -8187,7 +5150,7 @@ class Mission
 			class Item30
 			{
 				linkID=30;
-				item0=763;
+				item0=917;
 				item1=718;
 				class CustomData
 				{
@@ -8197,7 +5160,7 @@ class Mission
 			class Item31
 			{
 				linkID=31;
-				item0=764;
+				item0=918;
 				item1=718;
 				class CustomData
 				{
@@ -8207,7 +5170,7 @@ class Mission
 			class Item32
 			{
 				linkID=32;
-				item0=765;
+				item0=919;
 				item1=718;
 				class CustomData
 				{
@@ -8217,7 +5180,7 @@ class Mission
 			class Item33
 			{
 				linkID=33;
-				item0=767;
+				item0=920;
 				item1=718;
 				class CustomData
 				{
@@ -8227,7 +5190,7 @@ class Mission
 			class Item34
 			{
 				linkID=34;
-				item0=768;
+				item0=921;
 				item1=718;
 				class CustomData
 				{
@@ -8237,7 +5200,7 @@ class Mission
 			class Item35
 			{
 				linkID=35;
-				item0=769;
+				item0=922;
 				item1=718;
 				class CustomData
 				{
@@ -8247,7 +5210,7 @@ class Mission
 			class Item36
 			{
 				linkID=36;
-				item0=770;
+				item0=923;
 				item1=718;
 				class CustomData
 				{
@@ -8257,7 +5220,7 @@ class Mission
 			class Item37
 			{
 				linkID=37;
-				item0=771;
+				item0=924;
 				item1=718;
 				class CustomData
 				{
@@ -8267,227 +5230,7 @@ class Mission
 			class Item38
 			{
 				linkID=38;
-				item0=773;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item39
-			{
-				linkID=39;
-				item0=774;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item40
-			{
-				linkID=40;
-				item0=775;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item41
-			{
-				linkID=41;
-				item0=776;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item42
-			{
-				linkID=42;
-				item0=777;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item43
-			{
-				linkID=43;
-				item0=779;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item44
-			{
-				linkID=44;
-				item0=780;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item45
-			{
-				linkID=45;
-				item0=781;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item46
-			{
-				linkID=46;
-				item0=782;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item47
-			{
-				linkID=47;
-				item0=783;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item48
-			{
-				linkID=48;
-				item0=784;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item49
-			{
-				linkID=49;
-				item0=785;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item50
-			{
-				linkID=50;
-				item0=786;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item51
-			{
-				linkID=51;
-				item0=815;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item52
-			{
-				linkID=52;
-				item0=816;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item53
-			{
-				linkID=53;
-				item0=817;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item54
-			{
-				linkID=54;
-				item0=818;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item55
-			{
-				linkID=55;
-				item0=819;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item56
-			{
-				linkID=56;
-				item0=820;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item57
-			{
-				linkID=57;
-				item0=821;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item58
-			{
-				linkID=58;
-				item0=822;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item59
-			{
-				linkID=59;
-				item0=823;
-				item1=718;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item60
-			{
-				linkID=60;
-				item0=824;
+				item0=925;
 				item1=718;
 				class CustomData
 				{

--- a/Map-Templates/Antistasi-ChernarusWinter.chernarus_winter/mission.sqm
+++ b/Map-Templates/Antistasi-ChernarusWinter.chernarus_winter/mission.sqm
@@ -8,18 +8,18 @@ class EditorData
 	toggles=1;
 	class ItemIDProvider
 	{
-		nextID=302;
+		nextID=341;
 	};
 	class LayerIndexProvider
 	{
-		nextID=42;
+		nextID=56;
 	};
 	class Camera
 	{
-		pos[]={8397.6348,364.55566,5928.7485};
-		dir[]={0.10471021,-0.71442097,0.69185412};
-		up[]={0.10690976,0.69970715,0.70638883};
-		aside[]={0.9887526,-3.772584e-008,-0.1496447};
+		pos[]={8399.5889,318.0535,5975.4717};
+		dir[]={0.014823829,-0.63294464,0.77407736};
+		up[]={0.012118943,0.7741816,0.63284791};
+		aside[]={0.99983245,1.3861063e-007,-0.019146126};
 	};
 };
 binarizationWanted=0;
@@ -28,8 +28,6 @@ addons[]=
 	"A3_Ui_F",
 	"A3_Modules_F",
 	"A3_Characters_F",
-	"A3_Weapons_F",
-	"A3_Characters_F_Tank",
 	"A3_Structures_F_EPC_Civ_InfoBoards",
 	"A3_Structures_F_Mil_Flags",
 	"A3_Props_F_Enoch_Military_Camps",
@@ -40,13 +38,14 @@ addons[]=
 	"A3_Structures_F_Mil_Helipads",
 	"A3_Weapons_F_Ammoboxes",
 	"A3_Modules_F_Curator_Curator",
-	"A3_Modules_F_Hc"
+	"A3_Modules_F_Hc",
+	"A3_Weapons_F"
 };
 class AddonsMetaData
 {
 	class List
 	{
-		items=13;
+		items=12;
 		class Item0
 		{
 			className="A3_Ui_F";
@@ -70,68 +69,61 @@ class AddonsMetaData
 		};
 		class Item3
 		{
-			className="A3_Weapons_F";
-			name="Arma 3 Alpha - Weapons and Accessories";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item4
-		{
-			className="A3_Characters_F_Tank";
-			name="Arma 3 Tank - Characters and Clothing";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item5
-		{
 			className="A3_Structures_F_EPC";
 			name="Arma 3 Win Episode - Buildings and Structures";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item6
+		class Item4
 		{
 			className="A3_Structures_F_Mil";
 			name="Arma 3 - Military Buildings and Structures";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item7
+		class Item5
 		{
 			className="A3_Props_F_Enoch";
 			name="Arma 3 Enoch - Decorative and Mission Objects";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item8
+		class Item6
 		{
 			className="A3_Ui_F_Exp";
 			name="Arma 3 Apex - User Interface";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item9
+		class Item7
 		{
 			className="A3_Characters_F_Patrol";
 			name="Arma 3 Patrol - Characters and Clothing";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item10
+		class Item8
 		{
 			className="A3_Characters_F_Exp";
 			name="Arma 3 Apex - Characters and Clothing";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item11
+		class Item9
 		{
 			className="A3_Structures_F_Exp";
 			name="Arma 3 Apex - Buildings and Structures";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item12
+		class Item10
+		{
+			className="A3_Weapons_F";
+			name="Arma 3 Alpha - Weapons and Accessories";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item11
 		{
 			className="A3_Modules_F_Curator";
 			name="Arma 3 Zeus Update - Scripted Modules";
@@ -147,21 +139,11 @@ class Mission
 	{
 		briefingName=$STR_antistasi_mission_info_chernawinter_mapname_text;
 		resistanceWest=0;
-		timeOfChanges=1800.0002;
-		startWeather=0.25;
-		startWind=0.1;
-		startWaves=0.1;
-		forecastWeather=0.25;
-		forecastWind=0.1;
-		forecastWaves=0.1;
-		forecastLightnings=0.1;
 		year=2008;
 		month=10;
 		day=11;
 		hour=9;
 		minute=20;
-		startFogDecay=0.014;
-		forecastFogDecay=0.014;
 	};
 	class Entities
 	{
@@ -339,3436 +321,6 @@ class Mission
 			side="Independent";
 			class Entities
 			{
-				items=60;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8400.083,292.07764,5995.7441};
-						angles[]={6.2405434,0,6.2818484};
-					};
-					side="Independent";
-					flags=6;
-					class Attributes
-					{
-						skill=1;
-						name="commanderX";
-						description="Default Commander";
-						isPlayer=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=19;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item1
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8403.6162,291.93661,5992.2197};
-						angles[]={0,6.2412972,6.2818937};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=20;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item2
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8415.0752,291.93152,5998.3721};
-						angles[]={0,6.2412972,0.0012918708};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=21;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item3
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8421.0791,291.93954,5998.2588};
-						angles[]={0,0,0.0012918708};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=22;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item4
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8426.9658,291.94739,5998.6572};
-						angles[]={0,0,0.0012918708};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=24;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item5
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8412.6143,291.93143,5998.3115};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=25;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item6
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8414.9727,292.16516,6001.167};
-						angles[]={6.0768309,6.2412972,0.0066682254};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=26;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item7
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8420.9766,292.14963,6001.0537};
-						angles[]={6.0768313,0,0.0013372133};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=27;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item8
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8426.8633,292.22964,6001.4521};
-						angles[]={6.084507,0,0.0013372133};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=29;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item9
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8412.5117,292.14563,6001.1064};
-						angles[]={6.0832248,0,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=30;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item10
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8420.9766,292.75793,6004.0547};
-						angles[]={6.084507,0,6.276526};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=31;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item11
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8426.8633,292.80853,6004.4531};
-						angles[]={6.1038036,0,6.2645183};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=33;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item12
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8412.5117,292.76434,6004.1074};
-						angles[]={6.0768309,0,0.0066682254};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=34;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item13
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8420.8721,293.27954,6006.6416};
-						angles[]={6.084507,0,6.276526};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=35;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item14
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8426.7598,293.27954,6007.04};
-						angles[]={6.1038036,0,6.2645183};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=37;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item15
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8412.4072,293.30515,6006.6943};
-						angles[]={6.0768309,0,0.0066682254};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=38;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item16
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8415.0713,292.81781,6004.2832};
-						angles[]={6.0768313,6.1574922,0.0013372133};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=39;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item17
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8415.167,293.35944,6006.8701};
-						angles[]={6.0768313,0,0.0013372133};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=40;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item18
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8421.2051,293.91937,6009.2676};
-						angles[]={6.0238295,0,6.2738504};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=41;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item19
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8427.0918,293.92734,6009.666};
-						angles[]={6.0238295,0,6.2645183};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=43;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item20
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8412.7402,293.93967,6009.3203};
-						angles[]={6.0325699,0,0.0066682254};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=44;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item21
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8415.499,294.01974,6009.4961};
-						angles[]={6.0213375,0,6.2765174};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=45;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item22
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8421.2783,294.73441,6012.3418};
-						angles[]={6.0238295,0,6.2738504};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=46;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item23
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8427.165,294.70389,6012.7402};
-						angles[]={6.038835,0,6.2485313};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=48;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item24
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8412.8135,294.75909,6012.3945};
-						angles[]={6.0213375,0,0.018670246};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=49;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item25
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8415.5723,294.8432,6012.5703};
-						angles[]={6.0213375,0,6.2765174};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=50;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item26
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8418.3115,295.57495,6015.3281};
-						angles[]={5.9566455,0,6.2738504};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=51;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item27
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8424.1982,295.60916,6015.7266};
-						angles[]={5.9602342,0,6.2485328};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=53;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item28
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8409.8467,295.52615,6015.3809};
-						angles[]={5.9602342,0,0.018667053};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=54;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item29
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8412.6055,295.63647,6015.5566};
-						angles[]={5.9602342,0,0.018667053};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=55;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item30
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8418.1631,296.68182,6018.5928};
-						angles[]={5.9566455,0,6.2738504};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=56;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item31
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8424.0498,296.70688,6018.9912};
-						angles[]={5.9602342,0,6.2485328};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=58;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item32
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8409.6982,296.616,6018.6455};
-						angles[]={5.9602342,0,0.018667053};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=59;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item33
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8412.457,296.73126,6018.8213};
-						angles[]={5.9566455,0,0.022662206};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=60;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item34
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8416.9766,297.61957,6021.3379};
-						angles[]={5.9602346,0,6.2698579};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=61;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item35
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8422.8633,297.66675,6021.7363};
-						angles[]={5.9602342,0,6.2485328};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=63;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item36
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8408.5117,297.51242,6021.3906};
-						angles[]={5.9602342,0,0.018667053};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=64;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item37
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8411.2705,297.63391,6021.5664};
-						angles[]={5.9566455,0,0.022662206};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=65;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item38
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8409.6201,291.93143,5992.1064};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=66;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item39
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8415.2295,291.93173,5992.7715};
-						angles[]={0,0,0.0012918708};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=68;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item40
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8418.1494,291.93564,5998.6074};
-						angles[]={0,0,0.0012918708};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=69;
-					type="I_G_Soldier_LAT2_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item41
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8418.0459,292.21866,6001.4023};
-						angles[]={6.0768313,0,0.0013372133};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=70;
-					type="I_G_Soldier_LAT2_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item42
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8418.0459,292.84689,6004.4033};
-						angles[]={6.0768313,0,0.0013372133};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=71;
-					type="I_G_Soldier_LAT2_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item43
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8417.9424,293.3692,6006.9902};
-						angles[]={6.084507,0,6.276526};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=72;
-					type="I_G_Soldier_LAT2_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item44
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8418.2744,294.03351,6009.6162};
-						angles[]={6.0213375,0,6.2765174};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=73;
-					type="I_G_Soldier_LAT2_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item45
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8418.3486,294.85431,6012.6904};
-						angles[]={6.0238295,0,6.2738504};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=74;
-					type="I_G_Soldier_LAT2_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item46
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8415.3818,295.72028,6015.6768};
-						angles[]={5.9566455,0,6.2738504};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=75;
-					type="I_G_Soldier_LAT2_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item47
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8415.2334,296.82733,6018.9414};
-						angles[]={5.9566455,0,6.2738504};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=76;
-					type="I_G_Soldier_LAT2_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item48
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8414.0459,297.73758,6021.6865};
-						angles[]={5.9566455,0,0.022662206};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=77;
-					type="I_G_Soldier_LAT2_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item49
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8406.6895,291.9325,5992.4551};
-						angles[]={0,0,6.2818937};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=78;
-					type="I_G_Soldier_LAT2_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item50
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8420.123,297.57895,6021.3428};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=286;
-					type="I_G_engineer_F";
-					atlOffset=-0.00033569336;
-				};
-				class Item51
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8421.2002,296.67068,6018.6714};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=287;
-					type="I_G_engineer_F";
-					atlOffset=-0.00015258789;
-				};
-				class Item52
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8421.4307,295.64651,6015.626};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=288;
-					type="I_G_engineer_F";
-					atlOffset=-9.1552734e-005;
-				};
-				class Item53
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8424.2168,294.74435,6012.5439};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=289;
-					type="I_G_engineer_F";
-					atlOffset=-0.0002746582;
-				};
-				class Item54
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8424.2646,293.94699,6009.5425};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=290;
-					type="I_G_engineer_F";
-					atlOffset=-0.00033569336;
-				};
-				class Item55
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8424.2559,293.32309,6007.0225};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=291;
-					type="I_G_engineer_F";
-					atlOffset=-3.0517578e-005;
-				};
-				class Item56
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8424.2754,292.81985,6004.4004};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=292;
-					type="I_G_engineer_F";
-					atlOffset=3.0517578e-005;
-				};
-				class Item57
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8423.9922,292.1257,6000.9546};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=293;
-					type="I_G_engineer_F";
-					atlOffset=6.1035156e-005;
-				};
-				class Item58
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8424.2373,291.94376,5998.2524};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=294;
-					type="I_G_engineer_F";
-				};
-				class Item59
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8412.1709,291.93143,5992.6846};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=296;
-					type="I_G_engineer_F";
-				};
-			};
-			class Attributes
-			{
-			};
-			id=18;
-		};
-		class Item16
-		{
-			dataType="Group";
-			side="Independent";
-			class Entities
-			{
 				items=1;
 				class Item0
 				{
@@ -3854,7 +406,7 @@ class Mission
 			};
 			id=79;
 		};
-		class Item17
+		class Item16
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3894,7 +446,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item18
+		class Item17
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3934,7 +486,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item19
+		class Item18
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -3947,7 +499,7 @@ class Mission
 			id=83;
 			type="HeadlessClient_F";
 		};
-		class Item20
+		class Item19
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -3960,7 +512,7 @@ class Mission
 			id=84;
 			type="HeadlessClient_F";
 		};
-		class Item21
+		class Item20
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4001,7 +553,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item22
+		class Item21
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4018,7 +570,7 @@ class Mission
 			id=87;
 			type="Flag_NATO_F";
 		};
-		class Item23
+		class Item22
 		{
 			dataType="Marker";
 			position[]={-0.34570313,24.331726,1694.2678};
@@ -4026,7 +578,7 @@ class Mission
 			type="flag_CTRG";
 			id=88;
 		};
-		class Item24
+		class Item23
 		{
 			dataType="Group";
 			side="West";
@@ -4415,7 +967,7 @@ class Mission
 			id=89;
 			atlOffset=1.9073486e-006;
 		};
-		class Item25
+		class Item24
 		{
 			dataType="Group";
 			side="East";
@@ -4795,7 +1347,7 @@ class Mission
 			};
 			id=96;
 		};
-		class Item26
+		class Item25
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4812,7 +1364,7 @@ class Mission
 			id=103;
 			type="Flag_Viper_F";
 		};
-		class Item27
+		class Item26
 		{
 			dataType="Marker";
 			position[]={2220.9854,541.18561,15365.311};
@@ -4821,7 +1373,7 @@ class Mission
 			id=104;
 			atlOffset=18.415283;
 		};
-		class Item28
+		class Item27
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -4833,7 +1385,7 @@ class Mission
 			id=106;
 			type="Logic";
 		};
-		class Item29
+		class Item28
 		{
 			dataType="Layer";
 			name="Airports";
@@ -5095,7 +1647,7 @@ class Mission
 			id=107;
 			atlOffset=-156.33533;
 		};
-		class Item30
+		class Item29
 		{
 			dataType="Layer";
 			name="Outposts";
@@ -5505,7 +2057,7 @@ class Mission
 					colorName="ColorGreen";
 					a=12.214;
 					b=20.924999;
-					angle=225.60686;
+					angle=225.60683;
 					id=159;
 				};
 				class Item31
@@ -5525,7 +2077,7 @@ class Mission
 			id=128;
 			atlOffset=-140.4162;
 		};
-		class Item31
+		class Item30
 		{
 			dataType="Layer";
 			name="Seaports";
@@ -5630,7 +2182,7 @@ class Mission
 			id=161;
 			atlOffset=-108.57768;
 		};
-		class Item32
+		class Item31
 		{
 			dataType="Layer";
 			name="Factories";
@@ -5719,7 +2271,7 @@ class Mission
 			id=169;
 			atlOffset=-167.30002;
 		};
-		class Item33
+		class Item32
 		{
 			dataType="Layer";
 			name="Resources";
@@ -5875,7 +2427,7 @@ class Mission
 			id=176;
 			atlOffset=-274.14001;
 		};
-		class Item34
+		class Item33
 		{
 			dataType="Layer";
 			name="Roadblocks";
@@ -6362,7 +2914,7 @@ class Mission
 			id=188;
 			atlOffset=15.737294;
 		};
-		class Item35
+		class Item34
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -6417,7 +2969,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item36
+		class Item35
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6429,12 +2981,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=231;
 			type="Land_HelipadSquare_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item37
+		class Item36
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6446,11 +2999,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=232;
 			type="Land_HelipadSquare_F";
 		};
-		class Item38
+		class Item37
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6462,11 +3016,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=233;
 			type="Land_HelipadSquare_F";
 		};
-		class Item39
+		class Item38
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6478,11 +3033,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=234;
 			type="Land_HelipadSquare_F";
 		};
-		class Item40
+		class Item39
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6494,11 +3050,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=235;
 			type="Land_HelipadSquare_F";
 		};
-		class Item41
+		class Item40
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6510,11 +3067,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=236;
 			type="Land_HelipadSquare_F";
 		};
-		class Item42
+		class Item41
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6526,11 +3084,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=237;
 			type="Land_HelipadSquare_F";
 		};
-		class Item43
+		class Item42
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6542,11 +3101,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=238;
 			type="Land_HelipadSquare_F";
 		};
-		class Item44
+		class Item43
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -6601,7 +3161,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item45
+		class Item44
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -6657,7 +3217,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item46
+		class Item45
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6669,11 +3229,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=241;
 			type="Land_HelipadSquare_F";
 		};
-		class Item47
+		class Item46
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6685,11 +3246,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=242;
 			type="Land_HelipadSquare_F";
 		};
-		class Item48
+		class Item47
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6701,11 +3263,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=243;
 			type="Land_HelipadSquare_F";
 		};
-		class Item49
+		class Item48
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6717,11 +3280,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=244;
 			type="Land_HelipadSquare_F";
 		};
-		class Item50
+		class Item49
 		{
 			dataType="Layer";
 			name="Roads";
@@ -7095,7 +3659,7 @@ class Mission
 			id=245;
 			atlOffset=29.722382;
 		};
-		class Item51
+		class Item50
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7135,7 +3699,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item52
+		class Item51
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7152,7 +3716,7 @@ class Mission
 			id=298;
 			type="Box_East_AmmoVeh_F";
 		};
-		class Item53
+		class Item52
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -7243,7 +3807,7 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item54
+		class Item53
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -7254,7 +3818,7 @@ class Mission
 			id=300;
 			type="HighCommand";
 		};
-		class Item55
+		class Item54
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -7264,16 +3828,860 @@ class Mission
 			id=301;
 			type="HighCommandSubordinate";
 		};
+		class Item55
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=38;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8399.0459,292.43259,6001.5273};
+					};
+					side="Independent";
+					flags=7;
+					class Attributes
+					{
+						name="commanderX";
+						description="Default Commaner";
+						isPlayer=1;
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=303;
+					type="I_G_officer_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male04GRE";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1;
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8403.8408,292.09241,5998.8242};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=304;
+					type="I_G_officer_F";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8403.9795,292.22513,6001.0601};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=305;
+					type="I_G_officer_F";
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8403.9219,292.5481,6003.3936};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=306;
+					type="I_G_officer_F";
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8403.7588,292.9982,6005.707};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=307;
+					type="I_G_officer_F";
+					atlOffset=-3.0517578e-005;
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8403.7178,293.51508,6008.1611};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=308;
+					type="I_G_officer_F";
+				};
+				class Item6
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8403.5322,294.05768,6010.4771};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=309;
+					type="I_G_officer_F";
+				};
+				class Item7
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8403.3252,294.51358,6012.3726};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=310;
+					type="I_G_officer_F";
+				};
+				class Item8
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8406.2002,291.98859,5998.9478};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=311;
+					type="I_G_Soldier_F";
+				};
+				class Item9
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8406.1992,292.1586,6001.2871};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=312;
+					type="I_G_Soldier_F";
+				};
+				class Item10
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8406.0928,292.63327,6003.6606};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=313;
+					type="I_G_Soldier_F";
+					atlOffset=-3.0517578e-005;
+				};
+				class Item11
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8406.0342,293.07779,6005.8604};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=314;
+					type="I_G_Soldier_F";
+					atlOffset=-3.0517578e-005;
+				};
+				class Item12
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8405.8311,293.58893,6008.2827};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=315;
+					type="I_G_Soldier_F";
+				};
+				class Item13
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8405.6436,294.15921,6010.6138};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=316;
+					type="I_G_Soldier_F";
+				};
+				class Item14
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8408.3086,291.93143,5998.9839};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=317;
+					type="I_G_Soldier_AR_F";
+				};
+				class Item15
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8408.4707,292.20993,6001.4238};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=318;
+					type="I_G_Soldier_AR_F";
+				};
+				class Item16
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8408.0703,292.6994,6003.8389};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=319;
+					type="I_G_Soldier_AR_F";
+				};
+				class Item17
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8408.0469,293.13489,6005.9878};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=320;
+					type="I_G_Soldier_AR_F";
+				};
+				class Item18
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8407.8467,293.62769,6008.229};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=321;
+					type="I_G_Soldier_AR_F";
+				};
+				class Item19
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8407.7598,294.25662,6010.688};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=322;
+					type="I_G_Soldier_AR_F";
+				};
+				class Item20
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8410.3975,291.93143,5999.0635};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=323;
+					type="I_G_Soldier_GL_F";
+				};
+				class Item21
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8410.2676,292.20129,6001.3813};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=324;
+					type="I_G_Soldier_GL_F";
+				};
+				class Item22
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8410.1436,292.75751,6004.1255};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=325;
+					type="I_G_Soldier_GL_F";
+				};
+				class Item23
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8409.9697,293.1716,6006.1343};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=326;
+					type="I_G_Soldier_GL_F";
+				};
+				class Item24
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8409.9004,293.66443,6008.3188};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=327;
+					type="I_G_Soldier_GL_F";
+				};
+				class Item25
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8409.7949,294.30133,6010.8096};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=328;
+					type="I_G_Soldier_GL_F";
+				};
+				class Item26
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8411.9248,291.93143,5999.1411};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=329;
+					type="I_G_medic_F";
+				};
+				class Item27
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8411.749,292.20938,6001.4209};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=330;
+					type="I_G_medic_F";
+				};
+				class Item28
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8411.707,292.7977,6004.2925};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=331;
+					type="I_G_medic_F";
+				};
+				class Item29
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8411.6191,293.17532,6006.0991};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=332;
+					type="I_G_medic_F";
+				};
+				class Item30
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8411.4355,293.71042,6008.4585};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=333;
+					type="I_G_medic_F";
+				};
+				class Item31
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8411.4463,294.32758,6010.8691};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=334;
+					type="I_G_medic_F";
+				};
+				class Item32
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8413.7266,291.93143,5999.3062};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=335;
+					type="I_G_engineer_F";
+				};
+				class Item33
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8413.75,292.24899,6001.6064};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=336;
+					type="I_G_engineer_F";
+				};
+				class Item34
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8413.5078,292.83145,6004.3965};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=337;
+					type="I_G_engineer_F";
+				};
+				class Item35
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8413.2529,293.23746,6006.3442};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=338;
+					type="I_G_engineer_F";
+				};
+				class Item36
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8413.0576,293.75241,6008.5806};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=339;
+					type="I_G_engineer_F";
+				};
+				class Item37
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8412.9531,294.40137,6011.0498};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=340;
+					type="I_G_engineer_F";
+				};
+			};
+			class Attributes
+			{
+			};
+			id=302;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="Guerillas";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
 	};
 	class Connections
 	{
 		class LinkIDProvider
 		{
-			nextID=61;
+			nextID=39;
 		};
 		class Links
 		{
-			items=61;
+			items=39;
 			class Item0
 			{
 				linkID=0;
@@ -7287,7 +4695,7 @@ class Mission
 			class Item1
 			{
 				linkID=1;
-				item0=19;
+				item0=303;
 				item1=300;
 				class CustomData
 				{
@@ -7297,7 +4705,7 @@ class Mission
 			class Item2
 			{
 				linkID=2;
-				item0=20;
+				item0=304;
 				item1=300;
 				class CustomData
 				{
@@ -7307,7 +4715,7 @@ class Mission
 			class Item3
 			{
 				linkID=3;
-				item0=21;
+				item0=305;
 				item1=300;
 				class CustomData
 				{
@@ -7317,7 +4725,7 @@ class Mission
 			class Item4
 			{
 				linkID=4;
-				item0=26;
+				item0=306;
 				item1=300;
 				class CustomData
 				{
@@ -7327,7 +4735,7 @@ class Mission
 			class Item5
 			{
 				linkID=5;
-				item0=39;
+				item0=307;
 				item1=300;
 				class CustomData
 				{
@@ -7337,7 +4745,7 @@ class Mission
 			class Item6
 			{
 				linkID=6;
-				item0=40;
+				item0=308;
 				item1=300;
 				class CustomData
 				{
@@ -7347,7 +4755,7 @@ class Mission
 			class Item7
 			{
 				linkID=7;
-				item0=45;
+				item0=309;
 				item1=300;
 				class CustomData
 				{
@@ -7357,7 +4765,7 @@ class Mission
 			class Item8
 			{
 				linkID=8;
-				item0=50;
+				item0=310;
 				item1=300;
 				class CustomData
 				{
@@ -7367,7 +4775,7 @@ class Mission
 			class Item9
 			{
 				linkID=9;
-				item0=55;
+				item0=311;
 				item1=300;
 				class CustomData
 				{
@@ -7377,7 +4785,7 @@ class Mission
 			class Item10
 			{
 				linkID=10;
-				item0=60;
+				item0=312;
 				item1=300;
 				class CustomData
 				{
@@ -7387,7 +4795,7 @@ class Mission
 			class Item11
 			{
 				linkID=11;
-				item0=65;
+				item0=313;
 				item1=300;
 				class CustomData
 				{
@@ -7397,7 +4805,7 @@ class Mission
 			class Item12
 			{
 				linkID=12;
-				item0=22;
+				item0=314;
 				item1=300;
 				class CustomData
 				{
@@ -7407,7 +4815,7 @@ class Mission
 			class Item13
 			{
 				linkID=13;
-				item0=27;
+				item0=315;
 				item1=300;
 				class CustomData
 				{
@@ -7417,7 +4825,7 @@ class Mission
 			class Item14
 			{
 				linkID=14;
-				item0=31;
+				item0=316;
 				item1=300;
 				class CustomData
 				{
@@ -7427,7 +4835,7 @@ class Mission
 			class Item15
 			{
 				linkID=15;
-				item0=35;
+				item0=317;
 				item1=300;
 				class CustomData
 				{
@@ -7437,7 +4845,7 @@ class Mission
 			class Item16
 			{
 				linkID=16;
-				item0=41;
+				item0=318;
 				item1=300;
 				class CustomData
 				{
@@ -7447,7 +4855,7 @@ class Mission
 			class Item17
 			{
 				linkID=17;
-				item0=46;
+				item0=319;
 				item1=300;
 				class CustomData
 				{
@@ -7457,7 +4865,7 @@ class Mission
 			class Item18
 			{
 				linkID=18;
-				item0=51;
+				item0=320;
 				item1=300;
 				class CustomData
 				{
@@ -7467,7 +4875,7 @@ class Mission
 			class Item19
 			{
 				linkID=19;
-				item0=56;
+				item0=321;
 				item1=300;
 				class CustomData
 				{
@@ -7477,7 +4885,7 @@ class Mission
 			class Item20
 			{
 				linkID=20;
-				item0=61;
+				item0=322;
 				item1=300;
 				class CustomData
 				{
@@ -7487,7 +4895,7 @@ class Mission
 			class Item21
 			{
 				linkID=21;
-				item0=66;
+				item0=323;
 				item1=300;
 				class CustomData
 				{
@@ -7497,7 +4905,7 @@ class Mission
 			class Item22
 			{
 				linkID=22;
-				item0=24;
+				item0=324;
 				item1=300;
 				class CustomData
 				{
@@ -7507,7 +4915,7 @@ class Mission
 			class Item23
 			{
 				linkID=23;
-				item0=29;
+				item0=325;
 				item1=300;
 				class CustomData
 				{
@@ -7517,7 +4925,7 @@ class Mission
 			class Item24
 			{
 				linkID=24;
-				item0=33;
+				item0=326;
 				item1=300;
 				class CustomData
 				{
@@ -7527,7 +4935,7 @@ class Mission
 			class Item25
 			{
 				linkID=25;
-				item0=37;
+				item0=327;
 				item1=300;
 				class CustomData
 				{
@@ -7537,7 +4945,7 @@ class Mission
 			class Item26
 			{
 				linkID=26;
-				item0=43;
+				item0=328;
 				item1=300;
 				class CustomData
 				{
@@ -7547,7 +4955,7 @@ class Mission
 			class Item27
 			{
 				linkID=27;
-				item0=48;
+				item0=329;
 				item1=300;
 				class CustomData
 				{
@@ -7557,7 +4965,7 @@ class Mission
 			class Item28
 			{
 				linkID=28;
-				item0=53;
+				item0=330;
 				item1=300;
 				class CustomData
 				{
@@ -7567,7 +4975,7 @@ class Mission
 			class Item29
 			{
 				linkID=29;
-				item0=58;
+				item0=331;
 				item1=300;
 				class CustomData
 				{
@@ -7577,7 +4985,7 @@ class Mission
 			class Item30
 			{
 				linkID=30;
-				item0=63;
+				item0=332;
 				item1=300;
 				class CustomData
 				{
@@ -7587,7 +4995,7 @@ class Mission
 			class Item31
 			{
 				linkID=31;
-				item0=68;
+				item0=333;
 				item1=300;
 				class CustomData
 				{
@@ -7597,7 +5005,7 @@ class Mission
 			class Item32
 			{
 				linkID=32;
-				item0=25;
+				item0=334;
 				item1=300;
 				class CustomData
 				{
@@ -7607,7 +5015,7 @@ class Mission
 			class Item33
 			{
 				linkID=33;
-				item0=30;
+				item0=335;
 				item1=300;
 				class CustomData
 				{
@@ -7617,7 +5025,7 @@ class Mission
 			class Item34
 			{
 				linkID=34;
-				item0=34;
+				item0=336;
 				item1=300;
 				class CustomData
 				{
@@ -7627,7 +5035,7 @@ class Mission
 			class Item35
 			{
 				linkID=35;
-				item0=38;
+				item0=337;
 				item1=300;
 				class CustomData
 				{
@@ -7637,7 +5045,7 @@ class Mission
 			class Item36
 			{
 				linkID=36;
-				item0=44;
+				item0=338;
 				item1=300;
 				class CustomData
 				{
@@ -7647,7 +5055,7 @@ class Mission
 			class Item37
 			{
 				linkID=37;
-				item0=49;
+				item0=339;
 				item1=300;
 				class CustomData
 				{
@@ -7657,227 +5065,7 @@ class Mission
 			class Item38
 			{
 				linkID=38;
-				item0=54;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item39
-			{
-				linkID=39;
-				item0=59;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item40
-			{
-				linkID=40;
-				item0=64;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item41
-			{
-				linkID=41;
-				item0=69;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item42
-			{
-				linkID=42;
-				item0=70;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item43
-			{
-				linkID=43;
-				item0=71;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item44
-			{
-				linkID=44;
-				item0=72;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item45
-			{
-				linkID=45;
-				item0=73;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item46
-			{
-				linkID=46;
-				item0=74;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item47
-			{
-				linkID=47;
-				item0=75;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item48
-			{
-				linkID=48;
-				item0=76;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item49
-			{
-				linkID=49;
-				item0=77;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item50
-			{
-				linkID=50;
-				item0=78;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item51
-			{
-				linkID=51;
-				item0=286;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item52
-			{
-				linkID=52;
-				item0=287;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item53
-			{
-				linkID=53;
-				item0=288;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item54
-			{
-				linkID=54;
-				item0=289;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item55
-			{
-				linkID=55;
-				item0=290;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item56
-			{
-				linkID=56;
-				item0=291;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item57
-			{
-				linkID=57;
-				item0=292;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item58
-			{
-				linkID=58;
-				item0=293;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item59
-			{
-				linkID=59;
-				item0=294;
-				item1=300;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item60
-			{
-				linkID=60;
-				item0=296;
+				item0=340;
 				item1=300;
 				class CustomData
 				{

--- a/Map-Templates/Antistasi-Kunduz.Kunduz/mission.sqm
+++ b/Map-Templates/Antistasi-Kunduz.Kunduz/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=1026;
 	class ItemIDProvider
 	{
-		nextID=1349;
+		nextID=1390;
 	};
 	class MarkerIDProvider
 	{
@@ -16,14 +16,14 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=76;
+		nextID=98;
 	};
 	class Camera
 	{
-		pos[]={1100.3102,365.37076,1605.1041};
-		dir[]={0.64004093,-0.43384323,-0.63414103};
-		up[]={0.30819207,0.90098763,-0.30535144};
-		aside[]={-0.7038281,2.0611333e-007,-0.71037447};
+		pos[]={3934.9272,36.820293,4589.2261};
+		dir[]={-0.57010537,-0.57413942,0.58772248};
+		up[]={-0.39980498,0.81871247,0.41216198};
+		aside[]={0.71781546,-5.1133975e-007,0.69629622};
 	};
 };
 binarizationWanted=0;
@@ -32,7 +32,6 @@ addons[]=
 	"A3_Weapons_F_Ammoboxes",
 	"A3_Modules_F",
 	"A3_Characters_F",
-	"A3_Weapons_F",
 	"A3_Structures_F_EPC_Civ_InfoBoards",
 	"A3_Structures_F_Mil_Flags",
 	"A3_Characters_F_Patrol",
@@ -65,19 +64,18 @@ addons[]=
 	"A3_Structures_F_Heli_Civ_Constructions",
 	"A3_Structures_F_Heli_Furniture",
 	"A3_Structures_F_EPA_Civ_Constructions",
-	"A3_Structures_F_Orange_Humanitarian_Camps",
 	"A3_Structures_F_Heli_Ind_Machines",
-	"A3_Props_F_Orange_Humanitarian_Camps",
 	"A3_Structures_F_Enoch_Military_Radar",
 	"A3_Ui_F",
 	"A3_Ui_F_Exp",
-	"A3_Modules_F_Hc"
+	"A3_Modules_F_Hc",
+	"A3_Weapons_F"
 };
 class AddonsMetaData
 {
 	class List
 	{
-		items=21;
+		items=19;
 		class Item0
 		{
 			className="A3_Weapons_F";
@@ -199,26 +197,12 @@ class AddonsMetaData
 		};
 		class Item17
 		{
-			className="A3_Structures_F_Orange";
-			name="Arma 3 Orange - Buildings and Structures";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item18
-		{
-			className="A3_Props_F_Orange";
-			name="Arma 3 Orange - Decorative and Mission Objects";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item19
-		{
 			className="A3_Ui_F";
 			name="Arma 3 - User Interface";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item20
+		class Item18
 		{
 			className="A3_Ui_F_Exp";
 			name="Arma 3 Apex - User Interface";
@@ -234,20 +218,15 @@ class Mission
 	{
 		briefingName=$STR_antistasi_mission_info_kunduz_mapname_text;
 		resistanceWest=0;
-		startWind=0.1;
-		forecastWind=0.1;
-		forecastWaves=0.1;
 		year=2035;
 		month=6;
 		day=1;
 		hour=10;
 		minute=0;
-		startFogDecay=0.0049333;
-		forecastFogDecay=0.0049333;
 	};
 	class Entities
 	{
-		items=458;
+		items=447;
 		class Item0
 		{
 			dataType="Object";
@@ -468,1544 +447,6 @@ class Mission
 			side="Independent";
 			class Entities
 			{
-				items=24;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1328.1077,34.613026,383.85938};
-					};
-					side="Independent";
-					flags=2;
-					class Attributes
-					{
-						skill=1;
-						name="commanderX";
-						description="Default Commander";
-						isPlayer=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=147;
-					type="I_G_officer_F";
-					atlOffset=0.32158661;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item1
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1331.6409,34.291439,380.33594};
-						angles[]={0,6.2412972,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=151;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item2
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1343.1018,34.293846,386.48828};
-						angles[]={0,6.2412972,0.0039967569};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=152;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item3
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1349.1057,34.301437,386.375};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=154;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item4
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1342.9983,34.291439,389.28125};
-						angles[]={0,6.2412972,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=158;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item5
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1349.0022,34.297443,389.16797};
-						angles[]={0,0,0.0039967569};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=160;
-					type="I_G_medic_F";
-					atlOffset=-3.8146973e-006;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item6
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1348.8987,34.291439,394.75781};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=170;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item7
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1343.1917,34.291439,394.98438};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=175;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item8
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1349.2307,34.291439,397.38281};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=177;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item9
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1352.2034,34.291439,400.63672};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=184;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item10
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1355.1917,34.291439,400.85547};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=185;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item11
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1340.8401,34.291439,400.51172};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=186;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item12
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1343.4065,34.291439,403.79297};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=188;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item13
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1349.2366,34.291439,403.62109};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=190;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item14
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1352.2249,34.291439,403.84375};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=191;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item15
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1337.8733,34.608242,403.49609};
-					};
-					side="Independent";
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=192;
-					type="I_G_officer_F";
-					atlOffset=0.31680298;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item16
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1343.2581,34.291439,407.05859};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=194;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item17
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1352.0764,34.291439,407.10547};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=197;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item18
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1342.0725,34.382442,409.80078};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=200;
-					type="I_G_Soldier_LAT_F";
-					atlOffset=0.091003418;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item19
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1347.9006,34.291439,409.63281};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=202;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item20
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1336.5374,35.237858,409.50781};
-					};
-					side="Independent";
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=204;
-					type="I_G_officer_F";
-					atlOffset=0.94641876;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item21
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1340.6702,34.301437,380.48047};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=207;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item22
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1343.2561,34.301437,380.88672};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=208;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item23
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={1334.7151,34.291439,380.57031};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=209;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-			};
-			class Attributes
-			{
-			};
-			id=146;
-			atlOffset=0.32158661;
-		};
-		class Item11
-		{
-			dataType="Group";
-			side="Independent";
-			class Entities
-			{
 				items=1;
 				class Item0
 				{
@@ -2093,7 +534,7 @@ class Mission
 			id=148;
 			atlOffset=0.57365417;
 		};
-		class Item12
+		class Item11
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2132,7 +573,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item13
+		class Item12
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2171,7 +612,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item14
+		class Item13
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2188,7 +629,7 @@ class Mission
 			type="Flag_NATO_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item15
+		class Item14
 		{
 			dataType="Group";
 			side="West";
@@ -2575,7 +1016,7 @@ class Mission
 			};
 			id=218;
 		};
-		class Item16
+		class Item15
 		{
 			dataType="Group";
 			side="East";
@@ -2955,7 +1396,7 @@ class Mission
 			id=227;
 			atlOffset=0.30826855;
 		};
-		class Item17
+		class Item16
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2971,7 +1412,7 @@ class Mission
 			type="Flag_Viper_F";
 			atlOffset=0.71427345;
 		};
-		class Item18
+		class Item17
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -2984,7 +1425,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=0.51117706;
 		};
-		class Item19
+		class Item18
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -2997,7 +1438,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=0.41136932;
 		};
-		class Item20
+		class Item19
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -3088,7 +1529,7 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item21
+		class Item20
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3128,7 +1569,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item22
+		class Item21
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -3185,21 +1626,21 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item23
+		class Item22
 		{
 			dataType="Layer";
 			name="Open Ammo Dump";
 			id=249;
 			atlOffset=-124.86;
 		};
-		class Item24
+		class Item23
 		{
 			dataType="Layer";
 			name="Vehicle Repair";
 			id=274;
 			atlOffset=-124.86;
 		};
-		class Item25
+		class Item24
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3215,7 +1656,7 @@ class Mission
 			id=682;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item26
+		class Item25
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3231,7 +1672,7 @@ class Mission
 			id=683;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item27
+		class Item26
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -3286,7 +1727,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item28
+		class Item27
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3302,7 +1743,7 @@ class Mission
 			id=685;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item29
+		class Item28
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3319,7 +1760,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item30
+		class Item29
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3335,7 +1776,7 @@ class Mission
 			id=718;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item31
+		class Item30
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3351,7 +1792,7 @@ class Mission
 			id=719;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item32
+		class Item31
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3366,7 +1807,7 @@ class Mission
 			id=720;
 			type="Land_Cargo_HQ_V3_F";
 		};
-		class Item33
+		class Item32
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3382,7 +1823,7 @@ class Mission
 			id=721;
 			type="Land_Cargo_House_V3_F";
 		};
-		class Item34
+		class Item33
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3399,7 +1840,7 @@ class Mission
 			type="Land_Cargo_House_V3_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item35
+		class Item34
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3411,11 +1852,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=723;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item36
+		class Item35
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3427,11 +1869,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=724;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item37
+		class Item36
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3443,11 +1886,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=725;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item38
+		class Item37
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3459,12 +1903,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=726;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item39
+		class Item38
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3476,12 +1921,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=727;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item40
+		class Item39
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3493,12 +1939,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=728;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item41
+		class Item40
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3510,12 +1957,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=729;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item42
+		class Item41
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3527,11 +1975,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=730;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item43
+		class Item42
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3543,11 +1992,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=731;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item44
+		class Item43
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3559,11 +2009,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=732;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item45
+		class Item44
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3575,11 +2026,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=733;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item46
+		class Item45
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3591,11 +2043,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=734;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item47
+		class Item46
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3607,11 +2060,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=735;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item48
+		class Item47
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3623,12 +2077,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=736;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item49
+		class Item48
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3640,12 +2095,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=737;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item50
+		class Item49
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3657,11 +2113,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=738;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item51
+		class Item50
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3673,12 +2130,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=739;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item52
+		class Item51
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3690,12 +2148,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=740;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item53
+		class Item52
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3707,11 +2166,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=741;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item54
+		class Item53
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3723,11 +2183,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=742;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item55
+		class Item54
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3739,12 +2200,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=743;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item56
+		class Item55
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3756,11 +2218,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=744;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item57
+		class Item56
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3772,11 +2235,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=745;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item58
+		class Item57
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3788,12 +2252,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=746;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item59
+		class Item58
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3805,12 +2270,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=747;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item60
+		class Item59
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3822,11 +2288,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=748;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item61
+		class Item60
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3838,11 +2305,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=749;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item62
+		class Item61
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3858,7 +2326,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.25;
 		};
-		class Item63
+		class Item62
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3870,11 +2338,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=751;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item64
+		class Item63
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3886,11 +2355,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=752;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item65
+		class Item64
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3902,12 +2372,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=753;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item66
+		class Item65
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3919,11 +2390,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=754;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item67
+		class Item66
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3935,12 +2407,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=755;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item68
+		class Item67
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3952,12 +2425,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=756;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item69
+		class Item68
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3969,12 +2443,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=757;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item70
+		class Item69
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3990,7 +2465,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.25;
 		};
-		class Item71
+		class Item70
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4006,7 +2481,7 @@ class Mission
 			id=759;
 			type="Land_TTowerSmall_1_F";
 		};
-		class Item72
+		class Item71
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4023,7 +2498,7 @@ class Mission
 			type="Land_TTowerSmall_2_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item73
+		class Item72
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4039,7 +2514,7 @@ class Mission
 			id=761;
 			type="Land_Medevac_house_V1_F";
 		};
-		class Item74
+		class Item73
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4056,7 +2531,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item75
+		class Item74
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4072,7 +2547,7 @@ class Mission
 			id=763;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item76
+		class Item75
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4089,7 +2564,7 @@ class Mission
 			type="Land_Cargo_House_V3_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item77
+		class Item76
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4105,7 +2580,7 @@ class Mission
 			id=765;
 			type="Land_Cargo_House_V3_F";
 		};
-		class Item78
+		class Item77
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4121,7 +2596,7 @@ class Mission
 			id=766;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item79
+		class Item78
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4137,7 +2612,7 @@ class Mission
 			id=767;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item80
+		class Item79
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4149,12 +2624,14 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
 				disableSimulation=1;
 			};
 			id=768;
 			type="Land_Cargo40_sand_F";
+			atlOffset=-9.5367432e-007;
 		};
-		class Item81
+		class Item80
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4166,13 +2643,14 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
 				disableSimulation=1;
 			};
 			id=769;
 			type="Land_Cargo40_sand_F";
 			atlOffset=-0.27700043;
 		};
-		class Item82
+		class Item81
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4188,7 +2666,7 @@ class Mission
 			type="Land_dp_mainFactory_F";
 			atlOffset=-0.20000076;
 		};
-		class Item83
+		class Item82
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4203,7 +2681,7 @@ class Mission
 			id=848;
 			type="Land_dp_bigTank_F";
 		};
-		class Item84
+		class Item83
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4218,7 +2696,7 @@ class Mission
 			id=849;
 			type="Land_dp_bigTank_F";
 		};
-		class Item85
+		class Item84
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4234,7 +2712,7 @@ class Mission
 			id=850;
 			type="Land_dp_bigTank_F";
 		};
-		class Item86
+		class Item85
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4250,7 +2728,7 @@ class Mission
 			id=851;
 			type="Land_dp_bigTank_F";
 		};
-		class Item87
+		class Item86
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4265,7 +2743,7 @@ class Mission
 			id=852;
 			type="CargoPlaftorm_01_brown_ruins_F";
 		};
-		class Item88
+		class Item87
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4281,7 +2759,7 @@ class Mission
 			type="Land_Cargo_Tower_V3_ruins_F";
 			atlOffset=-0.11489105;
 		};
-		class Item89
+		class Item88
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4296,7 +2774,7 @@ class Mission
 			id=855;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item90
+		class Item89
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4308,12 +2786,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=856;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.008972168;
 		};
-		class Item91
+		class Item90
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4325,12 +2804,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=857;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item92
+		class Item91
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4342,11 +2822,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=858;
 			type="Land_HBarrier_5_F";
 		};
-		class Item93
+		class Item92
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4358,11 +2839,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=859;
 			type="Land_HBarrier_5_F";
 		};
-		class Item94
+		class Item93
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4374,12 +2856,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=860;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item95
+		class Item94
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4391,12 +2874,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=861;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item96
+		class Item95
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4408,11 +2892,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=862;
 			type="Land_HBarrier_5_F";
 		};
-		class Item97
+		class Item96
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4424,11 +2909,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=863;
 			type="Land_HBarrier_5_F";
 		};
-		class Item98
+		class Item97
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4440,11 +2926,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=864;
 			type="Land_HBarrier_5_F";
 		};
-		class Item99
+		class Item98
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4456,11 +2943,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=865;
 			type="Land_HBarrier_5_F";
 		};
-		class Item100
+		class Item99
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4472,12 +2960,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=866;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item101
+		class Item100
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4489,11 +2978,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=867;
 			type="Land_HBarrier_5_F";
 		};
-		class Item102
+		class Item101
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4505,12 +2995,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=868;
 			type="Land_HBarrier_5_F";
 			atlOffset=2.9563904e-005;
 		};
-		class Item103
+		class Item102
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4522,12 +3013,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=869;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.0089712143;
 		};
-		class Item104
+		class Item103
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4539,11 +3031,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=870;
 			type="Land_HBarrier_5_F";
 		};
-		class Item105
+		class Item104
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4555,12 +3048,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=871;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item106
+		class Item105
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4572,12 +3066,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=872;
 			type="Land_HBarrier_5_F";
 			atlOffset=2.9563904e-005;
 		};
-		class Item107
+		class Item106
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4589,11 +3084,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=873;
 			type="Land_HBarrier_5_F";
 		};
-		class Item108
+		class Item107
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4605,12 +3101,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=874;
 			type="Land_HBarrier_5_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item109
+		class Item108
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4622,12 +3119,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=875;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item110
+		class Item109
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4639,12 +3137,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=876;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.0089421272;
 		};
-		class Item111
+		class Item110
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4656,12 +3155,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=877;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item112
+		class Item111
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4673,11 +3173,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=878;
 			type="Land_HBarrier_5_F";
 		};
-		class Item113
+		class Item112
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4689,12 +3190,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=879;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item114
+		class Item113
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4706,11 +3208,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=880;
 			type="Land_HBarrier_5_F";
 		};
-		class Item115
+		class Item114
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4722,12 +3225,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=881;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item116
+		class Item115
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4739,11 +3243,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=882;
 			type="Land_HBarrier_5_F";
 		};
-		class Item117
+		class Item116
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4755,11 +3260,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=883;
 			type="Land_HBarrier_5_F";
 		};
-		class Item118
+		class Item117
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4771,11 +3277,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=884;
 			type="Land_HBarrier_5_F";
 		};
-		class Item119
+		class Item118
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4787,12 +3294,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=885;
 			type="Land_HBarrier_3_F";
 			atlOffset=6.1035156e-005;
 		};
-		class Item120
+		class Item119
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4804,12 +3312,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=886;
 			type="Land_HBarrier_3_F";
 			atlOffset=6.0558319e-005;
 		};
-		class Item121
+		class Item120
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4821,12 +3330,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=887;
 			type="Land_HBarrier_3_F";
 			atlOffset=6.1035156e-005;
 		};
-		class Item122
+		class Item121
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4838,12 +3348,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=888;
 			type="Land_HBarrier_5_F";
 			atlOffset=6.0081482e-005;
 		};
-		class Item123
+		class Item122
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4860,7 +3371,7 @@ class Mission
 			type="Land_Mil_WallBig_Corner_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item124
+		class Item123
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4877,7 +3388,7 @@ class Mission
 			type="Land_Mil_WallBig_Corner_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item125
+		class Item124
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4894,7 +3405,7 @@ class Mission
 			type="Land_Mil_WallBig_4m_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item126
+		class Item125
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4911,7 +3422,7 @@ class Mission
 			type="Land_Mil_WallBig_4m_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item127
+		class Item126
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4927,7 +3438,7 @@ class Mission
 			id=893;
 			type="Land_Mil_WallBig_4m_F";
 		};
-		class Item128
+		class Item127
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4943,7 +3454,7 @@ class Mission
 			id=894;
 			type="Land_Mil_WallBig_Corner_F";
 		};
-		class Item129
+		class Item128
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4960,7 +3471,7 @@ class Mission
 			type="Land_Mil_WallBig_Corner_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item130
+		class Item129
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4976,7 +3487,7 @@ class Mission
 			id=896;
 			type="Land_Mil_WallBig_4m_F";
 		};
-		class Item131
+		class Item130
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4988,11 +3499,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=901;
 			type="Land_HBarrier_5_F";
 		};
-		class Item132
+		class Item131
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5004,11 +3516,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=902;
 			type="Land_HBarrier_5_F";
 		};
-		class Item133
+		class Item132
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5020,11 +3533,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=903;
 			type="Land_HBarrier_5_F";
 		};
-		class Item134
+		class Item133
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5036,12 +3550,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=904;
 			type="Land_HBarrier_5_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item135
+		class Item134
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5053,12 +3568,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=905;
 			type="Land_HBarrier_5_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item136
+		class Item135
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5070,12 +3586,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=906;
 			type="Land_HBarrier_5_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item137
+		class Item136
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5087,11 +3604,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=910;
 			type="Land_HBarrier_5_F";
 		};
-		class Item138
+		class Item137
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5103,11 +3621,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=911;
 			type="Land_HBarrier_5_F";
 		};
-		class Item139
+		class Item138
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5119,12 +3638,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=912;
 			type="Land_HBarrier_5_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item140
+		class Item139
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5136,11 +3656,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=913;
 			type="Land_HBarrier_5_F";
 		};
-		class Item141
+		class Item140
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5156,7 +3677,7 @@ class Mission
 			id=916;
 			type="Land_Cargo_House_V3_F";
 		};
-		class Item142
+		class Item141
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5172,7 +3693,7 @@ class Mission
 			id=917;
 			type="Land_Cargo_House_V3_F";
 		};
-		class Item143
+		class Item142
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5188,7 +3709,7 @@ class Mission
 			id=918;
 			type="Land_Cargo_House_V3_F";
 		};
-		class Item144
+		class Item143
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5204,7 +3725,7 @@ class Mission
 			id=919;
 			type="Land_Cargo_House_V3_F";
 		};
-		class Item145
+		class Item144
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5221,7 +3742,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item146
+		class Item145
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5238,7 +3759,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item147
+		class Item146
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5254,7 +3775,7 @@ class Mission
 			id=922;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item148
+		class Item147
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5271,7 +3792,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item149
+		class Item148
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5288,7 +3809,7 @@ class Mission
 			type="Land_Cargo_Tower_V3_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item150
+		class Item149
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5305,7 +3826,7 @@ class Mission
 			type="Land_dp_transformer_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item151
+		class Item150
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5321,7 +3842,7 @@ class Mission
 			id=934;
 			type="Land_dp_transformer_F";
 		};
-		class Item152
+		class Item151
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5338,7 +3859,7 @@ class Mission
 			type="Land_dp_transformer_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item153
+		class Item152
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5353,7 +3874,7 @@ class Mission
 			id=936;
 			type="Land_dp_smallTank_F";
 		};
-		class Item154
+		class Item153
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5408,7 +3929,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item155
+		class Item154
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5424,7 +3945,7 @@ class Mission
 			id=938;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item156
+		class Item155
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5437,11 +3958,12 @@ class Mission
 			class Attributes
 			{
 				name="Jackknal";
+				disableSimulation=1;
 			};
 			id=939;
 			type="Land_HelipadSquare_F";
 		};
-		class Item157
+		class Item156
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5498,7 +4020,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item158
+		class Item157
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5514,7 +4036,7 @@ class Mission
 			id=941;
 			type="Land_BagFence_Long_F";
 		};
-		class Item159
+		class Item158
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5530,7 +4052,7 @@ class Mission
 			id=942;
 			type="Land_BagFence_Long_F";
 		};
-		class Item160
+		class Item159
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5546,7 +4068,7 @@ class Mission
 			id=943;
 			type="Land_BagFence_Long_F";
 		};
-		class Item161
+		class Item160
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5562,7 +4084,7 @@ class Mission
 			id=944;
 			type="Land_BagFence_Long_F";
 		};
-		class Item162
+		class Item161
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5578,7 +4100,7 @@ class Mission
 			id=945;
 			type="Land_BagFence_Round_F";
 		};
-		class Item163
+		class Item162
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5594,7 +4116,7 @@ class Mission
 			id=946;
 			type="Land_BagFence_Long_F";
 		};
-		class Item164
+		class Item163
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5610,7 +4132,7 @@ class Mission
 			id=947;
 			type="Land_BagFence_Long_F";
 		};
-		class Item165
+		class Item164
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5626,7 +4148,7 @@ class Mission
 			id=948;
 			type="Land_BagFence_Round_F";
 		};
-		class Item166
+		class Item165
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5642,7 +4164,7 @@ class Mission
 			id=949;
 			type="StorageBladder_01_fuel_sand_F";
 		};
-		class Item167
+		class Item166
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5658,7 +4180,7 @@ class Mission
 			type="Land_Cargo_Tower_V3_ruins_F";
 			atlOffset=-0.054344177;
 		};
-		class Item168
+		class Item167
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5674,7 +4196,7 @@ class Mission
 			id=951;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item169
+		class Item168
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5690,7 +4212,7 @@ class Mission
 			id=952;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item170
+		class Item169
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5707,7 +4229,7 @@ class Mission
 			type="Land_WoodenBox_F";
 			atlOffset=-4.5776367e-005;
 		};
-		class Item171
+		class Item170
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5724,7 +4246,7 @@ class Mission
 			type="Land_WoodenBox_F";
 			atlOffset=-5.197525e-005;
 		};
-		class Item172
+		class Item171
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5740,7 +4262,7 @@ class Mission
 			id=957;
 			type="Land_WoodenBox_F";
 		};
-		class Item173
+		class Item172
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5757,7 +4279,7 @@ class Mission
 			type="Land_WoodenBox_F";
 			atlOffset=3.9100647e-005;
 		};
-		class Item174
+		class Item173
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5773,7 +4295,7 @@ class Mission
 			id=959;
 			type="TyreBarrier_01_black_F";
 		};
-		class Item175
+		class Item174
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5790,7 +4312,7 @@ class Mission
 			type="Dirthump_3_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item176
+		class Item175
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5806,7 +4328,7 @@ class Mission
 			id=961;
 			type="Land_MarketShelter_F";
 		};
-		class Item177
+		class Item176
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5823,7 +4345,7 @@ class Mission
 			type="Land_WheelCart_F";
 			atlOffset=-1.4305115e-006;
 		};
-		class Item178
+		class Item177
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5840,7 +4362,7 @@ class Mission
 			type="Land_StallWater_F";
 			atlOffset=0.00066328049;
 		};
-		class Item179
+		class Item178
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5857,7 +4379,7 @@ class Mission
 			type="Land_cmp_Tower_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item180
+		class Item179
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5873,7 +4395,7 @@ class Mission
 			id=966;
 			type="Land_cmp_Tower_F";
 		};
-		class Item181
+		class Item180
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5889,7 +4411,7 @@ class Mission
 			id=967;
 			type="Land_Shed_Big_F";
 		};
-		class Item182
+		class Item181
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5906,7 +4428,7 @@ class Mission
 			id=968;
 			type="Land_dp_transformer_F";
 		};
-		class Item183
+		class Item182
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5923,7 +4445,7 @@ class Mission
 			id=969;
 			type="Land_dp_transformer_F";
 		};
-		class Item184
+		class Item183
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5941,7 +4463,7 @@ class Mission
 			type="Land_dp_transformer_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item185
+		class Item184
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5959,7 +4481,7 @@ class Mission
 			type="Land_dp_transformer_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item186
+		class Item185
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5977,7 +4499,7 @@ class Mission
 			type="Land_dp_transformer_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item187
+		class Item186
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5995,7 +4517,7 @@ class Mission
 			type="Land_dp_transformer_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item188
+		class Item187
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6012,7 +4534,7 @@ class Mission
 			id=974;
 			type="Land_dp_transformer_F";
 		};
-		class Item189
+		class Item188
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6030,7 +4552,7 @@ class Mission
 			type="Land_dp_transformer_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item190
+		class Item189
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6047,7 +4569,7 @@ class Mission
 			id=977;
 			type="Land_Tank_rust_F";
 		};
-		class Item191
+		class Item190
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6064,7 +4586,7 @@ class Mission
 			type="Land_LampShabby_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item192
+		class Item191
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6080,7 +4602,7 @@ class Mission
 			id=981;
 			type="Land_LampShabby_F";
 		};
-		class Item193
+		class Item192
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6097,7 +4619,7 @@ class Mission
 			type="Land_LampShabby_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item194
+		class Item193
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6114,7 +4636,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_ruins_F";
 			atlOffset=-0.019923687;
 		};
-		class Item195
+		class Item194
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6131,7 +4653,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item196
+		class Item195
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6147,7 +4669,7 @@ class Mission
 			id=986;
 			type="Land_MarketShelter_F";
 		};
-		class Item197
+		class Item196
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6162,7 +4684,7 @@ class Mission
 			id=987;
 			type="Land_StallWater_F";
 		};
-		class Item198
+		class Item197
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -6173,13 +4695,13 @@ class Mission
 			id=988;
 			type="Logic";
 		};
-		class Item199
+		class Item198
 		{
 			dataType="Layer";
 			name="Open Ammo Dump_4";
 			class Entities
 			{
-				items=24;
+				items=26;
 				class Item0
 				{
 					dataType="Object";
@@ -6262,6 +4784,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1001;
 					type="Land_HBarrier_5_F";
@@ -6475,6 +4998,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1013;
 					type="Land_HBarrier_5_F";
@@ -6529,6 +5053,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1016;
 					type="Land_HBarrier_5_F";
@@ -6546,6 +5071,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1017;
 					type="Land_HBarrier_5_F";
@@ -6563,6 +5089,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1018;
 					type="Land_HBarrier_5_F";
@@ -6580,6 +5107,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1019;
 					type="Land_HBarrier_5_F";
@@ -6602,11 +5130,45 @@ class Mission
 					id=1275;
 					type="CamoNet_OPFOR_open_F";
 				};
+				class Item24
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3878.3499,6.1936111,4621.2612};
+						angles[]={0,2.7474451,0};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=1388;
+					type="CamoNet_OPFOR_open_F";
+				};
+				class Item25
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={3963.3132,6.4288425,4654.1396};
+						angles[]={0,2.7474451,0};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=1389;
+					type="CamoNet_OPFOR_open_F";
+				};
 			};
 			id=996;
-			atlOffset=0.70263624;
+			atlOffset=0.80569601;
 		};
-		class Item200
+		class Item199
 		{
 			dataType="Layer";
 			name="Vehicle Repair_4";
@@ -6714,6 +5276,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1027;
 					type="Land_HBarrier_5_F";
@@ -6749,6 +5312,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1029;
 					type="Land_HBarrier_1_F";
@@ -6766,6 +5330,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1030;
 					type="Land_HBarrier_5_F";
@@ -6783,6 +5348,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1031;
 					type="Land_HBarrier_1_F";
@@ -6800,6 +5366,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1032;
 					type="Land_HBarrier_5_F";
@@ -6818,6 +5385,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1033;
 					type="Land_HBarrier_5_F";
@@ -6836,6 +5404,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1034;
 					type="Land_HBarrier_1_F";
@@ -6853,6 +5422,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=1035;
 					type="Land_HBarrier_1_F";
@@ -6879,7 +5449,7 @@ class Mission
 			id=1021;
 			atlOffset=0.14096165;
 		};
-		class Item201
+		class Item200
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6891,12 +5461,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1037;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item202
+		class Item201
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6908,11 +5479,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1038;
 			type="Land_HBarrier_5_F";
 		};
-		class Item203
+		class Item202
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6924,12 +5496,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1039;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.1444092e-005;
 		};
-		class Item204
+		class Item203
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6941,12 +5514,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1040;
 			type="Land_HBarrier_5_F";
 			atlOffset=2.6702881e-005;
 		};
-		class Item205
+		class Item204
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6958,11 +5532,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1041;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item206
+		class Item205
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6974,11 +5549,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1042;
 			type="Land_HBarrier_5_F";
 		};
-		class Item207
+		class Item206
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6990,11 +5566,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1043;
 			type="Land_HBarrier_5_F";
 		};
-		class Item208
+		class Item207
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7006,11 +5583,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1044;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item209
+		class Item208
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7022,12 +5600,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1045;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item210
+		class Item209
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7039,11 +5618,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1046;
 			type="Land_HBarrier_5_F";
 		};
-		class Item211
+		class Item210
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7055,11 +5635,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1047;
 			type="Land_HBarrier_3_F";
 		};
-		class Item212
+		class Item211
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7071,11 +5652,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1048;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item213
+		class Item212
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7087,11 +5669,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1049;
 			type="Land_HBarrier_5_F";
 		};
-		class Item214
+		class Item213
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7103,11 +5686,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1050;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item215
+		class Item214
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7119,12 +5703,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1051;
 			type="Land_HBarrier_Big_F";
 			atlOffset=2.3841858e-006;
 		};
-		class Item216
+		class Item215
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7136,11 +5721,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1052;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item217
+		class Item216
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7152,11 +5738,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1053;
 			type="Land_HBarrier_3_F";
 		};
-		class Item218
+		class Item217
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7168,12 +5755,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1054;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item219
+		class Item218
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7185,11 +5773,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1055;
 			type="Land_HBarrier_5_F";
 		};
-		class Item220
+		class Item219
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7201,12 +5790,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1056;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item221
+		class Item220
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7218,12 +5808,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1057;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item222
+		class Item221
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7235,11 +5826,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1058;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item223
+		class Item222
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7251,11 +5843,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1059;
 			type="Land_HBarrier_3_F";
 		};
-		class Item224
+		class Item223
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7267,11 +5860,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1060;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item225
+		class Item224
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7283,11 +5877,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1061;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item226
+		class Item225
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7299,11 +5894,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1062;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item227
+		class Item226
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7315,12 +5911,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1063;
 			type="Land_HBarrierWall6_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item228
+		class Item227
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7332,11 +5929,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1064;
 			type="Land_HBarrier_5_F";
 		};
-		class Item229
+		class Item228
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7353,7 +5951,7 @@ class Mission
 			type="Land_Mil_WiredFence_Gate_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item230
+		class Item229
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7365,11 +5963,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1066;
 			type="Land_HBarrier_5_F";
 		};
-		class Item231
+		class Item230
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7381,11 +5980,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1067;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item232
+		class Item231
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7397,11 +5997,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1068;
 			type="Land_HBarrier_5_F";
 		};
-		class Item233
+		class Item232
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7413,11 +6014,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1069;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item234
+		class Item233
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7429,11 +6031,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1070;
 			type="Land_HBarrier_5_F";
 		};
-		class Item235
+		class Item234
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7445,11 +6048,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1071;
 			type="Land_HBarrier_5_F";
 		};
-		class Item236
+		class Item235
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7461,12 +6065,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1072;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item237
+		class Item236
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7478,11 +6083,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1073;
 			type="Land_HBarrier_5_F";
 		};
-		class Item238
+		class Item237
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7494,11 +6100,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1074;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item239
+		class Item238
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7510,12 +6117,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1075;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item240
+		class Item239
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7527,11 +6135,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1076;
 			type="Land_HBarrier_5_F";
 		};
-		class Item241
+		class Item240
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7543,12 +6152,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1077;
 			type="Land_HBarrier_Big_F";
 			atlOffset=2.3841858e-007;
 		};
-		class Item242
+		class Item241
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7560,12 +6170,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1078;
 			type="Land_HBarrier_5_F";
 			atlOffset=2.3841858e-007;
 		};
-		class Item243
+		class Item242
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7577,12 +6188,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1079;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.1525574e-007;
 		};
-		class Item244
+		class Item243
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7594,11 +6206,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1080;
 			type="Land_HBarrier_5_F";
 		};
-		class Item245
+		class Item244
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7610,12 +6223,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1081;
 			type="Land_HBarrier_5_F";
 			atlOffset=-2.3841858e-007;
 		};
-		class Item246
+		class Item245
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7627,12 +6241,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1082;
 			type="Land_HBarrier_Big_F";
 			atlOffset=2.3841858e-007;
 		};
-		class Item247
+		class Item246
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7644,11 +6259,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1083;
 			type="Land_HBarrier_5_F";
 		};
-		class Item248
+		class Item247
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7660,11 +6276,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1084;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item249
+		class Item248
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7676,12 +6293,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1085;
 			type="Land_HBarrier_5_F";
 			atlOffset=2.3841858e-007;
 		};
-		class Item250
+		class Item249
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7693,11 +6311,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1086;
 			type="Land_HBarrier_5_F";
 		};
-		class Item251
+		class Item250
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7709,11 +6328,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1087;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item252
+		class Item251
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7725,11 +6345,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1088;
 			type="Land_HBarrier_5_F";
 		};
-		class Item253
+		class Item252
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7741,11 +6362,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1089;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item254
+		class Item253
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7757,51 +6379,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1090;
 			type="Land_HBarrier_3_F";
 		};
-		class Item255
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={3957.9419,6.6775398,4655.6328};
-				angles[]={0,5.9077477,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1091;
-			type="Land_MedicalTent_01_NATO_generic_open_F";
-			atlOffset=4.7683716e-007;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item256
+		class Item254
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7817,7 +6400,7 @@ class Mission
 			id=1092;
 			type="Land_Razorwire_F";
 		};
-		class Item257
+		class Item255
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7833,7 +6416,7 @@ class Mission
 			id=1093;
 			type="Land_Razorwire_F";
 		};
-		class Item258
+		class Item256
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7850,7 +6433,7 @@ class Mission
 			type="Land_Razorwire_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item259
+		class Item257
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7866,7 +6449,7 @@ class Mission
 			id=1095;
 			type="Land_Razorwire_F";
 		};
-		class Item260
+		class Item258
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7883,7 +6466,7 @@ class Mission
 			type="Land_Razorwire_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item261
+		class Item259
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7899,7 +6482,7 @@ class Mission
 			id=1097;
 			type="Land_Razorwire_F";
 		};
-		class Item262
+		class Item260
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7911,12 +6494,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1098;
 			type="Land_HBarrier_3_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item263
+		class Item261
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7933,40 +6517,7 @@ class Mission
 			type="Land_LampSolar_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item264
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={3966.3572,24.170511,4660.187};
-				angles[]={0,2.7661562,0};
-			};
-			side="Empty";
-			class Attributes
-			{
-			};
-			id=1100;
-			type="Land_MedicalTent_01_floor_dark_F";
-			atlOffset=15.524203;
-		};
-		class Item265
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={3957.9424,8.6621761,4655.6328};
-				angles[]={6.121582,2.7661562,0.27926266};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1101;
-			type="Land_MedicalTent_01_floor_dark_F";
-			atlOffset=0.14673996;
-		};
-		class Item266
+		class Item262
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7978,12 +6529,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1102;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item267
+		class Item263
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8000,118 +6552,7 @@ class Mission
 			type="Land_PressureWasher_01_F";
 			atlOffset=-0.0090379715;
 		};
-		class Item268
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={3965.6719,5.926352,4651.8423};
-				angles[]={0.047963165,2.7661562,0.011995304};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1104;
-			type="Land_AirConditioner_03_F";
-			atlOffset=-4.7683716e-007;
-		};
-		class Item269
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={3952.1726,5.5492673,4653.9609};
-				angles[]={0.027993103,4.3369527,0.019996032};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1105;
-			type="Land_AirConditioner_02_F";
-			atlOffset=-4.7683716e-007;
-		};
-		class Item270
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={3967.2451,6.72013,4659.2998};
-				angles[]={0,5.9077477,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1106;
-			type="Land_MedicalTent_01_NATO_generic_closed_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="MedSign_Hide";
-					expression="_this animateSource ['MedSign_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="Door_Hide";
-					expression="_this animateSource ['Door_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute2
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=3;
-			};
-		};
-		class Item271
+		class Item264
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8123,11 +6564,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1107;
 			type="Land_HBarrier_5_F";
 		};
-		class Item272
+		class Item265
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8139,11 +6581,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1108;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item273
+		class Item266
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8155,11 +6598,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1109;
 			type="Land_HBarrier_5_F";
 		};
-		class Item274
+		class Item267
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8171,11 +6615,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1110;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item275
+		class Item268
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8187,12 +6632,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1111;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item276
+		class Item269
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8204,11 +6650,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1112;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item277
+		class Item270
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8220,11 +6667,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1113;
 			type="Land_HBarrier_5_F";
 		};
-		class Item278
+		class Item271
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8236,11 +6684,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1114;
 			type="Land_HBarrier_3_F";
 		};
-		class Item279
+		class Item272
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8252,11 +6701,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1115;
 			type="Land_HBarrier_5_F";
 		};
-		class Item280
+		class Item273
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8268,11 +6718,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1116;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item281
+		class Item274
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8284,11 +6735,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1117;
 			type="Land_HBarrier_3_F";
 		};
-		class Item282
+		class Item275
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8300,11 +6752,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1118;
 			type="Land_HBarrier_5_F";
 		};
-		class Item283
+		class Item276
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8316,11 +6769,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1119;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item284
+		class Item277
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8332,11 +6786,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1120;
 			type="Land_HBarrier_3_F";
 		};
-		class Item285
+		class Item278
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8348,12 +6803,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1121;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item286
+		class Item279
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8365,11 +6821,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1122;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item287
+		class Item280
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8381,11 +6838,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1123;
 			type="Land_HBarrier_3_F";
 		};
-		class Item288
+		class Item281
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8397,11 +6855,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1124;
 			type="Land_HBarrier_5_F";
 		};
-		class Item289
+		class Item282
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8413,11 +6872,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1125;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item290
+		class Item283
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8429,12 +6889,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1126;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item291
+		class Item284
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8446,11 +6907,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1127;
 			type="Land_HBarrier_5_F";
 		};
-		class Item292
+		class Item285
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8462,11 +6924,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1128;
 			type="Land_HBarrier_5_F";
 		};
-		class Item293
+		class Item286
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8478,11 +6941,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1129;
 			type="Land_HBarrier_5_F";
 		};
-		class Item294
+		class Item287
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8494,11 +6958,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1130;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item295
+		class Item288
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8510,12 +6975,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1131;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.001358e-005;
 		};
-		class Item296
+		class Item289
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8527,12 +6993,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1132;
 			type="Land_HBarrier_5_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item297
+		class Item290
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8544,12 +7011,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1133;
 			type="Land_HBarrier_5_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item298
+		class Item291
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8561,12 +7029,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1134;
 			type="Land_HBarrier_5_F";
 			atlOffset=7.1525574e-006;
 		};
-		class Item299
+		class Item292
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8578,11 +7047,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1135;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item300
+		class Item293
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8594,11 +7064,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1136;
 			type="Land_HBarrier_5_F";
 		};
-		class Item301
+		class Item294
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8610,12 +7081,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1137;
 			type="Land_HBarrier_5_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item302
+		class Item295
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8627,11 +7099,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1138;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item303
+		class Item296
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8643,11 +7116,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1139;
 			type="Land_HBarrier_5_F";
 		};
-		class Item304
+		class Item297
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8659,12 +7133,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1140;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item305
+		class Item298
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8676,11 +7151,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1141;
 			type="Land_HBarrier_5_F";
 		};
-		class Item306
+		class Item299
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8692,11 +7168,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1142;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item307
+		class Item300
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8708,11 +7185,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1143;
 			type="Land_HBarrier_5_F";
 		};
-		class Item308
+		class Item301
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8724,11 +7202,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1144;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item309
+		class Item302
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8740,11 +7219,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1145;
 			type="Land_HBarrier_5_F";
 		};
-		class Item310
+		class Item303
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8756,11 +7236,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1146;
 			type="Land_HBarrier_5_F";
 		};
-		class Item311
+		class Item304
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8772,11 +7253,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1147;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item312
+		class Item305
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8788,12 +7270,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1148;
 			type="Land_HBarrier_5_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item313
+		class Item306
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8805,11 +7288,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1149;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item314
+		class Item307
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8821,12 +7305,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1150;
 			type="Land_HBarrier_5_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item315
+		class Item308
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8838,11 +7323,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1151;
 			type="Land_HBarrier_3_F";
 		};
-		class Item316
+		class Item309
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8854,12 +7340,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1152;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item317
+		class Item310
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8871,12 +7358,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1153;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item318
+		class Item311
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8888,12 +7376,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1154;
 			type="Land_HBarrier_5_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item319
+		class Item312
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8905,11 +7394,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1155;
 			type="Land_HBarrier_1_F";
 		};
-		class Item320
+		class Item313
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8921,12 +7411,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1156;
 			type="Land_HBarrier_1_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item321
+		class Item314
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8938,11 +7429,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1157;
 			type="Land_HBarrier_5_F";
 		};
-		class Item322
+		class Item315
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8954,11 +7446,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1158;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item323
+		class Item316
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8970,11 +7463,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1159;
 			type="Land_HBarrier_5_F";
 		};
-		class Item324
+		class Item317
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8986,12 +7480,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1160;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item325
+		class Item318
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9003,11 +7498,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1161;
 			type="Land_HBarrier_5_F";
 		};
-		class Item326
+		class Item319
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9019,11 +7515,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1162;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item327
+		class Item320
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9035,11 +7532,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1163;
 			type="Land_HBarrier_5_F";
 		};
-		class Item328
+		class Item321
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9051,11 +7549,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1164;
 			type="Land_HBarrier_3_F";
 		};
-		class Item329
+		class Item322
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9067,12 +7566,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1165;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item330
+		class Item323
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9084,11 +7584,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1166;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item331
+		class Item324
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9100,12 +7601,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1167;
 			type="Land_HBarrier_5_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item332
+		class Item325
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9117,11 +7619,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1168;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item333
+		class Item326
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9133,12 +7636,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1169;
 			type="Land_HBarrier_5_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item334
+		class Item327
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9150,11 +7654,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1170;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item335
+		class Item328
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9171,7 +7676,7 @@ class Mission
 			type="Land_MobileRadar_01_radar_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item336
+		class Item329
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9188,7 +7693,7 @@ class Mission
 			type="Land_MobileRadar_01_generator_F";
 			atlOffset=0.25139809;
 		};
-		class Item337
+		class Item330
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9200,12 +7705,13 @@ class Mission
 			class Attributes
 			{
 				init="call{this setVariable [""spawnableHelicopterTypes"", [""patrol"", ""transport"", ""attack""]];}";
+				disableSimulation=1;
 			};
 			id=1178;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.65579796;
 		};
-		class Item338
+		class Item331
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9217,11 +7723,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1179;
 			type="Land_HBarrier_5_F";
 		};
-		class Item339
+		class Item332
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9233,11 +7740,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1180;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item340
+		class Item333
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9249,11 +7757,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1181;
 			type="Land_HBarrier_5_F";
 		};
-		class Item341
+		class Item334
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9265,12 +7774,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1182;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item342
+		class Item335
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9282,12 +7792,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1183;
 			type="Land_HBarrier_5_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item343
+		class Item336
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9299,11 +7810,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1184;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item344
+		class Item337
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9315,11 +7827,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1185;
 			type="Land_HBarrier_5_F";
 		};
-		class Item345
+		class Item338
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9331,11 +7844,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1186;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item346
+		class Item339
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9347,11 +7861,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1187;
 			type="Land_HBarrier_5_F";
 		};
-		class Item347
+		class Item340
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9363,11 +7878,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1188;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item348
+		class Item341
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9379,12 +7895,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1189;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item349
+		class Item342
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9396,11 +7913,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1190;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item350
+		class Item343
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9412,12 +7930,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1191;
 			type="Land_HBarrier_5_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item351
+		class Item344
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9429,11 +7948,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1192;
 			type="Land_HBarrier_3_F";
 		};
-		class Item352
+		class Item345
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9445,11 +7965,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1193;
 			type="Land_HBarrier_5_F";
 		};
-		class Item353
+		class Item346
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9461,12 +7982,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1194;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item354
+		class Item347
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9478,12 +8000,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1195;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item355
+		class Item348
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9495,12 +8018,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1196;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item356
+		class Item349
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9512,11 +8036,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1197;
 			type="Land_HBarrier_5_F";
 		};
-		class Item357
+		class Item350
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9528,11 +8053,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1198;
 			type="Land_HBarrier_5_F";
 		};
-		class Item358
+		class Item351
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9544,12 +8070,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1199;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item359
+		class Item352
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9561,11 +8088,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1200;
 			type="Land_HBarrier_5_F";
 		};
-		class Item360
+		class Item353
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9577,11 +8105,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1201;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item361
+		class Item354
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9593,11 +8122,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1202;
 			type="Land_HBarrier_5_F";
 		};
-		class Item362
+		class Item355
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9609,11 +8139,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1203;
 			type="Land_HBarrier_5_F";
 		};
-		class Item363
+		class Item356
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9625,12 +8156,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1204;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item364
+		class Item357
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9642,11 +8174,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1205;
 			type="Land_HBarrier_5_F";
 		};
-		class Item365
+		class Item358
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9658,11 +8191,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1206;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item366
+		class Item359
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9674,12 +8208,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1207;
 			type="Land_HBarrier_3_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item367
+		class Item360
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9691,11 +8226,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1208;
 			type="Land_HBarrier_5_F";
 		};
-		class Item368
+		class Item361
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9707,12 +8243,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1209;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item369
+		class Item362
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9724,12 +8261,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1210;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item370
+		class Item363
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9741,11 +8279,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1211;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item371
+		class Item364
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9757,11 +8296,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1212;
 			type="Land_HBarrier_5_F";
 		};
-		class Item372
+		class Item365
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9773,11 +8313,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1213;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item373
+		class Item366
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9789,11 +8330,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1214;
 			type="Land_HBarrier_5_F";
 		};
-		class Item374
+		class Item367
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9805,12 +8347,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1215;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item375
+		class Item368
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9822,11 +8365,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1216;
 			type="Land_HBarrier_5_F";
 		};
-		class Item376
+		class Item369
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9838,11 +8382,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1217;
 			type="Land_HBarrier_3_F";
 		};
-		class Item377
+		class Item370
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9854,11 +8399,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1218;
 			type="Land_HBarrier_3_F";
 		};
-		class Item378
+		class Item371
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9870,11 +8416,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1219;
 			type="Land_HBarrier_3_F";
 		};
-		class Item379
+		class Item372
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9886,11 +8433,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1220;
 			type="Land_HBarrier_1_F";
 		};
-		class Item380
+		class Item373
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9902,12 +8450,13 @@ class Mission
 			class Attributes
 			{
 				init="call{this setVariable [""spawnableHelicopterTypes"", [""patrol"", ""transport"", ""attack""]];}";
+				disableSimulation=1;
 			};
 			id=1221;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.64489746;
 		};
-		class Item381
+		class Item374
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9919,11 +8468,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1222;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item382
+		class Item375
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9935,11 +8485,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1223;
 			type="Land_HBarrier_5_F";
 		};
-		class Item383
+		class Item376
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9951,12 +8502,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1224;
 			type="Land_HBarrier_5_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item384
+		class Item377
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9968,11 +8520,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1225;
 			type="Land_HBarrier_5_F";
 		};
-		class Item385
+		class Item378
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9984,11 +8537,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1226;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item386
+		class Item379
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10000,12 +8554,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1227;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.2874603e-005;
 		};
-		class Item387
+		class Item380
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10017,12 +8572,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1228;
 			type="Land_HBarrier_5_F";
 			atlOffset=5.7220459e-006;
 		};
-		class Item388
+		class Item381
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10034,12 +8590,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1229;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.1920929e-005;
 		};
-		class Item389
+		class Item382
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10051,12 +8608,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1230;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item390
+		class Item383
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10068,12 +8626,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1231;
 			type="Land_HBarrier_5_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item391
+		class Item384
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10085,12 +8644,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1232;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-006;
 		};
-		class Item392
+		class Item385
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10102,12 +8662,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1233;
 			type="Land_HBarrier_5_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item393
+		class Item386
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10119,11 +8680,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1234;
 			type="Land_HBarrier_5_F";
 		};
-		class Item394
+		class Item387
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10135,11 +8697,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1235;
 			type="Land_HBarrier_5_F";
 		};
-		class Item395
+		class Item388
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10151,12 +8714,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1236;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item396
+		class Item389
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10168,11 +8732,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1237;
 			type="Land_HBarrier_5_F";
 		};
-		class Item397
+		class Item390
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10184,12 +8749,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1238;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item398
+		class Item391
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10201,12 +8767,13 @@ class Mission
 			class Attributes
 			{
 				init="call{this setVariable [""spawnableHelicopterTypes"", [""patrol"", ""transport"", ""attack""]];}";
+				disableSimulation=1;
 			};
 			id=1242;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.70659685;
 		};
-		class Item399
+		class Item392
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10218,12 +8785,13 @@ class Mission
 			class Attributes
 			{
 				init="call{this setVariable [""spawnableHelicopterTypes"", [""patrol"", ""transport"", ""attack""]];}";
+				disableSimulation=1;
 			};
 			id=1243;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.63049507;
 		};
-		class Item400
+		class Item393
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10235,12 +8803,13 @@ class Mission
 			class Attributes
 			{
 				init="call{this setVariable [""spawnableHelicopterTypes"", [""patrol"", ""transport"", ""attack""]];}";
+				disableSimulation=1;
 			};
 			id=1244;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.66751099;
 		};
-		class Item401
+		class Item394
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10252,12 +8821,13 @@ class Mission
 			class Attributes
 			{
 				init="call{this setVariable [""spawnableHelicopterTypes"", [""patrol"", ""transport"", ""attack""]];}";
+				disableSimulation=1;
 			};
 			id=1245;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.61740541;
 		};
-		class Item402
+		class Item395
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10274,7 +8844,7 @@ class Mission
 			type="Land_LampAirport_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item403
+		class Item396
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10290,136 +8860,7 @@ class Mission
 			id=1247;
 			type="Land_LampAirport_F";
 		};
-		class Item404
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={3883.9009,6.1528006,4624.6758};
-				angles[]={0,4.3182416,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1248;
-			type="Land_MedicalTent_01_NATO_generic_open_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item405
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={3883.9006,8.4267359,4624.6758};
-				angles[]={6.0109882,4.3182392,6.1356149};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1249;
-			type="Land_MedicalTent_01_floor_dark_F";
-			atlOffset=0.16068745;
-		};
-		class Item406
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={3871.321,6.3422222,4619.4429};
-				angles[]={0,4.3182416,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1250;
-			type="Land_MedicalTent_01_NATO_generic_open_F";
-			atlOffset=4.7683716e-007;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item407
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={3871.3213,8.6255207,4619.4434};
-				angles[]={6.0052419,4.3182392,6.1942797};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1251;
-			type="Land_MedicalTent_01_floor_dark_F";
-			atlOffset=0.17014885;
-		};
-		class Item408
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={3865.9182,5.6197557,4613.2886};
-				angles[]={0.035984326,3.5328412,0.055941612};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=1252;
-			type="Land_AirConditioner_04_F";
-		};
-		class Item409
+		class Item397
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10431,11 +8872,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1255;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item410
+		class Item398
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10447,11 +8889,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1256;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item411
+		class Item399
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10463,11 +8906,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1257;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item412
+		class Item400
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10479,12 +8923,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1258;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item413
+		class Item401
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10496,12 +8941,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1259;
 			type="Land_HBarrier_Big_F";
 			atlOffset=2.3841858e-006;
 		};
-		class Item414
+		class Item402
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10518,7 +8964,7 @@ class Mission
 			type="Land_LampAirport_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item415
+		class Item403
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10535,7 +8981,7 @@ class Mission
 			type="Land_LampAirport_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item416
+		class Item404
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10552,7 +8998,7 @@ class Mission
 			type="Land_LampSolar_F";
 			atlOffset=2.8610229e-006;
 		};
-		class Item417
+		class Item405
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10564,11 +9010,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1263;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item418
+		class Item406
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10580,11 +9027,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1264;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item419
+		class Item407
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10600,7 +9048,7 @@ class Mission
 			id=1267;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item420
+		class Item408
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10616,7 +9064,7 @@ class Mission
 			id=1268;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item421
+		class Item409
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10632,7 +9080,7 @@ class Mission
 			id=1269;
 			type="Land_Cargo_HQ_V3_F";
 		};
-		class Item422
+		class Item410
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10649,7 +9097,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=1.4305115e-006;
 		};
-		class Item423
+		class Item411
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10666,7 +9114,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item424
+		class Item412
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10683,7 +9131,7 @@ class Mission
 			type="Land_Cargo_Tower_V3_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item425
+		class Item413
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10700,7 +9148,7 @@ class Mission
 			type="Land_Cargo_Tower_V3_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item426
+		class Item414
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10717,7 +9165,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item427
+		class Item415
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10733,7 +9181,7 @@ class Mission
 			id=1278;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item428
+		class Item416
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10750,7 +9198,7 @@ class Mission
 			type="Land_Cargo_Tower_V3_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item429
+		class Item417
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10766,7 +9214,7 @@ class Mission
 			id=1280;
 			type="StorageBladder_01_fuel_sand_F";
 		};
-		class Item430
+		class Item418
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10783,7 +9231,7 @@ class Mission
 			type="StorageBladder_01_fuel_sand_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item431
+		class Item419
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -10839,7 +9287,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item432
+		class Item420
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10851,11 +9299,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1289;
 			type="Land_HelipadSquare_F";
 		};
-		class Item433
+		class Item421
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -10911,7 +9360,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item434
+		class Item422
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10922,12 +9371,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1291;
 			type="Land_HelipadCircle_F";
 			atlOffset=3.7297664;
 		};
-		class Item435
+		class Item423
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10939,11 +9389,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1294;
 			type="Land_HelipadSquare_F";
 		};
-		class Item436
+		class Item424
 		{
 			dataType="Layer";
 			name="Resources";
@@ -11052,7 +9503,7 @@ class Mission
 			id=1295;
 			atlOffset=48.67535;
 		};
-		class Item437
+		class Item425
 		{
 			dataType="Layer";
 			name="Outposts";
@@ -11167,7 +9618,7 @@ class Mission
 					colorName="ColorGreen";
 					a=57.423988;
 					b=57.955338;
-					angle=165.46202;
+					angle=165.46199;
 					id=1319;
 				};
 				class Item8
@@ -11188,7 +9639,7 @@ class Mission
 			id=1296;
 			atlOffset=13.568083;
 		};
-		class Item438
+		class Item426
 		{
 			dataType="Layer";
 			name="Roadblocks";
@@ -11356,7 +9807,7 @@ class Mission
 			id=1297;
 			atlOffset=1.9014182;
 		};
-		class Item439
+		class Item427
 		{
 			dataType="Layer";
 			name="Spawner and Waypoints";
@@ -11545,7 +9996,7 @@ class Mission
 					position[]={3854.791,20.436001,4481.6221};
 					name="spawnpoint";
 					type="hd_start";
-					angle=28.14699;
+					angle=28.146986;
 					id=211;
 					atlOffset=12.870616;
 				};
@@ -11553,7 +10004,7 @@ class Mission
 			id=1313;
 			atlOffset=9.7822409;
 		};
-		class Item440
+		class Item428
 		{
 			dataType="Layer";
 			name="Factories";
@@ -11606,7 +10057,7 @@ class Mission
 			id=1314;
 			atlOffset=5.7408857;
 		};
-		class Item441
+		class Item429
 		{
 			dataType="Layer";
 			name="Airport";
@@ -11658,7 +10109,7 @@ class Mission
 			id=1315;
 			atlOffset=8.8944836;
 		};
-		class Item442
+		class Item430
 		{
 			dataType="Layer";
 			name="Standard marker";
@@ -11770,7 +10221,7 @@ class Mission
 			id=1316;
 			atlOffset=1.3518803e+012;
 		};
-		class Item443
+		class Item431
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -11781,7 +10232,7 @@ class Mission
 			id=1317;
 			type="HighCommand";
 		};
-		class Item444
+		class Item432
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -11791,7 +10242,7 @@ class Mission
 			id=1318;
 			type="HighCommandSubordinate";
 		};
-		class Item445
+		class Item433
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11808,7 +10259,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item446
+		class Item434
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11825,7 +10276,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item447
+		class Item435
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11842,7 +10293,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item448
+		class Item436
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11859,7 +10310,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item449
+		class Item437
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -11914,7 +10365,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item450
+		class Item438
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -11969,7 +10420,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item451
+		class Item439
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -12024,7 +10475,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item452
+		class Item440
 		{
 			dataType="Marker";
 			position[]={3284.5493,0.56900001,968.2691};
@@ -12033,11 +10484,11 @@ class Mission
 			type="rectangle";
 			a=14.98178;
 			b=5.3061624;
-			angle=335.49997;
+			angle=335.49991;
 			id=1335;
 			atlOffset=4.1576209;
 		};
-		class Item453
+		class Item441
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -12094,7 +10545,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item454
+		class Item442
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12111,7 +10562,7 @@ class Mission
 			type="Land_dp_transformer_F";
 			atlOffset=-0.049068451;
 		};
-		class Item455
+		class Item443
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12128,7 +10579,7 @@ class Mission
 			type="Land_dp_transformer_F";
 			atlOffset=0.37271881;
 		};
-		class Item456
+		class Item444
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12145,7 +10596,7 @@ class Mission
 			type="Land_dp_transformer_F";
 			atlOffset=0.65101624;
 		};
-		class Item457
+		class Item445
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12161,16 +10612,894 @@ class Mission
 			id=1344;
 			type="Land_Tank_rust_F";
 		};
+		class Item446
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=38;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1334.1346,34.291439,381.68088};
+					};
+					side="Independent";
+					flags=7;
+					class Attributes
+					{
+						name="commanderX";
+						description="Default Commaner";
+						isPlayer=1;
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1350;
+					type="I_G_officer_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male04GRE";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1;
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1338.9296,34.730358,378.97775};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1351;
+					type="I_G_officer_F";
+					atlOffset=0.42892075;
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1339.0682,34.733829,381.21359};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1352;
+					type="I_G_officer_F";
+					atlOffset=0.43611908;
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1339.0106,34.69775,383.54709};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1353;
+					type="I_G_officer_F";
+					atlOffset=0.40029907;
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1338.8475,34.601688,385.86057};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1354;
+					type="I_G_officer_F";
+					atlOffset=0.31024933;
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1338.8065,34.511631,388.31467};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1355;
+					type="I_G_officer_F";
+					atlOffset=0.22019196;
+				};
+				class Item6
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1338.621,34.391979,390.63058};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1356;
+					type="I_G_officer_F";
+					atlOffset=0.10054016;
+				};
+				class Item7
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1338.4139,34.264805,392.52609};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1357;
+					type="I_G_officer_F";
+					atlOffset=-0.026634216;
+				};
+				class Item8
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1341.2889,34.941303,379.10129};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1358;
+					type="I_G_Soldier_F";
+					atlOffset=0.63986588;
+				};
+				class Item9
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1341.288,34.931866,381.44064};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1359;
+					type="I_G_Soldier_F";
+					atlOffset=0.63042831;
+				};
+				class Item10
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1341.1815,34.882946,383.81418};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1360;
+					type="I_G_Soldier_F";
+					atlOffset=0.58656311;
+				};
+				class Item11
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1341.1229,34.800129,386.01389};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1361;
+					type="I_G_Soldier_F";
+					atlOffset=0.50868988;
+				};
+				class Item12
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1340.9198,34.672565,388.43625};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1362;
+					type="I_G_Soldier_F";
+					atlOffset=0.3811264;
+				};
+				class Item13
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1340.7323,34.520565,390.7673};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1363;
+					type="I_G_Soldier_F";
+					atlOffset=0.22912598;
+				};
+				class Item14
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1343.3973,35.130116,379.13742};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1364;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.82867813;
+				};
+				class Item15
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1343.5594,35.134899,381.57736};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1365;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.83346176;
+				};
+				class Item16
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1343.1591,35.053822,383.9924};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1366;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.75815201;
+				};
+				class Item17
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1343.1356,34.953831,386.14133};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1367;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.65985107;
+				};
+				class Item18
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1342.9354,34.806393,388.38254};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1368;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.51495361;
+				};
+				class Item19
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1342.8485,34.65324,390.84152};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1369;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.36180115;
+				};
+				class Item20
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1345.4862,35.316975,379.21701};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1370;
+					type="I_G_Soldier_GL_F";
+					atlOffset=1.0155373;
+				};
+				class Item21
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1345.3563,35.296062,381.53488};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1371;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.99462509;
+				};
+				class Item22
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1345.2323,35.201481,384.27902};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1372;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.90004349;
+				};
+				class Item23
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1345.0585,35.069653,386.28781};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1373;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.77316666;
+				};
+				class Item24
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1344.9891,34.934124,388.47238};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1374;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.64268494;
+				};
+				class Item25
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1344.8837,34.777798,390.9631};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1375;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.48635864;
+				};
+				class Item26
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1347.0135,35.318287,379.29465};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1376;
+					type="I_G_medic_F";
+					atlOffset=1.0168495;
+				};
+				class Item27
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1346.8378,35.309559,381.57443};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1377;
+					type="I_G_medic_F";
+					atlOffset=1.0081215;
+				};
+				class Item28
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1346.7958,35.213879,384.44601};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1378;
+					type="I_G_medic_F";
+					atlOffset=0.91244125;
+				};
+				class Item29
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1346.7079,35.105251,386.25266};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1379;
+					type="I_G_medic_F";
+					atlOffset=0.80698013;
+				};
+				class Item30
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1346.5243,34.96323,388.61203};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1380;
+					type="I_G_medic_F";
+					atlOffset=0.66603851;
+				};
+				class Item31
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1346.535,34.818661,391.02267};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1381;
+					type="I_G_medic_F";
+					atlOffset=0.52722168;
+				};
+				class Item32
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1348.8153,35.314739,379.45969};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1382;
+					type="I_G_engineer_F";
+					atlOffset=1.0133018;
+				};
+				class Item33
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1348.8387,35.314365,381.75998};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1383;
+					type="I_G_engineer_F";
+					atlOffset=1.012928;
+				};
+				class Item34
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1348.5966,35.211964,384.55002};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1384;
+					type="I_G_engineer_F";
+					atlOffset=0.91052628;
+				};
+				class Item35
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1348.3417,35.094501,386.49777};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1385;
+					type="I_G_engineer_F";
+					atlOffset=0.79306412;
+				};
+				class Item36
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1348.1464,34.959827,388.7341};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1386;
+					type="I_G_engineer_F";
+					atlOffset=0.66312408;
+				};
+				class Item37
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={1348.0419,34.811428,391.20334};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=1387;
+					type="I_G_engineer_F";
+					atlOffset=0.51782227;
+				};
+			};
+			class Attributes
+			{
+			};
+			id=1349;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="Guerillas";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
 	};
 	class Connections
 	{
 		class LinkIDProvider
 		{
-			nextID=25;
+			nextID=39;
 		};
 		class Links
 		{
-			items=25;
+			items=39;
 			class Item0
 			{
 				linkID=0;
@@ -12184,7 +11513,7 @@ class Mission
 			class Item1
 			{
 				linkID=1;
-				item0=147;
+				item0=1350;
 				item1=1317;
 				class CustomData
 				{
@@ -12194,7 +11523,7 @@ class Mission
 			class Item2
 			{
 				linkID=2;
-				item0=151;
+				item0=1351;
 				item1=1317;
 				class CustomData
 				{
@@ -12204,7 +11533,7 @@ class Mission
 			class Item3
 			{
 				linkID=3;
-				item0=152;
+				item0=1352;
 				item1=1317;
 				class CustomData
 				{
@@ -12214,7 +11543,7 @@ class Mission
 			class Item4
 			{
 				linkID=4;
-				item0=154;
+				item0=1353;
 				item1=1317;
 				class CustomData
 				{
@@ -12224,7 +11553,7 @@ class Mission
 			class Item5
 			{
 				linkID=5;
-				item0=158;
+				item0=1354;
 				item1=1317;
 				class CustomData
 				{
@@ -12234,7 +11563,7 @@ class Mission
 			class Item6
 			{
 				linkID=6;
-				item0=160;
+				item0=1355;
 				item1=1317;
 				class CustomData
 				{
@@ -12244,7 +11573,7 @@ class Mission
 			class Item7
 			{
 				linkID=7;
-				item0=170;
+				item0=1356;
 				item1=1317;
 				class CustomData
 				{
@@ -12254,7 +11583,7 @@ class Mission
 			class Item8
 			{
 				linkID=8;
-				item0=175;
+				item0=1357;
 				item1=1317;
 				class CustomData
 				{
@@ -12264,7 +11593,7 @@ class Mission
 			class Item9
 			{
 				linkID=9;
-				item0=177;
+				item0=1358;
 				item1=1317;
 				class CustomData
 				{
@@ -12274,7 +11603,7 @@ class Mission
 			class Item10
 			{
 				linkID=10;
-				item0=184;
+				item0=1359;
 				item1=1317;
 				class CustomData
 				{
@@ -12284,7 +11613,7 @@ class Mission
 			class Item11
 			{
 				linkID=11;
-				item0=185;
+				item0=1360;
 				item1=1317;
 				class CustomData
 				{
@@ -12294,7 +11623,7 @@ class Mission
 			class Item12
 			{
 				linkID=12;
-				item0=186;
+				item0=1361;
 				item1=1317;
 				class CustomData
 				{
@@ -12304,7 +11633,7 @@ class Mission
 			class Item13
 			{
 				linkID=13;
-				item0=188;
+				item0=1362;
 				item1=1317;
 				class CustomData
 				{
@@ -12314,7 +11643,7 @@ class Mission
 			class Item14
 			{
 				linkID=14;
-				item0=190;
+				item0=1363;
 				item1=1317;
 				class CustomData
 				{
@@ -12324,7 +11653,7 @@ class Mission
 			class Item15
 			{
 				linkID=15;
-				item0=191;
+				item0=1364;
 				item1=1317;
 				class CustomData
 				{
@@ -12334,7 +11663,7 @@ class Mission
 			class Item16
 			{
 				linkID=16;
-				item0=192;
+				item0=1365;
 				item1=1317;
 				class CustomData
 				{
@@ -12344,7 +11673,7 @@ class Mission
 			class Item17
 			{
 				linkID=17;
-				item0=194;
+				item0=1366;
 				item1=1317;
 				class CustomData
 				{
@@ -12354,7 +11683,7 @@ class Mission
 			class Item18
 			{
 				linkID=18;
-				item0=197;
+				item0=1367;
 				item1=1317;
 				class CustomData
 				{
@@ -12364,7 +11693,7 @@ class Mission
 			class Item19
 			{
 				linkID=19;
-				item0=200;
+				item0=1368;
 				item1=1317;
 				class CustomData
 				{
@@ -12374,7 +11703,7 @@ class Mission
 			class Item20
 			{
 				linkID=20;
-				item0=202;
+				item0=1369;
 				item1=1317;
 				class CustomData
 				{
@@ -12384,7 +11713,7 @@ class Mission
 			class Item21
 			{
 				linkID=21;
-				item0=204;
+				item0=1370;
 				item1=1317;
 				class CustomData
 				{
@@ -12394,7 +11723,7 @@ class Mission
 			class Item22
 			{
 				linkID=22;
-				item0=207;
+				item0=1371;
 				item1=1317;
 				class CustomData
 				{
@@ -12404,7 +11733,7 @@ class Mission
 			class Item23
 			{
 				linkID=23;
-				item0=208;
+				item0=1372;
 				item1=1317;
 				class CustomData
 				{
@@ -12414,7 +11743,147 @@ class Mission
 			class Item24
 			{
 				linkID=24;
-				item0=209;
+				item0=1373;
+				item1=1317;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item25
+			{
+				linkID=25;
+				item0=1374;
+				item1=1317;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item26
+			{
+				linkID=26;
+				item0=1375;
+				item1=1317;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item27
+			{
+				linkID=27;
+				item0=1376;
+				item1=1317;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item28
+			{
+				linkID=28;
+				item0=1377;
+				item1=1317;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item29
+			{
+				linkID=29;
+				item0=1378;
+				item1=1317;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item30
+			{
+				linkID=30;
+				item0=1379;
+				item1=1317;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item31
+			{
+				linkID=31;
+				item0=1380;
+				item1=1317;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item32
+			{
+				linkID=32;
+				item0=1381;
+				item1=1317;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item33
+			{
+				linkID=33;
+				item0=1382;
+				item1=1317;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item34
+			{
+				linkID=34;
+				item0=1383;
+				item1=1317;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item35
+			{
+				linkID=35;
+				item0=1384;
+				item1=1317;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item36
+			{
+				linkID=36;
+				item0=1385;
+				item1=1317;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item37
+			{
+				linkID=37;
+				item0=1386;
+				item1=1317;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item38
+			{
+				linkID=38;
+				item0=1387;
 				item1=1317;
 				class CustomData
 				{

--- a/Map-Templates/Antistasi-Livonia.Enoch/mission.sqm
+++ b/Map-Templates/Antistasi-Livonia.Enoch/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=1030;
 	class ItemIDProvider
 	{
-		nextID=3245;
+		nextID=3297;
 	};
 	class MarkerIDProvider
 	{
@@ -16,14 +16,14 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=204;
+		nextID=252;
 	};
 	class Camera
 	{
-		pos[]={962.53094,105.17551,5544.4683};
-		dir[]={-0.56049997,-0.64726299,0.51661855};
-		up[]={-0.47593507,0.7622658,0.43867427};
-		aside[]={0.67773896,-1.3553654e-007,0.73530573};
+		pos[]={3934.4375,231.14027,10366.936};
+		dir[]={0.70868301,-0.67734766,0.1974607};
+		up[]={0.65250069,0.73565513,0.18180642};
+		aside[]={0.26840818,1.5003025e-008,-0.96331376};
 	};
 };
 binarizationWanted=0;
@@ -32,7 +32,6 @@ addons[]=
 	"A3_Weapons_F_Ammoboxes",
 	"A3_Modules_F",
 	"A3_Characters_F",
-	"A3_Weapons_F",
 	"A3_Structures_F_Mil_Flags",
 	"A3_Modules_F_Curator_Curator",
 	"A3_Structures_F_Civ_Camping",
@@ -44,7 +43,6 @@ addons[]=
 	"A3_Structures_F_Mil_Helipads",
 	"A3_Structures_F_Mil_Fortification",
 	"A3_Structures_F_Enoch_Military_Barracks",
-	"A3_Structures_F_Enoch_Military_Camps",
 	"A3_Props_F_Enoch_Infrastructure_Traffic",
 	"A3_Structures_F_Enoch_Civilian_Accessories",
 	"A3_Structures_F_Enoch_Walls_Concrete",
@@ -59,24 +57,23 @@ addons[]=
 	"A3_Structures_F_EPA_Civ_Constructions",
 	"A3_Structures_F_Enoch_Military_Camonets",
 	"A3_Structures_F_Heli_Items_Airport",
-	"A3_Structures_F_Orange_Humanitarian_Camps",
 	"A3_Structures_F_Heli_Ind_Machines",
 	"A3_Structures_F_Mil_BagFence",
 	"A3_Structures_F_Items_Vessels",
 	"A3_Structures_F_Mil_Shelters",
 	"A3_Structures_F_Civ_Lamps",
-	"A3_Props_F_Orange_Humanitarian_Camps",
 	"A3_Structures_F_Enoch_Military_Radar",
 	"A3_Supplies_F_Heli_Bladders",
 	"A3_Ui_F",
 	"A3_Structures_F_Mil_TentHangar",
-	"A3_Ui_F_Exp"
+	"A3_Ui_F_Exp",
+	"A3_Weapons_F"
 };
 class AddonsMetaData
 {
 	class List
 	{
-		items=20;
+		items=18;
 		class Item0
 		{
 			className="A3_Weapons_F";
@@ -184,33 +181,19 @@ class AddonsMetaData
 		};
 		class Item15
 		{
-			className="A3_Structures_F_Orange";
-			name="Arma 3 Orange - Buildings and Structures";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item16
-		{
-			className="A3_Props_F_Orange";
-			name="Arma 3 Orange - Decorative and Mission Objects";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item17
-		{
 			className="A3_Supplies_F_Heli";
 			name="Arma 3 Helicopters - Ammoboxes and Supplies";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item18
+		class Item16
 		{
 			className="A3_Ui_F";
 			name="Arma 3 - User Interface";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item19
+		class Item17
 		{
 			className="A3_Ui_F_Exp";
 			name="Arma 3 Apex - User Interface";
@@ -226,20 +209,15 @@ class Mission
 	{
 		briefingName=$STR_antistasi_mission_info_livonia_mapname_text;
 		resistanceWest=0;
-		startWind=0.1;
-		forecastWind=0.1;
-		forecastWaves=0.1;
 		year=2035;
 		month=6;
 		day=1;
 		hour=10;
 		minute=0;
-		startFogDecay=0.0049333;
-		forecastFogDecay=0.0049333;
 	};
 	class Entities
 	{
-		items=803;
+		items=785;
 		class Item0
 		{
 			dataType="Object";
@@ -461,3870 +439,6 @@ class Mission
 			side="Independent";
 			class Entities
 			{
-				items=60;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={954.83466,77.172203,5564.3457};
-						angles[]={6.2751918,0,0.094119832};
-					};
-					side="Independent";
-					flags=6;
-					class Attributes
-					{
-						skill=1;
-						name="commanderX";
-						description="Default Commander";
-						isPlayer=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=93;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item1
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={958.36786,77.650902,5560.8213};
-						angles[]={0.0080009829,6.2412972,0.16177347};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=97;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item2
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={969.82758,80.046257,5566.9736};
-						angles[]={6.2527947,6.2412972,0.14771642};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=98;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item3
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={969.72455,80.101997,5569.7686};
-						angles[]={6.2735858,6.2412972,0.15397188};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=104;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item4
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={969.82367,80.147293,5572.8848};
-						angles[]={6.2735858,6.1574922,0.15397188};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=120;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item5
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={969.91864,80.176949,5575.4717};
-						angles[]={0.027193764,0,0.15865518};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=121;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item6
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={970.25092,80.158691,5578.0977};
-						angles[]={0.027193764,0,0.15865518};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=127;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item7
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={970.3244,80.109978,5581.1719};
-						angles[]={0.011198638,0,0.17421527};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=133;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item8
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={967.3576,79.37915,5584.1582};
-						angles[]={0.121006,0,0.075058199};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=139;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item9
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={967.20917,78.971016,5587.4229};
-						angles[]={0.121006,0,0.075058199};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=145;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item10
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={966.0224,79.046448,5590.168};
-						angles[]={6.2144933,0,0.075058997};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=151;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item11
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={975.83148,80.962456,5566.8604};
-						angles[]={6.2464013,0,0.14614981};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=100;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item12
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={975.72845,81.030983,5569.6553};
-						angles[]={6.2687874,0,0.14615022};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=106;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item13
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={975.72845,81.074196,5572.6563};
-						angles[]={6.2687874,0,0.14615022};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=111;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item14
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={975.62469,81.094223,5575.2432};
-						angles[]={0.011203959,0,0.15084518};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=116;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item15
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={975.95697,81.115326,5577.8691};
-						angles[]={0.011203959,0,0.15084518};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=123;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item16
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={976.03046,81.095299,5580.9434};
-						angles[]={0.006394445,0,0.15553415};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=129;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item17
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={973.06366,80.311913,5583.9297};
-						angles[]={0.062319059,0,0.23100168};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=135;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item18
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={972.91522,80.07328,5587.1943};
-						angles[]={0.062319059,0,0.23100168};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=141;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item19
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={971.72845,79.928719,5589.9395};
-						angles[]={6.2176785,0,0.23100168};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=147;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item20
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={964.37177,78.666084,5560.708};
-						angles[]={6.2416081,0,0.22644857};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=152;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item21
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={978.73065,81.395782,5567.0391};
-						angles[]={6.2464013,0,0.14614981};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=101;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item22
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={978.62762,81.46032,5569.834};
-						angles[]={6.2687874,0,0.14615022};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=107;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item23
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={978.62762,81.510307,5572.835};
-						angles[]={6.2639894,0,0.1508448};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=112;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item24
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={978.52386,81.532898,5575.4219};
-						angles[]={0.011203959,0,0.15084518};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=117;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item25
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={978.85614,81.556892,5578.0479};
-						angles[]={0.006394445,0,0.15553415};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=124;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item26
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={978.92963,81.548744,5581.1221};
-						angles[]={0.006394445,0,0.15553415};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=130;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item27
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={975.96283,80.907173,5584.1084};
-						angles[]={0.062319059,0,0.15553415};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=136;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item28
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={975.81439,80.705673,5587.373};
-						angles[]={0.022397626,0,0.19431612};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=142;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item29
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={974.62762,80.316681,5590.1182};
-						angles[]={0.07346756,0,0.095706634};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=148;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item30
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={967.39691,79.373833,5560.9668};
-						angles[]={6.2416081,0,0.22644857};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=153;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item31
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={981.71844,81.842186,5567.2588};
-						angles[]={6.2464013,0,0.14301735};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=102;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item32
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={981.61542,81.909882,5570.0537};
-						angles[]={6.2639894,0,0.147716};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=108;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item33
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={981.61542,81.967499,5573.0547};
-						angles[]={6.2639894,0,0.147716};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=113;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item34
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={981.51166,81.987419,5575.6416};
-						angles[]={0.006394445,0,0.15084599};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=118;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item35
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={981.84393,82.021126,5578.2676};
-						angles[]={0.006394445,0,0.15084599};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=125;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item36
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={981.91742,82.015152,5581.3418};
-						angles[]={0.022397626,0,0.155533};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=131;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item37
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={978.95062,81.39109,5584.3281};
-						angles[]={0.022397626,0,0.19431612};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=137;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item38
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={978.80219,81.286568,5587.5928};
-						angles[]={0.07346756,0,0.19431612};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=143;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item39
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={977.61542,80.850967,5590.3379};
-						angles[]={0.07346756,0,0.19431612};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=149;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item40
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={969.98163,79.880096,5561.373};
-						angles[]={6.2368193,0,0.147716};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=154;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item41
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={967.36664,79.487877,5566.9131};
-						angles[]={6.2527947,0,0.27893379};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=103;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item42
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={967.26361,79.534622,5569.708};
-						angles[]={6.2623887,0,0.27893379};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=109;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item43
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={967.26361,79.569908,5572.709};
-						angles[]={6.2735858,0,0.2685523};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=114;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item44
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={967.15985,79.565796,5575.2959};
-						angles[]={6.2751846,0,0.2685523};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=119;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item45
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={967.49213,79.621429,5577.9219};
-						angles[]={0.027193764,0,0.23554493};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=126;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item46
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={967.56561,79.555458,5580.9961};
-						angles[]={0.027193764,0,0.23554493};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=132;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item47
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={964.59882,78.951027,5583.9824};
-						angles[]={6.2400126,0,0.23554493};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=138;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item48
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={964.45038,78.784943,5587.2471};
-						angles[]={0.121006,0,0.075058199};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=144;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item49
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={963.26361,78.826889,5589.9922};
-						angles[]={6.2144933,0,0.075058997};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=150;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item50
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={972.90155,80.527206,5567.209};
-						angles[]={6.2464013,0,0.15397149};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=99;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item51
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={972.79852,80.581337,5570.0039};
-						angles[]={6.2735858,0,0.15397188};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=105;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item52
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={972.79852,80.619759,5573.0049};
-						angles[]={6.2687874,0,0.15865518};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=110;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item53
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={972.69476,80.617874,5575.5918};
-						angles[]={0.027193764,0,0.15865518};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=115;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item54
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={973.02704,80.618721,5578.2178};
-						angles[]={0.011198638,0,0.17421527};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=122;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item55
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={973.10052,80.597214,5581.292};
-						angles[]={0.011198638,0,0.17421527};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=128;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item56
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={970.13373,79.712784,5584.2783};
-						angles[]={0.1210065,0,0.17421561};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=134;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item57
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={969.98529,79.362411,5587.543};
-						angles[]={0.062319059,0,0.23100168};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=140;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item58
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={968.79852,79.262482,5590.2881};
-						angles[]={6.2176785,0,0.23100168};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=146;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item59
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={961.44183,78.150688,5561.0566};
-						angles[]={0.0080009829,0,0.16177347};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=155;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-			};
-			class Attributes
-			{
-			};
-			id=92;
-		};
-		class Item11
-		{
-			dataType="Group";
-			side="Independent";
-			class Entities
-			{
 				items=1;
 				class Item0
 				{
@@ -4410,7 +524,7 @@ class Mission
 			};
 			id=94;
 		};
-		class Item12
+		class Item11
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4450,7 +564,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item13
+		class Item12
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -4464,7 +578,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item14
+		class Item13
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -4478,7 +592,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item15
+		class Item14
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -4568,7 +682,7 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item16
+		class Item15
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4609,7 +723,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item17
+		class Item16
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4649,7 +763,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item18
+		class Item17
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4666,7 +780,7 @@ class Mission
 			type="Flag_NATO_F";
 			atlOffset=-0.64300537;
 		};
-		class Item19
+		class Item18
 		{
 			dataType="Group";
 			side="West";
@@ -5048,7 +1162,7 @@ class Mission
 			};
 			id=176;
 		};
-		class Item20
+		class Item19
 		{
 			dataType="Group";
 			side="East";
@@ -5421,7 +1535,7 @@ class Mission
 			};
 			id=184;
 		};
-		class Item21
+		class Item20
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5438,7 +1552,7 @@ class Mission
 			id=191;
 			type="Flag_Viper_F";
 		};
-		class Item22
+		class Item21
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5453,63 +1567,63 @@ class Mission
 			id=209;
 			type="Land_TTowerBig_2_F";
 		};
-		class Item23
+		class Item22
 		{
 			dataType="Layer";
 			name="Open Ammo Dump";
 			id=214;
 			atlOffset=-252.33;
 		};
-		class Item24
+		class Item23
 		{
 			dataType="Layer";
 			name="Vehicle Repair";
 			id=239;
 			atlOffset=-252.33;
 		};
-		class Item25
+		class Item24
 		{
 			dataType="Layer";
 			name="Check Point (Large)";
 			id=631;
 			atlOffset=-252.33;
 		};
-		class Item26
+		class Item25
 		{
 			dataType="Layer";
 			name="Check Point (Medium)";
 			id=636;
 			atlOffset=-252.33;
 		};
-		class Item27
+		class Item26
 		{
 			dataType="Layer";
 			name="Check Point (Small)";
 			id=641;
 			atlOffset=-252.33;
 		};
-		class Item28
+		class Item27
 		{
 			dataType="Layer";
 			name="Camp Ant";
 			id=678;
 			atlOffset=-252.33;
 		};
-		class Item29
+		class Item28
 		{
 			dataType="Layer";
 			name="Camp Crow";
 			id=711;
 			atlOffset=-252.33;
 		};
-		class Item30
+		class Item29
 		{
 			dataType="Layer";
 			name="One-Way Reinforced";
 			id=771;
 			atlOffset=-252.33;
 		};
-		class Item31
+		class Item30
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5520,7 +1634,7 @@ class Mission
 			id=820;
 			type="HighCommand";
 		};
-		class Item32
+		class Item31
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5530,7 +1644,7 @@ class Mission
 			id=821;
 			type="HighCommandSubordinate";
 		};
-		class Item33
+		class Item32
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5542,11 +1656,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=825;
 			type="Land_HelipadSquare_F";
 		};
-		class Item34
+		class Item33
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5558,11 +1673,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=826;
 			type="Land_HelipadSquare_F";
 		};
-		class Item35
+		class Item34
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5574,12 +1690,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=827;
 			type="Land_HelipadSquare_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item36
+		class Item35
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5591,11 +1708,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=836;
 			type="Land_HBarrier_5_F";
 		};
-		class Item37
+		class Item36
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5607,11 +1725,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=837;
 			type="Land_HBarrier_5_F";
 		};
-		class Item38
+		class Item37
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5623,11 +1742,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=838;
 			type="Land_HBarrier_5_F";
 		};
-		class Item39
+		class Item38
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5639,11 +1759,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=839;
 			type="Land_HBarrier_5_F";
 		};
-		class Item40
+		class Item39
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5655,11 +1776,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=840;
 			type="Land_HBarrier_5_F";
 		};
-		class Item41
+		class Item40
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5671,11 +1793,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=841;
 			type="Land_HBarrier_5_F";
 		};
-		class Item42
+		class Item41
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5687,11 +1810,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=842;
 			type="Land_HBarrier_5_F";
 		};
-		class Item43
+		class Item42
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5703,11 +1827,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=843;
 			type="Land_HBarrier_5_F";
 		};
-		class Item44
+		class Item43
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5719,11 +1844,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=844;
 			type="Land_HBarrier_5_F";
 		};
-		class Item45
+		class Item44
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5735,11 +1861,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=845;
 			type="Land_HBarrier_5_F";
 		};
-		class Item46
+		class Item45
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5751,11 +1878,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=846;
 			type="Land_HBarrier_5_F";
 		};
-		class Item47
+		class Item46
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5767,11 +1895,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=847;
 			type="Land_HBarrier_5_F";
 		};
-		class Item48
+		class Item47
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5783,11 +1912,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=848;
 			type="Land_HBarrier_5_F";
 		};
-		class Item49
+		class Item48
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5799,11 +1929,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=849;
 			type="Land_HBarrier_5_F";
 		};
-		class Item50
+		class Item49
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5815,11 +1946,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=850;
 			type="Land_HBarrier_5_F";
 		};
-		class Item51
+		class Item50
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5831,11 +1963,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=851;
 			type="Land_HBarrier_5_F";
 		};
-		class Item52
+		class Item51
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5847,11 +1980,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=852;
 			type="Land_HBarrier_5_F";
 		};
-		class Item53
+		class Item52
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5863,11 +1997,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=853;
 			type="Land_HBarrier_5_F";
 		};
-		class Item54
+		class Item53
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5883,39 +2018,7 @@ class Mission
 			id=854;
 			type="Land_Barracks_06_F";
 		};
-		class Item55
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={7809.25,151.25615,9764.25};
-				angles[]={6.271987,4.8673191,0.02399601};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=855;
-			type="Land_MedicalTent_01_wdl_generic_open_F";
-		};
-		class Item56
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={7807.7944,151.37607,9752.373};
-				angles[]={0.012798273,4.8673191,0.033588443};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=856;
-			type="Land_MedicalTent_01_wdl_generic_open_F";
-		};
-		class Item57
+		class Item54
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5931,7 +2034,7 @@ class Mission
 			id=859;
 			type="Land_GuardBox_01_brown_F";
 		};
-		class Item58
+		class Item55
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5947,7 +2050,7 @@ class Mission
 			id=860;
 			type="Land_GuardBox_01_brown_F";
 		};
-		class Item59
+		class Item56
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5964,7 +2067,7 @@ class Mission
 			type="Land_WoodenWindBreak_01_F";
 			atlOffset=0.0035858154;
 		};
-		class Item60
+		class Item57
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5981,7 +2084,7 @@ class Mission
 			type="Land_WoodenWindBreak_01_F";
 			atlOffset=0.00010681152;
 		};
-		class Item61
+		class Item58
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5998,7 +2101,7 @@ class Mission
 			type="Land_WoodenWindBreak_01_F";
 			atlOffset=0.00062561035;
 		};
-		class Item62
+		class Item59
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6015,7 +2118,7 @@ class Mission
 			type="Land_WoodenWindBreak_01_F";
 			atlOffset=0.00079345703;
 		};
-		class Item63
+		class Item60
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6032,7 +2135,7 @@ class Mission
 			type="Land_WoodenWindBreak_01_F";
 			atlOffset=-0.0002746582;
 		};
-		class Item64
+		class Item61
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6049,7 +2152,7 @@ class Mission
 			type="Land_WoodenWindBreak_01_F";
 			atlOffset=0.00024414063;
 		};
-		class Item65
+		class Item62
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6066,7 +2169,7 @@ class Mission
 			type="Land_WoodenWindBreak_01_F";
 			atlOffset=-6.1035156e-005;
 		};
-		class Item66
+		class Item63
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6083,7 +2186,7 @@ class Mission
 			type="Land_WoodenWindBreak_01_F";
 			atlOffset=6.1035156e-005;
 		};
-		class Item67
+		class Item64
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6100,7 +2203,7 @@ class Mission
 			type="Land_WoodenWindBreak_01_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item68
+		class Item65
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6117,7 +2220,7 @@ class Mission
 			type="Land_WoodenWindBreak_01_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item69
+		class Item66
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6133,7 +2236,7 @@ class Mission
 			id=873;
 			type="Land_ConcreteTreePlanter_02_F";
 		};
-		class Item70
+		class Item67
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6150,7 +2253,7 @@ class Mission
 			type="Land_WoodenWindBreak_01_F";
 			atlOffset=0.033691406;
 		};
-		class Item71
+		class Item68
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6166,7 +2269,7 @@ class Mission
 			id=877;
 			type="Land_CamoConcreteWall_01_l_4m_v2_F";
 		};
-		class Item72
+		class Item69
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6182,7 +2285,7 @@ class Mission
 			id=878;
 			type="Land_CamoConcreteWall_01_l_4m_v2_F";
 		};
-		class Item73
+		class Item70
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -6237,7 +2340,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item74
+		class Item71
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6253,7 +2356,7 @@ class Mission
 			id=881;
 			type="Land_ConcreteTreePlanter_02_F";
 		};
-		class Item75
+		class Item72
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6270,7 +2373,7 @@ class Mission
 			type="Land_WoodenWindBreak_01_F";
 			atlOffset=0.00021362305;
 		};
-		class Item76
+		class Item73
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6286,7 +2389,7 @@ class Mission
 			id=883;
 			type="Land_ConcreteTreePlanter_02_F";
 		};
-		class Item77
+		class Item74
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6303,7 +2406,7 @@ class Mission
 			type="Land_WoodenWindBreak_01_F";
 			atlOffset=0.031066895;
 		};
-		class Item78
+		class Item75
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -6359,7 +2462,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item79
+		class Item76
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6375,7 +2478,7 @@ class Mission
 			id=886;
 			type="Land_CamoConcreteWall_01_l_4m_v2_F";
 		};
-		class Item80
+		class Item77
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6391,7 +2494,7 @@ class Mission
 			id=887;
 			type="Land_CamoConcreteWall_01_l_4m_v2_F";
 		};
-		class Item81
+		class Item78
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -6447,7 +2550,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item82
+		class Item79
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6464,7 +2567,7 @@ class Mission
 			type="Land_WoodenWindBreak_01_F";
 			atlOffset=0.00012207031;
 		};
-		class Item83
+		class Item80
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6481,7 +2584,7 @@ class Mission
 			type="Land_WoodenWindBreak_01_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item84
+		class Item81
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6497,7 +2600,7 @@ class Mission
 			id=891;
 			type="Land_CamoConcreteWall_01_l_4m_v2_F";
 		};
-		class Item85
+		class Item82
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -6553,7 +2656,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item86
+		class Item83
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -6610,7 +2713,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item87
+		class Item84
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -6667,7 +2770,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item88
+		class Item85
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -6724,7 +2827,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item89
+		class Item86
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6736,11 +2839,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=896;
 			type="Land_HelipadSquare_F";
 		};
-		class Item90
+		class Item87
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6752,11 +2856,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=897;
 			type="Land_HBarrier_5_F";
 		};
-		class Item91
+		class Item88
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6768,11 +2873,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=898;
 			type="Land_HBarrier_5_F";
 		};
-		class Item92
+		class Item89
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6784,11 +2890,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=899;
 			type="Land_HBarrier_5_F";
 		};
-		class Item93
+		class Item90
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6800,11 +2907,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=900;
 			type="Land_HBarrier_5_F";
 		};
-		class Item94
+		class Item91
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6816,11 +2924,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=901;
 			type="Land_HBarrier_5_F";
 		};
-		class Item95
+		class Item92
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6832,11 +2941,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=902;
 			type="Land_HBarrier_5_F";
 		};
-		class Item96
+		class Item93
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -6893,7 +3003,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item97
+		class Item94
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6909,7 +3019,7 @@ class Mission
 			id=904;
 			type="Land_Cargo_Tower_V2_F";
 		};
-		class Item98
+		class Item95
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6925,7 +3035,7 @@ class Mission
 			id=905;
 			type="Land_Cargo_Tower_V2_F";
 		};
-		class Item99
+		class Item96
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6942,7 +3052,7 @@ class Mission
 			type="Land_Cargo_Tower_V2_ruins_F";
 			atlOffset=-0.14894104;
 		};
-		class Item100
+		class Item97
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6958,7 +3068,7 @@ class Mission
 			id=907;
 			type="Land_Cargo_HQ_V2_F";
 		};
-		class Item101
+		class Item98
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6975,7 +3085,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=0.030258179;
 		};
-		class Item102
+		class Item99
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6992,7 +3102,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=0.030258179;
 		};
-		class Item103
+		class Item100
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7009,7 +3119,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=0.030258179;
 		};
-		class Item104
+		class Item101
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -7064,7 +3174,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item105
+		class Item102
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7076,11 +3186,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=912;
 			type="Land_HelipadSquare_F";
 		};
-		class Item106
+		class Item103
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7092,12 +3203,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=915;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.02041626;
 		};
-		class Item107
+		class Item104
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7109,11 +3221,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=916;
 			type="Land_HBarrier_5_F";
 		};
-		class Item108
+		class Item105
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -7168,7 +3281,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item109
+		class Item106
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7184,7 +3297,7 @@ class Mission
 			id=918;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item110
+		class Item107
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -7238,7 +3351,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item111
+		class Item108
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7255,7 +3368,7 @@ class Mission
 			type="Land_WoodenWindBreak_01_F";
 			atlOffset=0.0048522949;
 		};
-		class Item112
+		class Item109
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7272,7 +3385,7 @@ class Mission
 			type="Land_WoodenWindBreak_01_F";
 			atlOffset=0.00044250488;
 		};
-		class Item113
+		class Item110
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7288,7 +3401,7 @@ class Mission
 			id=922;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item114
+		class Item111
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7300,11 +3413,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=923;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item115
+		class Item112
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7316,12 +3430,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=924;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item116
+		class Item113
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7333,12 +3448,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=925;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item117
+		class Item114
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7350,11 +3466,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=926;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item118
+		class Item115
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7366,11 +3483,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=927;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item119
+		class Item116
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7382,12 +3500,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=928;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item120
+		class Item117
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7399,11 +3518,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=929;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item121
+		class Item118
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7415,11 +3535,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=930;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item122
+		class Item119
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7431,11 +3552,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=931;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item123
+		class Item120
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7446,11 +3568,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=932;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item124
+		class Item121
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7461,11 +3584,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=933;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item125
+		class Item122
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7477,11 +3601,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=934;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item126
+		class Item123
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7493,12 +3618,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=935;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item127
+		class Item124
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7510,11 +3636,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=936;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item128
+		class Item125
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7526,12 +3653,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=937;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item129
+		class Item126
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7543,11 +3671,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=938;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item130
+		class Item127
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7559,11 +3688,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=939;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item131
+		class Item128
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7575,11 +3705,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=940;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item132
+		class Item129
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7591,11 +3722,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=941;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item133
+		class Item130
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7607,11 +3739,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=942;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item134
+		class Item131
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7623,11 +3756,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=943;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item135
+		class Item132
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7639,11 +3773,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=944;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item136
+		class Item133
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7655,11 +3790,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=945;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item137
+		class Item134
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7671,11 +3807,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=946;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item138
+		class Item135
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7687,12 +3824,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=947;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item139
+		class Item136
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7704,11 +3842,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=948;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item140
+		class Item137
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7720,12 +3859,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=949;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item141
+		class Item138
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7741,7 +3881,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.25;
 		};
-		class Item142
+		class Item139
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7753,11 +3893,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=951;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item143
+		class Item140
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7769,11 +3910,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=952;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item144
+		class Item141
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7785,11 +3927,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=953;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item145
+		class Item142
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7801,12 +3944,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=954;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item146
+		class Item143
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7818,11 +3962,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=955;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item147
+		class Item144
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7834,11 +3979,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=956;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item148
+		class Item145
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7850,11 +3996,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=957;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item149
+		class Item146
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7870,7 +4017,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.25;
 		};
-		class Item150
+		class Item147
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7887,7 +4034,7 @@ class Mission
 			type="Land_TTowerSmall_1_F";
 			atlOffset=0.11544037;
 		};
-		class Item151
+		class Item148
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7903,7 +4050,7 @@ class Mission
 			id=960;
 			type="Land_TTowerSmall_2_F";
 		};
-		class Item152
+		class Item149
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7920,7 +4067,7 @@ class Mission
 			type="Land_Medevac_house_V1_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item153
+		class Item150
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7936,7 +4083,7 @@ class Mission
 			id=962;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item154
+		class Item151
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7952,7 +4099,7 @@ class Mission
 			id=963;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item155
+		class Item152
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7969,7 +4116,7 @@ class Mission
 			type="Land_Cargo_House_V2_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item156
+		class Item153
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7984,7 +4131,7 @@ class Mission
 			id=965;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item157
+		class Item154
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8000,7 +4147,7 @@ class Mission
 			id=966;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item158
+		class Item155
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8015,7 +4162,7 @@ class Mission
 			id=967;
 			type="Land_Cargo_House_V2_F";
 		};
-		class Item159
+		class Item156
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8026,12 +4173,14 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=968;
 			type="Land_Cargo40_orange_F";
 			atlOffset=0.15374756;
 		};
-		class Item160
+		class Item157
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -8087,7 +4236,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item161
+		class Item158
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8097,12 +4246,14 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=972;
 			type="Land_Cargo20_grey_F";
 			atlOffset=2.489975;
 		};
-		class Item162
+		class Item159
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8113,12 +4264,14 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=977;
 			type="Land_Cargo40_light_green_F";
 			atlOffset=0.1780014;
 		};
-		class Item163
+		class Item160
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -8173,7 +4326,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item164
+		class Item161
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -8227,7 +4380,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item165
+		class Item162
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -8282,7 +4435,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item166
+		class Item163
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8298,7 +4451,7 @@ class Mission
 			id=981;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item167
+		class Item164
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -8353,7 +4506,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item168
+		class Item165
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8369,7 +4522,7 @@ class Mission
 			id=983;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item169
+		class Item166
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8386,7 +4539,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=0.095653534;
 		};
-		class Item170
+		class Item167
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8403,7 +4556,7 @@ class Mission
 			type="Land_BarGate_01_open_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item171
+		class Item168
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8419,7 +4572,7 @@ class Mission
 			id=987;
 			type="Land_BagFence_01_short_green_F";
 		};
-		class Item172
+		class Item169
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8435,7 +4588,7 @@ class Mission
 			id=988;
 			type="Land_BagFence_01_short_green_F";
 		};
-		class Item173
+		class Item170
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8451,7 +4604,7 @@ class Mission
 			id=991;
 			type="Land_Cargo_Tower_V2_F";
 		};
-		class Item174
+		class Item171
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8467,7 +4620,7 @@ class Mission
 			id=992;
 			type="Land_Cargo_Tower_V2_F";
 		};
-		class Item175
+		class Item172
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8484,7 +4637,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=4.850193;
 		};
-		class Item176
+		class Item173
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8500,7 +4653,7 @@ class Mission
 			id=994;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item177
+		class Item174
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8517,7 +4670,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=0.017974854;
 		};
-		class Item178
+		class Item175
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8534,7 +4687,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=0.017974854;
 		};
-		class Item179
+		class Item176
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8551,7 +4704,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=-1.8950119;
 		};
-		class Item180
+		class Item177
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8567,7 +4720,7 @@ class Mission
 			id=998;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item181
+		class Item178
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8583,7 +4736,7 @@ class Mission
 			id=999;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item182
+		class Item179
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8595,11 +4748,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1020;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item183
+		class Item180
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8611,11 +4765,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1026;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item184
+		class Item181
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8627,11 +4782,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1027;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item185
+		class Item182
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8643,11 +4799,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1028;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item186
+		class Item183
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8659,12 +4816,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1029;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item187
+		class Item184
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8676,11 +4834,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1031;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item188
+		class Item185
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8692,11 +4851,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1032;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item189
+		class Item186
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8708,11 +4868,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1033;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item190
+		class Item187
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8724,12 +4885,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1034;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item191
+		class Item188
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8741,11 +4903,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1035;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item192
+		class Item189
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8761,7 +4924,7 @@ class Mission
 			id=1055;
 			type="Land_TTowerSmall_2_F";
 		};
-		class Item193
+		class Item190
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8777,7 +4940,7 @@ class Mission
 			id=1056;
 			type="Land_Medevac_house_V1_F";
 		};
-		class Item194
+		class Item191
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8793,7 +4956,7 @@ class Mission
 			id=1059;
 			type="Land_Cargo_House_V2_F";
 		};
-		class Item195
+		class Item192
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8810,7 +4973,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item196
+		class Item193
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8826,7 +4989,7 @@ class Mission
 			id=1061;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item197
+		class Item194
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8838,11 +5001,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1066;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item198
+		class Item195
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8854,11 +5018,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1067;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item199
+		class Item196
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8870,11 +5035,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1068;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item200
+		class Item197
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8886,11 +5052,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1069;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item201
+		class Item198
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8902,11 +5069,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1070;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item202
+		class Item199
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8918,11 +5086,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1071;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item203
+		class Item200
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8934,11 +5103,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1072;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item204
+		class Item201
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8950,11 +5120,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1073;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item205
+		class Item202
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8966,11 +5137,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1074;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item206
+		class Item203
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8982,11 +5154,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1075;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item207
+		class Item204
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8998,12 +5171,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1076;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item208
+		class Item205
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9015,11 +5189,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1077;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item209
+		class Item206
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9035,7 +5210,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.31480598;
 		};
-		class Item210
+		class Item207
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9051,7 +5226,7 @@ class Mission
 			id=1079;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item211
+		class Item208
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9067,7 +5242,7 @@ class Mission
 			id=1080;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item212
+		class Item209
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9083,7 +5258,7 @@ class Mission
 			id=1081;
 			type="Land_Cargo_House_V2_F";
 		};
-		class Item213
+		class Item210
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9095,12 +5270,14 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=1082;
 			type="Land_Cargo40_orange_F";
 			atlOffset=-6.1988831e-006;
 		};
-		class Item214
+		class Item211
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9112,12 +5289,14 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=1083;
 			type="Land_Cargo40_red_F";
 			atlOffset=0.017612457;
 		};
-		class Item215
+		class Item212
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9134,7 +5313,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=0.0079727173;
 		};
-		class Item216
+		class Item213
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9146,10 +5325,11 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1093;
 			type="Land_HelipadSquare_F";
-			atlOffset=0.053001404;
+			atlOffset=0.00021743774;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -9174,7 +5354,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item217
+		class Item214
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9190,7 +5370,7 @@ class Mission
 			id=1094;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item218
+		class Item215
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9206,7 +5386,7 @@ class Mission
 			id=1095;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item219
+		class Item216
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9222,7 +5402,7 @@ class Mission
 			id=1097;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item220
+		class Item217
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9238,7 +5418,7 @@ class Mission
 			id=1098;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item221
+		class Item218
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9250,11 +5430,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1100;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item222
+		class Item219
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9270,7 +5451,7 @@ class Mission
 			id=1101;
 			type="Land_BarGate_01_open_F";
 		};
-		class Item223
+		class Item220
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9286,7 +5467,7 @@ class Mission
 			id=1102;
 			type="Land_BagFence_01_long_green_F";
 		};
-		class Item224
+		class Item221
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9302,7 +5483,7 @@ class Mission
 			id=1103;
 			type="Land_BagFence_01_long_green_F";
 		};
-		class Item225
+		class Item222
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9318,7 +5499,7 @@ class Mission
 			id=1104;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item226
+		class Item223
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9334,21 +5515,21 @@ class Mission
 			id=1105;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item227
+		class Item224
 		{
 			dataType="Layer";
 			name="Open Ammo Dump_1";
 			id=1106;
 			atlOffset=-252.33;
 		};
-		class Item228
+		class Item225
 		{
 			dataType="Layer";
 			name="Vehicle Repair_1";
 			id=1131;
 			atlOffset=-252.33;
 		};
-		class Item229
+		class Item226
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9364,7 +5545,7 @@ class Mission
 			id=1524;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item230
+		class Item227
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9380,14 +5561,14 @@ class Mission
 			id=1525;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item231
+		class Item228
 		{
 			dataType="Layer";
 			name="Open Ammo Dump_2";
 			id=1574;
 			atlOffset=-252.33;
 		};
-		class Item232
+		class Item229
 		{
 			dataType="Layer";
 			name="Vehicle Repair_2";
@@ -9495,6 +5676,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2120;
 					type="Land_HBarrier_5_F";
@@ -9530,6 +5712,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2122;
 					type="Land_HBarrier_1_F";
@@ -9547,6 +5730,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2123;
 					type="Land_HBarrier_5_F";
@@ -9564,6 +5748,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2124;
 					type="Land_HBarrier_1_F";
@@ -9581,6 +5766,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2125;
 					type="Land_HBarrier_5_F";
@@ -9598,6 +5784,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2126;
 					type="Land_HBarrier_5_F";
@@ -9615,6 +5802,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2127;
 					type="Land_HBarrier_1_F";
@@ -9649,6 +5837,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2129;
 					type="Land_HBarrier_1_F";
@@ -9674,7 +5863,7 @@ class Mission
 			id=1599;
 			atlOffset=0.0049133301;
 		};
-		class Item233
+		class Item230
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9686,11 +5875,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2003;
 			type="Land_HBarrier_5_F";
 		};
-		class Item234
+		class Item231
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9702,11 +5892,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2004;
 			type="Land_HBarrier_5_F";
 		};
-		class Item235
+		class Item232
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9718,11 +5909,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2005;
 			type="Land_HBarrier_5_F";
 		};
-		class Item236
+		class Item233
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9734,11 +5926,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2006;
 			type="Land_HBarrier_5_F";
 		};
-		class Item237
+		class Item234
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9750,11 +5943,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2007;
 			type="Land_HBarrier_5_F";
 		};
-		class Item238
+		class Item235
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9766,11 +5960,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2008;
 			type="Land_HBarrier_5_F";
 		};
-		class Item239
+		class Item236
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9782,11 +5977,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2009;
 			type="Land_HBarrier_5_F";
 		};
-		class Item240
+		class Item237
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9798,11 +5994,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2010;
 			type="Land_HBarrier_5_F";
 		};
-		class Item241
+		class Item238
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9814,11 +6011,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2011;
 			type="Land_HBarrier_5_F";
 		};
-		class Item242
+		class Item239
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9830,11 +6028,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2012;
 			type="Land_HBarrier_5_F";
 		};
-		class Item243
+		class Item240
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9846,11 +6045,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2013;
 			type="Land_HBarrier_5_F";
 		};
-		class Item244
+		class Item241
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9862,12 +6062,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2014;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item245
+		class Item242
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9879,11 +6080,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2015;
 			type="Land_HBarrier_5_F";
 		};
-		class Item246
+		class Item243
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9895,12 +6097,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2016;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item247
+		class Item244
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9912,11 +6115,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2017;
 			type="Land_HBarrier_5_F";
 		};
-		class Item248
+		class Item245
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9928,12 +6132,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2018;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item249
+		class Item246
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9945,11 +6150,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2019;
 			type="Land_HBarrier_5_F";
 		};
-		class Item250
+		class Item247
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9961,11 +6167,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2020;
 			type="Land_HBarrier_5_F";
 		};
-		class Item251
+		class Item248
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9977,11 +6184,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2021;
 			type="Land_HBarrier_5_F";
 		};
-		class Item252
+		class Item249
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9993,11 +6201,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2022;
 			type="Land_HBarrier_5_F";
 		};
-		class Item253
+		class Item250
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10009,11 +6218,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2023;
 			type="Land_HBarrier_5_F";
 		};
-		class Item254
+		class Item251
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10025,11 +6235,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2024;
 			type="Land_HBarrier_5_F";
 		};
-		class Item255
+		class Item252
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10041,11 +6252,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2025;
 			type="Land_HBarrier_5_F";
 		};
-		class Item256
+		class Item253
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10057,11 +6269,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2026;
 			type="Land_HBarrier_5_F";
 		};
-		class Item257
+		class Item254
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10073,12 +6286,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2027;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item258
+		class Item255
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10095,7 +6309,7 @@ class Mission
 			type="Land_PortableLight_single_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item259
+		class Item256
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10111,7 +6325,7 @@ class Mission
 			id=2031;
 			type="Land_PortableLight_single_F";
 		};
-		class Item260
+		class Item257
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10122,12 +6336,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2033;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.75;
 		};
-		class Item261
+		class Item258
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10139,12 +6354,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2035;
 			type="Land_HelipadSquare_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item262
+		class Item259
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10156,10 +6372,136 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=2045;
 			type="PortableHelipadLight_01_green_F";
 			atlOffset=-6.1035156e-005;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item260
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={9867.7725,181.0589,3940.6455};
+				angles[]={6.278389,4.7920895,6.2799835};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
+			};
+			id=2046;
+			type="PortableHelipadLight_01_green_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item261
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={9873.0469,181.04066,3934.4561};
+				angles[]={0,3.221293,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
+			};
+			id=2047;
+			type="PortableHelipadLight_01_green_F";
+			atlOffset=-1.5258789e-005;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item262
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={9879.2363,181.04068,3939.7305};
+				angles[]={0,1.6504965,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
+			};
+			id=2048;
+			type="PortableHelipadLight_01_green_F";
 			class CustomAttributes
 			{
 				class Attribute0
@@ -10189,16 +6531,19 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9867.7725,181.0589,3940.6455};
-				angles[]={6.278389,4.7920895,6.2799835};
+				position[]={9868.2305,181.189,3946.3777};
+				angles[]={6.2464013,5.5774879,6.2416096};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2046;
+			id=2049;
 			type="PortableHelipadLight_01_green_F";
+			atlOffset=-0.00019836426;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -10228,17 +6573,19 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9873.0469,181.04066,3934.4561};
-				angles[]={0,3.221293,0};
+				position[]={9867.3145,181.04759,3934.9138};
+				angles[]={0,4.0066915,6.2784014};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2047;
+			id=2050;
 			type="PortableHelipadLight_01_green_F";
-			atlOffset=-1.5258789e-005;
+			atlOffset=3.0517578e-005;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -10268,15 +6615,17 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9879.2363,181.04068,3939.7305};
-				angles[]={0,1.6504965,0};
+				position[]={9878.7783,181.04068,3933.9983};
+				angles[]={0,2.435895,0};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2048;
+			id=2051;
 			type="PortableHelipadLight_01_green_F";
 			class CustomAttributes
 			{
@@ -10307,17 +6656,19 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9868.2305,181.189,3946.3777};
-				angles[]={6.2464013,5.5774879,6.2416096};
+				position[]={9879.6943,181.04817,3945.4622};
+				angles[]={0,0.86509848,6.2784014};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2049;
+			id=2052;
 			type="PortableHelipadLight_01_green_F";
-			atlOffset=-0.00019836426;
+			atlOffset=3.0517578e-005;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -10347,17 +6698,19 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9867.3145,181.04759,3934.9138};
-				angles[]={0,4.0066915,6.2784014};
+				position[]={9871.7529,181.03548,3918.2581};
+				angles[]={0,0.079700232,0.001544081};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2050;
+			id=2053;
 			type="PortableHelipadLight_01_green_F";
-			atlOffset=3.0517578e-005;
+			atlOffset=-1.5258789e-005;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -10387,16 +6740,19 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9878.7783,181.04068,3933.9983};
-				angles[]={0,2.435895,0};
+				position[]={9865.5635,181.01108,3912.9841};
+				angles[]={6.2816033,4.7920895,0.006394445};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2051;
+			id=2054;
 			type="PortableHelipadLight_01_green_F";
+			atlOffset=1.5258789e-005;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -10426,17 +6782,19 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9879.6943,181.04817,3945.4622};
-				angles[]={0,0.86509848,6.2784014};
+				position[]={9870.8369,181.00174,3906.7947};
+				angles[]={6.2751846,3.221293,0.0080009829};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2052;
+			id=2055;
 			type="PortableHelipadLight_01_green_F";
-			atlOffset=3.0517578e-005;
+			atlOffset=1.5258789e-005;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -10466,17 +6824,18 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9871.7529,181.03548,3918.2581};
-				angles[]={0,0.079700232,0.001544081};
+				position[]={9877.0264,181.04068,3912.0686};
+				angles[]={0,1.6504965,0};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2053;
+			id=2056;
 			type="PortableHelipadLight_01_green_F";
-			atlOffset=-1.5258789e-005;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -10506,15 +6865,17 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9865.5635,181.01108,3912.9841};
-				angles[]={6.2816033,4.7920895,0.006394445};
+				position[]={9866.0215,181.01759,3918.7158};
+				angles[]={0,5.5774879,0.004784164};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2054;
+			id=2057;
 			type="PortableHelipadLight_01_green_F";
 			atlOffset=1.5258789e-005;
 			class CustomAttributes
@@ -10546,17 +6907,18 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9870.8369,181.00174,3906.7947};
-				angles[]={6.2751846,3.221293,0.0080009829};
+				position[]={9865.1055,180.98228,3907.2524};
+				angles[]={6.2816033,4.0066915,0};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2055;
+			id=2058;
 			type="PortableHelipadLight_01_green_F";
-			atlOffset=1.5258789e-005;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -10586,15 +6948,17 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9877.0264,181.04068,3912.0686};
-				angles[]={0,1.6504965,0};
+				position[]={9876.5693,181.03333,3906.3367};
+				angles[]={6.2816033,2.435895,0.0015822123};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2056;
+			id=2059;
 			type="PortableHelipadLight_01_green_F";
 			class CustomAttributes
 			{
@@ -10625,17 +6989,18 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9866.0215,181.01759,3918.7158};
-				angles[]={0,5.5774879,0.004784164};
+				position[]={9877.4844,181.04068,3917.8003};
+				angles[]={0,0.86509848,0};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2057;
+			id=2060;
 			type="PortableHelipadLight_01_green_F";
-			atlOffset=1.5258789e-005;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -10665,123 +7030,6 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9865.1055,180.98228,3907.2524};
-				angles[]={6.2816033,4.0066915,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=2058;
-			type="PortableHelipadLight_01_green_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item276
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={9876.5693,181.03333,3906.3367};
-				angles[]={6.2816033,2.435895,0.0015822123};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=2059;
-			type="PortableHelipadLight_01_green_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item277
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={9877.4844,181.04068,3917.8003};
-				angles[]={0,0.86509848,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=2060;
-			type="PortableHelipadLight_01_green_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item278
-		{
-			dataType="Object";
-			class PositionInfo
-			{
 				position[]={9949.5811,181.4864,3855.0955};
 				angles[]={6.2703872,3.1677177,6.2816033};
 			};
@@ -10789,12 +7037,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2070;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item279
+		class Item276
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10806,11 +7055,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2071;
 			type="Land_HBarrier_5_F";
 		};
-		class Item280
+		class Item277
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10822,11 +7072,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2072;
 			type="Land_HBarrier_5_F";
 		};
-		class Item281
+		class Item278
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10838,11 +7089,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2073;
 			type="Land_HBarrier_5_F";
 		};
-		class Item282
+		class Item279
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10854,11 +7106,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2074;
 			type="Land_HBarrier_5_F";
 		};
-		class Item283
+		class Item280
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10870,11 +7123,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2075;
 			type="Land_HBarrier_5_F";
 		};
-		class Item284
+		class Item281
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10886,11 +7140,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2076;
 			type="Land_HBarrier_5_F";
 		};
-		class Item285
+		class Item282
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10902,11 +7157,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2077;
 			type="Land_HBarrier_5_F";
 		};
-		class Item286
+		class Item283
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10918,11 +7174,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2078;
 			type="Land_HBarrier_5_F";
 		};
-		class Item287
+		class Item284
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10934,11 +7191,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2079;
 			type="Land_HBarrier_5_F";
 		};
-		class Item288
+		class Item285
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10950,11 +7208,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2080;
 			type="Land_HBarrier_5_F";
 		};
-		class Item289
+		class Item286
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10966,11 +7225,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2081;
 			type="Land_HBarrier_5_F";
 		};
-		class Item290
+		class Item287
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10982,11 +7242,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2082;
 			type="Land_HBarrier_5_F";
 		};
-		class Item291
+		class Item288
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10998,11 +7259,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2083;
 			type="Land_HBarrier_5_F";
 		};
-		class Item292
+		class Item289
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11014,11 +7276,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2084;
 			type="Land_HBarrier_5_F";
 		};
-		class Item293
+		class Item290
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11030,11 +7293,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2085;
 			type="Land_HBarrier_5_F";
 		};
-		class Item294
+		class Item291
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11046,11 +7310,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2086;
 			type="Land_HBarrier_5_F";
 		};
-		class Item295
+		class Item292
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11062,11 +7327,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2087;
 			type="Land_HBarrier_5_F";
 		};
-		class Item296
+		class Item293
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11078,11 +7344,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2088;
 			type="Land_HBarrier_5_F";
 		};
-		class Item297
+		class Item294
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11094,12 +7361,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2089;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item298
+		class Item295
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11111,11 +7379,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2090;
 			type="Land_HBarrier_5_F";
 		};
-		class Item299
+		class Item296
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11127,11 +7396,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2091;
 			type="Land_HBarrier_5_F";
 		};
-		class Item300
+		class Item297
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11143,11 +7413,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2092;
 			type="Land_HBarrier_5_F";
 		};
-		class Item301
+		class Item298
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11159,11 +7430,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2093;
 			type="Land_HBarrier_5_F";
 		};
-		class Item302
+		class Item299
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11175,12 +7447,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2094;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item303
+		class Item300
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11196,7 +7469,7 @@ class Mission
 			id=2095;
 			type="Land_PortableLight_single_F";
 		};
-		class Item304
+		class Item301
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11212,7 +7485,7 @@ class Mission
 			id=2096;
 			type="Land_PortableLight_single_F";
 		};
-		class Item305
+		class Item302
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11223,12 +7496,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2097;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.75;
 		};
-		class Item306
+		class Item303
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11240,11 +7514,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2098;
 			type="Land_HelipadSquare_F";
 		};
-		class Item307
+		class Item304
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11256,8 +7531,133 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=2099;
+			type="PortableHelipadLight_01_green_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item305
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={9933.1953,180.89841,3869.2783};
+				angles[]={6.2816033,4.7385139,6.2816033};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
+			};
+			id=2100;
+			type="PortableHelipadLight_01_green_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item306
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={9938.793,180.89069,3863.3801};
+				angles[]={0,3.1677177,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
+			};
+			id=2101;
+			type="PortableHelipadLight_01_green_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item307
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={9944.6914,180.89069,3868.9785};
+				angles[]={0,1.5969212,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
+			};
+			id=2102;
 			type="PortableHelipadLight_01_green_F";
 			class CustomAttributes
 			{
@@ -11288,15 +7688,17 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9933.1953,180.89841,3869.2783};
-				angles[]={6.2816033,4.7385139,6.2816033};
+				position[]={9933.3457,180.90398,3875.0269};
+				angles[]={0,5.5239124,6.2799835};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2100;
+			id=2103;
 			type="PortableHelipadLight_01_green_F";
 			class CustomAttributes
 			{
@@ -11327,15 +7729,17 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9938.793,180.89069,3863.3801};
-				angles[]={0,3.1677177,0};
+				position[]={9933.0449,180.89781,3863.5303};
+				angles[]={0,3.9531162,6.2816415};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2101;
+			id=2104;
 			type="PortableHelipadLight_01_green_F";
 			class CustomAttributes
 			{
@@ -11366,15 +7770,17 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9944.6914,180.89069,3868.9785};
-				angles[]={0,1.5969212,0};
+				position[]={9944.541,180.88942,3863.23};
+				angles[]={0,2.3823197,6.2816415};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2102;
+			id=2105;
 			type="PortableHelipadLight_01_green_F";
 			class CustomAttributes
 			{
@@ -11405,15 +7811,17 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9933.3457,180.90398,3875.0269};
-				angles[]={0,5.5239124,6.2799835};
+				position[]={9944.8418,180.89069,3874.7263};
+				angles[]={0,0.8115232,0};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2103;
+			id=2106;
 			type="PortableHelipadLight_01_green_F";
 			class CustomAttributes
 			{
@@ -11444,15 +7852,17 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9933.0449,180.89781,3863.5303};
-				angles[]={0,3.9531162,6.2816415};
+				position[]={9938.3691,180.8793,3847.136};
+				angles[]={0,0.026124954,6.2816033};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2104;
+			id=2107;
 			type="PortableHelipadLight_01_green_F";
 			class CustomAttributes
 			{
@@ -11483,16 +7893,19 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9944.541,180.88942,3863.23};
-				angles[]={0,2.3823197,6.2816415};
+				position[]={9932.4707,180.8643,3841.5383};
+				angles[]={6.2799835,4.7385139,6.2591896};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2105;
+			id=2108;
 			type="PortableHelipadLight_01_green_F";
+			atlOffset=-3.0517578e-005;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -11522,16 +7935,19 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9944.8418,180.89069,3874.7263};
-				angles[]={0,0.8115232,0};
+				position[]={9938.0674,180.76877,3835.6401};
+				angles[]={0.011198638,3.1677177,0.030390549};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2106;
+			id=2109;
 			type="PortableHelipadLight_01_green_F";
+			atlOffset=-1.5258789e-005;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -11561,16 +7977,19 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9938.3691,180.8793,3847.136};
-				angles[]={0,0.026124954,6.2816033};
+				position[]={9943.9658,180.84833,3841.2378};
+				angles[]={6.2703872,1.5969212,0.046366453};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2107;
+			id=2110;
 			type="PortableHelipadLight_01_green_F";
+			atlOffset=-0.00030517578;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -11600,17 +8019,18 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9932.4707,180.8643,3841.5383};
-				angles[]={6.2799835,4.7385139,6.2591896};
+				position[]={9932.6211,180.8963,3847.2864};
+				angles[]={0,5.5239124,6.2799835};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2108;
+			id=2111;
 			type="PortableHelipadLight_01_green_F";
-			atlOffset=-3.0517578e-005;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -11640,17 +8060,18 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9938.0674,180.76877,3835.6401};
-				angles[]={0.011198638,3.1677177,0.030390549};
+				position[]={9932.3203,180.87315,3835.7903};
+				angles[]={0.0095932409,3.9531162,6.2607903};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2109;
+			id=2112;
 			type="PortableHelipadLight_01_green_F";
-			atlOffset=-1.5258789e-005;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -11680,17 +8101,19 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9943.9658,180.84833,3841.2378};
-				angles[]={6.2703872,1.5969212,0.046366453};
+				position[]={9943.8164,180.85744,3835.4895};
+				angles[]={0.031990308,2.3823197,0.03837828};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2110;
+			id=2113;
 			type="PortableHelipadLight_01_green_F";
-			atlOffset=-0.00030517578;
+			atlOffset=-0.00024414063;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -11720,16 +8143,19 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9932.6211,180.8963,3847.2864};
-				angles[]={0,5.5239124,6.2799835};
+				position[]={9944.1162,180.87289,3846.9858};
+				angles[]={6.2816033,0.8115232,6.2751918};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
-			id=2111;
+			id=2114;
 			type="PortableHelipadLight_01_green_F";
+			atlOffset=-4.5776367e-005;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -11759,125 +8185,6 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9932.3203,180.87315,3835.7903};
-				angles[]={0.0095932409,3.9531162,6.2607903};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=2112;
-			type="PortableHelipadLight_01_green_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item321
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={9943.8164,180.85744,3835.4895};
-				angles[]={0.031990308,2.3823197,0.03837828};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=2113;
-			type="PortableHelipadLight_01_green_F";
-			atlOffset=-0.00024414063;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item322
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={9944.1162,180.87289,3846.9858};
-				angles[]={6.2816033,0.8115232,6.2751918};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=2114;
-			type="PortableHelipadLight_01_green_F";
-			atlOffset=-4.5776367e-005;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item323
-		{
-			dataType="Object";
-			class PositionInfo
-			{
 				position[]={9955.875,182.58728,3950.75};
 				angles[]={6.1843095,1.5707964,0.073465936};
 			};
@@ -11885,26 +8192,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2131;
 			type="Land_HBarrier_5_F";
 		};
-		class Item324
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={9932.25,197.77466,3954.375};
-			};
-			side="Empty";
-			class Attributes
-			{
-			};
-			id=2132;
-			type="Land_MedicalTent_01_floor_dark_F";
-			atlOffset=13.34729;
-		};
-		class Item325
+		class Item321
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11921,7 +8214,7 @@ class Mission
 			type="Land_PressureWasher_01_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item326
+		class Item322
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11937,152 +8230,7 @@ class Mission
 			id=2134;
 			type="Land_Cargo_Tower_V2_F";
 		};
-		class Item327
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={9932.25,182.32275,3954.375};
-				angles[]={6.2816033,0,0.011198638};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=2135;
-			type="Land_MedicalTent_01_wdl_generic_open_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item328
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={9917.375,197.75645,3954.875};
-			};
-			side="Empty";
-			class Attributes
-			{
-			};
-			id=2136;
-			type="Land_MedicalTent_01_floor_dark_F";
-			atlOffset=13.338715;
-		};
-		class Item329
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={9917.375,182.30455,3954.875};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=2137;
-			type="Land_MedicalTent_01_wdl_generic_open_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item330
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={9904.0332,197.75645,3955.1919};
-			};
-			side="Empty";
-			class Attributes
-			{
-			};
-			id=2138;
-			type="Land_MedicalTent_01_floor_dark_F";
-			atlOffset=13.338715;
-		};
-		class Item331
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={9904.0332,182.30455,3955.1919};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=2139;
-			type="Land_MedicalTent_01_wdl_generic_open_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item332
+		class Item323
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12098,7 +8246,7 @@ class Mission
 			id=2140;
 			type="Land_Cargo_HQ_V2_F";
 		};
-		class Item333
+		class Item324
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12114,7 +8262,7 @@ class Mission
 			id=2141;
 			type="Land_Cargo_HQ_V2_F";
 		};
-		class Item334
+		class Item325
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12130,7 +8278,7 @@ class Mission
 			id=2142;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item335
+		class Item326
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12146,138 +8294,21 @@ class Mission
 			id=2143;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item336
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={9862.9531,182.17456,3852.1628};
-				angles[]={0,1.6160313,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=2144;
-			type="Land_MedicalTent_01_wdl_generic_open_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item337
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={9864.125,182.17456,3867};
-				angles[]={0,1.6160313,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=2145;
-			type="Land_MedicalTent_01_wdl_generic_open_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item338
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={9865.0449,182.17456,3880.3137};
-				angles[]={0,1.6160313,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=2146;
-			type="Land_MedicalTent_01_wdl_generic_open_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item339
+		class Item327
 		{
 			dataType="Layer";
 			name="Open Ammo Dump_3";
 			id=2147;
 			atlOffset=-252.33;
 		};
-		class Item340
+		class Item328
 		{
 			dataType="Layer";
 			name="Vehicle Repair_3";
 			id=2172;
 			atlOffset=-252.33;
 		};
-		class Item341
+		class Item329
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12289,11 +8320,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2562;
 			type="Land_HBarrier_5_F";
 		};
-		class Item342
+		class Item330
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12305,11 +8337,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2563;
 			type="Land_HBarrier_5_F";
 		};
-		class Item343
+		class Item331
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12321,12 +8354,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2564;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.0730896;
 		};
-		class Item344
+		class Item332
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12337,12 +8371,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2573;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.69500732;
 		};
-		class Item345
+		class Item333
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12353,12 +8388,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2582;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.92480469;
 		};
-		class Item346
+		class Item334
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12374,7 +8410,7 @@ class Mission
 			id=2583;
 			type="Land_Cargo_Tower_V2_F";
 		};
-		class Item347
+		class Item335
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12390,7 +8426,7 @@ class Mission
 			id=2584;
 			type="Land_Cargo_Tower_V2_F";
 		};
-		class Item348
+		class Item336
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12406,7 +8442,7 @@ class Mission
 			id=2585;
 			type="Land_Cargo_Tower_V2_F";
 		};
-		class Item349
+		class Item337
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12418,11 +8454,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2586;
 			type="Land_HBarrier_5_F";
 		};
-		class Item350
+		class Item338
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12434,11 +8471,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2587;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item351
+		class Item339
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12450,11 +8488,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2588;
 			type="Land_HBarrier_5_F";
 		};
-		class Item352
+		class Item340
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12466,12 +8505,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2589;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item353
+		class Item341
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12483,11 +8523,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2590;
 			type="Land_HBarrier_5_F";
 		};
-		class Item354
+		class Item342
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12499,11 +8540,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2591;
 			type="Land_HBarrier_5_F";
 		};
-		class Item355
+		class Item343
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12515,12 +8557,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2592;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item356
+		class Item344
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12532,11 +8575,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2593;
 			type="Land_HBarrier_5_F";
 		};
-		class Item357
+		class Item345
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12548,11 +8592,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2594;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item358
+		class Item346
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12564,11 +8609,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2595;
 			type="Land_HBarrier_5_F";
 		};
-		class Item359
+		class Item347
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12580,12 +8626,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2596;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item360
+		class Item348
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12597,12 +8644,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2597;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item361
+		class Item349
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12614,11 +8662,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2598;
 			type="Land_HBarrier_5_F";
 		};
-		class Item362
+		class Item350
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12630,11 +8679,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2599;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item363
+		class Item351
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12646,11 +8696,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2600;
 			type="Land_HBarrier_5_F";
 		};
-		class Item364
+		class Item352
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12662,11 +8713,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2601;
 			type="Land_HBarrier_5_F";
 		};
-		class Item365
+		class Item353
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12678,12 +8730,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2602;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item366
+		class Item354
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12695,12 +8748,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2603;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item367
+		class Item355
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12712,11 +8766,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2604;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item368
+		class Item356
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12728,11 +8783,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2605;
 			type="Land_HBarrier_5_F";
 		};
-		class Item369
+		class Item357
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12744,11 +8800,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2606;
 			type="Land_HBarrier_5_F";
 		};
-		class Item370
+		class Item358
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12760,11 +8817,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2607;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item371
+		class Item359
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12776,11 +8834,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2608;
 			type="Land_HBarrier_5_F";
 		};
-		class Item372
+		class Item360
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12792,11 +8851,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2609;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item373
+		class Item361
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12808,11 +8868,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2610;
 			type="Land_HBarrier_5_F";
 		};
-		class Item374
+		class Item362
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12824,12 +8885,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2611;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item375
+		class Item363
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12841,11 +8903,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2612;
 			type="Land_HBarrier_5_F";
 		};
-		class Item376
+		class Item364
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12857,12 +8920,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2613;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item377
+		class Item365
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12874,11 +8938,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2614;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item378
+		class Item366
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12890,11 +8955,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2615;
 			type="Land_HBarrier_5_F";
 		};
-		class Item379
+		class Item367
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12906,11 +8972,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2616;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item380
+		class Item368
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12922,12 +8989,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2617;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item381
+		class Item369
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12939,11 +9007,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2618;
 			type="Land_HBarrier_5_F";
 		};
-		class Item382
+		class Item370
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12955,12 +9024,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2619;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item383
+		class Item371
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12972,11 +9042,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2620;
 			type="Land_HBarrier_5_F";
 		};
-		class Item384
+		class Item372
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12988,12 +9059,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2621;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item385
+		class Item373
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13005,11 +9077,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2622;
 			type="Land_HBarrier_5_F";
 		};
-		class Item386
+		class Item374
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13021,11 +9094,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2623;
 			type="Land_HBarrier_5_F";
 		};
-		class Item387
+		class Item375
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13037,11 +9111,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2624;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item388
+		class Item376
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13053,11 +9128,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2625;
 			type="Land_HBarrier_5_F";
 		};
-		class Item389
+		class Item377
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13069,12 +9145,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2626;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item390
+		class Item378
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13086,12 +9163,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2627;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item391
+		class Item379
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13103,12 +9181,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2628;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item392
+		class Item380
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13120,12 +9199,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2629;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item393
+		class Item381
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13137,11 +9217,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2630;
 			type="Land_HBarrier_5_F";
 		};
-		class Item394
+		class Item382
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13153,12 +9234,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2631;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item395
+		class Item383
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13170,12 +9252,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2632;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item396
+		class Item384
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13187,11 +9270,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2633;
 			type="Land_HBarrier_5_F";
 		};
-		class Item397
+		class Item385
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13203,11 +9287,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2634;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item398
+		class Item386
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13219,11 +9304,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2635;
 			type="Land_HBarrier_5_F";
 		};
-		class Item399
+		class Item387
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13235,11 +9321,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2636;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item400
+		class Item388
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13251,11 +9338,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2637;
 			type="Land_HBarrier_5_F";
 		};
-		class Item401
+		class Item389
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13267,12 +9355,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2638;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item402
+		class Item390
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13284,11 +9373,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2639;
 			type="Land_HBarrier_5_F";
 		};
-		class Item403
+		class Item391
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13300,12 +9390,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2640;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item404
+		class Item392
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13317,12 +9408,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2641;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item405
+		class Item393
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13334,12 +9426,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2642;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item406
+		class Item394
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13351,12 +9444,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2643;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item407
+		class Item395
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13368,12 +9462,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2644;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.5776367e-005;
 		};
-		class Item408
+		class Item396
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13385,12 +9480,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2645;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item409
+		class Item397
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13402,11 +9498,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2646;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item410
+		class Item398
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13418,12 +9515,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2647;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item411
+		class Item399
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13435,12 +9533,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2648;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item412
+		class Item400
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13452,12 +9551,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2649;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item413
+		class Item401
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13469,12 +9569,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2650;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item414
+		class Item402
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13486,12 +9587,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2651;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item415
+		class Item403
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13503,12 +9605,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2652;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item416
+		class Item404
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13520,12 +9623,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2653;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item417
+		class Item405
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13537,12 +9641,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2654;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item418
+		class Item406
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13554,11 +9659,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2655;
 			type="Land_HBarrier_5_F";
 		};
-		class Item419
+		class Item407
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13570,11 +9676,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2656;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item420
+		class Item408
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13586,12 +9693,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2657;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item421
+		class Item409
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13603,12 +9711,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2658;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item422
+		class Item410
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13620,12 +9729,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2659;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item423
+		class Item411
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13637,12 +9747,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2660;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item424
+		class Item412
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13654,12 +9765,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2661;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item425
+		class Item413
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13671,11 +9783,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2662;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item426
+		class Item414
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13687,12 +9800,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2663;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item427
+		class Item415
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13704,12 +9818,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2664;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.5776367e-005;
 		};
-		class Item428
+		class Item416
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13721,12 +9836,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2665;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item429
+		class Item417
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13738,12 +9854,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2666;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item430
+		class Item418
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13755,11 +9872,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2667;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item431
+		class Item419
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13771,11 +9889,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2668;
 			type="Land_HBarrier_5_F";
 		};
-		class Item432
+		class Item420
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13787,12 +9906,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2669;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item433
+		class Item421
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13804,12 +9924,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2670;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item434
+		class Item422
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13821,11 +9942,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2671;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item435
+		class Item423
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13837,11 +9959,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2672;
 			type="Land_HBarrier_5_F";
 		};
-		class Item436
+		class Item424
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13853,12 +9976,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2673;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item437
+		class Item425
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13870,12 +9994,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2674;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item438
+		class Item426
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13887,11 +10012,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2675;
 			type="Land_HBarrier_5_F";
 		};
-		class Item439
+		class Item427
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13903,12 +10029,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2676;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item440
+		class Item428
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13920,11 +10047,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2677;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item441
+		class Item429
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13936,12 +10064,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2678;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item442
+		class Item430
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13953,12 +10082,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2679;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item443
+		class Item431
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13970,12 +10100,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2680;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item444
+		class Item432
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13987,12 +10118,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2681;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item445
+		class Item433
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14004,12 +10136,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2682;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item446
+		class Item434
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14021,12 +10154,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2683;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item447
+		class Item435
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14038,11 +10172,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2684;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item448
+		class Item436
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14054,11 +10189,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2685;
 			type="Land_HBarrier_5_F";
 		};
-		class Item449
+		class Item437
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14070,11 +10206,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2686;
 			type="Land_HBarrier_5_F";
 		};
-		class Item450
+		class Item438
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14086,11 +10223,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2687;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item451
+		class Item439
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14102,12 +10240,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2688;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item452
+		class Item440
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14119,11 +10258,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2689;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item453
+		class Item441
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14135,12 +10275,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2690;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item454
+		class Item442
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14152,11 +10293,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2693;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item455
+		class Item443
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14168,11 +10310,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2694;
 			type="Land_HBarrier_5_F";
 		};
-		class Item456
+		class Item444
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14184,12 +10327,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2695;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item457
+		class Item445
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14201,11 +10345,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2696;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item458
+		class Item446
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14217,12 +10362,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2697;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item459
+		class Item447
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14234,11 +10380,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2698;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item460
+		class Item448
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14250,12 +10397,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2699;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item461
+		class Item449
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14267,11 +10415,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2700;
 			type="Land_HBarrier_5_F";
 		};
-		class Item462
+		class Item450
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14283,12 +10432,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2701;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item463
+		class Item451
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14300,11 +10450,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2702;
 			type="Land_HBarrier_5_F";
 		};
-		class Item464
+		class Item452
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14316,11 +10467,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2703;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item465
+		class Item453
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14332,11 +10484,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2704;
 			type="Land_HBarrier_5_F";
 		};
-		class Item466
+		class Item454
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14348,11 +10501,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2705;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item467
+		class Item455
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14364,12 +10518,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2706;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item468
+		class Item456
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14381,11 +10536,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2707;
 			type="Land_HBarrier_5_F";
 		};
-		class Item469
+		class Item457
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14397,11 +10553,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2708;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item470
+		class Item458
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14413,12 +10570,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2709;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item471
+		class Item459
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14430,12 +10588,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2710;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item472
+		class Item460
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14447,11 +10606,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2711;
 			type="Land_HBarrier_5_F";
 		};
-		class Item473
+		class Item461
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14463,12 +10623,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2712;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item474
+		class Item462
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14480,12 +10641,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2713;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item475
+		class Item463
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14497,11 +10659,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2714;
 			type="Land_HBarrier_5_F";
 		};
-		class Item476
+		class Item464
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14513,12 +10676,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2715;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item477
+		class Item465
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14530,12 +10694,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2716;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item478
+		class Item466
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -14592,7 +10757,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item479
+		class Item467
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -14649,7 +10814,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item480
+		class Item468
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -14706,7 +10871,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item481
+		class Item469
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -14763,7 +10928,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item482
+		class Item470
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -14820,7 +10985,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item483
+		class Item471
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14832,12 +10997,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2722;
 			type="Land_HBarrier_5_F";
 			atlOffset=-0.054992676;
 		};
-		class Item484
+		class Item472
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14849,12 +11015,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2723;
 			type="Land_HBarrier_5_F";
 			atlOffset=-0.054992676;
 		};
-		class Item485
+		class Item473
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14866,12 +11033,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2724;
 			type="Land_HBarrier_5_F";
 			atlOffset=-0.054992676;
 		};
-		class Item486
+		class Item474
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14882,12 +11050,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2733;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.69500732;
 		};
-		class Item487
+		class Item475
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14898,12 +11067,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2742;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.64001465;
 		};
-		class Item488
+		class Item476
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14919,7 +11089,7 @@ class Mission
 			id=2743;
 			type="Land_Cargo_Tower_V2_F";
 		};
-		class Item489
+		class Item477
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14931,11 +11101,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2745;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item490
+		class Item478
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14947,11 +11118,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2747;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item491
+		class Item479
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14963,11 +11135,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2750;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item492
+		class Item480
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14979,11 +11152,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2752;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item493
+		class Item481
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14995,11 +11169,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2754;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item494
+		class Item482
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15011,11 +11186,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2757;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item495
+		class Item483
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15027,11 +11203,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2760;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item496
+		class Item484
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15043,12 +11220,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2762;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item497
+		class Item485
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15060,11 +11238,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2764;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item498
+		class Item486
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15076,11 +11255,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2765;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item499
+		class Item487
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15092,11 +11272,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2766;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item500
+		class Item488
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15108,11 +11289,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2767;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item501
+		class Item489
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15124,11 +11306,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2768;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item502
+		class Item490
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15140,11 +11323,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2769;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item503
+		class Item491
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15156,11 +11340,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2770;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item504
+		class Item492
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15172,12 +11357,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2771;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item505
+		class Item493
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15189,11 +11375,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2772;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item506
+		class Item494
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15205,11 +11392,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2773;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item507
+		class Item495
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15221,11 +11409,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2774;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item508
+		class Item496
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15237,11 +11426,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2775;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item509
+		class Item497
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15253,11 +11443,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2776;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item510
+		class Item498
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15269,11 +11460,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2777;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item511
+		class Item499
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15285,11 +11477,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2778;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item512
+		class Item500
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15301,11 +11494,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2779;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item513
+		class Item501
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15317,11 +11511,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2780;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item514
+		class Item502
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15333,11 +11528,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2781;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item515
+		class Item503
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15353,7 +11549,7 @@ class Mission
 			id=2782;
 			type="Land_Mil_WiredFence_Gate_F";
 		};
-		class Item516
+		class Item504
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15369,7 +11565,7 @@ class Mission
 			id=2783;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item517
+		class Item505
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15386,7 +11582,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=-0.025588989;
 		};
-		class Item518
+		class Item506
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15403,7 +11599,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=-0.025588989;
 		};
-		class Item519
+		class Item507
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15420,7 +11616,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=-0.025588989;
 		};
-		class Item520
+		class Item508
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15437,7 +11633,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=-0.025588989;
 		};
-		class Item521
+		class Item509
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15453,7 +11649,7 @@ class Mission
 			id=2789;
 			type="Land_Cargo_Tower_V2_F";
 		};
-		class Item522
+		class Item510
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15469,7 +11665,7 @@ class Mission
 			id=2790;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item523
+		class Item511
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15485,7 +11681,7 @@ class Mission
 			id=2791;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item524
+		class Item512
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15502,7 +11698,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item525
+		class Item513
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15518,7 +11714,7 @@ class Mission
 			id=2793;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item526
+		class Item514
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15535,74 +11731,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=0.0091171265;
 		};
-		class Item527
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={8906,140.06662,6548.125};
-				angles[]={0.00034526698,2.7269034,0.0075565549};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=2888;
-			type="Land_DeconTent_01_AAF_F";
-		};
-		class Item528
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={8947.3496,139.98642,6567.0693};
-				angles[]={0.00034526698,2.7269034,0.0075565549};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=2889;
-			type="Land_DeconTent_01_AAF_F";
-			atlOffset=0.023544312;
-		};
-		class Item529
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={8926.4697,140.0873,6557.6382};
-				angles[]={6.2660117,5.838604,6.2749715};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=2891;
-			type="Land_MedicalTent_01_aaf_generic_open_F";
-			atlOffset=0.0002746582;
-		};
-		class Item530
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={8926.9014,140.35733,6611.603};
-				angles[]={6.2528124,5.838604,6.2694311};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=2892;
-			type="Land_MedicalTent_01_aaf_generic_open_F";
-			atlOffset=0.0002746582;
-		};
-		class Item531
+		class Item515
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15618,7 +11747,7 @@ class Mission
 			id=2893;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item532
+		class Item516
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15634,7 +11763,7 @@ class Mission
 			id=2894;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item533
+		class Item517
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15650,7 +11779,7 @@ class Mission
 			id=2895;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item534
+		class Item518
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15666,72 +11795,7 @@ class Mission
 			id=2896;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item535
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={11063,187.9892,2444.25};
-				angles[]={6.2719817,3.0360308,6.251195};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=2897;
-			type="Land_DeconTent_01_AAF_F";
-			atlOffset=0.22538757;
-		};
-		class Item536
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={11120.5,185.59541,2455};
-				angles[]={0,6.0400758,6.2496004};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=2898;
-			type="Land_DeconTent_01_AAF_F";
-		};
-		class Item537
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={11100.625,186.58017,2447.625};
-				angles[]={0.011198638,2.8414578,6.2336264};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=2899;
-			type="Land_MedicalTent_01_aaf_generic_open_F";
-		};
-		class Item538
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={11091.5,186.67776,2470.875};
-				angles[]={6.2799835,4.5131998,6.2448072};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=2900;
-			type="Land_MedicalTent_01_aaf_generic_open_F";
-		};
-		class Item539
+		class Item519
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15747,7 +11811,7 @@ class Mission
 			id=2901;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item540
+		class Item520
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15763,7 +11827,7 @@ class Mission
 			id=2902;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item541
+		class Item521
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15779,7 +11843,7 @@ class Mission
 			id=2903;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item542
+		class Item522
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -15836,7 +11900,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item543
+		class Item523
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15852,7 +11916,7 @@ class Mission
 			id=2906;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item544
+		class Item524
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -15863,7 +11927,7 @@ class Mission
 			id=2910;
 			type="Logic";
 		};
-		class Item545
+		class Item525
 		{
 			dataType="Layer";
 			name="Open Ammo Dump_4";
@@ -15953,6 +12017,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2916;
 					type="Land_HBarrier_5_F";
@@ -16167,6 +12232,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2928;
 					type="Land_HBarrier_5_F";
@@ -16220,6 +12286,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2931;
 					type="Land_HBarrier_5_F";
@@ -16237,6 +12304,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2932;
 					type="Land_HBarrier_5_F";
@@ -16254,6 +12322,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2933;
 					type="Land_HBarrier_5_F";
@@ -16271,6 +12340,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2934;
 					type="Land_HBarrier_5_F";
@@ -16297,7 +12367,7 @@ class Mission
 			id=2911;
 			atlOffset=1.3202038;
 		};
-		class Item546
+		class Item526
 		{
 			dataType="Layer";
 			name="Vehicle Repair_4";
@@ -16406,6 +12476,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2942;
 					type="Land_HBarrier_5_F";
@@ -16441,6 +12512,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2944;
 					type="Land_HBarrier_1_F";
@@ -16459,6 +12531,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2945;
 					type="Land_HBarrier_5_F";
@@ -16476,6 +12549,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2946;
 					type="Land_HBarrier_1_F";
@@ -16494,6 +12568,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2947;
 					type="Land_HBarrier_5_F";
@@ -16511,6 +12586,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2948;
 					type="Land_HBarrier_5_F";
@@ -16529,6 +12605,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2949;
 					type="Land_HBarrier_1_F";
@@ -16547,6 +12624,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=2950;
 					type="Land_HBarrier_1_F";
@@ -16573,7 +12651,7 @@ class Mission
 			id=2936;
 			atlOffset=-0.0021696091;
 		};
-		class Item547
+		class Item527
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16585,11 +12663,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2952;
 			type="Land_HBarrier_5_F";
 		};
-		class Item548
+		class Item528
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16601,11 +12680,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2953;
 			type="Land_HBarrier_5_F";
 		};
-		class Item549
+		class Item529
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16617,12 +12697,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2954;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item550
+		class Item530
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16634,12 +12715,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2955;
 			type="Land_HBarrier_5_F";
 			atlOffset=2.7656555e-005;
 		};
-		class Item551
+		class Item531
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16651,12 +12733,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2956;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.4305115e-006;
 		};
-		class Item552
+		class Item532
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16668,12 +12751,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2957;
 			type="Land_HBarrier_5_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item553
+		class Item533
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16685,11 +12769,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2958;
 			type="Land_HBarrier_5_F";
 		};
-		class Item554
+		class Item534
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16701,11 +12786,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2959;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item555
+		class Item535
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16717,11 +12803,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2960;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item556
+		class Item536
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16733,12 +12820,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2961;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.4305115e-006;
 		};
-		class Item557
+		class Item537
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16750,12 +12838,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2962;
 			type="Land_HBarrier_3_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item558
+		class Item538
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16767,12 +12856,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2963;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item559
+		class Item539
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16784,11 +12874,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2964;
 			type="Land_HBarrier_5_F";
 		};
-		class Item560
+		class Item540
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16800,12 +12891,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2965;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item561
+		class Item541
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16817,12 +12909,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2966;
 			type="Land_HBarrier_Big_F";
 			atlOffset=2.8610229e-006;
 		};
-		class Item562
+		class Item542
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16834,12 +12927,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2967;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item563
+		class Item543
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16851,11 +12945,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2968;
 			type="Land_HBarrier_3_F";
 		};
-		class Item564
+		class Item544
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16867,12 +12962,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2969;
 			type="Land_HBarrier_Big_F";
 			atlOffset=2.8610229e-006;
 		};
-		class Item565
+		class Item545
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16884,12 +12980,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2970;
 			type="Land_HBarrier_5_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item566
+		class Item546
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16901,11 +12998,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2971;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item567
+		class Item547
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16917,12 +13015,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2972;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-2.9563904e-005;
 		};
-		class Item568
+		class Item548
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16934,11 +13033,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2973;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item569
+		class Item549
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16950,12 +13050,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2974;
 			type="Land_HBarrier_3_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item570
+		class Item550
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16967,11 +13068,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2975;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item571
+		class Item551
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16983,11 +13085,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2976;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item572
+		class Item552
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16999,12 +13102,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2977;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item573
+		class Item553
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17016,11 +13120,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2978;
 			type="Land_HBarrierWall6_F";
 		};
-		class Item574
+		class Item554
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17032,11 +13137,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2979;
 			type="Land_HBarrier_5_F";
 		};
-		class Item575
+		class Item555
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17052,7 +13158,7 @@ class Mission
 			id=2980;
 			type="Land_Mil_WiredFence_Gate_F";
 		};
-		class Item576
+		class Item556
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17064,12 +13170,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2981;
 			type="Land_HBarrier_5_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item577
+		class Item557
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17081,12 +13188,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2982;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item578
+		class Item558
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17098,11 +13206,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2983;
 			type="Land_HBarrier_5_F";
 		};
-		class Item579
+		class Item559
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17114,11 +13223,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2984;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item580
+		class Item560
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17130,11 +13240,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2985;
 			type="Land_HBarrier_5_F";
 		};
-		class Item581
+		class Item561
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17146,11 +13257,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2986;
 			type="Land_HBarrier_5_F";
 		};
-		class Item582
+		class Item562
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17162,12 +13274,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2987;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item583
+		class Item563
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17179,12 +13292,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2988;
 			type="Land_HBarrier_5_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item584
+		class Item564
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17196,11 +13310,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2989;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item585
+		class Item565
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17212,11 +13327,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2990;
 			type="Land_HBarrier_5_F";
 		};
-		class Item586
+		class Item566
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17228,12 +13344,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2991;
 			type="Land_HBarrier_5_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item587
+		class Item567
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17245,12 +13362,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2992;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item588
+		class Item568
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17262,11 +13380,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2993;
 			type="Land_HBarrier_5_F";
 		};
-		class Item589
+		class Item569
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17278,12 +13397,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2994;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item590
+		class Item570
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17295,12 +13415,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2995;
 			type="Land_HBarrier_5_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item591
+		class Item571
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17312,11 +13433,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2996;
 			type="Land_HBarrier_5_F";
 		};
-		class Item592
+		class Item572
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17328,11 +13450,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2997;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item593
+		class Item573
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17344,11 +13467,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2998;
 			type="Land_HBarrier_5_F";
 		};
-		class Item594
+		class Item574
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17360,12 +13484,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2999;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item595
+		class Item575
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17377,11 +13502,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3000;
 			type="Land_HBarrier_5_F";
 		};
-		class Item596
+		class Item576
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17393,12 +13519,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3001;
 			type="Land_HBarrier_5_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item597
+		class Item577
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17410,12 +13537,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3002;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item598
+		class Item578
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17427,12 +13555,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3003;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item599
+		class Item579
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17444,11 +13573,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3004;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item600
+		class Item580
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17460,52 +13590,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3005;
 			type="Land_HBarrier_3_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item601
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={11323.436,13.722235,8912.2236};
-				angles[]={0.090948731,2.8277617,0.036783949};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=3006;
-			type="Land_MedicalTent_01_NATO_generic_open_F";
-			atlOffset=-9.5367432e-007;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item602
+		class Item581
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17521,7 +13612,7 @@ class Mission
 			id=3007;
 			type="Land_Razorwire_F";
 		};
-		class Item603
+		class Item582
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17537,7 +13628,7 @@ class Mission
 			id=3008;
 			type="Land_Razorwire_F";
 		};
-		class Item604
+		class Item583
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17553,7 +13644,7 @@ class Mission
 			id=3009;
 			type="Land_Razorwire_F";
 		};
-		class Item605
+		class Item584
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17570,7 +13661,7 @@ class Mission
 			type="Land_Razorwire_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item606
+		class Item585
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17587,7 +13678,7 @@ class Mission
 			type="Land_Razorwire_F";
 			atlOffset=-3.1471252e-005;
 		};
-		class Item607
+		class Item586
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17604,7 +13695,7 @@ class Mission
 			type="Land_Razorwire_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item608
+		class Item587
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17616,11 +13707,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3013;
 			type="Land_HBarrier_3_F";
 		};
-		class Item609
+		class Item588
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17636,40 +13728,7 @@ class Mission
 			id=3014;
 			type="Land_LampSolar_F";
 		};
-		class Item610
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={11314.758,29.555788,8908.1963};
-				angles[]={0,5.9693551,0};
-			};
-			side="Empty";
-			class Attributes
-			{
-			};
-			id=3015;
-			type="Land_MedicalTent_01_floor_dark_F";
-			atlOffset=13.827841;
-		};
-		class Item611
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={11323.436,12.496593,8912.2236};
-				angles[]={0.090948731,5.9693551,0.036783949};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=3016;
-			type="Land_MedicalTent_01_floor_dark_F";
-			atlOffset=0.14892101;
-		};
-		class Item612
+		class Item589
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17681,12 +13740,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3017;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item613
+		class Item590
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17703,117 +13763,7 @@ class Mission
 			type="Land_PressureWasher_01_F";
 			atlOffset=-0.0014600754;
 		};
-		class Item614
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={11315.955,12.152332,8916.4834};
-				angles[]={0.10046093,5.9693551,0.036783949};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=3019;
-			type="Land_AirConditioner_03_F";
-			atlOffset=-9.5367432e-007;
-		};
-		class Item615
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={11329.296,12.934837,8913.5391};
-				angles[]={0.098875925,1.2569656,0.035185181};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=3020;
-			type="Land_AirConditioner_02_F";
-		};
-		class Item616
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={11313.924,13.675396,8909.1357};
-				angles[]={0.095706634,2.8277617,0.03358667};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=3021;
-			type="Land_MedicalTent_01_NATO_generic_closed_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="MedSign_Hide";
-					expression="_this animateSource ['MedSign_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="Door_Hide";
-					expression="_this animateSource ['Door_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute2
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=3;
-			};
-		};
-		class Item617
+		class Item591
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17825,11 +13775,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3022;
 			type="Land_HBarrier_5_F";
 		};
-		class Item618
+		class Item592
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17841,12 +13792,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3023;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item619
+		class Item593
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17858,11 +13810,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3024;
 			type="Land_HBarrier_5_F";
 		};
-		class Item620
+		class Item594
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17874,12 +13827,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3025;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-3.6239624e-005;
 		};
-		class Item621
+		class Item595
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17891,11 +13845,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3026;
 			type="Land_HBarrier_5_F";
 		};
-		class Item622
+		class Item596
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17907,12 +13862,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3027;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item623
+		class Item597
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17924,11 +13880,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3028;
 			type="Land_HBarrier_5_F";
 		};
-		class Item624
+		class Item598
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17940,12 +13897,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3029;
 			type="Land_HBarrier_3_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item625
+		class Item599
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17957,11 +13915,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3030;
 			type="Land_HBarrier_5_F";
 		};
-		class Item626
+		class Item600
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17973,11 +13932,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3031;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item627
+		class Item601
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17989,11 +13949,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3032;
 			type="Land_HBarrier_3_F";
 		};
-		class Item628
+		class Item602
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18005,11 +13966,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3033;
 			type="Land_HBarrier_5_F";
 		};
-		class Item629
+		class Item603
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18021,12 +13983,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3034;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item630
+		class Item604
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18038,12 +14001,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3035;
 			type="Land_HBarrier_3_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item631
+		class Item605
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18055,12 +14019,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3036;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item632
+		class Item606
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18072,12 +14037,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3037;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item633
+		class Item607
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18089,12 +14055,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3038;
 			type="Land_HBarrier_3_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item634
+		class Item608
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18106,11 +14073,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3039;
 			type="Land_HBarrier_5_F";
 		};
-		class Item635
+		class Item609
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18122,11 +14090,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3040;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item636
+		class Item610
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18138,11 +14107,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3041;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item637
+		class Item611
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18154,12 +14124,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3042;
 			type="Land_HBarrier_5_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item638
+		class Item612
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18171,12 +14142,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3043;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.9073486e-006;
 		};
-		class Item639
+		class Item613
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18188,12 +14160,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3044;
 			type="Land_HBarrier_5_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item640
+		class Item614
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18205,12 +14178,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3045;
 			type="Land_HBarrier_Big_F";
 			atlOffset=5.7220459e-006;
 		};
-		class Item641
+		class Item615
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18222,12 +14196,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3046;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item642
+		class Item616
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18239,12 +14214,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3047;
 			type="Land_HBarrier_5_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item643
+		class Item617
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18256,12 +14232,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3048;
 			type="Land_HBarrier_5_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item644
+		class Item618
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18273,12 +14250,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3049;
 			type="Land_HBarrier_5_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item645
+		class Item619
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18290,12 +14268,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3050;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item646
+		class Item620
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18307,12 +14286,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3051;
 			type="Land_HBarrier_5_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item647
+		class Item621
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18324,11 +14304,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3052;
 			type="Land_HBarrier_5_F";
 		};
-		class Item648
+		class Item622
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18340,12 +14321,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3053;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item649
+		class Item623
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18357,12 +14339,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3054;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item650
+		class Item624
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18374,12 +14357,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3055;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item651
+		class Item625
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18391,12 +14375,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3056;
 			type="Land_HBarrier_5_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item652
+		class Item626
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18408,12 +14393,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3057;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item653
+		class Item627
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18425,11 +14411,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3058;
 			type="Land_HBarrier_5_F";
 		};
-		class Item654
+		class Item628
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18441,12 +14428,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3059;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item655
+		class Item629
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18458,12 +14446,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3060;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.4305115e-006;
 		};
-		class Item656
+		class Item630
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18475,12 +14464,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3061;
 			type="Land_HBarrier_5_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item657
+		class Item631
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18492,11 +14482,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3062;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item658
+		class Item632
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18508,12 +14499,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3063;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item659
+		class Item633
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18525,12 +14517,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3064;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item660
+		class Item634
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18542,11 +14535,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3065;
 			type="Land_HBarrier_5_F";
 		};
-		class Item661
+		class Item635
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18558,12 +14552,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3066;
 			type="Land_HBarrier_3_F";
 			atlOffset=4.7683716e-006;
 		};
-		class Item662
+		class Item636
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18575,12 +14570,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3067;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item663
+		class Item637
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18592,11 +14588,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3068;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item664
+		class Item638
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18608,12 +14605,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3069;
 			type="Land_HBarrier_5_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item665
+		class Item639
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18625,12 +14623,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3070;
 			type="Land_HBarrier_1_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item666
+		class Item640
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18642,11 +14641,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3071;
 			type="Land_HBarrier_1_F";
 		};
-		class Item667
+		class Item641
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18658,11 +14658,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3072;
 			type="Land_HBarrier_5_F";
 		};
-		class Item668
+		class Item642
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18674,12 +14675,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3073;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item669
+		class Item643
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18691,12 +14693,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3074;
 			type="Land_HBarrier_5_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item670
+		class Item644
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18708,12 +14711,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3075;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item671
+		class Item645
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18725,12 +14729,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3076;
 			type="Land_HBarrier_5_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item672
+		class Item646
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18742,12 +14747,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3077;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item673
+		class Item647
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18759,12 +14765,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3078;
 			type="Land_HBarrier_5_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item674
+		class Item648
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18776,12 +14783,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3079;
 			type="Land_HBarrier_3_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item675
+		class Item649
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18793,11 +14801,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3080;
 			type="Land_HBarrier_5_F";
 		};
-		class Item676
+		class Item650
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18809,12 +14818,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3081;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item677
+		class Item651
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18826,12 +14836,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3082;
 			type="Land_HBarrier_5_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item678
+		class Item652
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18843,12 +14854,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3083;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item679
+		class Item653
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18860,11 +14872,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3084;
 			type="Land_HBarrier_5_F";
 		};
-		class Item680
+		class Item654
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18876,12 +14889,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3085;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item681
+		class Item655
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18897,7 +14911,7 @@ class Mission
 			id=3086;
 			type="Land_MobileRadar_01_radar_F";
 		};
-		class Item682
+		class Item656
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18914,7 +14928,7 @@ class Mission
 			type="Land_MobileRadar_01_generator_F";
 			atlOffset=0.2510004;
 		};
-		class Item683
+		class Item657
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18931,7 +14945,7 @@ class Mission
 			type="Land_Cargo_HQ_V1_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item684
+		class Item658
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18948,7 +14962,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item685
+		class Item659
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18964,7 +14978,7 @@ class Mission
 			id=3090;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item686
+		class Item660
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18981,7 +14995,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item687
+		class Item661
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18998,7 +15012,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item688
+		class Item662
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19009,12 +15023,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3093;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.65579605;
 		};
-		class Item689
+		class Item663
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19026,12 +15041,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3094;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item690
+		class Item664
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19043,12 +15059,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3095;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item691
+		class Item665
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19060,11 +15077,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3096;
 			type="Land_HBarrier_5_F";
 		};
-		class Item692
+		class Item666
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19076,12 +15094,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3097;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item693
+		class Item667
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19093,12 +15112,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3098;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item694
+		class Item668
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19110,12 +15130,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3099;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item695
+		class Item669
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19127,12 +15148,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3100;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item696
+		class Item670
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19144,12 +15166,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3101;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item697
+		class Item671
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19161,12 +15184,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3102;
 			type="Land_HBarrier_5_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item698
+		class Item672
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19178,12 +15202,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3103;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item699
+		class Item673
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19195,11 +15220,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3104;
 			type="Land_HBarrier_5_F";
 		};
-		class Item700
+		class Item674
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19211,12 +15237,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3105;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item701
+		class Item675
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19228,12 +15255,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3106;
 			type="Land_HBarrier_5_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item702
+		class Item676
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19245,11 +15273,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3107;
 			type="Land_HBarrier_3_F";
 		};
-		class Item703
+		class Item677
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19261,11 +15290,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3108;
 			type="Land_HBarrier_5_F";
 		};
-		class Item704
+		class Item678
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19277,12 +15307,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3109;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item705
+		class Item679
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19294,12 +15325,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3110;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item706
+		class Item680
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19311,12 +15343,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3111;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item707
+		class Item681
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19328,12 +15361,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3112;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item708
+		class Item682
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19345,12 +15379,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3113;
 			type="Land_HBarrier_5_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item709
+		class Item683
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19362,12 +15397,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3114;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item710
+		class Item684
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19379,12 +15415,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3115;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item711
+		class Item685
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19396,12 +15433,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3116;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item712
+		class Item686
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19413,12 +15451,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3117;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item713
+		class Item687
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19430,11 +15469,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3118;
 			type="Land_HBarrier_5_F";
 		};
-		class Item714
+		class Item688
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19446,12 +15486,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3119;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item715
+		class Item689
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19463,12 +15504,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3120;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item716
+		class Item690
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19480,12 +15522,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3121;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item717
+		class Item691
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19497,12 +15540,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3122;
 			type="Land_HBarrier_3_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item718
+		class Item692
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19514,12 +15558,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3123;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item719
+		class Item693
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19531,11 +15576,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3124;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item720
+		class Item694
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19547,12 +15593,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3125;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item721
+		class Item695
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19564,12 +15611,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3126;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.5762787e-005;
 		};
-		class Item722
+		class Item696
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19581,12 +15629,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3127;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item723
+		class Item697
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19598,12 +15647,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3128;
 			type="Land_HBarrier_Big_F";
 			atlOffset=5.2452087e-006;
 		};
-		class Item724
+		class Item698
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19615,11 +15665,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3129;
 			type="Land_HBarrier_5_F";
 		};
-		class Item725
+		class Item699
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19631,11 +15682,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3130;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item726
+		class Item700
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19647,12 +15699,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3131;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item727
+		class Item701
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19664,12 +15717,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3132;
 			type="Land_HBarrier_3_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item728
+		class Item702
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19681,11 +15735,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3133;
 			type="Land_HBarrier_3_F";
 		};
-		class Item729
+		class Item703
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19697,12 +15752,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3134;
 			type="Land_HBarrier_3_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item730
+		class Item704
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19714,12 +15770,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3135;
 			type="Land_HBarrier_1_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item731
+		class Item705
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19730,12 +15787,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3136;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.64489794;
 		};
-		class Item732
+		class Item706
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19747,12 +15805,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3137;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item733
+		class Item707
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19764,12 +15823,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3138;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item734
+		class Item708
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19781,11 +15841,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3139;
 			type="Land_HBarrier_5_F";
 		};
-		class Item735
+		class Item709
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19797,12 +15858,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3140;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item736
+		class Item710
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19814,12 +15876,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3141;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item737
+		class Item711
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19831,12 +15894,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3142;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item738
+		class Item712
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19848,11 +15912,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3143;
 			type="Land_HBarrier_5_F";
 		};
-		class Item739
+		class Item713
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19864,12 +15929,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3144;
 			type="Land_HBarrier_5_F";
 			atlOffset=8.1062317e-006;
 		};
-		class Item740
+		class Item714
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19881,12 +15947,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3145;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item741
+		class Item715
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19898,11 +15965,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3146;
 			type="Land_HBarrier_5_F";
 		};
-		class Item742
+		class Item716
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19914,12 +15982,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3147;
 			type="Land_HBarrier_Big_F";
 			atlOffset=8.5830688e-006;
 		};
-		class Item743
+		class Item717
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19931,11 +16000,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3148;
 			type="Land_HBarrier_5_F";
 		};
-		class Item744
+		class Item718
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19947,12 +16017,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3149;
 			type="Land_HBarrier_5_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item745
+		class Item719
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19964,12 +16035,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3150;
 			type="Land_HBarrier_5_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item746
+		class Item720
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19981,12 +16053,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3151;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item747
+		class Item721
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19998,12 +16071,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3152;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.9073486e-006;
 		};
-		class Item748
+		class Item722
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20015,12 +16089,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3153;
 			type="Land_HBarrier_Big_F";
 			atlOffset=2.8610229e-006;
 		};
-		class Item749
+		class Item723
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20036,7 +16111,7 @@ class Mission
 			id=3154;
 			type="Land_Cargo_Tower_V1_F";
 		};
-		class Item750
+		class Item724
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20052,7 +16127,7 @@ class Mission
 			id=3155;
 			type="Land_Cargo_Tower_V1_F";
 		};
-		class Item751
+		class Item725
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20069,7 +16144,7 @@ class Mission
 			type="Land_Cargo_Tower_V1_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item752
+		class Item726
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20080,12 +16155,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3157;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.70659256;
 		};
-		class Item753
+		class Item727
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20096,12 +16172,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3158;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.63049412;
 		};
-		class Item754
+		class Item728
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20112,12 +16189,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3159;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.66751099;
 		};
-		class Item755
+		class Item729
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20128,12 +16206,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3160;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.61739731;
 		};
-		class Item756
+		class Item730
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20150,7 +16229,7 @@ class Mission
 			type="Land_LampAirport_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item757
+		class Item731
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20166,136 +16245,7 @@ class Mission
 			id=3162;
 			type="Land_LampAirport_F";
 		};
-		class Item758
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={11399.243,12.236088,8938.5645};
-				angles[]={0.059130985,1.2382526,6.2639894};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=3163;
-			type="Land_MedicalTent_01_NATO_generic_open_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item759
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={11399.243,14.485369,8938.5645};
-				angles[]={6.0024781,1.2382526,6.145391};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=3164;
-			type="Land_MedicalTent_01_floor_dark_F";
-			atlOffset=0.17053032;
-		};
-		class Item760
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={11412.12,11.615068,8943.0127};
-				angles[]={0.052750662,1.2382526,6.2527947};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=3165;
-			type="Land_MedicalTent_01_NATO_generic_open_F";
-			atlOffset=1.9073486e-006;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item761
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={11412.12,13.908028,8943.0127};
-				angles[]={5.9955802,1.2382526,6.1341295};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=3166;
-			type="Land_MedicalTent_01_floor_dark_F";
-			atlOffset=0.2069521;
-		};
-		class Item762
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={11417.893,10.220989,8948.8223};
-				angles[]={0.054345392,0.45285416,6.2480001};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=3167;
-			type="Land_AirConditioner_04_F";
-		};
-		class Item763
+		class Item732
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20311,7 +16261,7 @@ class Mission
 			id=3168;
 			type="StorageBladder_01_fuel_forest_F";
 		};
-		class Item764
+		class Item733
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20327,7 +16277,7 @@ class Mission
 			id=3169;
 			type="StorageBladder_01_fuel_forest_F";
 		};
-		class Item765
+		class Item734
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20339,12 +16289,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3170;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item766
+		class Item735
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20356,12 +16307,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3171;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item767
+		class Item736
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20373,12 +16325,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3172;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item768
+		class Item737
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20390,12 +16343,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3173;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item769
+		class Item738
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20407,12 +16361,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3174;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item770
+		class Item739
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20428,7 +16383,7 @@ class Mission
 			id=3175;
 			type="Land_LampAirport_F";
 		};
-		class Item771
+		class Item740
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20445,7 +16400,7 @@ class Mission
 			type="Land_LampAirport_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item772
+		class Item741
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20462,7 +16417,7 @@ class Mission
 			type="Land_LampSolar_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item773
+		class Item742
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20474,12 +16429,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3178;
 			type="Land_HBarrier_Big_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item774
+		class Item743
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20491,12 +16447,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3179;
 			type="Land_HBarrier_Big_F";
 			atlOffset=9.5367432e-007;
 		};
-		class Item775
+		class Item744
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20512,7 +16469,7 @@ class Mission
 			id=3180;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item776
+		class Item745
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20528,13 +16485,13 @@ class Mission
 			id=3181;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item777
+		class Item746
 		{
 			dataType="Layer";
 			name="Airfields";
 			class Entities
 			{
-				items=12;
+				items=13;
 				class Item0
 				{
 					dataType="Marker";
@@ -20545,7 +16502,7 @@ class Mission
 					colorName="ColorEAST";
 					a=239.14899;
 					b=151.89774;
-					angle=248.19386;
+					angle=248.19385;
 					id=212;
 					atlOffset=1.3180084;
 				};
@@ -20559,7 +16516,7 @@ class Mission
 					colorName="ColorEAST";
 					a=361.85641;
 					b=148.96893;
-					angle=320.09518;
+					angle=320.09512;
 					id=210;
 					atlOffset=0.15761566;
 				};
@@ -20666,7 +16623,7 @@ class Mission
 					colorName="ColorGreen";
 					a=20.010422;
 					b=8.6266327;
-					angle=90.943764;
+					angle=90.943748;
 					id=3206;
 					atlOffset=-18.179993;
 				};
@@ -20680,7 +16637,7 @@ class Mission
 					colorName="ColorRed";
 					a=50;
 					b=25.348;
-					angle=312.93091;
+					angle=312.93088;
 					id=3203;
 					atlOffset=-0.00019836426;
 				};
@@ -20698,11 +16655,25 @@ class Mission
 					id=3216;
 					atlOffset=-0.00051355362;
 				};
+				class Item12
+				{
+					dataType="Marker";
+					position[]={7818.5342,144.71147,9551.4424};
+					name="airp_2_vehicle_1";
+					markerType="RECTANGLE";
+					type="rectangle";
+					colorName="ColorGreen";
+					a=4.4136686;
+					b=7.3692002;
+					angle=26.459686;
+					id=3292;
+					atlOffset=0.0365448;
+				};
 			};
 			id=3184;
-			atlOffset=-75.780121;
+			atlOffset=-6.9927597;
 		};
-		class Item778
+		class Item747
 		{
 			dataType="Layer";
 			name="Resources";
@@ -20952,7 +16923,7 @@ class Mission
 			id=3185;
 			atlOffset=-48.311417;
 		};
-		class Item779
+		class Item748
 		{
 			dataType="Layer";
 			name="Outposts";
@@ -21303,7 +17274,7 @@ class Mission
 					colorName="ColorGreen";
 					a=17.457001;
 					b=7.158;
-					angle=92.50798;
+					angle=92.507965;
 					id=3220;
 				};
 				class Item26
@@ -21329,7 +17300,7 @@ class Mission
 					colorName="ColorGreen";
 					a=13.047;
 					b=5.342;
-					angle=146.63097;
+					angle=146.63095;
 					id=3213;
 				};
 				class Item28
@@ -21356,7 +17327,7 @@ class Mission
 					colorName="ColorGreen";
 					a=12.536;
 					b=5.2579999;
-					angle=72.349976;
+					angle=72.34996;
 					id=3208;
 					atlOffset=0.00020599365;
 				};
@@ -21384,7 +17355,7 @@ class Mission
 					colorName="ColorGreen";
 					a=20.01;
 					b=8.6269999;
-					angle=50.79599;
+					angle=50.795986;
 					id=3210;
 				};
 				class Item32
@@ -21437,14 +17408,14 @@ class Mission
 					colorName="ColorGreen";
 					a=13.547;
 					b=5.6399999;
-					angle=88.968979;
+					angle=88.968964;
 					id=3223;
 				};
 			};
 			id=3186;
 			atlOffset=46.574249;
 		};
-		class Item780
+		class Item749
 		{
 			dataType="Layer";
 			name="Factories";
@@ -21585,7 +17556,7 @@ class Mission
 					colorName="ColorGreen";
 					a=16.91;
 					b=7.704;
-					angle=51.057987;
+					angle=51.05798;
 					id=3212;
 					atlOffset=0.003200531;
 				};
@@ -21612,7 +17583,7 @@ class Mission
 					colorName="ColorGreen";
 					a=17.457001;
 					b=7.158;
-					angle=155.29495;
+					angle=155.29492;
 					id=3215;
 					atlOffset=-0.00020313263;
 				};
@@ -21647,7 +17618,7 @@ class Mission
 			id=3187;
 			atlOffset=25.882332;
 		};
-		class Item781
+		class Item750
 		{
 			dataType="Layer";
 			name="Roadblocks";
@@ -22290,7 +18261,7 @@ class Mission
 					type="rectangle";
 					a=231.71259;
 					b=81.80806;
-					angle=339.95712;
+					angle=339.95706;
 					id=3183;
 					atlOffset=0.019996643;
 				};
@@ -22298,7 +18269,7 @@ class Mission
 			id=3188;
 			atlOffset=20.586609;
 		};
-		class Item782
+		class Item751
 		{
 			dataType="Layer";
 			name="Old marker";
@@ -22690,9 +18661,9 @@ class Mission
 				};
 			};
 			id=3193;
-			atlOffset=23.501625;
+			atlOffset=6.4507904;
 		};
-		class Item783
+		class Item752
 		{
 			dataType="Layer";
 			name="SeaAttackSpawnPoints";
@@ -22775,7 +18746,7 @@ class Mission
 			id=3194;
 			atlOffset=54.222801;
 		};
-		class Item784
+		class Item753
 		{
 			dataType="Object";
 			class PositionInfo
@@ -22792,7 +18763,7 @@ class Mission
 			type="Land_TentHangar_V1_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item785
+		class Item754
 		{
 			dataType="Object";
 			class PositionInfo
@@ -22808,7 +18779,7 @@ class Mission
 			id=3196;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item786
+		class Item755
 		{
 			dataType="Object";
 			class PositionInfo
@@ -22824,7 +18795,7 @@ class Mission
 			id=3197;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item787
+		class Item756
 		{
 			dataType="Object";
 			class PositionInfo
@@ -22836,12 +18807,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3198;
 			type="Land_HelipadSquare_F";
 			atlOffset=8.392334e-005;
 		};
-		class Item788
+		class Item757
 		{
 			dataType="Object";
 			class PositionInfo
@@ -22853,12 +18825,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3199;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.00024414063;
 		};
-		class Item789
+		class Item758
 		{
 			dataType="Object";
 			class PositionInfo
@@ -22870,12 +18843,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3200;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.074050903;
 		};
-		class Item790
+		class Item759
 		{
 			dataType="Layer";
 			name="Basics";
@@ -22945,7 +18919,7 @@ class Mission
 			id=3207;
 			atlOffset=1.3518803e+012;
 		};
-		class Item791
+		class Item760
 		{
 			dataType="Object";
 			class PositionInfo
@@ -22957,11 +18931,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3228;
 			type="Land_HelipadCircle_F";
 		};
-		class Item792
+		class Item761
 		{
 			dataType="Object";
 			class PositionInfo
@@ -22973,11 +18948,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3229;
 			type="Land_HelipadCircle_F";
+			atlOffset=-1.0154114;
 		};
-		class Item793
+		class Item762
 		{
 			dataType="Object";
 			class PositionInfo
@@ -22988,12 +18965,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3230;
 			type="Land_HelipadCircle_F";
 			atlOffset=1.8399506;
 		};
-		class Item794
+		class Item763
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23005,11 +18983,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3232;
 			type="Land_HelipadCircle_F";
 		};
-		class Item795
+		class Item764
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23021,11 +19000,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3233;
 			type="Land_HelipadCircle_F";
 		};
-		class Item796
+		class Item765
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23037,11 +19017,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3234;
 			type="Land_HelipadCircle_F";
 		};
-		class Item797
+		class Item766
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23057,7 +19038,7 @@ class Mission
 			id=3235;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item798
+		class Item767
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23069,11 +19050,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3236;
 			type="Land_HelipadCircle_F";
 		};
-		class Item799
+		class Item768
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23085,12 +19067,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3238;
 			type="Land_HelipadCircle_F";
 			atlOffset=5.3405762e-005;
 		};
-		class Item800
+		class Item769
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23102,11 +19085,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3239;
 			type="Land_HelipadCircle_F";
+			atlOffset=-1.5735626e-005;
 		};
-		class Item801
+		class Item770
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23118,12 +19103,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3240;
 			type="Land_HelipadCircle_F";
 			atlOffset=2.8610229e-006;
 		};
-		class Item802
+		class Item771
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23135,20 +19121,1094 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=3241;
 			type="Land_HelipadCircle_F";
+		};
+		class Item772
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=38;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={961.62061,80.294884,5566.9243};
+					};
+					side="Independent";
+					flags=3;
+					class Attributes
+					{
+						name="commanderX";
+						description="Default Commaner";
+						isPlayer=1;
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3246;
+					type="I_G_officer_F";
+					atlOffset=2.2093887;
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male04GRE";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1;
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={966.41553,80.733803,5564.2212};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3247;
+					type="I_G_officer_F";
+					atlOffset=1.5630188;
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={966.5542,80.737274,5566.457};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3248;
+					type="I_G_officer_F";
+					atlOffset=1.4959488;
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={966.49658,80.701195,5568.7905};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3249;
+					type="I_G_officer_F";
+					atlOffset=1.405426;
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={966.3335,80.605133,5571.104};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3250;
+					type="I_G_officer_F";
+					atlOffset=1.3078613;
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={966.29248,80.515076,5573.5581};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3251;
+					type="I_G_officer_F";
+					atlOffset=1.2042618;
+				};
+				class Item6
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={966.10693,80.395424,5575.874};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3252;
+					type="I_G_officer_F";
+					atlOffset=1.1147766;
+				};
+				class Item7
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={965.8999,80.26825,5577.7695};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3253;
+					type="I_G_officer_F";
+					atlOffset=1.0294113;
+				};
+				class Item8
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={968.7749,80.944748,5564.3447};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3254;
+					type="I_G_Soldier_F";
+					atlOffset=1.1350403;
+				};
+				class Item9
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={968.77393,80.93531,5566.6841};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3255;
+					type="I_G_Soldier_F";
+					atlOffset=1.0546341;
+				};
+				class Item10
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={968.66748,80.886391,5569.0576};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3256;
+					type="I_G_Soldier_F";
+					atlOffset=0.96520233;
+				};
+				class Item11
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={968.60889,80.803574,5571.2573};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3257;
+					type="I_G_Soldier_F";
+					atlOffset=0.87738037;
+				};
+				class Item12
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={968.40576,80.67601,5573.6797};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3258;
+					type="I_G_Soldier_F";
+					atlOffset=0.78246307;
+				};
+				class Item13
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={968.21826,80.52401,5576.0107};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3259;
+					type="I_G_Soldier_F";
+					atlOffset=0.67633057;
+				};
+				class Item14
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={970.8833,81.13356,5564.3809};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3260;
+					type="I_G_Soldier_AR_F";
+					atlOffset=1.0090256;
+				};
+				class Item15
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={971.04541,81.138344,5566.8208};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3261;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.91348267;
+				};
+				class Item16
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={970.64502,81.057266,5569.2358};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3262;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.8175354;
+				};
+				class Item17
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={970.62158,80.957275,5571.3848};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3263;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.70054626;
+				};
+				class Item18
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={970.42139,80.809837,5573.626};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3264;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.56147766;
+				};
+				class Item19
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={970.33447,80.656685,5576.085};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3265;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.42988586;
+				};
+				class Item20
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={972.97217,81.320419,5564.4604};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3266;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.88265228;
+				};
+				class Item21
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={972.84229,81.299507,5566.7783};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3267;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.79734802;
+				};
+				class Item22
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={972.71826,81.204926,5569.5225};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3268;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.64067841;
+				};
+				class Item23
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={972.54443,81.073097,5571.5313};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3269;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.51522064;
+				};
+				class Item24
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={972.4751,80.937569,5573.7158};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3270;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.35932922;
+				};
+				class Item25
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={972.36963,80.781242,5576.2065};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3271;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.23212433;
+				};
+				class Item26
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={974.49951,81.321732,5564.5381};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3272;
+					type="I_G_medic_F";
+					atlOffset=0.64479828;
+				};
+				class Item27
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={974.32373,81.313004,5566.8179};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3273;
+					type="I_G_medic_F";
+					atlOffset=0.57946014;
+				};
+				class Item28
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={974.28174,81.217323,5569.6895};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3274;
+					type="I_G_medic_F";
+					atlOffset=0.40799713;
+				};
+				class Item29
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={974.19385,81.108696,5571.4961};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3275;
+					type="I_G_medic_F";
+					atlOffset=0.28740692;
+				};
+				class Item30
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={974.01025,80.966675,5573.8555};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3276;
+					type="I_G_medic_F";
+					atlOffset=0.14078522;
+				};
+				class Item31
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={974.021,80.822105,5576.2661};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3277;
+					type="I_G_medic_F";
+					atlOffset=0.0065917969;
+				};
+				class Item32
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={976.30127,81.318184,5564.7031};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3278;
+					type="I_G_engineer_F";
+					atlOffset=0.36595917;
+				};
+				class Item33
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={976.32471,81.31781,5567.0034};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3279;
+					type="I_G_engineer_F";
+					atlOffset=0.27748108;
+				};
+				class Item34
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={976.08252,81.215408,5569.7935};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3280;
+					type="I_G_engineer_F";
+					atlOffset=0.13031006;
+				};
+				class Item35
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={975.82764,81.097946,5571.7412};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3281;
+					type="I_G_engineer_F";
+					atlOffset=0.022331238;
+				};
+				class Item36
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={975.63232,80.963272,5573.9775};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3282;
+					type="I_G_engineer_F";
+					atlOffset=-0.11579895;
+				};
+				class Item37
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={975.52783,80.814873,5576.4468};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=3283;
+					type="I_G_engineer_F";
+					atlOffset=-0.25114441;
+				};
+			};
+			class Attributes
+			{
+			};
+			id=3245;
+			atlOffset=2.2093887;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="Guerillas";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item773
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={8904.125,139.94028,6548.25};
+				angles[]={0,4.224834,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=3284;
+			type="CamoNet_OPFOR_F";
+		};
+		class Item774
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={8926.625,139.86855,6559.125};
+				angles[]={0,1.1843517,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=3285;
+			type="CamoNet_OPFOR_open_F";
+		};
+		class Item775
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={8948.375,139.85318,6568.375};
+				angles[]={0,1.1212085,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=3286;
+			type="CamoNet_OPFOR_F";
+		};
+		class Item776
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={11093.375,186.39807,2472};
+				angles[]={0,2.9576545,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=3287;
+			type="CamoNet_OPFOR_open_F";
+		};
+		class Item777
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={11119.473,185.43359,2458.3208};
+				angles[]={0,2.9576545,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=3288;
+			type="CamoNet_OPFOR_open_F";
+			atlOffset=3.0517578e-005;
+		};
+		class Item778
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={7806.8916,151.14426,9752.0244};
+				angles[]={0.012798273,0,0.033588443};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=3289;
+			type="CamoNet_OPFOR_open_F";
+			atlOffset=0.00076293945;
+		};
+		class Item779
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={7891.25,151.13785,9769.375};
+				angles[]={0.012798273,0,0.033588443};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=3290;
+			type="CamoNet_OPFOR_open_F";
+		};
+		class Item780
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={8030.125,136.17107,9659.125};
+				angles[]={0,3.9002712,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=3291;
+			type="CamoNet_OPFOR_open_F";
+		};
+		class Item781
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={9858.875,181.96223,3853.375};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=3293;
+			type="CamoNet_OPFOR_open_F";
+		};
+		class Item782
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={9859.8965,181.96785,3878.011};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=3294;
+			type="CamoNet_OPFOR_open_F";
+		};
+		class Item783
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={9908.9727,182.10333,3959.6809};
+				angles[]={0,4.8142505,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=3295;
+			type="CamoNet_OPFOR_open_F";
+		};
+		class Item784
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={9929.7227,182.13855,3958.2808};
+				angles[]={0,3.2094893,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=3296;
+			type="CamoNet_OPFOR_open_F";
+			atlOffset=6.1035156e-005;
 		};
 	};
 	class Connections
 	{
 		class LinkIDProvider
 		{
-			nextID=61;
+			nextID=39;
 		};
 		class Links
 		{
-			items=61;
+			items=39;
 			class Item0
 			{
 				linkID=0;
@@ -23162,7 +20222,7 @@ class Mission
 			class Item1
 			{
 				linkID=1;
-				item0=93;
+				item0=3246;
 				item1=820;
 				class CustomData
 				{
@@ -23172,7 +20232,7 @@ class Mission
 			class Item2
 			{
 				linkID=2;
-				item0=97;
+				item0=3247;
 				item1=820;
 				class CustomData
 				{
@@ -23182,7 +20242,7 @@ class Mission
 			class Item3
 			{
 				linkID=3;
-				item0=98;
+				item0=3248;
 				item1=820;
 				class CustomData
 				{
@@ -23192,7 +20252,7 @@ class Mission
 			class Item4
 			{
 				linkID=4;
-				item0=104;
+				item0=3249;
 				item1=820;
 				class CustomData
 				{
@@ -23202,7 +20262,7 @@ class Mission
 			class Item5
 			{
 				linkID=5;
-				item0=120;
+				item0=3250;
 				item1=820;
 				class CustomData
 				{
@@ -23212,7 +20272,7 @@ class Mission
 			class Item6
 			{
 				linkID=6;
-				item0=121;
+				item0=3251;
 				item1=820;
 				class CustomData
 				{
@@ -23222,7 +20282,7 @@ class Mission
 			class Item7
 			{
 				linkID=7;
-				item0=127;
+				item0=3252;
 				item1=820;
 				class CustomData
 				{
@@ -23232,7 +20292,7 @@ class Mission
 			class Item8
 			{
 				linkID=8;
-				item0=133;
+				item0=3253;
 				item1=820;
 				class CustomData
 				{
@@ -23242,7 +20302,7 @@ class Mission
 			class Item9
 			{
 				linkID=9;
-				item0=139;
+				item0=3254;
 				item1=820;
 				class CustomData
 				{
@@ -23252,7 +20312,7 @@ class Mission
 			class Item10
 			{
 				linkID=10;
-				item0=145;
+				item0=3255;
 				item1=820;
 				class CustomData
 				{
@@ -23262,7 +20322,7 @@ class Mission
 			class Item11
 			{
 				linkID=11;
-				item0=151;
+				item0=3256;
 				item1=820;
 				class CustomData
 				{
@@ -23272,7 +20332,7 @@ class Mission
 			class Item12
 			{
 				linkID=12;
-				item0=100;
+				item0=3257;
 				item1=820;
 				class CustomData
 				{
@@ -23282,7 +20342,7 @@ class Mission
 			class Item13
 			{
 				linkID=13;
-				item0=106;
+				item0=3258;
 				item1=820;
 				class CustomData
 				{
@@ -23292,7 +20352,7 @@ class Mission
 			class Item14
 			{
 				linkID=14;
-				item0=111;
+				item0=3259;
 				item1=820;
 				class CustomData
 				{
@@ -23302,7 +20362,7 @@ class Mission
 			class Item15
 			{
 				linkID=15;
-				item0=116;
+				item0=3260;
 				item1=820;
 				class CustomData
 				{
@@ -23312,7 +20372,7 @@ class Mission
 			class Item16
 			{
 				linkID=16;
-				item0=123;
+				item0=3261;
 				item1=820;
 				class CustomData
 				{
@@ -23322,7 +20382,7 @@ class Mission
 			class Item17
 			{
 				linkID=17;
-				item0=129;
+				item0=3262;
 				item1=820;
 				class CustomData
 				{
@@ -23332,7 +20392,7 @@ class Mission
 			class Item18
 			{
 				linkID=18;
-				item0=135;
+				item0=3263;
 				item1=820;
 				class CustomData
 				{
@@ -23342,7 +20402,7 @@ class Mission
 			class Item19
 			{
 				linkID=19;
-				item0=141;
+				item0=3264;
 				item1=820;
 				class CustomData
 				{
@@ -23352,7 +20412,7 @@ class Mission
 			class Item20
 			{
 				linkID=20;
-				item0=147;
+				item0=3265;
 				item1=820;
 				class CustomData
 				{
@@ -23362,7 +20422,7 @@ class Mission
 			class Item21
 			{
 				linkID=21;
-				item0=152;
+				item0=3266;
 				item1=820;
 				class CustomData
 				{
@@ -23372,7 +20432,7 @@ class Mission
 			class Item22
 			{
 				linkID=22;
-				item0=101;
+				item0=3267;
 				item1=820;
 				class CustomData
 				{
@@ -23382,7 +20442,7 @@ class Mission
 			class Item23
 			{
 				linkID=23;
-				item0=107;
+				item0=3268;
 				item1=820;
 				class CustomData
 				{
@@ -23392,7 +20452,7 @@ class Mission
 			class Item24
 			{
 				linkID=24;
-				item0=112;
+				item0=3269;
 				item1=820;
 				class CustomData
 				{
@@ -23402,7 +20462,7 @@ class Mission
 			class Item25
 			{
 				linkID=25;
-				item0=117;
+				item0=3270;
 				item1=820;
 				class CustomData
 				{
@@ -23412,7 +20472,7 @@ class Mission
 			class Item26
 			{
 				linkID=26;
-				item0=124;
+				item0=3271;
 				item1=820;
 				class CustomData
 				{
@@ -23422,7 +20482,7 @@ class Mission
 			class Item27
 			{
 				linkID=27;
-				item0=130;
+				item0=3272;
 				item1=820;
 				class CustomData
 				{
@@ -23432,7 +20492,7 @@ class Mission
 			class Item28
 			{
 				linkID=28;
-				item0=136;
+				item0=3273;
 				item1=820;
 				class CustomData
 				{
@@ -23442,7 +20502,7 @@ class Mission
 			class Item29
 			{
 				linkID=29;
-				item0=142;
+				item0=3274;
 				item1=820;
 				class CustomData
 				{
@@ -23452,7 +20512,7 @@ class Mission
 			class Item30
 			{
 				linkID=30;
-				item0=148;
+				item0=3275;
 				item1=820;
 				class CustomData
 				{
@@ -23462,7 +20522,7 @@ class Mission
 			class Item31
 			{
 				linkID=31;
-				item0=153;
+				item0=3276;
 				item1=820;
 				class CustomData
 				{
@@ -23472,7 +20532,7 @@ class Mission
 			class Item32
 			{
 				linkID=32;
-				item0=102;
+				item0=3277;
 				item1=820;
 				class CustomData
 				{
@@ -23482,7 +20542,7 @@ class Mission
 			class Item33
 			{
 				linkID=33;
-				item0=108;
+				item0=3278;
 				item1=820;
 				class CustomData
 				{
@@ -23492,7 +20552,7 @@ class Mission
 			class Item34
 			{
 				linkID=34;
-				item0=113;
+				item0=3279;
 				item1=820;
 				class CustomData
 				{
@@ -23502,7 +20562,7 @@ class Mission
 			class Item35
 			{
 				linkID=35;
-				item0=118;
+				item0=3280;
 				item1=820;
 				class CustomData
 				{
@@ -23512,7 +20572,7 @@ class Mission
 			class Item36
 			{
 				linkID=36;
-				item0=125;
+				item0=3281;
 				item1=820;
 				class CustomData
 				{
@@ -23522,7 +20582,7 @@ class Mission
 			class Item37
 			{
 				linkID=37;
-				item0=131;
+				item0=3282;
 				item1=820;
 				class CustomData
 				{
@@ -23532,227 +20592,7 @@ class Mission
 			class Item38
 			{
 				linkID=38;
-				item0=137;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item39
-			{
-				linkID=39;
-				item0=143;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item40
-			{
-				linkID=40;
-				item0=149;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item41
-			{
-				linkID=41;
-				item0=154;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item42
-			{
-				linkID=42;
-				item0=103;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item43
-			{
-				linkID=43;
-				item0=109;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item44
-			{
-				linkID=44;
-				item0=114;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item45
-			{
-				linkID=45;
-				item0=119;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item46
-			{
-				linkID=46;
-				item0=126;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item47
-			{
-				linkID=47;
-				item0=132;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item48
-			{
-				linkID=48;
-				item0=138;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item49
-			{
-				linkID=49;
-				item0=144;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item50
-			{
-				linkID=50;
-				item0=150;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item51
-			{
-				linkID=51;
-				item0=99;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item52
-			{
-				linkID=52;
-				item0=105;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item53
-			{
-				linkID=53;
-				item0=110;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item54
-			{
-				linkID=54;
-				item0=115;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item55
-			{
-				linkID=55;
-				item0=122;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item56
-			{
-				linkID=56;
-				item0=128;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item57
-			{
-				linkID=57;
-				item0=134;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item58
-			{
-				linkID=58;
-				item0=140;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item59
-			{
-				linkID=59;
-				item0=146;
-				item1=820;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item60
-			{
-				linkID=60;
-				item0=155;
+				item0=3283;
 				item1=820;
 				class CustomData
 				{

--- a/Map-Templates/Antistasi-Malden.Malden/mission.sqm
+++ b/Map-Templates/Antistasi-Malden.Malden/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=1030;
 	class ItemIDProvider
 	{
-		nextID=8768;
+		nextID=8817;
 	};
 	class MarkerIDProvider
 	{
@@ -16,14 +16,14 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=869;
+		nextID=1040;
 	};
 	class Camera
 	{
-		pos[]={9683.874,332.13535,3695.8391};
-		dir[]={0,-0.70710683,0.70710683};
-		up[]={0,0.70710677,0.70710677};
-		aside[]={0.99999994,0,0};
+		pos[]={8289.8438,38.673866,5978.6899};
+		dir[]={-0.54349416,-0.83919847,0.019481568};
+		up[]={-0.8386578,0.54382408,0.030061338};
+		aside[]={0.035821356,-2.587185e-007,0.99936658};
 	};
 };
 binarizationWanted=0;
@@ -37,7 +37,6 @@ addons[]=
 	"A3_Structures_F_Exp_Military_Flags",
 	"A3_Weapons_F_Ammoboxes",
 	"A3_Modules_F",
-	"A3_Weapons_F",
 	"A3_Structures_F_EPC_Civ_InfoBoards",
 	"A3_Modules_F_Curator_Curator",
 	"A3_Structures_F_Civ_Camping",
@@ -66,20 +65,18 @@ addons[]=
 	"A3_Structures_F_Heli_Furniture",
 	"A3_Structures_F_Ind_AirPort",
 	"A3_Structures_F_Mil_TentHangar",
-	"A3_Structures_F_Enoch_Military_Camps",
-	"A3_Structures_F_Orange_Humanitarian_Camps",
 	"A3_Structures_F_Heli_Ind_Machines",
-	"A3_Props_F_Orange_Humanitarian_Camps",
 	"A3_Structures_F_Enoch_Military_Radar",
 	"A3_Supplies_F_Heli_Bladders",
 	"A3_Structures_F_Exp_Military_ContainerBases",
-	"A3_Modules_F_Hc"
+	"A3_Modules_F_Hc",
+	"A3_Weapons_F"
 };
 class AddonsMetaData
 {
 	class List
 	{
-		items=19;
+		items=17;
 		class Item0
 		{
 			className="A3_Ui_F";
@@ -194,20 +191,6 @@ class AddonsMetaData
 		};
 		class Item16
 		{
-			className="A3_Structures_F_Orange";
-			name="Arma 3 Orange - Buildings and Structures";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item17
-		{
-			className="A3_Props_F_Orange";
-			name="Arma 3 Orange - Decorative and Mission Objects";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item18
-		{
 			className="A3_Supplies_F_Heli";
 			name="Arma 3 Helicopters - Ammoboxes and Supplies";
 			author="Bohemia Interactive";
@@ -222,20 +205,15 @@ class Mission
 	{
 		briefingName=$STR_antistasi_mission_info_malden_mapname_text;
 		resistanceWest=0;
-		startWind=0.1;
-		forecastWind=0.1;
-		forecastWaves=0.1;
 		year=2035;
 		month=6;
 		day=1;
 		hour=10;
 		minute=0;
-		startFogDecay=0.0049333;
-		forecastFogDecay=0.0049333;
 	};
 	class Entities
 	{
-		items=860;
+		items=846;
 		class Item0
 		{
 			dataType="Marker";
@@ -1664,1643 +1642,6 @@ class Mission
 			side="Independent";
 			class Entities
 			{
-				items=25;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8258.625,11.349237,5971.1748};
-						angles[]={6.2136974,0,0.041575778};
-					};
-					side="Independent";
-					flags=6;
-					class Attributes
-					{
-						skill=1;
-						name="commanderX";
-						description="Default Commander";
-						isPlayer=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=451;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item1
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8273.625,12.233256,5973.7998};
-						angles[]={0.0095994528,6.2412972,6.2105141};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=456;
-					type="I_G_Soldier_AR_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item2
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8276.625,12.35534,5974.0498};
-						angles[]={0.0095994528,0,6.2105141};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=457;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item3
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8279.6777,11.9591,5973.6211};
-						angles[]={0.0095994528,0,6.2105141};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=458;
-					type="I_G_medic_F";
-					atlOffset=-0.40356541;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item4
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8282.5527,11.965999,5973.7461};
-						angles[]={0.0095994528,0,6.2105141};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=459;
-					type="I_G_engineer_F";
-					atlOffset=-0.40356636;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item5
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8285.4258,11.897231,5974.0918};
-						angles[]={6.2791886,0,6.2208662};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=460;
-					type="I_G_Soldier_GL_F";
-					atlOffset=-0.47922993;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item6
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8271.125,12.009743,5973.6748};
-						angles[]={0.064709939,0,6.2384152};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=461;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item7
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8273.5215,12.213982,5976.5947};
-						angles[]={0.0095994528,6.2412972,6.2105141};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=462;
-					type="I_G_Soldier_AR_F";
-					atlOffset=0.05105114;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item8
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8276.5225,12.336002,5976.8447};
-						angles[]={0.0095994528,0,6.2105141};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=463;
-					type="I_G_Soldier_LAT_F";
-					atlOffset=0.088599205;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item9
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8279.5742,11.939761,5976.416};
-						angles[]={0.0095994528,0,6.2105141};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=464;
-					type="I_G_medic_F";
-					atlOffset=-0.34069252;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item10
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8282.4492,11.965801,5976.541};
-						angles[]={6.2791886,0,6.2240543};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=465;
-					type="I_G_engineer_F";
-					atlOffset=-0.31404686;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item11
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8285.3223,11.914836,5976.8857};
-						angles[]={6.2791886,0,6.2208662};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=466;
-					type="I_G_Soldier_GL_F";
-					atlOffset=-0.3512373;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item12
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8271.0215,11.966632,5976.4697};
-						angles[]={0.0095994528,0,0.010398259};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=467;
-					type="I_G_officer_F";
-					atlOffset=0.021665573;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item13
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8276.5225,12.307196,5979.8457};
-						angles[]={0.0095994528,0,6.2105141};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=468;
-					type="I_G_Soldier_LAT_F";
-					atlOffset=0.23985386;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item14
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8279.5215,12.33248,5979.4707};
-						angles[]={6.2791886,0,6.2240543};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=469;
-					type="I_G_medic_F";
-					atlOffset=0.23544121;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item15
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8282.4492,11.977805,5979.542};
-						angles[]={6.2791886,0,6.2240543};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=470;
-					type="I_G_engineer_F";
-					atlOffset=-0.12198162;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item16
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8285.3223,11.926839,5979.8867};
-						angles[]={6.2791886,0,6.2208662};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=471;
-					type="I_G_Soldier_GL_F";
-					atlOffset=-0.1995821;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item17
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8271.0215,11.937826,5979.4707};
-						angles[]={0.0095994528,0,0.010398259};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=472;
-					type="I_G_officer_F";
-					atlOffset=0.10945988;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item18
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8276.4189,12.30667,5982.4336};
-						angles[]={6.2791886,0,6.2240543};
-					};
-					side="Independent";
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=473;
-					type="I_G_Soldier_LAT_F";
-					atlOffset=0.39484882;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item19
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8279.418,12.348971,5982.0576};
-						angles[]={6.2791886,0,6.2240543};
-					};
-					side="Independent";
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=474;
-					type="I_G_medic_F";
-					atlOffset=0.40738583;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item20
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8282.3457,11.994295,5982.1289};
-						angles[]={6.2791886,0,6.2240543};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=475;
-					type="I_G_engineer_F";
-					atlOffset=0.020709991;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item21
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8285.2188,11.943662,5982.4736};
-						angles[]={6.2791886,0,6.2208662};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=476;
-					type="I_G_Soldier_GL_F";
-					atlOffset=-0.065043449;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item22
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8270.918,11.911911,5982.0576};
-						angles[]={0.0095994528,0,0.010398259};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=477;
-					type="I_G_officer_F";
-					atlOffset=0.24547291;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item23
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8273.6211,12.176786,5979.7109};
-						angles[]={0.0095994528,6.1574922,6.2105141};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=478;
-					type="I_G_Soldier_AR_F";
-					atlOffset=0.19440269;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item24
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={8273.7148,12.14507,5982.2979};
-						angles[]={0.0095994528,0,6.2105141};
-					};
-					side="Independent";
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=479;
-					type="I_G_Soldier_AR_F";
-					atlOffset=0.31180954;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-			};
-			class Attributes
-			{
-			};
-			id=450;
-		};
-		class Item54
-		{
-			dataType="Group";
-			side="Independent";
-			class Entities
-			{
 				items=1;
 				class Item0
 				{
@@ -3386,7 +1727,7 @@ class Mission
 			};
 			id=452;
 		};
-		class Item55
+		class Item54
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3427,7 +1768,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item56
+		class Item55
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3467,7 +1808,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item57
+		class Item56
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -3481,7 +1822,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=0.13149166;
 		};
-		class Item58
+		class Item57
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -3495,7 +1836,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=0.12053108;
 		};
-		class Item59
+		class Item58
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -3585,7 +1926,7 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item60
+		class Item59
 		{
 			dataType="Marker";
 			position[]={5459.8188,4.5114121,11656.509};
@@ -3594,7 +1935,7 @@ class Mission
 			id=525;
 			atlOffset=10.4767;
 		};
-		class Item61
+		class Item60
 		{
 			dataType="Marker";
 			position[]={899.90588,-2.0057058,11832.569};
@@ -3603,7 +1944,7 @@ class Mission
 			id=526;
 			atlOffset=10.4767;
 		};
-		class Item62
+		class Item61
 		{
 			dataType="Marker";
 			position[]={3027.8069,2.2266998,8529.0439};
@@ -3612,7 +1953,7 @@ class Mission
 			id=527;
 			atlOffset=10.4767;
 		};
-		class Item63
+		class Item62
 		{
 			dataType="Marker";
 			position[]={978.70819,-0.040159225,702.729};
@@ -3621,7 +1962,7 @@ class Mission
 			id=528;
 			atlOffset=10.4767;
 		};
-		class Item64
+		class Item63
 		{
 			dataType="Marker";
 			position[]={3560.2771,-6.8308105,3182.5996};
@@ -3630,7 +1971,7 @@ class Mission
 			id=529;
 			atlOffset=10.4767;
 		};
-		class Item65
+		class Item64
 		{
 			dataType="Marker";
 			position[]={5749.25,-7.1310101,2344.25};
@@ -3638,7 +1979,7 @@ class Mission
 			type="Empty";
 			id=530;
 		};
-		class Item66
+		class Item65
 		{
 			dataType="Marker";
 			position[]={7620.25,-8.875,3294.125};
@@ -3647,7 +1988,7 @@ class Mission
 			id=532;
 			atlOffset=1.779027;
 		};
-		class Item67
+		class Item66
 		{
 			dataType="Marker";
 			position[]={8522.9141,2.2630234,3814.4736};
@@ -3656,7 +1997,7 @@ class Mission
 			id=533;
 			atlOffset=10.4767;
 		};
-		class Item68
+		class Item67
 		{
 			dataType="Marker";
 			position[]={9290.0762,-4.8026781,3807.6021};
@@ -3665,7 +2006,7 @@ class Mission
 			id=534;
 			atlOffset=10.4767;
 		};
-		class Item69
+		class Item68
 		{
 			dataType="Marker";
 			position[]={3344.8081,97.235451,3924.2493};
@@ -3674,7 +2015,7 @@ class Mission
 			id=537;
 			atlOffset=-1.9511871;
 		};
-		class Item70
+		class Item69
 		{
 			dataType="Marker";
 			position[]={3792.2085,54.855759,4022.9133};
@@ -3683,7 +2024,7 @@ class Mission
 			id=538;
 			atlOffset=-1.9511871;
 		};
-		class Item71
+		class Item70
 		{
 			dataType="Marker";
 			position[]={3968.5962,62.769188,4546.5127};
@@ -3692,7 +2033,7 @@ class Mission
 			id=539;
 			atlOffset=-1.9511871;
 		};
-		class Item72
+		class Item71
 		{
 			dataType="Marker";
 			position[]={4313.1338,34.167179,4250.2256};
@@ -3701,7 +2042,7 @@ class Mission
 			id=540;
 			atlOffset=-1.9511871;
 		};
-		class Item73
+		class Item72
 		{
 			dataType="Marker";
 			position[]={5062.6729,58.106449,3772.0818};
@@ -3710,7 +2051,7 @@ class Mission
 			id=541;
 			atlOffset=-1.9511871;
 		};
-		class Item74
+		class Item73
 		{
 			dataType="Marker";
 			position[]={5951.0396,52.085911,3526.146};
@@ -3719,7 +2060,7 @@ class Mission
 			id=542;
 			atlOffset=-1.9511871;
 		};
-		class Item75
+		class Item74
 		{
 			dataType="Marker";
 			position[]={6805.5649,80.418816,3504.238};
@@ -3728,7 +2069,7 @@ class Mission
 			id=543;
 			atlOffset=-1.9511871;
 		};
-		class Item76
+		class Item75
 		{
 			dataType="Marker";
 			position[]={7515.189,24.038086,3867.199};
@@ -3737,7 +2078,7 @@ class Mission
 			id=544;
 			atlOffset=-1.9962158;
 		};
-		class Item77
+		class Item76
 		{
 			dataType="Marker";
 			position[]={7921.5635,33.903698,4095.3789};
@@ -3746,7 +2087,7 @@ class Mission
 			id=545;
 			atlOffset=-1.9511871;
 		};
-		class Item78
+		class Item77
 		{
 			dataType="Marker";
 			position[]={7627.2896,28.220585,4787.7188};
@@ -3755,7 +2096,7 @@ class Mission
 			id=546;
 			atlOffset=-1.9511871;
 		};
-		class Item79
+		class Item78
 		{
 			dataType="Marker";
 			position[]={7107.0107,71.474724,5913.645};
@@ -3764,7 +2105,7 @@ class Mission
 			id=547;
 			atlOffset=-1.9511871;
 		};
-		class Item80
+		class Item79
 		{
 			dataType="Marker";
 			position[]={7030.9258,97.153801,6764.1006};
@@ -3773,7 +2114,7 @@ class Mission
 			id=548;
 			atlOffset=-1.9511871;
 		};
-		class Item81
+		class Item80
 		{
 			dataType="Marker";
 			position[]={7243.9956,165.60881,7771.7681};
@@ -3782,7 +2123,7 @@ class Mission
 			id=549;
 			atlOffset=-1.9511871;
 		};
-		class Item82
+		class Item81
 		{
 			dataType="Marker";
 			position[]={7294.104,85.09877,8842.1563};
@@ -3791,7 +2132,7 @@ class Mission
 			id=550;
 			atlOffset=-1.9511871;
 		};
-		class Item83
+		class Item82
 		{
 			dataType="Marker";
 			position[]={6629.5889,191.49059,9293.9961};
@@ -3800,7 +2141,7 @@ class Mission
 			id=551;
 			atlOffset=-1.9511871;
 		};
-		class Item84
+		class Item83
 		{
 			dataType="Marker";
 			position[]={8163.3667,28.222548,9480.6104};
@@ -3809,7 +2150,7 @@ class Mission
 			id=552;
 			atlOffset=-1.9511871;
 		};
-		class Item85
+		class Item84
 		{
 			dataType="Marker";
 			position[]={7468.5342,80.622108,9119.1592};
@@ -3818,7 +2159,7 @@ class Mission
 			id=553;
 			atlOffset=-1.9511871;
 		};
-		class Item86
+		class Item85
 		{
 			dataType="Marker";
 			position[]={5970.4902,189.11472,9280.1641};
@@ -3826,7 +2167,7 @@ class Mission
 			type="hd_arrow";
 			id=554;
 		};
-		class Item87
+		class Item86
 		{
 			dataType="Marker";
 			position[]={5196.2578,343.00293,9170.8027};
@@ -3835,7 +2176,7 @@ class Mission
 			id=555;
 			atlOffset=-17.439423;
 		};
-		class Item88
+		class Item87
 		{
 			dataType="Marker";
 			position[]={4860.9658,393.61743,8432.3506};
@@ -3844,7 +2185,7 @@ class Mission
 			id=556;
 			atlOffset=-1.9512024;
 		};
-		class Item89
+		class Item88
 		{
 			dataType="Marker";
 			position[]={4922.2153,407.42645,7354.0083};
@@ -3853,7 +2194,7 @@ class Mission
 			id=557;
 			atlOffset=-1.9511719;
 		};
-		class Item90
+		class Item89
 		{
 			dataType="Marker";
 			position[]={4174.2476,381.46332,6480.6943};
@@ -3862,7 +2203,7 @@ class Mission
 			id=558;
 			atlOffset=-1.9512024;
 		};
-		class Item91
+		class Item90
 		{
 			dataType="Marker";
 			position[]={3058.4907,222.3761,6334.5635};
@@ -3871,7 +2212,7 @@ class Mission
 			id=559;
 			atlOffset=-1.9511871;
 		};
-		class Item92
+		class Item91
 		{
 			dataType="Marker";
 			position[]={3375.7668,120.64616,5182.2998};
@@ -3880,7 +2221,7 @@ class Mission
 			id=560;
 			atlOffset=-1.9511871;
 		};
-		class Item93
+		class Item92
 		{
 			dataType="Marker";
 			position[]={7808.6372,31.142761,9909.6582};
@@ -3889,7 +2230,7 @@ class Mission
 			id=561;
 			atlOffset=-1.9511871;
 		};
-		class Item94
+		class Item93
 		{
 			dataType="Marker";
 			position[]={7443.7866,26.908813,10655.921};
@@ -3898,7 +2239,7 @@ class Mission
 			id=562;
 			atlOffset=-1.9511871;
 		};
-		class Item95
+		class Item94
 		{
 			dataType="Marker";
 			position[]={6492.2104,88.4114,10943.818};
@@ -3907,7 +2248,7 @@ class Mission
 			id=563;
 			atlOffset=-1.9511871;
 		};
-		class Item96
+		class Item95
 		{
 			dataType="Marker";
 			position[]={4225.5396,310.06995,7875.4868};
@@ -3916,7 +2257,7 @@ class Mission
 			id=564;
 			atlOffset=-1.9512024;
 		};
-		class Item97
+		class Item96
 		{
 			dataType="Marker";
 			position[]={3584.8003,120.46836,8686.3906};
@@ -3925,7 +2266,7 @@ class Mission
 			id=565;
 			atlOffset=-1.9511871;
 		};
-		class Item98
+		class Item97
 		{
 			dataType="Marker";
 			position[]={2216.0876,184.90233,2970.9983};
@@ -3934,7 +2275,7 @@ class Mission
 			id=566;
 			atlOffset=-1.9511871;
 		};
-		class Item99
+		class Item98
 		{
 			dataType="Marker";
 			position[]={1652.4279,79.741798,1621.9436};
@@ -3943,7 +2284,7 @@ class Mission
 			id=567;
 			atlOffset=-1.9511871;
 		};
-		class Item100
+		class Item99
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3983,7 +2324,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item101
+		class Item100
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3995,12 +2336,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=927;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.0089416504;
 		};
-		class Item102
+		class Item101
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4012,11 +2354,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=928;
 			type="Land_HBarrier_5_F";
 		};
-		class Item103
+		class Item102
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4028,12 +2371,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=929;
 			type="Land_HBarrier_5_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item104
+		class Item103
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4045,11 +2389,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=930;
 			type="Land_HBarrier_5_F";
 		};
-		class Item105
+		class Item104
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4061,11 +2406,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=931;
 			type="Land_HBarrier_5_F";
 		};
-		class Item106
+		class Item105
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4077,11 +2423,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=932;
 			type="Land_HBarrier_5_F";
 		};
-		class Item107
+		class Item106
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4093,11 +2440,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=933;
 			type="Land_HBarrier_5_F";
 		};
-		class Item108
+		class Item107
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4109,11 +2457,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=934;
 			type="Land_HBarrier_5_F";
 		};
-		class Item109
+		class Item108
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4125,11 +2474,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=935;
 			type="Land_HBarrier_5_F";
 		};
-		class Item110
+		class Item109
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4141,11 +2491,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=936;
 			type="Land_HBarrier_5_F";
 		};
-		class Item111
+		class Item110
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4157,12 +2508,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=937;
 			type="Land_HBarrier_5_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item112
+		class Item111
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4174,11 +2526,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=938;
 			type="Land_HBarrier_5_F";
 		};
-		class Item113
+		class Item112
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4190,11 +2543,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=939;
 			type="Land_HBarrier_5_F";
 		};
-		class Item114
+		class Item113
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4206,12 +2560,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=940;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.008972168;
 		};
-		class Item115
+		class Item114
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4223,11 +2578,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=941;
 			type="Land_HBarrier_5_F";
 		};
-		class Item116
+		class Item115
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4239,11 +2595,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=942;
 			type="Land_HBarrier_5_F";
 		};
-		class Item117
+		class Item116
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4255,11 +2612,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=943;
 			type="Land_HBarrier_5_F";
 		};
-		class Item118
+		class Item117
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4271,12 +2629,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=944;
 			type="Land_HBarrier_5_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item119
+		class Item118
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4288,11 +2647,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=946;
 			type="Land_HBarrier_5_F";
 		};
-		class Item120
+		class Item119
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4304,11 +2664,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=947;
 			type="Land_HBarrier_5_F";
 		};
-		class Item121
+		class Item120
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4320,12 +2681,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=948;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.008972168;
 		};
-		class Item122
+		class Item121
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4337,11 +2699,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=949;
 			type="Land_HBarrier_5_F";
 		};
-		class Item123
+		class Item122
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4353,11 +2716,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=950;
 			type="Land_HBarrier_5_F";
 		};
-		class Item124
+		class Item123
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4369,11 +2733,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=951;
 			type="Land_HBarrier_5_F";
 		};
-		class Item125
+		class Item124
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4385,12 +2750,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=952;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item126
+		class Item125
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4402,12 +2768,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=953;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item127
+		class Item126
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4419,12 +2786,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=954;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item128
+		class Item127
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4436,12 +2804,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=955;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item129
+		class Item128
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4453,11 +2822,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=956;
 			type="Land_HBarrier_5_F";
 		};
-		class Item130
+		class Item129
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4469,11 +2839,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=957;
 			type="Land_HBarrier_3_F";
 		};
-		class Item131
+		class Item130
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4485,12 +2856,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=958;
 			type="Land_HBarrier_3_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item132
+		class Item131
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4502,11 +2874,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=960;
 			type="Land_HBarrier_3_F";
 		};
-		class Item133
+		class Item132
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4518,11 +2891,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=962;
 			type="Land_HBarrier_5_F";
 		};
-		class Item134
+		class Item133
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4538,7 +2912,7 @@ class Mission
 			id=963;
 			type="Land_Mil_WallBig_Corner_F";
 		};
-		class Item135
+		class Item134
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4554,7 +2928,7 @@ class Mission
 			id=964;
 			type="Land_Mil_WallBig_Corner_F";
 		};
-		class Item136
+		class Item135
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4570,7 +2944,7 @@ class Mission
 			id=965;
 			type="Land_Mil_WallBig_4m_F";
 		};
-		class Item137
+		class Item136
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4586,7 +2960,7 @@ class Mission
 			id=967;
 			type="Land_Mil_WallBig_4m_F";
 		};
-		class Item138
+		class Item137
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4603,7 +2977,7 @@ class Mission
 			type="Land_Mil_WallBig_4m_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item139
+		class Item138
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4620,7 +2994,7 @@ class Mission
 			type="Land_Mil_WallBig_Corner_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item140
+		class Item139
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4636,7 +3010,7 @@ class Mission
 			id=970;
 			type="Land_Mil_WallBig_Corner_F";
 		};
-		class Item141
+		class Item140
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4653,7 +3027,7 @@ class Mission
 			type="Land_Mil_WallBig_4m_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item142
+		class Item141
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4669,7 +3043,7 @@ class Mission
 			id=972;
 			type="Land_Cargo_Tower_V1_F";
 		};
-		class Item143
+		class Item142
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4685,7 +3059,7 @@ class Mission
 			id=973;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item144
+		class Item143
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4701,7 +3075,7 @@ class Mission
 			id=974;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item145
+		class Item144
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4717,7 +3091,7 @@ class Mission
 			id=975;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item146
+		class Item145
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4729,12 +3103,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=976;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item147
+		class Item146
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4746,12 +3121,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=977;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item148
+		class Item147
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4763,11 +3139,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=978;
 			type="Land_HBarrier_5_F";
 		};
-		class Item149
+		class Item148
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4779,11 +3156,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=979;
 			type="Land_HBarrier_5_F";
 		};
-		class Item150
+		class Item149
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4795,11 +3173,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=980;
 			type="Land_HBarrier_5_F";
 		};
-		class Item151
+		class Item150
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4811,12 +3190,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=981;
 			type="Land_HBarrier_5_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item152
+		class Item151
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4832,7 +3212,7 @@ class Mission
 			id=982;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item153
+		class Item152
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4849,7 +3229,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item154
+		class Item153
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4865,7 +3245,7 @@ class Mission
 			id=984;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item155
+		class Item154
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4877,11 +3257,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=985;
 			type="Land_HBarrier_5_F";
 		};
-		class Item156
+		class Item155
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4893,11 +3274,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=986;
 			type="Land_HBarrier_5_F";
 		};
-		class Item157
+		class Item156
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4909,11 +3291,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=987;
 			type="Land_HBarrier_5_F";
 		};
-		class Item158
+		class Item157
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4925,11 +3308,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=988;
 			type="Land_HBarrier_5_F";
 		};
-		class Item159
+		class Item158
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4945,7 +3329,7 @@ class Mission
 			id=989;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item160
+		class Item159
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4961,7 +3345,7 @@ class Mission
 			id=990;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item161
+		class Item160
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4973,12 +3357,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1117;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.0090026855;
 		};
-		class Item162
+		class Item161
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4990,11 +3375,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1118;
 			type="Land_HBarrier_5_F";
 		};
-		class Item163
+		class Item162
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5006,11 +3392,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1119;
 			type="Land_HBarrier_5_F";
 		};
-		class Item164
+		class Item163
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5022,11 +3409,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1120;
 			type="Land_HBarrier_5_F";
 		};
-		class Item165
+		class Item164
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5038,11 +3426,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1121;
 			type="Land_HBarrier_5_F";
 		};
-		class Item166
+		class Item165
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5054,11 +3443,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1122;
 			type="Land_HBarrier_5_F";
 		};
-		class Item167
+		class Item166
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5070,11 +3460,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1123;
 			type="Land_HBarrier_5_F";
 		};
-		class Item168
+		class Item167
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5086,11 +3477,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1124;
 			type="Land_HBarrier_5_F";
 		};
-		class Item169
+		class Item168
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5102,11 +3494,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1125;
 			type="Land_HBarrier_5_F";
 		};
-		class Item170
+		class Item169
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5118,11 +3511,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1126;
 			type="Land_HBarrier_5_F";
 		};
-		class Item171
+		class Item170
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5134,11 +3528,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1127;
 			type="Land_HBarrier_5_F";
 		};
-		class Item172
+		class Item171
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5150,12 +3545,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1128;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item173
+		class Item172
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5167,12 +3563,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1129;
 			type="Land_HBarrier_5_F";
 			atlOffset=6.1035156e-005;
 		};
-		class Item174
+		class Item173
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5184,12 +3581,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1130;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.0090026855;
 		};
-		class Item175
+		class Item174
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5201,12 +3599,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1131;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item176
+		class Item175
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5218,12 +3617,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1132;
 			type="Land_HBarrier_5_F";
 			atlOffset=6.1035156e-005;
 		};
-		class Item177
+		class Item176
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5235,12 +3635,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1133;
 			type="Land_HBarrier_5_F";
 			atlOffset=6.1035156e-005;
 		};
-		class Item178
+		class Item177
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5252,12 +3653,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1134;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item179
+		class Item178
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5269,12 +3671,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1135;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item180
+		class Item179
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5286,12 +3689,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1136;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item181
+		class Item180
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5303,12 +3707,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1137;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.008972168;
 		};
-		class Item182
+		class Item181
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5320,12 +3725,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1138;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item183
+		class Item182
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5337,12 +3743,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1139;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item184
+		class Item183
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5354,12 +3761,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1140;
 			type="Land_HBarrier_5_F";
 			atlOffset=6.1035156e-005;
 		};
-		class Item185
+		class Item184
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5371,11 +3779,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1141;
 			type="Land_HBarrier_5_F";
 		};
-		class Item186
+		class Item185
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5387,12 +3796,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1142;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item187
+		class Item186
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5404,12 +3814,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1143;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item188
+		class Item187
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5421,11 +3832,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1144;
 			type="Land_HBarrier_5_F";
 		};
-		class Item189
+		class Item188
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5437,11 +3849,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1145;
 			type="Land_HBarrier_5_F";
 		};
-		class Item190
+		class Item189
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5453,12 +3866,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1146;
 			type="Land_HBarrier_3_F";
 			atlOffset=9.1552734e-005;
 		};
-		class Item191
+		class Item190
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5470,12 +3884,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1147;
 			type="Land_HBarrier_3_F";
 			atlOffset=9.1552734e-005;
 		};
-		class Item192
+		class Item191
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5487,12 +3902,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1148;
 			type="Land_HBarrier_3_F";
 			atlOffset=9.1552734e-005;
 		};
-		class Item193
+		class Item192
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5504,12 +3920,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1149;
 			type="Land_HBarrier_5_F";
 			atlOffset=9.1552734e-005;
 		};
-		class Item194
+		class Item193
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5525,7 +3942,7 @@ class Mission
 			id=1150;
 			type="Land_Mil_WallBig_Corner_F";
 		};
-		class Item195
+		class Item194
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5541,7 +3958,7 @@ class Mission
 			id=1151;
 			type="Land_Mil_WallBig_Corner_F";
 		};
-		class Item196
+		class Item195
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5557,7 +3974,7 @@ class Mission
 			id=1152;
 			type="Land_Mil_WallBig_4m_F";
 		};
-		class Item197
+		class Item196
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5573,7 +3990,7 @@ class Mission
 			id=1153;
 			type="Land_Mil_WallBig_4m_F";
 		};
-		class Item198
+		class Item197
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5590,7 +4007,7 @@ class Mission
 			type="Land_Mil_WallBig_4m_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item199
+		class Item198
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5606,7 +4023,7 @@ class Mission
 			id=1155;
 			type="Land_Mil_WallBig_Corner_F";
 		};
-		class Item200
+		class Item199
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5622,7 +4039,7 @@ class Mission
 			id=1156;
 			type="Land_Mil_WallBig_Corner_F";
 		};
-		class Item201
+		class Item200
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5639,7 +4056,7 @@ class Mission
 			type="Land_Mil_WallBig_4m_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item202
+		class Item201
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5655,7 +4072,7 @@ class Mission
 			id=1158;
 			type="Land_Cargo_Tower_V1_F";
 		};
-		class Item203
+		class Item202
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5671,7 +4088,7 @@ class Mission
 			id=1159;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item204
+		class Item203
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5687,7 +4104,7 @@ class Mission
 			id=1160;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item205
+		class Item204
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5703,7 +4120,7 @@ class Mission
 			id=1161;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item206
+		class Item205
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5715,11 +4132,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1162;
 			type="Land_HBarrier_5_F";
 		};
-		class Item207
+		class Item206
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5731,11 +4149,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1163;
 			type="Land_HBarrier_5_F";
 		};
-		class Item208
+		class Item207
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5747,11 +4166,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1164;
 			type="Land_HBarrier_5_F";
 		};
-		class Item209
+		class Item208
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5763,11 +4183,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1165;
 			type="Land_HBarrier_5_F";
 		};
-		class Item210
+		class Item209
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5779,11 +4200,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1166;
 			type="Land_HBarrier_5_F";
 		};
-		class Item211
+		class Item210
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5795,11 +4217,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1167;
 			type="Land_HBarrier_5_F";
 		};
-		class Item212
+		class Item211
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5815,7 +4238,7 @@ class Mission
 			id=1168;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item213
+		class Item212
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5831,7 +4254,7 @@ class Mission
 			id=1169;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item214
+		class Item213
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5847,7 +4270,7 @@ class Mission
 			id=1170;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item215
+		class Item214
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5859,11 +4282,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1171;
 			type="Land_HBarrier_5_F";
 		};
-		class Item216
+		class Item215
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5875,12 +4299,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1172;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item217
+		class Item216
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5892,11 +4317,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1173;
 			type="Land_HBarrier_5_F";
 		};
-		class Item218
+		class Item217
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5908,11 +4334,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1174;
 			type="Land_HBarrier_5_F";
 		};
-		class Item219
+		class Item218
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5929,7 +4356,7 @@ class Mission
 			type="Land_Cargo_House_V1_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item220
+		class Item219
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5945,7 +4372,7 @@ class Mission
 			id=1176;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item221
+		class Item220
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5957,12 +4384,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1238;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.0089454651;
 		};
-		class Item222
+		class Item221
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5974,11 +4402,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1239;
 			type="Land_HBarrier_5_F";
 		};
-		class Item223
+		class Item222
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5990,11 +4419,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1240;
 			type="Land_HBarrier_5_F";
 		};
-		class Item224
+		class Item223
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6006,11 +4436,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1241;
 			type="Land_HBarrier_5_F";
 		};
-		class Item225
+		class Item224
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6022,11 +4453,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1242;
 			type="Land_HBarrier_5_F";
 		};
-		class Item226
+		class Item225
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6038,11 +4470,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1243;
 			type="Land_HBarrier_5_F";
 		};
-		class Item227
+		class Item226
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6054,11 +4487,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1244;
 			type="Land_HBarrier_5_F";
 		};
-		class Item228
+		class Item227
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6070,12 +4504,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1245;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item229
+		class Item228
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6087,11 +4522,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1246;
 			type="Land_HBarrier_5_F";
 		};
-		class Item230
+		class Item229
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6103,12 +4539,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1247;
 			type="Land_HBarrier_5_F";
 			atlOffset=-3.8146973e-006;
 		};
-		class Item231
+		class Item230
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6120,11 +4557,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1248;
 			type="Land_HBarrier_5_F";
 		};
-		class Item232
+		class Item231
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6136,12 +4574,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1249;
 			type="Land_HBarrier_5_F";
 			atlOffset=-3.8146973e-006;
 		};
-		class Item233
+		class Item232
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6153,12 +4592,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1250;
 			type="Land_HBarrier_5_F";
 			atlOffset=-3.8146973e-006;
 		};
-		class Item234
+		class Item233
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6170,12 +4610,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1251;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.0089416504;
 		};
-		class Item235
+		class Item234
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6187,11 +4628,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1252;
 			type="Land_HBarrier_5_F";
 		};
-		class Item236
+		class Item235
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6203,11 +4645,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1253;
 			type="Land_HBarrier_5_F";
 		};
-		class Item237
+		class Item236
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6219,11 +4662,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1254;
 			type="Land_HBarrier_5_F";
 		};
-		class Item238
+		class Item237
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6235,11 +4679,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1255;
 			type="Land_HBarrier_5_F";
 		};
-		class Item239
+		class Item238
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6251,12 +4696,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1256;
 			type="Land_HBarrier_5_F";
 			atlOffset=-3.8146973e-006;
 		};
-		class Item240
+		class Item239
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6268,12 +4714,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1257;
 			type="Land_HBarrier_5_F";
 			atlOffset=-3.8146973e-006;
 		};
-		class Item241
+		class Item240
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6285,12 +4732,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1258;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.0089187622;
 		};
-		class Item242
+		class Item241
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6302,12 +4750,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1259;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item243
+		class Item242
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6319,12 +4768,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1260;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item244
+		class Item243
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6336,11 +4786,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1261;
 			type="Land_HBarrier_5_F";
 		};
-		class Item245
+		class Item244
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6352,11 +4803,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1262;
 			type="Land_HBarrier_5_F";
 		};
-		class Item246
+		class Item245
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6368,11 +4820,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1263;
 			type="Land_HBarrier_5_F";
 		};
-		class Item247
+		class Item246
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6384,11 +4837,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1264;
 			type="Land_HBarrier_5_F";
 		};
-		class Item248
+		class Item247
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6400,12 +4854,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1265;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item249
+		class Item248
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6417,11 +4872,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1266;
 			type="Land_HBarrier_5_F";
 		};
-		class Item250
+		class Item249
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6433,12 +4889,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1267;
 			type="Land_HBarrier_3_F";
 			atlOffset=3.4332275e-005;
 		};
-		class Item251
+		class Item250
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6450,12 +4907,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1268;
 			type="Land_HBarrier_3_F";
 			atlOffset=2.6702881e-005;
 		};
-		class Item252
+		class Item251
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6467,12 +4925,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1269;
 			type="Land_HBarrier_3_F";
 			atlOffset=2.2888184e-005;
 		};
-		class Item253
+		class Item252
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6484,12 +4943,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1270;
 			type="Land_HBarrier_5_F";
 			atlOffset=2.6702881e-005;
 		};
-		class Item254
+		class Item253
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6505,7 +4965,7 @@ class Mission
 			id=1271;
 			type="Land_Mil_WallBig_Corner_F";
 		};
-		class Item255
+		class Item254
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6521,7 +4981,7 @@ class Mission
 			id=1272;
 			type="Land_Mil_WallBig_Corner_F";
 		};
-		class Item256
+		class Item255
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6538,7 +4998,7 @@ class Mission
 			type="Land_Mil_WallBig_4m_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item257
+		class Item256
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6554,7 +5014,7 @@ class Mission
 			id=1274;
 			type="Land_Mil_WallBig_4m_F";
 		};
-		class Item258
+		class Item257
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6571,7 +5031,7 @@ class Mission
 			type="Land_Mil_WallBig_4m_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item259
+		class Item258
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6587,7 +5047,7 @@ class Mission
 			id=1276;
 			type="Land_Mil_WallBig_Corner_F";
 		};
-		class Item260
+		class Item259
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6603,7 +5063,7 @@ class Mission
 			id=1277;
 			type="Land_Mil_WallBig_Corner_F";
 		};
-		class Item261
+		class Item260
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6619,7 +5079,7 @@ class Mission
 			id=1278;
 			type="Land_Mil_WallBig_4m_F";
 		};
-		class Item262
+		class Item261
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6636,7 +5096,7 @@ class Mission
 			type="Land_Cargo_Tower_V1_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item263
+		class Item262
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6652,7 +5112,7 @@ class Mission
 			id=1280;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item264
+		class Item263
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6668,7 +5128,7 @@ class Mission
 			id=1281;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item265
+		class Item264
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6684,7 +5144,7 @@ class Mission
 			id=1282;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item266
+		class Item265
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6696,11 +5156,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1283;
 			type="Land_HBarrier_5_F";
 		};
-		class Item267
+		class Item266
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6712,12 +5173,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1284;
 			type="Land_HBarrier_5_F";
 			atlOffset=-3.8146973e-006;
 		};
-		class Item268
+		class Item267
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6729,11 +5191,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1285;
 			type="Land_HBarrier_5_F";
 		};
-		class Item269
+		class Item268
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6745,11 +5208,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1286;
 			type="Land_HBarrier_5_F";
 		};
-		class Item270
+		class Item269
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6761,11 +5225,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1287;
 			type="Land_HBarrier_5_F";
 		};
-		class Item271
+		class Item270
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6777,12 +5242,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1288;
 			type="Land_HBarrier_5_F";
 			atlOffset=-3.8146973e-006;
 		};
-		class Item272
+		class Item271
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6798,7 +5264,7 @@ class Mission
 			id=1289;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item273
+		class Item272
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6814,7 +5280,7 @@ class Mission
 			id=1290;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item274
+		class Item273
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6830,7 +5296,7 @@ class Mission
 			id=1291;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item275
+		class Item274
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6842,11 +5308,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1292;
 			type="Land_HBarrier_5_F";
 		};
-		class Item276
+		class Item275
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6858,11 +5325,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1293;
 			type="Land_HBarrier_5_F";
 		};
-		class Item277
+		class Item276
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6874,11 +5342,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1294;
 			type="Land_HBarrier_5_F";
 		};
-		class Item278
+		class Item277
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6890,12 +5359,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1295;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item279
+		class Item278
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6911,7 +5381,7 @@ class Mission
 			id=1296;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item280
+		class Item279
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6927,7 +5397,7 @@ class Mission
 			id=1297;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item281
+		class Item280
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6939,12 +5409,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1358;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.0089569092;
 		};
-		class Item282
+		class Item281
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6956,11 +5427,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1359;
 			type="Land_HBarrier_5_F";
 		};
-		class Item283
+		class Item282
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6972,12 +5444,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1360;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item284
+		class Item283
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6989,11 +5462,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1361;
 			type="Land_HBarrier_5_F";
 		};
-		class Item285
+		class Item284
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7005,11 +5479,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1362;
 			type="Land_HBarrier_5_F";
 		};
-		class Item286
+		class Item285
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7021,12 +5496,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1363;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item287
+		class Item286
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7038,11 +5514,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1364;
 			type="Land_HBarrier_5_F";
 		};
-		class Item288
+		class Item287
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7054,11 +5531,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1365;
 			type="Land_HBarrier_5_F";
 		};
-		class Item289
+		class Item288
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7070,11 +5548,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1366;
 			type="Land_HBarrier_5_F";
 		};
-		class Item290
+		class Item289
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7086,11 +5565,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1367;
 			type="Land_HBarrier_5_F";
 		};
-		class Item291
+		class Item290
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7102,11 +5582,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1368;
 			type="Land_HBarrier_5_F";
 		};
-		class Item292
+		class Item291
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7118,11 +5599,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1369;
 			type="Land_HBarrier_5_F";
 		};
-		class Item293
+		class Item292
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7134,11 +5616,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1370;
 			type="Land_HBarrier_5_F";
 		};
-		class Item294
+		class Item293
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7150,12 +5633,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1371;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.0089569092;
 		};
-		class Item295
+		class Item294
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7167,12 +5651,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1372;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item296
+		class Item295
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7184,12 +5669,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1373;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item297
+		class Item296
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7201,12 +5687,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1374;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item298
+		class Item297
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7218,11 +5705,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1375;
 			type="Land_HBarrier_5_F";
 		};
-		class Item299
+		class Item298
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7234,11 +5722,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1376;
 			type="Land_HBarrier_5_F";
 		};
-		class Item300
+		class Item299
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7250,11 +5739,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1377;
 			type="Land_HBarrier_5_F";
 		};
-		class Item301
+		class Item300
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7266,12 +5756,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1378;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.0089111328;
 		};
-		class Item302
+		class Item301
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7283,11 +5774,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1379;
 			type="Land_HBarrier_5_F";
 		};
-		class Item303
+		class Item302
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7299,12 +5791,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1380;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item304
+		class Item303
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7316,12 +5809,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1381;
 			type="Land_HBarrier_5_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item305
+		class Item304
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7333,11 +5827,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1382;
 			type="Land_HBarrier_5_F";
 		};
-		class Item306
+		class Item305
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7349,12 +5844,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1383;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item307
+		class Item306
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7366,12 +5862,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1384;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item308
+		class Item307
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7383,11 +5880,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1385;
 			type="Land_HBarrier_5_F";
 		};
-		class Item309
+		class Item308
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7399,12 +5897,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1386;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item310
+		class Item309
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7416,12 +5915,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1387;
 			type="Land_HBarrier_3_F";
 			atlOffset=4.5776367e-005;
 		};
-		class Item311
+		class Item310
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7433,12 +5933,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1388;
 			type="Land_HBarrier_3_F";
 			atlOffset=4.5776367e-005;
 		};
-		class Item312
+		class Item311
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7450,12 +5951,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1389;
 			type="Land_HBarrier_3_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item313
+		class Item312
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7467,12 +5969,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1390;
 			type="Land_HBarrier_5_F";
 			atlOffset=4.5776367e-005;
 		};
-		class Item314
+		class Item313
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7488,7 +5991,7 @@ class Mission
 			id=1391;
 			type="Land_Mil_WallBig_Corner_F";
 		};
-		class Item315
+		class Item314
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7504,7 +6007,7 @@ class Mission
 			id=1392;
 			type="Land_Mil_WallBig_Corner_F";
 		};
-		class Item316
+		class Item315
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7520,7 +6023,7 @@ class Mission
 			id=1393;
 			type="Land_Mil_WallBig_4m_F";
 		};
-		class Item317
+		class Item316
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7536,7 +6039,7 @@ class Mission
 			id=1394;
 			type="Land_Mil_WallBig_4m_F";
 		};
-		class Item318
+		class Item317
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7553,7 +6056,7 @@ class Mission
 			type="Land_Mil_WallBig_4m_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item319
+		class Item318
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7569,7 +6072,7 @@ class Mission
 			id=1396;
 			type="Land_Mil_WallBig_Corner_F";
 		};
-		class Item320
+		class Item319
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7585,7 +6088,7 @@ class Mission
 			id=1397;
 			type="Land_Mil_WallBig_Corner_F";
 		};
-		class Item321
+		class Item320
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7602,7 +6105,7 @@ class Mission
 			type="Land_Mil_WallBig_4m_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item322
+		class Item321
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7619,7 +6122,7 @@ class Mission
 			type="Land_Cargo_Tower_V1_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item323
+		class Item322
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7635,7 +6138,7 @@ class Mission
 			id=1400;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item324
+		class Item323
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7651,7 +6154,7 @@ class Mission
 			id=1401;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item325
+		class Item324
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7667,7 +6170,7 @@ class Mission
 			id=1402;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item326
+		class Item325
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7679,12 +6182,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1403;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item327
+		class Item326
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7696,11 +6200,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1404;
 			type="Land_HBarrier_5_F";
 		};
-		class Item328
+		class Item327
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7712,12 +6217,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1405;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item329
+		class Item328
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7729,11 +6235,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1406;
 			type="Land_HBarrier_5_F";
 		};
-		class Item330
+		class Item329
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7745,11 +6252,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1407;
 			type="Land_HBarrier_5_F";
 		};
-		class Item331
+		class Item330
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7761,12 +6269,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1408;
 			type="Land_HBarrier_5_F";
 			atlOffset=0.027923584;
 		};
-		class Item332
+		class Item331
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7782,7 +6291,7 @@ class Mission
 			id=1409;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item333
+		class Item332
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7799,7 +6308,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item334
+		class Item333
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7815,7 +6324,7 @@ class Mission
 			id=1411;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item335
+		class Item334
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7827,11 +6336,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1412;
 			type="Land_HBarrier_5_F";
 		};
-		class Item336
+		class Item335
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7843,11 +6353,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1413;
 			type="Land_HBarrier_5_F";
 		};
-		class Item337
+		class Item336
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7859,11 +6370,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1414;
 			type="Land_HBarrier_5_F";
 		};
-		class Item338
+		class Item337
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7875,11 +6387,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=1415;
 			type="Land_HBarrier_5_F";
 		};
-		class Item339
+		class Item338
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7896,7 +6409,7 @@ class Mission
 			type="Land_Cargo_House_V1_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item340
+		class Item339
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7912,7 +6425,7 @@ class Mission
 			id=1417;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item341
+		class Item340
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7928,7 +6441,7 @@ class Mission
 			id=1418;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item342
+		class Item341
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7944,7 +6457,7 @@ class Mission
 			id=1419;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item343
+		class Item342
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7960,7 +6473,7 @@ class Mission
 			id=1420;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item344
+		class Item343
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7976,7 +6489,7 @@ class Mission
 			id=1421;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item345
+		class Item344
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7992,7 +6505,7 @@ class Mission
 			id=1422;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item346
+		class Item345
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8008,28 +6521,28 @@ class Mission
 			id=1423;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item347
+		class Item346
 		{
 			dataType="Layer";
 			name="Open Ammo Dump";
 			id=1424;
 			atlOffset=96.5;
 		};
-		class Item348
+		class Item347
 		{
 			dataType="Layer";
 			name="Vehicle Repair";
 			id=1449;
 			atlOffset=96.5;
 		};
-		class Item349
+		class Item348
 		{
 			dataType="Layer";
 			name="Camp Audacity";
 			id=1883;
 			atlOffset=96.5;
 		};
-		class Item350
+		class Item349
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -8084,7 +6597,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item351
+		class Item350
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8100,7 +6613,7 @@ class Mission
 			id=1886;
 			type="Land_Wall_IndCnc_4_F";
 		};
-		class Item352
+		class Item351
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -8155,7 +6668,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item353
+		class Item352
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8171,7 +6684,7 @@ class Mission
 			id=1889;
 			type="Land_ConcreteWall_01_l_8m_F";
 		};
-		class Item354
+		class Item353
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -8226,7 +6739,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item355
+		class Item354
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8242,7 +6755,7 @@ class Mission
 			id=1891;
 			type="Land_ConcreteWall_01_l_8m_F";
 		};
-		class Item356
+		class Item355
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8258,35 +6771,35 @@ class Mission
 			id=1892;
 			type="Land_ConcreteWall_01_l_4m_F";
 		};
-		class Item357
+		class Item356
 		{
 			dataType="Layer";
 			name="Open Ammo Dump_1";
 			id=1955;
 			atlOffset=96.5;
 		};
-		class Item358
+		class Item357
 		{
 			dataType="Layer";
 			name="Vehicle Repair_1";
 			id=1980;
 			atlOffset=96.5;
 		};
-		class Item359
+		class Item358
 		{
 			dataType="Layer";
 			name="Open Ammo Dump_2";
 			id=2357;
 			atlOffset=96.5;
 		};
-		class Item360
+		class Item359
 		{
 			dataType="Layer";
 			name="Vehicle Repair_2";
 			id=2382;
 			atlOffset=96.5;
 		};
-		class Item361
+		class Item360
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8298,11 +6811,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2848;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item362
+		class Item361
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8314,12 +6828,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2849;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item363
+		class Item362
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8331,11 +6846,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2850;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item364
+		class Item363
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8347,12 +6863,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2851;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item365
+		class Item364
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8364,12 +6881,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2852;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item366
+		class Item365
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8381,12 +6899,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2853;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-3.8146973e-006;
 		};
-		class Item367
+		class Item366
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8398,12 +6917,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2854;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item368
+		class Item367
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8415,12 +6935,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2855;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item369
+		class Item368
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8432,12 +6953,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2856;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item370
+		class Item369
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8449,11 +6971,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2857;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item371
+		class Item370
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8465,11 +6988,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2858;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item372
+		class Item371
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8481,11 +7005,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2859;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item373
+		class Item372
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8497,11 +7022,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2860;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item374
+		class Item373
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8513,12 +7039,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2861;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item375
+		class Item374
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8530,11 +7057,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2862;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item376
+		class Item375
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8546,11 +7074,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2863;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item377
+		class Item376
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8562,11 +7091,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2864;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item378
+		class Item377
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8578,11 +7108,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2865;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item379
+		class Item378
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8594,11 +7125,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2866;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item380
+		class Item379
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8610,11 +7142,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2867;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item381
+		class Item380
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8626,11 +7159,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2868;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item382
+		class Item381
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8642,11 +7176,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2869;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item383
+		class Item382
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8658,11 +7193,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2870;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item384
+		class Item383
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8674,12 +7210,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2871;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-3.8146973e-006;
 		};
-		class Item385
+		class Item384
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8691,11 +7228,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2872;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item386
+		class Item385
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8707,11 +7245,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2873;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item387
+		class Item386
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8723,12 +7262,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2874;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-3.8146973e-006;
 		};
-		class Item388
+		class Item387
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8744,7 +7284,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.25;
 		};
-		class Item389
+		class Item388
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8761,7 +7301,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item390
+		class Item389
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8773,11 +7313,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2877;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item391
+		class Item390
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8789,12 +7330,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2878;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item392
+		class Item391
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8806,11 +7348,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2879;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item393
+		class Item392
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8822,11 +7365,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2880;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item394
+		class Item393
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8838,11 +7382,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2881;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item395
+		class Item394
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8854,11 +7399,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2882;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item396
+		class Item395
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8870,11 +7416,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2883;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item397
+		class Item396
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8891,7 +7438,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.24999619;
 		};
-		class Item398
+		class Item397
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8908,7 +7455,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item399
+		class Item398
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8925,7 +7472,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item400
+		class Item399
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8941,7 +7488,7 @@ class Mission
 			id=2887;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item401
+		class Item400
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8957,7 +7504,7 @@ class Mission
 			id=2888;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item402
+		class Item401
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8973,7 +7520,7 @@ class Mission
 			id=2889;
 			type="Land_TTowerSmall_1_F";
 		};
-		class Item403
+		class Item402
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8990,7 +7537,7 @@ class Mission
 			type="Land_TTowerSmall_2_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item404
+		class Item403
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9007,7 +7554,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item405
+		class Item404
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9019,11 +7566,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=2892;
 			type="Land_Cargo40_military_green_F";
 		};
-		class Item406
+		class Item405
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9035,12 +7584,14 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=2893;
 			type="Land_Cargo40_military_green_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item407
+		class Item406
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9052,11 +7603,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=2894;
 			type="Land_Cargo40_military_green_F";
 		};
-		class Item408
+		class Item407
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9072,7 +7625,7 @@ class Mission
 			id=2895;
 			type="Land_Medevac_house_V1_F";
 		};
-		class Item409
+		class Item408
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9084,11 +7637,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2896;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item410
+		class Item409
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9100,11 +7654,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2897;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item411
+		class Item410
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9116,11 +7671,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2898;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item412
+		class Item411
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9132,12 +7688,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2899;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item413
+		class Item412
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9149,12 +7706,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2900;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item414
+		class Item413
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9166,11 +7724,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2901;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item415
+		class Item414
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9182,11 +7741,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2902;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item416
+		class Item415
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9198,11 +7758,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2903;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item417
+		class Item416
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9214,11 +7775,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2904;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item418
+		class Item417
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9230,11 +7792,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2905;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item419
+		class Item418
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9246,11 +7809,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2906;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item420
+		class Item419
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9262,12 +7826,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2907;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item421
+		class Item420
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9279,11 +7844,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2908;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item422
+		class Item421
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9295,11 +7861,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2909;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item423
+		class Item422
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9311,12 +7878,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2910;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item424
+		class Item423
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9328,11 +7896,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2911;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item425
+		class Item424
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9344,12 +7913,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2912;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item426
+		class Item425
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9361,12 +7931,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2913;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item427
+		class Item426
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9378,12 +7949,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2914;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item428
+		class Item427
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9395,11 +7967,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2915;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item429
+		class Item428
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9411,12 +7984,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2916;
 			type="Land_HBarrier_Big_F";
 			atlOffset=6.1035156e-005;
 		};
-		class Item430
+		class Item429
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9428,11 +8002,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2917;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item431
+		class Item430
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9444,11 +8019,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2918;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item432
+		class Item431
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9460,12 +8036,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2919;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item433
+		class Item432
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9477,12 +8054,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2920;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item434
+		class Item433
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9494,12 +8072,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2921;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item435
+		class Item434
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9511,12 +8090,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2922;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item436
+		class Item435
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9532,7 +8112,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.25006104;
 		};
-		class Item437
+		class Item436
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9548,7 +8128,7 @@ class Mission
 			id=2924;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item438
+		class Item437
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9560,12 +8140,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2925;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item439
+		class Item438
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9577,12 +8158,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2926;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item440
+		class Item439
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9594,11 +8176,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2927;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item441
+		class Item440
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9610,12 +8193,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2928;
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item442
+		class Item441
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9627,11 +8211,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2929;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item443
+		class Item442
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9643,11 +8228,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2930;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item444
+		class Item443
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9659,11 +8245,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=2931;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item445
+		class Item444
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9679,7 +8266,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.25003052;
 		};
-		class Item446
+		class Item445
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9695,7 +8282,7 @@ class Mission
 			id=2933;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item447
+		class Item446
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9711,7 +8298,7 @@ class Mission
 			id=2934;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item448
+		class Item447
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9727,7 +8314,7 @@ class Mission
 			id=2935;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item449
+		class Item448
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9743,7 +8330,7 @@ class Mission
 			id=2936;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item450
+		class Item449
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9760,7 +8347,7 @@ class Mission
 			type="Land_TTowerSmall_1_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item451
+		class Item450
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9777,7 +8364,7 @@ class Mission
 			type="Land_TTowerSmall_2_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item452
+		class Item451
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9794,7 +8381,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item453
+		class Item452
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9806,12 +8393,14 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=2940;
 			type="Land_Cargo40_military_green_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item454
+		class Item453
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9823,12 +8412,14 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=2941;
 			type="Land_Cargo40_military_green_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item455
+		class Item454
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9839,12 +8430,14 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=2942;
 			type="Land_Cargo40_military_green_F";
 			atlOffset=2.6217957;
 		};
-		class Item456
+		class Item455
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9860,56 +8453,56 @@ class Mission
 			id=2943;
 			type="Land_Medevac_house_V1_F";
 		};
-		class Item457
+		class Item456
 		{
 			dataType="Layer";
 			name="Open Ammo Dump_3";
 			id=2945;
 			atlOffset=96.5;
 		};
-		class Item458
+		class Item457
 		{
 			dataType="Layer";
 			name="Vehicle Repair_3";
 			id=2970;
 			atlOffset=96.5;
 		};
-		class Item459
+		class Item458
 		{
 			dataType="Layer";
 			name="Abandoned AA Gun Emplacement";
 			id=3316;
 			atlOffset=96.5;
 		};
-		class Item460
+		class Item459
 		{
 			dataType="Layer";
 			name="Abandoned Field Hospital";
 			id=3423;
 			atlOffset=96.5;
 		};
-		class Item461
+		class Item460
 		{
 			dataType="Layer";
 			name="Hasty Landing Zone";
 			id=3470;
 			atlOffset=96.5;
 		};
-		class Item462
+		class Item461
 		{
 			dataType="Layer";
 			name="Landing Zone";
 			id=3571;
 			atlOffset=96.5;
 		};
-		class Item463
+		class Item462
 		{
 			dataType="Layer";
 			name="Roadblock";
 			id=3599;
 			atlOffset=96.5;
 		};
-		class Item464
+		class Item463
 		{
 			dataType="Layer";
 			name="Landing Zone";
@@ -9929,6 +8522,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3651;
 					type="Land_HBarrier_Big_F";
@@ -9947,6 +8541,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3652;
 					type="Land_HBarrier_Big_F";
@@ -9965,6 +8560,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3653;
 					type="Land_HBarrier_Big_F";
@@ -9983,6 +8579,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3654;
 					type="Land_HBarrier_Big_F";
@@ -10017,6 +8614,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3656;
 					type="Land_HBarrier_Big_F";
@@ -10035,6 +8633,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3657;
 					type="Land_HBarrier_5_F";
@@ -10052,6 +8651,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3658;
 					type="Land_HBarrier_Big_F";
@@ -10069,6 +8669,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3659;
 					type="Land_HBarrier_5_F";
@@ -10087,6 +8688,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3660;
 					type="Land_HBarrier_Big_F";
@@ -10122,6 +8724,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3662;
 					type="Land_HBarrier_Big_F";
@@ -10174,6 +8777,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3665;
 					type="Land_HBarrier_5_F";
@@ -10192,6 +8796,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3666;
 					type="Land_HBarrier_5_F";
@@ -10210,6 +8815,8 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						createAsSimpleObject=1;
+						disableSimulation=1;
 					};
 					id=3667;
 					type="Land_Cargo10_light_green_F";
@@ -10228,6 +8835,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3668;
 					type="Land_HBarrier_Big_F";
@@ -10246,6 +8854,8 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						createAsSimpleObject=1;
+						disableSimulation=1;
 					};
 					id=3669;
 					type="Land_Cargo10_light_blue_F";
@@ -10264,6 +8874,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3670;
 					type="Land_HBarrier_Big_F";
@@ -10282,6 +8893,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3671;
 					type="Land_HBarrier_Big_F";
@@ -10299,6 +8911,8 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						createAsSimpleObject=1;
+						disableSimulation=1;
 					};
 					id=3672;
 					type="Land_Cargo10_light_green_F";
@@ -10317,6 +8931,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3673;
 					type="Land_HBarrier_Big_F";
@@ -10334,6 +8949,8 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						createAsSimpleObject=1;
+						disableSimulation=1;
 					};
 					id=3674;
 					type="Land_Cargo10_light_green_F";
@@ -10352,6 +8969,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3675;
 					type="Land_HBarrier_Big_F";
@@ -10370,6 +8988,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3676;
 					type="Land_HBarrier_Big_F";
@@ -10388,6 +9007,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3677;
 					type="Land_HBarrier_Big_F";
@@ -10406,6 +9026,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3678;
 					type="Land_HBarrier_3_F";
@@ -10424,6 +9045,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3679;
 					type="Land_HBarrier_Big_F";
@@ -10442,6 +9064,8 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						createAsSimpleObject=1;
+						disableSimulation=1;
 					};
 					id=3680;
 					type="Land_Cargo10_light_green_F";
@@ -10460,6 +9084,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3681;
 					type="Land_HBarrier_3_F";
@@ -10477,6 +9102,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3682;
 					type="Land_HBarrier_Big_F";
@@ -10495,6 +9121,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3683;
 					type="Land_HBarrier_Big_F";
@@ -10513,6 +9140,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3684;
 					type="Land_HBarrier_Big_F";
@@ -10530,6 +9158,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3685;
 					type="Land_HBarrier_Big_F";
@@ -10548,6 +9177,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3686;
 					type="Land_HBarrier_Big_F";
@@ -10566,6 +9196,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3687;
 					type="Land_HBarrier_Big_F";
@@ -10584,6 +9215,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3688;
 					type="Land_HBarrier_Big_F";
@@ -10602,6 +9234,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3689;
 					type="Land_HBarrier_Big_F";
@@ -10620,6 +9253,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3690;
 					type="Land_HBarrier_Big_F";
@@ -10638,6 +9272,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3691;
 					type="Land_HBarrier_Big_F";
@@ -10656,6 +9291,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3692;
 					type="Land_HBarrier_Big_F";
@@ -10674,6 +9310,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3693;
 					type="Land_HBarrier_Big_F";
@@ -10728,6 +9365,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3696;
 					type="Land_HBarrier_5_F";
@@ -10746,6 +9384,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3697;
 					type="Land_HBarrier_5_F";
@@ -10764,6 +9403,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3698;
 					type="Land_HBarrier_5_F";
@@ -10782,6 +9422,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=3699;
 					type="Land_HBarrier_5_F";
@@ -10826,245 +9467,245 @@ class Mission
 			id=3700;
 			atlOffset=-10.067444;
 		};
-		class Item465
+		class Item464
 		{
 			dataType="Layer";
 			name="Industrial Compound (Large)";
 			id=3996;
 			atlOffset=96.5;
 		};
-		class Item466
+		class Item465
 		{
 			dataType="Layer";
 			name="Storage Facility and Warehouse";
 			id=4280;
 			atlOffset=96.5;
 		};
-		class Item467
+		class Item466
 		{
 			dataType="Layer";
 			name="IDAP Refugee Camp Large";
 			id=4597;
 			atlOffset=96.5;
 		};
-		class Item468
+		class Item467
 		{
 			dataType="Layer";
 			name="Basketball Court";
 			id=4615;
 			atlOffset=96.5;
 		};
-		class Item469
+		class Item468
 		{
 			dataType="Layer";
 			name="Gas Station";
 			id=4676;
 			atlOffset=96.5;
 		};
-		class Item470
+		class Item469
 		{
 			dataType="Layer";
 			name="Cargo Post";
 			id=4692;
 			atlOffset=96.5;
 		};
-		class Item471
+		class Item470
 		{
 			dataType="Layer";
 			name="Bunker (Small) #1";
 			id=4710;
 			atlOffset=96.5;
 		};
-		class Item472
+		class Item471
 		{
 			dataType="Layer";
 			name="Shoot House";
 			id=5060;
 			atlOffset=96.5;
 		};
-		class Item473
+		class Item472
 		{
 			dataType="Layer";
 			name="Depot [BLU]";
 			id=5115;
 			atlOffset=96.5;
 		};
-		class Item474
+		class Item473
 		{
 			dataType="Layer";
 			name="Hangar";
 			id=5227;
 			atlOffset=96.5;
 		};
-		class Item475
+		class Item474
 		{
 			dataType="Layer";
 			name="Hangar";
 			id=5339;
 			atlOffset=96.5;
 		};
-		class Item476
+		class Item475
 		{
 			dataType="Layer";
 			name="Factory Headquarters";
 			id=5415;
 			atlOffset=96.5;
 		};
-		class Item477
+		class Item476
 		{
 			dataType="Layer";
 			name="Main Headquarters";
 			id=5477;
 			atlOffset=96.5;
 		};
-		class Item478
+		class Item477
 		{
 			dataType="Layer";
 			name="Radar Dome";
 			id=5539;
 			atlOffset=96.5;
 		};
-		class Item479
+		class Item478
 		{
 			dataType="Layer";
 			name="Fortified Comms Tower";
 			id=5612;
 			atlOffset=96.5;
 		};
-		class Item480
+		class Item479
 		{
 			dataType="Layer";
 			name="Communications Post";
 			id=5672;
 			atlOffset=96.5;
 		};
-		class Item481
+		class Item480
 		{
 			dataType="Layer";
 			name="Comms Post [BLU]";
 			id=5708;
 			atlOffset=96.5;
 		};
-		class Item482
+		class Item481
 		{
 			dataType="Layer";
 			name="Comms Post [OPF]";
 			id=5760;
 			atlOffset=96.5;
 		};
-		class Item483
+		class Item482
 		{
 			dataType="Layer";
 			name="Cargo HQ [BLU] #1";
 			id=5851;
 			atlOffset=96.5;
 		};
-		class Item484
+		class Item483
 		{
 			dataType="Layer";
 			name="Cargo Tower [BLU]";
 			id=5981;
 			atlOffset=96.5;
 		};
-		class Item485
+		class Item484
 		{
 			dataType="Layer";
 			name="Field Depot [BLU]";
 			id=6077;
 			atlOffset=96.5;
 		};
-		class Item486
+		class Item485
 		{
 			dataType="Layer";
 			name="Field HQ [BLU]";
 			id=6205;
 			atlOffset=96.5;
 		};
-		class Item487
+		class Item486
 		{
 			dataType="Layer";
 			name="Concrete Wall LZ";
 			id=6319;
 			atlOffset=96.5;
 		};
-		class Item488
+		class Item487
 		{
 			dataType="Layer";
 			name="Heliport - Fortified [BLU]";
 			id=6393;
 			atlOffset=96.5;
 		};
-		class Item489
+		class Item488
 		{
 			dataType="Layer";
 			name="Heliport [BLU]";
 			id=6439;
 			atlOffset=96.5;
 		};
-		class Item490
+		class Item489
 		{
 			dataType="Layer";
 			name="Command Centre";
 			id=6566;
 			atlOffset=96.5;
 		};
-		class Item491
+		class Item490
 		{
 			dataType="Layer";
 			name="Main Headquarters [BLU]";
 			id=6757;
 			atlOffset=96.5;
 		};
-		class Item492
+		class Item491
 		{
 			dataType="Layer";
 			name="Headquarters";
 			id=6794;
 			atlOffset=96.5;
 		};
-		class Item493
+		class Item492
 		{
 			dataType="Layer";
 			name="Headquarters (Fortified)";
 			id=6858;
 			atlOffset=96.5;
 		};
-		class Item494
+		class Item493
 		{
 			dataType="Layer";
 			name="Military Compound";
 			id=7018;
 			atlOffset=96.5;
 		};
-		class Item495
+		class Item494
 		{
 			dataType="Layer";
 			name="VIP Compound";
 			id=7156;
 			atlOffset=96.5;
 		};
-		class Item496
+		class Item495
 		{
 			dataType="Layer";
 			name="Main Headquarters [OPF]";
 			id=7410;
 			atlOffset=96.5;
 		};
-		class Item497
+		class Item496
 		{
 			dataType="Layer";
 			name="Main Headquarters [BLU]";
 			id=7601;
 			atlOffset=96.5;
 		};
-		class Item498
+		class Item497
 		{
 			dataType="Layer";
 			name="Military Compound";
 			id=7761;
 			atlOffset=96.5;
 		};
-		class Item499
+		class Item498
 		{
 			dataType="Layer";
 			name="Command Centre";
@@ -11404,6 +10045,8 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						createAsSimpleObject=1;
+						disableSimulation=1;
 					};
 					id=7782;
 					type="Land_Cargo40_yellow_F";
@@ -11928,18 +10571,18 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5722.7505,352.88428,5555.875};
-						angles[]={0.067896426,3.1421337,6.2105141};
+						position[]={5722.75,352.88431,5555.875};
+						angles[]={0.067893311,3.1421337,6.2105098};
 					};
 					side="Empty";
 					flags=4;
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=7814;
 					type="Land_HelipadSquare_F";
-					atlOffset=3.0517578e-005;
 				};
 				class Item49
 				{
@@ -12134,6 +10777,8 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						createAsSimpleObject=1;
+						disableSimulation=1;
 					};
 					id=7825;
 					type="Land_Cargo20_cyan_F";
@@ -12479,6 +11124,8 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						createAsSimpleObject=1;
+						disableSimulation=1;
 					};
 					id=7857;
 					type="Land_Cargo20_light_green_F";
@@ -12766,6 +11413,8 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						createAsSimpleObject=1;
+						disableSimulation=1;
 					};
 					id=7874;
 					type="Land_Cargo40_military_green_F";
@@ -13006,7 +11655,7 @@ class Mission
 			id=7888;
 			atlOffset=0.17941284;
 		};
-		class Item500
+		class Item499
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -13063,7 +11712,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item501
+		class Item500
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13075,12 +11724,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7893;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item502
+		class Item501
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13092,12 +11742,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7894;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item503
+		class Item502
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13109,11 +11760,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7895;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item504
+		class Item503
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13125,11 +11777,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7896;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item505
+		class Item504
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13141,12 +11794,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7897;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item506
+		class Item505
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13158,11 +11812,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7898;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item507
+		class Item506
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13174,12 +11829,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7899;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item508
+		class Item507
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13191,12 +11847,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7900;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item509
+		class Item508
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13208,11 +11865,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7901;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item510
+		class Item509
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13224,12 +11882,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7902;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item511
+		class Item510
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13240,12 +11899,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7903;
 			type="Land_HBarrier_Big_F";
 			atlOffset=0.4550705;
 		};
-		class Item512
+		class Item511
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13257,12 +11917,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7904;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item513
+		class Item512
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13274,11 +11935,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7905;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item514
+		class Item513
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13290,11 +11952,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7906;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item515
+		class Item514
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13306,11 +11969,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7907;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item516
+		class Item515
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13322,11 +11986,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7908;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item517
+		class Item516
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13338,11 +12003,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7909;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item518
+		class Item517
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13354,11 +12020,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7910;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item519
+		class Item518
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13370,11 +12037,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7911;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item520
+		class Item519
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13386,11 +12054,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7912;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item521
+		class Item520
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13402,11 +12071,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7913;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item522
+		class Item521
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13418,11 +12088,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7914;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item523
+		class Item522
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13434,11 +12105,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7915;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item524
+		class Item523
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13450,11 +12122,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7916;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item525
+		class Item524
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13466,12 +12139,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7917;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item526
+		class Item525
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13483,11 +12157,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7918;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item527
+		class Item526
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13499,11 +12174,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7919;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item528
+		class Item527
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13519,7 +12195,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.25;
 		};
-		class Item529
+		class Item528
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13536,7 +12212,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item530
+		class Item529
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13548,11 +12224,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7922;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item531
+		class Item530
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13564,11 +12241,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7923;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item532
+		class Item531
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13580,11 +12258,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7924;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item533
+		class Item532
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13596,12 +12275,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7925;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item534
+		class Item533
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13613,12 +12293,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7926;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item535
+		class Item534
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13630,12 +12311,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7927;
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item536
+		class Item535
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13647,11 +12329,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=7928;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item537
+		class Item536
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13668,7 +12351,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.24999237;
 		};
-		class Item538
+		class Item537
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13684,7 +12367,7 @@ class Mission
 			id=7930;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item539
+		class Item538
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13700,7 +12383,7 @@ class Mission
 			id=7931;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item540
+		class Item539
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13716,7 +12399,7 @@ class Mission
 			id=7932;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item541
+		class Item540
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13733,7 +12416,7 @@ class Mission
 			type="Land_Cargo_House_V1_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item542
+		class Item541
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13750,7 +12433,7 @@ class Mission
 			type="Land_TTowerSmall_1_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item543
+		class Item542
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13767,7 +12450,7 @@ class Mission
 			type="Land_TTowerSmall_2_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item544
+		class Item543
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13783,7 +12466,7 @@ class Mission
 			id=7936;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item545
+		class Item544
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13794,12 +12477,14 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=7937;
 			type="Land_Cargo40_military_green_F";
 			atlOffset=0.41942596;
 		};
-		class Item546
+		class Item545
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13810,12 +12495,14 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=7938;
 			type="Land_Cargo40_military_green_F";
 			atlOffset=0.34242249;
 		};
-		class Item547
+		class Item546
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13826,12 +12513,14 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=7939;
 			type="Land_Cargo40_military_green_F";
 			atlOffset=5.8844223;
 		};
-		class Item548
+		class Item547
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13848,7 +12537,7 @@ class Mission
 			type="Land_Medevac_house_V1_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item549
+		class Item548
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -13905,7 +12594,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item550
+		class Item549
 		{
 			dataType="Marker";
 			position[]={5411.4707,451.25,5968.7446};
@@ -13920,7 +12609,7 @@ class Mission
 			id=7946;
 			atlOffset=80.688202;
 		};
-		class Item551
+		class Item550
 		{
 			dataType="Marker";
 			position[]={10685.275,38.889198,3810.7349};
@@ -13935,7 +12624,7 @@ class Mission
 			id=7947;
 			atlOffset=15.959801;
 		};
-		class Item552
+		class Item551
 		{
 			dataType="Marker";
 			position[]={1119.0909,16.625,11948.07};
@@ -13950,7 +12639,7 @@ class Mission
 			id=7948;
 			atlOffset=-13.964973;
 		};
-		class Item553
+		class Item552
 		{
 			dataType="Marker";
 			position[]={9662.0869,33.314789,3789.7827};
@@ -13959,7 +12648,7 @@ class Mission
 			id=7950;
 			atlOffset=-1.9511871;
 		};
-		class Item554
+		class Item553
 		{
 			dataType="Marker";
 			position[]={9430.9902,15.582298,3615.3931};
@@ -13968,7 +12657,7 @@ class Mission
 			id=7951;
 			atlOffset=-1.9511871;
 		};
-		class Item555
+		class Item554
 		{
 			dataType="Marker";
 			position[]={9767.667,36.92873,3990.6501};
@@ -13977,7 +12666,7 @@ class Mission
 			id=7952;
 			atlOffset=-1.9511871;
 		};
-		class Item556
+		class Item555
 		{
 			dataType="Marker";
 			position[]={10066.299,26.17466,4027.6467};
@@ -13986,7 +12675,7 @@ class Mission
 			id=7953;
 			atlOffset=-1.9511871;
 		};
-		class Item557
+		class Item556
 		{
 			dataType="Marker";
 			position[]={10486.761,15.848598,4196.1509};
@@ -13995,7 +12684,7 @@ class Mission
 			id=7954;
 			atlOffset=-1.9511881;
 		};
-		class Item558
+		class Item557
 		{
 			dataType="Marker";
 			position[]={11058.517,22.712757,4197.6699};
@@ -14004,7 +12693,7 @@ class Mission
 			id=7955;
 			atlOffset=-1.9511871;
 		};
-		class Item559
+		class Item558
 		{
 			dataType="Marker";
 			position[]={11261.775,15.748955,4268.458};
@@ -14013,7 +12702,7 @@ class Mission
 			id=7956;
 			atlOffset=-1.9511871;
 		};
-		class Item560
+		class Item559
 		{
 			dataType="Marker";
 			position[]={833.31549,14.35758,11943.996};
@@ -14022,7 +12711,7 @@ class Mission
 			id=7958;
 			atlOffset=-1.9511871;
 		};
-		class Item561
+		class Item560
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -14079,7 +12768,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item562
+		class Item561
 		{
 			dataType="Layer";
 			name="Open Ammo Dump_4";
@@ -14168,6 +12857,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=8489;
 					type="Land_HBarrier_5_F";
@@ -14379,6 +13069,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=8501;
 					type="Land_HBarrier_5_F";
@@ -14432,6 +13123,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=8504;
 					type="Land_HBarrier_5_F";
@@ -14449,6 +13141,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=8505;
 					type="Land_HBarrier_5_F";
@@ -14467,6 +13160,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=8506;
 					type="Land_HBarrier_5_F";
@@ -14484,6 +13178,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=8507;
 					type="Land_HBarrier_5_F";
@@ -14510,7 +13205,7 @@ class Mission
 			id=7962;
 			atlOffset=1.3211975;
 		};
-		class Item563
+		class Item562
 		{
 			dataType="Layer";
 			name="Vehicle Repair_4";
@@ -14618,6 +13313,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=8514;
 					type="Land_HBarrier_5_F";
@@ -14654,6 +13350,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=8516;
 					type="Land_HBarrier_1_F";
@@ -14671,6 +13368,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=8517;
 					type="Land_HBarrier_5_F";
@@ -14689,6 +13387,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=8518;
 					type="Land_HBarrier_1_F";
@@ -14706,6 +13405,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=8519;
 					type="Land_HBarrier_5_F";
@@ -14723,6 +13423,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=8520;
 					type="Land_HBarrier_5_F";
@@ -14740,6 +13441,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=8521;
 					type="Land_HBarrier_1_F";
@@ -14757,6 +13459,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.2;
+						disableSimulation=1;
 					};
 					id=8522;
 					type="Land_HBarrier_1_F";
@@ -14782,7 +13485,7 @@ class Mission
 			id=7987;
 			atlOffset=-0.01071167;
 		};
-		class Item564
+		class Item563
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14799,7 +13502,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=2.3841858e-007;
 		};
-		class Item565
+		class Item564
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14816,7 +13519,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item566
+		class Item565
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14833,7 +13536,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=-2.3841858e-007;
 		};
-		class Item567
+		class Item566
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14850,7 +13553,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item568
+		class Item567
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14867,7 +13570,7 @@ class Mission
 			type="Land_Cargo_Tower_V2_F";
 			atlOffset=-1.9073486e-006;
 		};
-		class Item569
+		class Item568
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14883,7 +13586,7 @@ class Mission
 			type="Land_Cargo_Tower_V2_F";
 			atlOffset=-1.9073486e-006;
 		};
-		class Item570
+		class Item569
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14899,7 +13602,7 @@ class Mission
 			id=8386;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item571
+		class Item570
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -14910,7 +13613,7 @@ class Mission
 			id=8387;
 			type="Logic";
 		};
-		class Item572
+		class Item571
 		{
 			dataType="Marker";
 			position[]={8515.5879,-1.2098112,3849.7024};
@@ -14919,7 +13622,7 @@ class Mission
 			id=8388;
 			atlOffset=6.3372011;
 		};
-		class Item573
+		class Item572
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14931,12 +13634,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8389;
 			type="Land_HelipadCircle_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item574
+		class Item573
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14948,12 +13652,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8390;
 			type="Land_HelipadCircle_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item575
+		class Item574
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14965,12 +13670,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8391;
 			type="Land_HelipadCircle_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item576
+		class Item575
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14982,12 +13688,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8392;
 			type="Land_HelipadCircle_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item577
+		class Item576
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15003,7 +13710,7 @@ class Mission
 			id=8393;
 			type="Land_Hangar_F";
 		};
-		class Item578
+		class Item577
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15019,7 +13726,7 @@ class Mission
 			id=8394;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item579
+		class Item578
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15035,7 +13742,7 @@ class Mission
 			id=8395;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item580
+		class Item579
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15051,7 +13758,7 @@ class Mission
 			id=8396;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item581
+		class Item580
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15063,29 +13770,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8399;
 			type="Land_HelipadCircle_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item582
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={8038.3208,30.15959,10313.423};
-				angles[]={6.2807932,4.6746531,6.2799835};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=8400;
-			type="Land_HelipadCircle_F";
-			atlOffset=1.9073486e-006;
-		};
-		class Item583
+		class Item581
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15097,12 +13788,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8401;
 			type="Land_HelipadCircle_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item584
+		class Item582
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15118,7 +13810,7 @@ class Mission
 			id=8402;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item585
+		class Item583
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15135,7 +13827,7 @@ class Mission
 			type="Land_TentHangar_V1_F";
 			atlOffset=-1.9073486e-006;
 		};
-		class Item586
+		class Item584
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15151,7 +13843,7 @@ class Mission
 			id=8404;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item587
+		class Item585
 		{
 			dataType="Layer";
 			name="Airports";
@@ -15310,7 +14002,7 @@ class Mission
 			id=8407;
 			atlOffset=-188.48845;
 		};
-		class Item588
+		class Item586
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15322,11 +14014,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8410;
 			type="Land_HelipadCircle_F";
+			atlOffset=-3.0517578e-005;
 		};
-		class Item589
+		class Item587
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15338,11 +14032,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8413;
 			type="Land_HelipadCircle_F";
 		};
-		class Item590
+		class Item588
 		{
 			dataType="Layer";
 			name="Factories";
@@ -15447,7 +14142,7 @@ class Mission
 			id=8415;
 			atlOffset=-70.355667;
 		};
-		class Item591
+		class Item589
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15459,11 +14154,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8418;
 			type="Land_HelipadCircle_F";
 		};
-		class Item592
+		class Item590
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15475,12 +14171,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8419;
 			type="Land_HelipadCircle_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item593
+		class Item591
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15492,11 +14189,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8420;
 			type="Land_HelipadCircle_F";
 		};
-		class Item594
+		class Item592
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15508,11 +14206,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8422;
 			type="Land_HelipadSquare_F";
 		};
-		class Item595
+		class Item593
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15524,11 +14223,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8423;
 			type="Land_HelipadSquare_F";
 		};
-		class Item596
+		class Item594
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15540,12 +14240,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8426;
 			type="Land_HelipadSquare_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item597
+		class Item595
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15557,11 +14258,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8428;
 			type="Land_HelipadSquare_F";
 		};
-		class Item598
+		class Item596
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15573,11 +14275,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8430;
 			type="Land_HelipadSquare_F";
 		};
-		class Item599
+		class Item597
 		{
 			dataType="Layer";
 			name="Resources";
@@ -15778,24 +14481,24 @@ class Mission
 			id=8431;
 			atlOffset=12.317612;
 		};
-		class Item600
+		class Item598
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={1050.157,3.4221988,691.05896};
-				angles[]={0.0087958695,1.6255023,0.022394964};
+				position[]={1050.157,3.4221969,691.05902};
+				angles[]={0.0087964591,1.625495,0.022392575};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8434;
 			type="Land_HelipadSquare_F";
-			atlOffset=1.1920929e-006;
 		};
-		class Item601
+		class Item599
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15807,11 +14510,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8435;
 			type="Land_HelipadSquare_F";
+			atlOffset=-3.3378601e-006;
 		};
-		class Item602
+		class Item600
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15823,12 +14528,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8438;
 			type="Land_HelipadSquare_F";
 			atlOffset=3.3378601e-006;
 		};
-		class Item603
+		class Item601
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15840,11 +14546,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8441;
 			type="Land_HelipadSquare_F";
+			atlOffset=-2.3841858e-007;
 		};
-		class Item604
+		class Item602
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15856,11 +14564,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8442;
 			type="Land_HelipadSquare_F";
 		};
-		class Item605
+		class Item603
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15871,12 +14580,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8445;
 			type="Land_HelipadSquare_F";
 			atlOffset=1.4099998;
 		};
-		class Item606
+		class Item604
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15888,11 +14598,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8447;
 			type="Land_HelipadSquare_F";
 		};
-		class Item607
+		class Item605
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15904,11 +14615,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8448;
 			type="Land_HelipadSquare_F";
 		};
-		class Item608
+		class Item606
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15920,11 +14632,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8449;
 			type="Land_HelipadSquare_F";
 		};
-		class Item609
+		class Item607
 		{
 			dataType="Layer";
 			name="Seaports";
@@ -15968,7 +14681,7 @@ class Mission
 					colorName="ColorGreen";
 					a=7.539;
 					b=6;
-					angle=54.692429;
+					angle=54.692421;
 					id=8437;
 					atlOffset=0.90610528;
 				};
@@ -16189,39 +14902,7 @@ class Mission
 			id=8452;
 			atlOffset=14.458153;
 		};
-		class Item610
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={8002.9717,30.53899,10683.684};
-				angles[]={0.0055992967,4.6181393,6.2824135};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=8453;
-			type="Land_HelipadCircle_F";
-		};
-		class Item611
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={8011.3784,30.589775,10625.852};
-				angles[]={6.2824135,4.6181393,0.00077204045};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=8455;
-			type="Land_HelipadCircle_F";
-		};
-		class Item612
+		class Item608
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16233,11 +14914,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8456;
 			type="Land_HelipadCircle_F";
+			atlOffset=-9.5367432e-006;
 		};
-		class Item613
+		class Item609
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16249,12 +14932,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8462;
 			type="Land_HelipadSquare_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item614
+		class Item610
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16266,11 +14950,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8463;
 			type="Land_HelipadSquare_F";
 		};
-		class Item615
+		class Item611
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16282,11 +14967,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8471;
 			type="Land_HelipadSquare_F";
 		};
-		class Item616
+		class Item612
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16298,11 +14984,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8472;
 			type="Land_HelipadSquare_F";
 		};
-		class Item617
+		class Item613
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16314,11 +15001,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8476;
 			type="Land_HelipadSquare_F";
+			atlOffset=-7.6293945e-006;
 		};
-		class Item618
+		class Item614
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16330,11 +15019,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8477;
 			type="Land_HelipadSquare_F";
+			atlOffset=-3.8146973e-006;
 		};
-		class Item619
+		class Item615
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16346,12 +15037,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8480;
 			type="Land_HelipadSquare_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item620
+		class Item616
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16363,11 +15055,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8481;
 			type="Land_HelipadSquare_F";
 		};
-		class Item621
+		class Item617
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16379,11 +15072,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8483;
 			type="Land_HelipadSquare_F";
 		};
-		class Item622
+		class Item618
 		{
 			dataType="Layer";
 			name="Outposts";
@@ -16414,7 +15108,7 @@ class Mission
 					colorName="ColorGreen";
 					a=20.476999;
 					b=6;
-					angle=220.9269;
+					angle=220.9268;
 					id=8461;
 					atlOffset=0.00021362305;
 				};
@@ -16483,7 +15177,7 @@ class Mission
 					colorName="ColorGreen";
 					a=13.154379;
 					b=5.3131795;
-					angle=83.795937;
+					angle=83.795929;
 					id=8467;
 					atlOffset=0.8065567;
 				};
@@ -16792,7 +15486,7 @@ class Mission
 			id=8484;
 			atlOffset=25.185242;
 		};
-		class Item623
+		class Item619
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16804,12 +15498,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8524;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item624
+		class Item620
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16821,11 +15516,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8525;
 			type="Land_HBarrier_5_F";
 		};
-		class Item625
+		class Item621
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16837,11 +15533,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8526;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item626
+		class Item622
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16853,12 +15550,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8527;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item627
+		class Item623
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16870,11 +15568,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8528;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item628
+		class Item624
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16886,11 +15585,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8529;
 			type="Land_HBarrier_5_F";
 		};
-		class Item629
+		class Item625
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16902,11 +15602,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8530;
 			type="Land_HBarrier_5_F";
 		};
-		class Item630
+		class Item626
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16918,11 +15619,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8531;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item631
+		class Item627
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16934,11 +15636,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8532;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item632
+		class Item628
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16950,12 +15653,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8533;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item633
+		class Item629
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16967,11 +15671,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8534;
 			type="Land_HBarrier_3_F";
 		};
-		class Item634
+		class Item630
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16983,11 +15688,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8535;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item635
+		class Item631
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16999,11 +15705,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8536;
 			type="Land_HBarrier_5_F";
 		};
-		class Item636
+		class Item632
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17015,12 +15722,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8537;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item637
+		class Item633
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17032,12 +15740,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8538;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item638
+		class Item634
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17049,11 +15758,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8539;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item639
+		class Item635
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17065,12 +15775,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8540;
 			type="Land_HBarrier_3_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item640
+		class Item636
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17082,11 +15793,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8541;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item641
+		class Item637
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17098,12 +15810,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8542;
 			type="Land_HBarrier_5_F";
 			atlOffset=-0.19999695;
 		};
-		class Item642
+		class Item638
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17115,12 +15828,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8543;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item643
+		class Item639
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17132,11 +15846,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8544;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item644
+		class Item640
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17148,11 +15863,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8545;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item645
+		class Item641
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17164,11 +15880,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8546;
 			type="Land_HBarrier_3_F";
 		};
-		class Item646
+		class Item642
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17180,11 +15897,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8547;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item647
+		class Item643
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17196,11 +15914,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8548;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item648
+		class Item644
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17212,11 +15931,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8549;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item649
+		class Item645
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17228,11 +15948,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8550;
 			type="Land_HBarrierWall6_F";
 		};
-		class Item650
+		class Item646
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17244,12 +15965,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8551;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item651
+		class Item647
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17266,7 +15988,7 @@ class Mission
 			type="Land_Mil_WiredFence_Gate_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item652
+		class Item648
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17278,12 +16000,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8553;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item653
+		class Item649
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17295,12 +16018,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8554;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item654
+		class Item650
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17312,11 +16036,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8555;
 			type="Land_HBarrier_5_F";
 		};
-		class Item655
+		class Item651
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17328,12 +16053,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8556;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item656
+		class Item652
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17345,12 +16071,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8557;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item657
+		class Item653
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17362,11 +16089,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8558;
 			type="Land_HBarrier_5_F";
 		};
-		class Item658
+		class Item654
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17378,12 +16106,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8559;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item659
+		class Item655
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17395,12 +16124,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8560;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item660
+		class Item656
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17412,11 +16142,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8561;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item661
+		class Item657
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17428,11 +16159,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8562;
 			type="Land_HBarrier_5_F";
 		};
-		class Item662
+		class Item658
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17444,11 +16176,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8563;
 			type="Land_HBarrier_5_F";
 		};
-		class Item663
+		class Item659
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17460,11 +16193,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8564;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item664
+		class Item660
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17476,12 +16210,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8565;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item665
+		class Item661
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17493,11 +16228,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8566;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item666
+		class Item662
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17509,11 +16245,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8567;
 			type="Land_HBarrier_5_F";
 		};
-		class Item667
+		class Item663
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17525,11 +16262,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8568;
 			type="Land_HBarrier_5_F";
 		};
-		class Item668
+		class Item664
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17541,11 +16279,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8569;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item669
+		class Item665
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17557,12 +16296,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8570;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item670
+		class Item666
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17574,11 +16314,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8571;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item671
+		class Item667
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17590,11 +16331,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8572;
 			type="Land_HBarrier_5_F";
 		};
-		class Item672
+		class Item668
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17606,11 +16348,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8573;
 			type="Land_HBarrier_5_F";
 		};
-		class Item673
+		class Item669
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17622,11 +16365,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8574;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item674
+		class Item670
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17638,11 +16382,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8575;
 			type="Land_HBarrier_5_F";
 		};
-		class Item675
+		class Item671
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17654,11 +16399,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8576;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item676
+		class Item672
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17670,50 +16416,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8577;
 			type="Land_HBarrier_3_F";
 		};
-		class Item677
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={2502.2781,202.54012,3615.8379};
-				angles[]={6.2344246,5.9818177,6.2711854};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=8578;
-			type="Land_MedicalTent_01_NATO_generic_open_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item678
+		class Item673
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17729,7 +16437,7 @@ class Mission
 			id=8579;
 			type="Land_Razorwire_F";
 		};
-		class Item679
+		class Item674
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17745,7 +16453,7 @@ class Mission
 			id=8580;
 			type="Land_Razorwire_F";
 		};
-		class Item680
+		class Item675
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17761,7 +16469,7 @@ class Mission
 			id=8581;
 			type="Land_Razorwire_F";
 		};
-		class Item681
+		class Item676
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17777,7 +16485,7 @@ class Mission
 			id=8582;
 			type="Land_Razorwire_F";
 		};
-		class Item682
+		class Item677
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17793,7 +16501,7 @@ class Mission
 			id=8583;
 			type="Land_Razorwire_F";
 		};
-		class Item683
+		class Item678
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17809,7 +16517,7 @@ class Mission
 			id=8584;
 			type="Land_Razorwire_F";
 		};
-		class Item684
+		class Item679
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17821,11 +16529,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8585;
 			type="Land_HBarrier_3_F";
 		};
-		class Item685
+		class Item680
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17842,40 +16551,7 @@ class Mission
 			type="Land_LampSolar_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item686
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={2511.0068,222.79994,3619.7566};
-				angles[]={0,2.8402252,0};
-			};
-			side="Empty";
-			class Attributes
-			{
-			};
-			id=8587;
-			type="Land_MedicalTent_01_floor_dark_F";
-			atlOffset=18.18277;
-		};
-		class Item687
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={2502.2781,204.76514,3615.8379};
-				angles[]={0.062013965,2.8402252,5.9302912};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=8588;
-			type="Land_MedicalTent_01_floor_dark_F";
-			atlOffset=0.11151123;
-		};
-		class Item688
+		class Item681
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17887,11 +16563,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8589;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item689
+		class Item682
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17908,117 +16585,7 @@ class Mission
 			type="Land_PressureWasher_01_F";
 			atlOffset=-0.00012207031;
 		};
-		class Item690
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={2509.7061,201.3537,3611.4856};
-				angles[]={6.2176785,2.8402252,6.2711854};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=8591;
-			type="Land_AirConditioner_03_F";
-		};
-		class Item691
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={2496.4004,201.65584,3614.5972};
-				angles[]={6.236022,4.4110217,6.277586};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=8592;
-			type="Land_AirConditioner_02_F";
-		};
-		class Item692
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={2511.8264,202.61993,3618.8059};
-				angles[]={6.2256494,5.9818177,6.2799835};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=8593;
-			type="Land_MedicalTent_01_NATO_generic_closed_F";
-			atlOffset=1.5258789e-005;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="MedSign_Hide";
-					expression="_this animateSource ['MedSign_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="Door_Hide";
-					expression="_this animateSource ['Door_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute2
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=3;
-			};
-		};
-		class Item693
+		class Item683
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18030,11 +16597,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8594;
 			type="Land_HBarrier_5_F";
 		};
-		class Item694
+		class Item684
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18046,11 +16614,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8595;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item695
+		class Item685
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18062,11 +16631,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8596;
 			type="Land_HBarrier_5_F";
 		};
-		class Item696
+		class Item686
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18078,11 +16648,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8597;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item697
+		class Item687
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18094,11 +16665,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8598;
 			type="Land_HBarrier_5_F";
 		};
-		class Item698
+		class Item688
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18110,11 +16682,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8599;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item699
+		class Item689
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18126,11 +16699,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8600;
 			type="Land_HBarrier_5_F";
 		};
-		class Item700
+		class Item690
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18142,11 +16716,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8601;
 			type="Land_HBarrier_3_F";
 		};
-		class Item701
+		class Item691
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18158,12 +16733,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8602;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item702
+		class Item692
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18175,12 +16751,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8603;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item703
+		class Item693
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18192,11 +16769,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8604;
 			type="Land_HBarrier_3_F";
 		};
-		class Item704
+		class Item694
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18208,12 +16786,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8605;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item705
+		class Item695
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18225,11 +16804,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8606;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item706
+		class Item696
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18241,12 +16821,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8607;
 			type="Land_HBarrier_3_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item707
+		class Item697
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18258,12 +16839,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8608;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item708
+		class Item698
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18275,12 +16857,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8609;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item709
+		class Item699
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18292,11 +16875,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8610;
 			type="Land_HBarrier_3_F";
 		};
-		class Item710
+		class Item700
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18308,11 +16892,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8611;
 			type="Land_HBarrier_5_F";
 		};
-		class Item711
+		class Item701
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18324,11 +16909,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8612;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item712
+		class Item702
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18340,11 +16926,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8613;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item713
+		class Item703
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18356,11 +16943,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8614;
 			type="Land_HBarrier_5_F";
 		};
-		class Item714
+		class Item704
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18372,12 +16960,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8615;
 			type="Land_HBarrier_5_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item715
+		class Item705
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18389,11 +16978,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8616;
 			type="Land_HBarrier_5_F";
 		};
-		class Item716
+		class Item706
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18405,11 +16995,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8617;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item717
+		class Item707
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18421,11 +17012,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8618;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item718
+		class Item708
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18437,12 +17029,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8619;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item719
+		class Item709
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18454,11 +17047,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8620;
 			type="Land_HBarrier_5_F";
 		};
-		class Item720
+		class Item710
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18470,11 +17064,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8621;
 			type="Land_HBarrier_5_F";
 		};
-		class Item721
+		class Item711
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18486,11 +17081,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8622;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item722
+		class Item712
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18502,11 +17098,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8623;
 			type="Land_HBarrier_5_F";
 		};
-		class Item723
+		class Item713
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18518,11 +17115,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8624;
 			type="Land_HBarrier_5_F";
 		};
-		class Item724
+		class Item714
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18534,11 +17132,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8625;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item725
+		class Item715
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18550,11 +17149,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8626;
 			type="Land_HBarrier_5_F";
 		};
-		class Item726
+		class Item716
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18566,11 +17166,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8627;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item727
+		class Item717
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18582,11 +17183,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8628;
 			type="Land_HBarrier_5_F";
 		};
-		class Item728
+		class Item718
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18598,11 +17200,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8629;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item729
+		class Item719
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18614,11 +17217,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8630;
 			type="Land_HBarrier_5_F";
 		};
-		class Item730
+		class Item720
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18630,11 +17234,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8631;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item731
+		class Item721
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18646,11 +17251,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8632;
 			type="Land_HBarrier_5_F";
 		};
-		class Item732
+		class Item722
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18662,11 +17268,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8633;
 			type="Land_HBarrier_5_F";
 		};
-		class Item733
+		class Item723
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18678,11 +17285,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8634;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item734
+		class Item724
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18694,12 +17302,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8635;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item735
+		class Item725
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18711,11 +17320,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8636;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item736
+		class Item726
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18727,11 +17337,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8637;
 			type="Land_HBarrier_5_F";
 		};
-		class Item737
+		class Item727
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18743,12 +17354,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8638;
 			type="Land_HBarrier_3_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item738
+		class Item728
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18760,12 +17372,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8639;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item739
+		class Item729
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18777,11 +17390,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8640;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item740
+		class Item730
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18793,11 +17407,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8641;
 			type="Land_HBarrier_5_F";
 		};
-		class Item741
+		class Item731
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18809,11 +17424,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8642;
 			type="Land_HBarrier_1_F";
 		};
-		class Item742
+		class Item732
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18825,11 +17441,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8643;
 			type="Land_HBarrier_1_F";
 		};
-		class Item743
+		class Item733
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18841,12 +17458,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8644;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item744
+		class Item734
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18858,12 +17476,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8645;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item745
+		class Item735
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18875,11 +17494,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8646;
 			type="Land_HBarrier_5_F";
 		};
-		class Item746
+		class Item736
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18891,11 +17511,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8647;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item747
+		class Item737
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18907,11 +17528,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8648;
 			type="Land_HBarrier_5_F";
 		};
-		class Item748
+		class Item738
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18923,11 +17545,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8649;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item749
+		class Item739
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18939,11 +17562,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8650;
 			type="Land_HBarrier_5_F";
 		};
-		class Item750
+		class Item740
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18955,11 +17579,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8651;
 			type="Land_HBarrier_3_F";
 		};
-		class Item751
+		class Item741
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18971,11 +17596,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8652;
 			type="Land_HBarrier_5_F";
 		};
-		class Item752
+		class Item742
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18987,11 +17613,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8653;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item753
+		class Item743
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19003,11 +17630,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8654;
 			type="Land_HBarrier_5_F";
 		};
-		class Item754
+		class Item744
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19019,11 +17647,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8655;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item755
+		class Item745
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19035,11 +17664,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8656;
 			type="Land_HBarrier_5_F";
 		};
-		class Item756
+		class Item746
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19051,12 +17681,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8657;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item757
+		class Item747
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19072,7 +17703,7 @@ class Mission
 			id=8658;
 			type="Land_MobileRadar_01_radar_F";
 		};
-		class Item758
+		class Item748
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19089,7 +17720,7 @@ class Mission
 			type="Land_MobileRadar_01_generator_F";
 			atlOffset=0.25138855;
 		};
-		class Item759
+		class Item749
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19105,7 +17736,7 @@ class Mission
 			id=8660;
 			type="Land_Cargo_HQ_V1_F";
 		};
-		class Item760
+		class Item750
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19121,7 +17752,7 @@ class Mission
 			id=8661;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item761
+		class Item751
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19137,7 +17768,7 @@ class Mission
 			id=8662;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item762
+		class Item752
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19153,7 +17784,7 @@ class Mission
 			id=8663;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item763
+		class Item753
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19169,7 +17800,7 @@ class Mission
 			id=8664;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item764
+		class Item754
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19181,12 +17812,13 @@ class Mission
 			class Attributes
 			{
 				init="call{this setVariable [""spawnableHelicopterTypes"", [""patrol"", ""transport"", ""attack""]];}";
+				disableSimulation=1;
 			};
 			id=8665;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.65576172;
 		};
-		class Item765
+		class Item755
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19198,12 +17830,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8666;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item766
+		class Item756
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19215,12 +17848,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8667;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item767
+		class Item757
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19232,12 +17866,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8668;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item768
+		class Item758
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19249,12 +17884,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8669;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item769
+		class Item759
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19266,11 +17902,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8670;
 			type="Land_HBarrier_5_F";
 		};
-		class Item770
+		class Item760
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19282,11 +17919,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8671;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item771
+		class Item761
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19298,11 +17936,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8672;
 			type="Land_HBarrier_5_F";
 		};
-		class Item772
+		class Item762
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19314,11 +17953,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8673;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item773
+		class Item763
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19330,11 +17970,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8674;
 			type="Land_HBarrier_5_F";
 		};
-		class Item774
+		class Item764
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19346,11 +17987,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8675;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item775
+		class Item765
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19362,11 +18004,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8676;
 			type="Land_HBarrier_5_F";
 		};
-		class Item776
+		class Item766
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19378,12 +18021,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8677;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item777
+		class Item767
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19395,11 +18039,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8678;
 			type="Land_HBarrier_5_F";
 		};
-		class Item778
+		class Item768
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19411,11 +18056,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8679;
 			type="Land_HBarrier_3_F";
 		};
-		class Item779
+		class Item769
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19427,12 +18073,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8680;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item780
+		class Item770
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19444,11 +18091,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8681;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item781
+		class Item771
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19460,11 +18108,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8682;
 			type="Land_HBarrier_5_F";
 		};
-		class Item782
+		class Item772
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19476,11 +18125,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8683;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item783
+		class Item773
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19492,12 +18142,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8684;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item784
+		class Item774
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19509,12 +18160,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8685;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item785
+		class Item775
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19526,11 +18178,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8686;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item786
+		class Item776
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19542,11 +18195,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8687;
 			type="Land_HBarrier_5_F";
 		};
-		class Item787
+		class Item777
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19558,11 +18212,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8688;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item788
+		class Item778
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19574,11 +18229,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8689;
 			type="Land_HBarrier_5_F";
 		};
-		class Item789
+		class Item779
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19590,11 +18246,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8690;
 			type="Land_HBarrier_5_F";
 		};
-		class Item790
+		class Item780
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19606,11 +18263,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8691;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item791
+		class Item781
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19622,11 +18280,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8692;
 			type="Land_HBarrier_5_F";
 		};
-		class Item792
+		class Item782
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19638,12 +18297,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8693;
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item793
+		class Item783
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19655,11 +18315,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8694;
 			type="Land_HBarrier_3_F";
 		};
-		class Item794
+		class Item784
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19671,11 +18332,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8695;
 			type="Land_HBarrier_5_F";
 		};
-		class Item795
+		class Item785
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19687,11 +18349,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8696;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item796
+		class Item786
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19703,11 +18366,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8697;
 			type="Land_HBarrier_5_F";
 		};
-		class Item797
+		class Item787
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19719,11 +18383,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8698;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item798
+		class Item788
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19735,11 +18400,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8699;
 			type="Land_HBarrier_5_F";
 		};
-		class Item799
+		class Item789
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19751,12 +18417,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8700;
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item800
+		class Item790
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19768,12 +18435,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8701;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item801
+		class Item791
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19785,11 +18453,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8702;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item802
+		class Item792
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19801,12 +18470,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8703;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item803
+		class Item793
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19818,11 +18488,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8704;
 			type="Land_HBarrier_3_F";
 		};
-		class Item804
+		class Item794
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19834,12 +18505,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8705;
 			type="Land_HBarrier_3_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item805
+		class Item795
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19851,12 +18523,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8706;
 			type="Land_HBarrier_3_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item806
+		class Item796
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19868,12 +18541,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8707;
 			type="Land_HBarrier_1_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item807
+		class Item797
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19885,12 +18559,13 @@ class Mission
 			class Attributes
 			{
 				init="call{this setVariable [""spawnableHelicopterTypes"", [""patrol"", ""transport"", ""attack""]];}";
+				disableSimulation=1;
 			};
 			id=8708;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.64489746;
 		};
-		class Item808
+		class Item798
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19902,11 +18577,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8709;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item809
+		class Item799
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19918,11 +18594,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8710;
 			type="Land_HBarrier_5_F";
 		};
-		class Item810
+		class Item800
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19934,11 +18611,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8711;
 			type="Land_HBarrier_5_F";
 		};
-		class Item811
+		class Item801
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19950,12 +18628,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8712;
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item812
+		class Item802
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19967,11 +18646,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8713;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item813
+		class Item803
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19983,11 +18663,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8714;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item814
+		class Item804
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19999,12 +18680,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8715;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item815
+		class Item805
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20016,12 +18698,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8716;
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item816
+		class Item806
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20033,11 +18716,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8717;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item817
+		class Item807
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20049,11 +18733,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8718;
 			type="Land_HBarrier_5_F";
 		};
-		class Item818
+		class Item808
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20065,11 +18750,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8719;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item819
+		class Item809
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20081,11 +18767,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8720;
 			type="Land_HBarrier_5_F";
 		};
-		class Item820
+		class Item810
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20097,11 +18784,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8721;
 			type="Land_HBarrier_5_F";
 		};
-		class Item821
+		class Item811
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20113,11 +18801,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8722;
 			type="Land_HBarrier_5_F";
 		};
-		class Item822
+		class Item812
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20129,11 +18818,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8723;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item823
+		class Item813
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20145,11 +18835,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8724;
 			type="Land_HBarrier_5_F";
 		};
-		class Item824
+		class Item814
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20161,11 +18852,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8725;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item825
+		class Item815
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20181,7 +18873,7 @@ class Mission
 			id=8726;
 			type="Land_Cargo_Tower_V1_F";
 		};
-		class Item826
+		class Item816
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20198,7 +18890,7 @@ class Mission
 			type="Land_Cargo_Tower_V1_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item827
+		class Item817
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20214,7 +18906,7 @@ class Mission
 			id=8728;
 			type="Land_Cargo_Tower_V1_F";
 		};
-		class Item828
+		class Item818
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20226,12 +18918,13 @@ class Mission
 			class Attributes
 			{
 				init="call{this setVariable [""spawnableHelicopterTypes"", [""patrol"", ""transport"", ""attack""]];}";
+				disableSimulation=1;
 			};
 			id=8729;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.70658875;
 		};
-		class Item829
+		class Item819
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20243,12 +18936,13 @@ class Mission
 			class Attributes
 			{
 				init="call{this setVariable [""spawnableHelicopterTypes"", [""patrol"", ""transport"", ""attack""]];}";
+				disableSimulation=1;
 			};
 			id=8730;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.63046265;
 		};
-		class Item830
+		class Item820
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20260,12 +18954,13 @@ class Mission
 			class Attributes
 			{
 				init="call{this setVariable [""spawnableHelicopterTypes"", [""patrol"", ""transport"", ""attack""]];}";
+				disableSimulation=1;
 			};
 			id=8731;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.66749573;
 		};
-		class Item831
+		class Item821
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20277,12 +18972,13 @@ class Mission
 			class Attributes
 			{
 				init="call{this setVariable [""spawnableHelicopterTypes"", [""patrol"", ""transport"", ""attack""]];}";
+				disableSimulation=1;
 			};
 			id=8732;
 			type="Land_HelipadSquare_F";
 			atlOffset=0.61737061;
 		};
-		class Item832
+		class Item822
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20298,7 +18994,7 @@ class Mission
 			id=8733;
 			type="Land_LampAirport_F";
 		};
-		class Item833
+		class Item823
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20314,140 +19010,12 @@ class Mission
 			id=8734;
 			type="Land_LampAirport_F";
 		};
-		class Item834
+		class Item824
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={2426.1484,199.48441,3590.4441};
-				angles[]={6.2424059,4.3923078,0.051954471};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=8735;
-			type="Land_MedicalTent_01_NATO_generic_open_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item835
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={2426.1484,201.75349,3590.4441};
-				angles[]={0.3019498,4.3923078,0.16657287};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=8736;
-			type="Land_MedicalTent_01_floor_dark_F";
-			atlOffset=0.1688385;
-		};
-		class Item836
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={2413.2163,198.60815,3586.157};
-				angles[]={6.2424088,4.3923078,0.053548392};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=8737;
-			type="Land_MedicalTent_01_NATO_generic_open_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="SolarPanel2_Hide";
-					expression="_this animateSource ['SolarPanel2_Hide',_value,true]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item837
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={2413.2163,200.89568,3586.157};
-				angles[]={0.302039,4.3923078,0.16814582};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=8738;
-			type="Land_MedicalTent_01_floor_dark_F";
-			atlOffset=0.18666077;
-		};
-		class Item838
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={2407.3728,197.13968,3580.4194};
-				angles[]={6.2424088,3.6069102,0.063912325};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=8739;
-			type="Land_AirConditioner_04_F";
-		};
-		class Item839
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={2452.5063,200.01665,3585.814};
+				position[]={2452.5,199.94958,3585.875};
 				angles[]={6.2320304,2.8215117,0.047164604};
 			};
 			side="Empty";
@@ -20457,25 +19025,24 @@ class Mission
 			};
 			id=8740;
 			type="StorageBladder_01_fuel_forest_F";
-			atlOffset=0.069885254;
 		};
-		class Item840
+		class Item825
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={2442.0063,200.05913,3582.1289};
+				position[]={2442,199.3362,3582.125};
 				angles[]={6.2368193,2.8215117,0.042374056};
 			};
 			side="Empty";
+			flags=4;
 			class Attributes
 			{
 			};
 			id=8741;
 			type="StorageBladder_01_fuel_forest_F";
-			atlOffset=0.7224884;
 		};
-		class Item841
+		class Item826
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20487,11 +19054,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8742;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item842
+		class Item827
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20503,11 +19071,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8743;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item843
+		class Item828
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20519,11 +19088,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8744;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item844
+		class Item829
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20535,11 +19105,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8745;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item845
+		class Item830
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20551,11 +19122,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8746;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item846
+		class Item831
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20572,7 +19144,7 @@ class Mission
 			type="Land_LampAirport_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item847
+		class Item832
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20588,7 +19160,7 @@ class Mission
 			id=8748;
 			type="Land_LampAirport_F";
 		};
-		class Item848
+		class Item833
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20605,7 +19177,7 @@ class Mission
 			type="Land_LampSolar_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item849
+		class Item834
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20617,11 +19189,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8750;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item850
+		class Item835
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20632,12 +19205,13 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8751;
 			type="Land_HBarrier_Big_F";
 			atlOffset=0.265625;
 		};
-		class Item851
+		class Item836
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20653,7 +19227,7 @@ class Mission
 			id=8752;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item852
+		class Item837
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20670,7 +19244,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item853
+		class Item838
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20682,11 +19256,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=8756;
 			type="Land_HelipadCircle_F";
 		};
-		class Item854
+		class Item839
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20703,7 +19278,7 @@ class Mission
 			type="Land_Cargo_Patrol_V4_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item855
+		class Item840
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20715,7 +19290,7 @@ class Mission
 			type="HighCommand";
 			atlOffset=0.043842316;
 		};
-		class Item856
+		class Item841
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20726,7 +19301,7 @@ class Mission
 			type="HighCommandSubordinate";
 			atlOffset=-0.043831825;
 		};
-		class Item857
+		class Item842
 		{
 			dataType="Marker";
 			position[]={737.70398,27.885,12084.651};
@@ -20735,7 +19310,7 @@ class Mission
 			id=8765;
 			atlOffset=0.00016021729;
 		};
-		class Item858
+		class Item843
 		{
 			dataType="Marker";
 			position[]={8157.2852,29.357891,9844.3545};
@@ -20743,7 +19318,7 @@ class Mission
 			type="hd_start";
 			id=8766;
 		};
-		class Item859
+		class Item844
 		{
 			dataType="Marker";
 			position[]={2353.4297,193.33873,3599.1111};
@@ -20751,16 +19326,894 @@ class Mission
 			type="hd_start";
 			id=8767;
 		};
+		class Item845
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=38;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8263.6035,11.336456,5973.8779};
+					};
+					side="Independent";
+					flags=7;
+					class Attributes
+					{
+						name="commanderX";
+						description="Default Commaner";
+						isPlayer=1;
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8779;
+					type="I_G_officer_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male04GRE";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1;
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8268.3984,11.775373,5971.1748};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8780;
+					type="I_G_officer_F";
+					atlOffset=-5.1498413e-005;
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8268.5371,11.778847,5973.4106};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8781;
+					type="I_G_officer_F";
+					atlOffset=-7.6293945e-005;
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8268.4795,11.742768,5975.7441};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8782;
+					type="I_G_officer_F";
+					atlOffset=3.528595e-005;
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8268.3164,11.646703,5978.0576};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8783;
+					type="I_G_officer_F";
+					atlOffset=2.4795532e-005;
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8268.2754,11.556644,5980.5117};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8784;
+					type="I_G_officer_F";
+					atlOffset=-1.7166138e-005;
+				};
+				class Item6
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8268.0898,11.436996,5982.8276};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8785;
+					type="I_G_officer_F";
+					atlOffset=3.7193298e-005;
+				};
+				class Item7
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8267.8828,11.309816,5984.7231};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8786;
+					type="I_G_officer_F";
+					atlOffset=-1.2397766e-005;
+				};
+				class Item8
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8270.7578,11.98632,5971.2983};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8787;
+					type="I_G_Soldier_F";
+					atlOffset=2.0027161e-005;
+				};
+				class Item9
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8270.7568,11.976884,5973.6377};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8788;
+					type="I_G_Soldier_F";
+					atlOffset=1.0490417e-005;
+				};
+				class Item10
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8270.6504,11.927962,5976.0112};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8789;
+					type="I_G_Soldier_F";
+					atlOffset=7.8201294e-005;
+				};
+				class Item11
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8270.5918,11.845141,5978.2109};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8790;
+					type="I_G_Soldier_F";
+					atlOffset=-5.531311e-005;
+				};
+				class Item12
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8270.3887,11.71758,5980.6333};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8791;
+					type="I_G_Soldier_F";
+					atlOffset=-6.1988831e-005;
+				};
+				class Item13
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8270.2012,11.565583,5982.9644};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8792;
+					type="I_G_Soldier_F";
+					atlOffset=-2.6702881e-005;
+				};
+				class Item14
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8272.8662,12.17513,5971.3345};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8793;
+					type="I_G_Soldier_AR_F";
+					atlOffset=2.9563904e-005;
+				};
+				class Item15
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8273.0283,12.179917,5973.7744};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8794;
+					type="I_G_Soldier_AR_F";
+					atlOffset=8.4877014e-005;
+				};
+				class Item16
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8272.6279,12.098839,5976.1895};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8795;
+					type="I_G_Soldier_AR_F";
+					atlOffset=3.7193298e-005;
+				};
+				class Item17
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8272.6045,11.998848,5978.3384};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8796;
+					type="I_G_Soldier_AR_F";
+					atlOffset=-5.8174133e-005;
+				};
+				class Item18
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8272.4043,11.851407,5980.5796};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8797;
+					type="I_G_Soldier_AR_F";
+					atlOffset=-5.531311e-005;
+				};
+				class Item19
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8272.3174,11.698255,5983.0386};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8798;
+					type="I_G_Soldier_AR_F";
+					atlOffset=-3.4332275e-005;
+				};
+				class Item20
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8274.9551,12.361992,5971.4141};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8799;
+					type="I_G_Soldier_GL_F";
+					atlOffset=4.2915344e-005;
+				};
+				class Item21
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8274.8252,12.341078,5973.7319};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8800;
+					type="I_G_Soldier_GL_F";
+					atlOffset=2.0980835e-005;
+				};
+				class Item22
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8274.7012,12.246495,5976.4761};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8801;
+					type="I_G_Soldier_GL_F";
+					atlOffset=1.4305115e-005;
+				};
+				class Item23
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8274.5273,12.114664,5978.4849};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8802;
+					type="I_G_Soldier_GL_F";
+					atlOffset=-3.8146973e-005;
+				};
+				class Item24
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8274.458,11.979136,5980.6694};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8803;
+					type="I_G_Soldier_GL_F";
+					atlOffset=1.2397766e-005;
+				};
+				class Item25
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8274.3525,11.822813,5983.1602};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8804;
+					type="I_G_Soldier_GL_F";
+					atlOffset=-5.0544739e-005;
+				};
+				class Item26
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8276.4824,12.363299,5971.4917};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8805;
+					type="I_G_medic_F";
+					atlOffset=-1.9073486e-006;
+				};
+				class Item27
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8276.3066,12.354573,5973.7715};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8806;
+					type="I_G_medic_F";
+					atlOffset=-9.5367432e-007;
+				};
+				class Item28
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8276.2646,12.258889,5976.6431};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8807;
+					type="I_G_medic_F";
+					atlOffset=-2.8610229e-006;
+				};
+				class Item29
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8276.1768,12.150266,5978.4497};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8808;
+					type="I_G_medic_F";
+					atlOffset=-1.8119812e-005;
+				};
+				class Item30
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8275.9932,12.008243,5980.8091};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8809;
+					type="I_G_medic_F";
+					atlOffset=-3.8146973e-005;
+				};
+				class Item31
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8276.0039,11.863671,5983.2197};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8810;
+					type="I_G_medic_F";
+					atlOffset=1.8119812e-005;
+				};
+				class Item32
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8278.2842,12.359756,5971.6567};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8811;
+					type="I_G_engineer_F";
+					atlOffset=-2.8610229e-006;
+				};
+				class Item33
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8278.3076,12.359378,5973.957};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8812;
+					type="I_G_engineer_F";
+					atlOffset=9.5367432e-007;
+				};
+				class Item34
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8278.0654,12.256976,5976.7471};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8813;
+					type="I_G_engineer_F";
+					atlOffset=9.5367432e-006;
+				};
+				class Item35
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8277.8105,12.139514,5978.6948};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8814;
+					type="I_G_engineer_F";
+					atlOffset=2.5749207e-005;
+				};
+				class Item36
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8277.6152,12.004844,5980.9312};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8815;
+					type="I_G_engineer_F";
+					atlOffset=-5.7220459e-006;
+				};
+				class Item37
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={8277.5107,11.856441,5983.4004};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=8816;
+					type="I_G_engineer_F";
+					atlOffset=-2.8610229e-006;
+				};
+			};
+			class Attributes
+			{
+			};
+			id=8778;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="Guerillas";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
 	};
 	class Connections
 	{
 		class LinkIDProvider
 		{
-			nextID=26;
+			nextID=39;
 		};
 		class Links
 		{
-			items=26;
+			items=39;
 			class Item0
 			{
 				linkID=0;
@@ -20774,7 +20227,7 @@ class Mission
 			class Item1
 			{
 				linkID=1;
-				item0=451;
+				item0=8779;
 				item1=8761;
 				class CustomData
 				{
@@ -20784,7 +20237,7 @@ class Mission
 			class Item2
 			{
 				linkID=2;
-				item0=456;
+				item0=8793;
 				item1=8761;
 				class CustomData
 				{
@@ -20794,7 +20247,7 @@ class Mission
 			class Item3
 			{
 				linkID=3;
-				item0=457;
+				item0=8794;
 				item1=8761;
 				class CustomData
 				{
@@ -20804,7 +20257,7 @@ class Mission
 			class Item4
 			{
 				linkID=4;
-				item0=458;
+				item0=8795;
 				item1=8761;
 				class CustomData
 				{
@@ -20814,7 +20267,7 @@ class Mission
 			class Item5
 			{
 				linkID=5;
-				item0=459;
+				item0=8796;
 				item1=8761;
 				class CustomData
 				{
@@ -20824,7 +20277,7 @@ class Mission
 			class Item6
 			{
 				linkID=6;
-				item0=460;
+				item0=8797;
 				item1=8761;
 				class CustomData
 				{
@@ -20834,7 +20287,7 @@ class Mission
 			class Item7
 			{
 				linkID=7;
-				item0=461;
+				item0=8798;
 				item1=8761;
 				class CustomData
 				{
@@ -20844,7 +20297,7 @@ class Mission
 			class Item8
 			{
 				linkID=8;
-				item0=462;
+				item0=8805;
 				item1=8761;
 				class CustomData
 				{
@@ -20854,7 +20307,7 @@ class Mission
 			class Item9
 			{
 				linkID=9;
-				item0=463;
+				item0=8806;
 				item1=8761;
 				class CustomData
 				{
@@ -20864,7 +20317,7 @@ class Mission
 			class Item10
 			{
 				linkID=10;
-				item0=464;
+				item0=8807;
 				item1=8761;
 				class CustomData
 				{
@@ -20874,7 +20327,7 @@ class Mission
 			class Item11
 			{
 				linkID=11;
-				item0=465;
+				item0=8808;
 				item1=8761;
 				class CustomData
 				{
@@ -20884,7 +20337,7 @@ class Mission
 			class Item12
 			{
 				linkID=12;
-				item0=466;
+				item0=8809;
 				item1=8761;
 				class CustomData
 				{
@@ -20894,7 +20347,7 @@ class Mission
 			class Item13
 			{
 				linkID=13;
-				item0=467;
+				item0=8810;
 				item1=8761;
 				class CustomData
 				{
@@ -20904,7 +20357,7 @@ class Mission
 			class Item14
 			{
 				linkID=14;
-				item0=468;
+				item0=8811;
 				item1=8761;
 				class CustomData
 				{
@@ -20914,7 +20367,7 @@ class Mission
 			class Item15
 			{
 				linkID=15;
-				item0=469;
+				item0=8812;
 				item1=8761;
 				class CustomData
 				{
@@ -20924,7 +20377,7 @@ class Mission
 			class Item16
 			{
 				linkID=16;
-				item0=470;
+				item0=8813;
 				item1=8761;
 				class CustomData
 				{
@@ -20934,7 +20387,7 @@ class Mission
 			class Item17
 			{
 				linkID=17;
-				item0=471;
+				item0=8814;
 				item1=8761;
 				class CustomData
 				{
@@ -20944,7 +20397,7 @@ class Mission
 			class Item18
 			{
 				linkID=18;
-				item0=472;
+				item0=8815;
 				item1=8761;
 				class CustomData
 				{
@@ -20954,7 +20407,7 @@ class Mission
 			class Item19
 			{
 				linkID=19;
-				item0=473;
+				item0=8816;
 				item1=8761;
 				class CustomData
 				{
@@ -20964,7 +20417,7 @@ class Mission
 			class Item20
 			{
 				linkID=20;
-				item0=474;
+				item0=8799;
 				item1=8761;
 				class CustomData
 				{
@@ -20974,7 +20427,7 @@ class Mission
 			class Item21
 			{
 				linkID=21;
-				item0=475;
+				item0=8800;
 				item1=8761;
 				class CustomData
 				{
@@ -20984,7 +20437,7 @@ class Mission
 			class Item22
 			{
 				linkID=22;
-				item0=476;
+				item0=8801;
 				item1=8761;
 				class CustomData
 				{
@@ -20994,7 +20447,7 @@ class Mission
 			class Item23
 			{
 				linkID=23;
-				item0=477;
+				item0=8802;
 				item1=8761;
 				class CustomData
 				{
@@ -21004,7 +20457,7 @@ class Mission
 			class Item24
 			{
 				linkID=24;
-				item0=478;
+				item0=8803;
 				item1=8761;
 				class CustomData
 				{
@@ -21014,7 +20467,137 @@ class Mission
 			class Item25
 			{
 				linkID=25;
-				item0=479;
+				item0=8804;
+				item1=8761;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item26
+			{
+				linkID=26;
+				item0=8780;
+				item1=8761;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item27
+			{
+				linkID=27;
+				item0=8781;
+				item1=8761;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item28
+			{
+				linkID=28;
+				item0=8782;
+				item1=8761;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item29
+			{
+				linkID=29;
+				item0=8783;
+				item1=8761;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item30
+			{
+				linkID=30;
+				item0=8784;
+				item1=8761;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item31
+			{
+				linkID=31;
+				item0=8785;
+				item1=8761;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item32
+			{
+				linkID=32;
+				item0=8786;
+				item1=8761;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item33
+			{
+				linkID=33;
+				item0=8787;
+				item1=8761;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item34
+			{
+				linkID=34;
+				item0=8788;
+				item1=8761;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item35
+			{
+				linkID=35;
+				item0=8789;
+				item1=8761;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item36
+			{
+				linkID=36;
+				item0=8790;
+				item1=8761;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item37
+			{
+				linkID=37;
+				item0=8791;
+				item1=8761;
+				class CustomData
+				{
+					type="Sync";
+				};
+			};
+			class Item38
+			{
+				linkID=38;
+				item0=8792;
 				item1=8761;
 				class CustomData
 				{

--- a/Map-Templates/Antistasi-Tembelan-Island.Tembelan/mission.sqm
+++ b/Map-Templates/Antistasi-Tembelan-Island.Tembelan/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=1025;
 	class ItemIDProvider
 	{
-		nextID=355;
+		nextID=416;
 	};
 	class MarkerIDProvider
 	{
@@ -16,14 +16,14 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=51;
+		nextID=63;
 	};
 	class Camera
 	{
-		pos[]={4825.2744,308.02106,1269.7025};
-		dir[]={-0.16478749,-0.85274255,-0.49571803};
-		up[]={-0.2689963,0.52234536,-0.80920202};
-		aside[]={-0.94897389,-6.4563937e-007,0.31545871};
+		pos[]={4508.1592,400.49188,6609.5586};
+		dir[]={-0.48622143,-0.47012073,-0.73674458};
+		up[]={-0.25901672,0.88251239,-0.39247584};
+		aside[]={-0.83470458,4.3335604e-007,0.55087155};
 	};
 };
 binarizationWanted=0;
@@ -33,7 +33,6 @@ addons[]=
 	"A3_Weapons_F_Ammoboxes",
 	"A3_Modules_F",
 	"A3_Characters_F",
-	"A3_Weapons_F",
 	"A3_Structures_F_EPC_Civ_InfoBoards",
 	"A3_Structures_F_Mil_Flags",
 	"A3_Ui_F_Exp",
@@ -50,18 +49,19 @@ addons[]=
 	"A3_Structures_F_Heli_Items_Luggage",
 	"A3_Structures_F_Heli_Ind_Cargo",
 	"A3_Structures_F_Ind_Cargo",
-	"A3_Structures_F_Enoch_Military_Camps",
-	"A3_Structures_F_Orange_Humanitarian_Camps",
-	"A3_Structures_F_Mil_Helipads",
 	"A3_Structures_F_Exp_Military_ContainerBases",
 	"A3_Modules_F_Hc",
-	"A3_Structures_F_Mil_Fortification"
+	"A3_Structures_F_Mil_Fortification",
+	"A3_Weapons_F",
+	"A3_Structures_F_Mil_Helipads",
+	"A3_Structures_F_Mil_Shelters",
+	"A3_Structures_F_Enoch_Cultural_OrthodoxChurches"
 };
 class AddonsMetaData
 {
 	class List
 	{
-		items=18;
+		items=17;
 		class Item0
 		{
 			className="A3_Ui_F";
@@ -176,15 +176,8 @@ class AddonsMetaData
 		};
 		class Item16
 		{
-			className="A3_Structures_F_Enoch_Military";
-			name="Arma 3 Enoch - Military Buildings and Structures";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item17
-		{
-			className="A3_Structures_F_Orange";
-			name="Arma 3 Orange - Buildings and Structures";
+			className="A3_Structures_F_Enoch_Cultural";
+			name="Arma 3 Enoch - Cultural Buildings";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
@@ -197,20 +190,15 @@ class Mission
 	{
 		briefingName=$STR_antistasi_mission_info_tembelan_mapname_text;											 
 		resistanceWest=0;
-		startWind=0.1;
-		forecastWind=0.1;
-		forecastWaves=0.1;
 		year=2035;
 		month=6;
 		day=1;
 		hour=10;
 		minute=0;
-		startFogDecay=0.0049333;
-		forecastFogDecay=0.0049333;
 	};
 	class Entities
 	{
-		items=164;
+		items=166;
 		class Item0
 		{
 			dataType="Marker";
@@ -471,3868 +459,6 @@ class Mission
 			side="Independent";
 			class Entities
 			{
-				items=60;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={872.28076,9.9314394,5455.6367};
-					};
-					side="Independent";
-					flags=6;
-					class Attributes
-					{
-						skill=1;
-						name="commanderX";
-						description="Default Commander";
-						isPlayer=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=23;
-					type="I_G_officer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item1
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={874.17572,10.536942,5449.3467};
-						angles[]={0,6.2412972,0};
-					};
-					side="Independent";
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=27;
-					type="I_G_Soldier_AR_F";
-					atlOffset=0.60550213;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item2
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={907.51428,10.107938,5430.9507};
-						angles[]={0,1.5460157,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=28;
-					type="I_G_Soldier_AR_F";
-					atlOffset=0.17649841;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item3
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={907.69604,9.9836626,5427.8726};
-						angles[]={0,1.5879039,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=29;
-					type="I_G_Soldier_LAT_F";
-					atlOffset=0.052223206;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item4
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={907.29834,9.9314394,5424.9492};
-						angles[]={0,1.5879039,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=30;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item5
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={907.42841,9.9314394,5422.0483};
-						angles[]={0,1.5879039,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=31;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item6
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={907.59601,9.9314394,5419.0566};
-						angles[]={0,1.5879039,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=32;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item7
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={907.4939,10.269444,5433.4121};
-						angles[]={0,1.5879039,0};
-					};
-					side="Independent";
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=33;
-					type="I_G_officer_F";
-					atlOffset=0.33800507;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item8
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={910.30865,10.081128,5431.0063};
-						angles[]={0,1.5460157,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=34;
-					type="I_G_Soldier_AR_F";
-					atlOffset=0.14968872;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item9
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={910.49426,9.9778872,5427.9282};
-						angles[]={0,1.5879039,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=35;
-					type="I_G_Soldier_LAT_F";
-					atlOffset=0.046447754;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item10
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={910.09265,9.9314394,5425.0049};
-						angles[]={0,1.5879039,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=36;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item11
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={910.22272,9.9314394,5422.104};
-						angles[]={0,1.5879039,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=37;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item12
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={910.39032,9.9314394,5419.1123};
-						angles[]={0,1.5879039,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=38;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item13
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={910.29211,10.242635,5433.4678};
-						angles[]={0,1.5879039,0};
-					};
-					side="Independent";
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=39;
-					type="I_G_officer_F";
-					atlOffset=0.31119537;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item14
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={913.49384,10.006875,5427.877};
-						angles[]={0,1.5879039,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=40;
-					type="I_G_Soldier_LAT_F";
-					atlOffset=0.075435638;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item15
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={913.09613,9.9314394,5424.9536};
-						angles[]={0,1.5879039,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=41;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item16
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={913.22229,9.9314394,5422.0527};
-						angles[]={0,1.5879039,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=42;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item17
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={913.3938,9.9314394,5419.061};
-						angles[]={0,1.5879039,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=43;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item18
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={913.29169,10.305421,5433.4165};
-						angles[]={0,1.5879039,0};
-					};
-					side="Independent";
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=44;
-					type="I_G_officer_F";
-					atlOffset=0.37398148;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item19
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={934.73773,9.9744692,5452.0723};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=45;
-					type="I_G_Soldier_LAT_F";
-					atlOffset=0.043029785;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item20
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={937.66742,9.9314394,5451.7246};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=46;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item21
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={940.56586,9.9314394,5451.9043};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=47;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item22
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={943.55414,9.9314394,5452.123};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=48;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item23
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={929.20258,10.331502,5451.7754};
-					};
-					side="Independent";
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=49;
-					type="I_G_officer_F";
-					atlOffset=0.40006256;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item24
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={913.42365,10.084859,5430.853};
-						angles[]={0,1.4622107,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=50;
-					type="I_G_Soldier_AR_F";
-					atlOffset=0.15341949;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item25
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={931.96039,10.039815,5451.9512};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=51;
-					type="I_G_Soldier_AR_F";
-					atlOffset=0.10837555;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item26
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={935.06976,10.001584,5454.6973};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=52;
-					type="I_G_Soldier_LAT_F";
-					atlOffset=0.070144653;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item27
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={937.99945,9.9314394,5454.3496};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=53;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item28
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={940.89789,9.9314394,5454.5293};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=54;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item29
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={943.88617,9.9314394,5454.748};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=55;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item30
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={929.53461,10.334573,5454.4043};
-					};
-					side="Independent";
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=56;
-					type="I_G_officer_F";
-					atlOffset=0.40313339;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item31
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={932.29242,10.069871,5454.5801};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=57;
-					type="I_G_Soldier_AR_F";
-					atlOffset=0.13843155;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item32
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={935.14398,10.104962,5457.7715};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=58;
-					type="I_G_Soldier_LAT_F";
-					atlOffset=0.17352295;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item33
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={938.07367,10.00879,5457.4238};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=59;
-					type="I_G_medic_F";
-					atlOffset=0.077350616;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item34
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={940.97211,9.9776468,5457.6035};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=60;
-					type="I_G_engineer_F";
-					atlOffset=0.046207428;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item35
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={943.96039,10.011685,5457.8223};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=61;
-					type="I_G_Soldier_GL_F";
-					atlOffset=0.080245972;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item36
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={929.60883,10.443479,5457.4785};
-					};
-					side="Independent";
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=62;
-					type="I_G_officer_F";
-					atlOffset=0.51203918;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item37
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={932.36664,10.170617,5457.6543};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=63;
-					type="I_G_Soldier_AR_F";
-					atlOffset=0.2391777;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item38
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={912.66119,9.9314394,5477.187};
-						angles[]={0,4.7202539,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=64;
-					type="I_G_Soldier_LAT_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item39
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={913.03186,9.9314394,5480.1157};
-						angles[]={0,4.7202539,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=65;
-					type="I_G_medic_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item40
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={912.87891,9.9314394,5483.0156};
-						angles[]={0,4.7202539,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=66;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item41
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={912.67975,9.9314394,5486.0054};
-						angles[]={0,4.7202539,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=67;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item42
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={912.91449,10.535169,5471.6519};
-						angles[]={0,4.7202539,0};
-					};
-					side="Independent";
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=68;
-					type="I_G_officer_F";
-					atlOffset=0.60372925;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item43
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={912.76044,10.226407,5474.4106};
-						angles[]={0,4.7202539,0};
-					};
-					side="Independent";
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=69;
-					type="I_G_Soldier_AR_F";
-					atlOffset=0.29496765;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item44
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={909.39447,10.059045,5477.0645};
-						angles[]={0,4.7202539,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=70;
-					type="I_G_Soldier_LAT_F";
-					atlOffset=0.12760544;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item45
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={909.7691,9.9405794,5479.9932};
-						angles[]={0,4.7202539,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=71;
-					type="I_G_medic_F";
-					atlOffset=0.0091400146;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item46
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={909.61218,9.9314394,5482.8926};
-						angles[]={0,4.7202539,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=72;
-					type="I_G_engineer_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item47
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={909.41693,9.9314394,5485.8828};
-						angles[]={0,4.7202539,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=73;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item48
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={909.64783,10.692422,5471.5288};
-						angles[]={0,4.7202539,0};
-					};
-					side="Independent";
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=74;
-					type="I_G_officer_F";
-					atlOffset=0.76098251;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item49
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={909.49371,10.385228,5474.2881};
-						angles[]={0,4.7202539,0};
-					};
-					side="Independent";
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=75;
-					type="I_G_Soldier_AR_F";
-					atlOffset=0.45378876;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item50
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={906.64307,10.309373,5475.9004};
-						angles[]={0,4.7202539,0};
-					};
-					side="Independent";
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=76;
-					type="I_G_Soldier_LAT_F";
-					atlOffset=0.3779335;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item51
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={907.01373,10.3663,5478.8271};
-						angles[]={0,4.7202539,0};
-					};
-					side="Independent";
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=77;
-					type="I_G_medic_F";
-					atlOffset=0.43486023;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item52
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={906.85687,10.016458,5481.7271};
-						angles[]={0,4.7202539,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=78;
-					type="I_G_engineer_F";
-					atlOffset=0.085018158;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item53
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={906.66162,10.009507,5484.7168};
-						angles[]={0,4.7202539,0};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=79;
-					type="I_G_Soldier_GL_F";
-					atlOffset=0.07806778;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item54
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={906.89246,11.164788,5470.3628};
-						angles[]={0,4.7202539,0};
-					};
-					side="Independent";
-					class Attributes
-					{
-						skill=1;
-						description="Officer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=80;
-					type="I_G_officer_F";
-					atlOffset=1.2333488;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item55
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={906.7384,10.663938,5473.124};
-						angles[]={0,4.7202539,0};
-					};
-					side="Independent";
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=81;
-					type="I_G_Soldier_AR_F";
-					atlOffset=0.73249817;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item56
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={880.17963,10.153695,5449.2334};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=82;
-					type="I_G_medic_F";
-					atlOffset=0.22225571;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item57
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={883.20502,10.025476,5449.4912};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=83;
-					type="I_G_engineer_F";
-					atlOffset=0.094037056;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item58
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={885.79095,9.9314394,5449.8975};
-					};
-					side="Independent";
-					flags=4;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=84;
-					type="I_G_Soldier_GL_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male03FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item59
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={877.24994,10.330724,5449.5811};
-					};
-					side="Independent";
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=85;
-					type="I_G_Soldier_LAT_F";
-					atlOffset=0.39928436;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-			};
-			class Attributes
-			{
-			};
-			id=22;
-		};
-		class Item15
-		{
-			dataType="Group";
-			side="Independent";
-			class Entities
-			{
 				items=1;
 				class Item0
 				{
@@ -4418,7 +544,7 @@ class Mission
 			};
 			id=24;
 		};
-		class Item16
+		class Item15
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4457,7 +583,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item17
+		class Item16
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4496,7 +622,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item18
+		class Item17
 		{
 			dataType="Object";
 			class PositionInfo
@@ -4513,7 +639,7 @@ class Mission
 			type="Flag_NATO_F";
 			atlOffset=-2.3841858e-007;
 		};
-		class Item19
+		class Item18
 		{
 			dataType="Marker";
 			position[]={1553.0457,3.9030445,9024.1406};
@@ -4521,7 +647,7 @@ class Mission
 			type="flag_CTRG";
 			id=93;
 		};
-		class Item20
+		class Item19
 		{
 			dataType="Group";
 			side="West";
@@ -4909,7 +1035,7 @@ class Mission
 			id=94;
 			atlOffset=2.3841858e-007;
 		};
-		class Item21
+		class Item20
 		{
 			dataType="Marker";
 			position[]={2186.6816,98.928207,9258.084};
@@ -4918,7 +1044,7 @@ class Mission
 			id=102;
 			atlOffset=92.907089;
 		};
-		class Item22
+		class Item21
 		{
 			dataType="Group";
 			side="East";
@@ -5298,7 +1424,7 @@ class Mission
 			id=103;
 			atlOffset=88.093887;
 		};
-		class Item23
+		class Item22
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5314,7 +1440,7 @@ class Mission
 			type="Flag_Viper_F";
 			atlOffset=88.499908;
 		};
-		class Item24
+		class Item23
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5327,7 +1453,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=0.82494164;
 		};
-		class Item25
+		class Item24
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5340,7 +1466,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=0.7251339;
 		};
-		class Item26
+		class Item25
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5431,7 +1557,7 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item27
+		class Item26
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5471,7 +1597,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item28
+		class Item27
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5488,7 +1614,7 @@ class Mission
 			id=138;
 			type="Land_dp_transformer_F";
 		};
-		class Item29
+		class Item28
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5505,7 +1631,7 @@ class Mission
 			id=139;
 			type="Land_Medevac_house_V1_F";
 		};
-		class Item30
+		class Item29
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5523,7 +1649,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=0.2539978;
 		};
-		class Item31
+		class Item30
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5535,11 +1661,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=146;
 			type="Land_HBarrier_01_big_4_green_F";
 		};
-		class Item32
+		class Item31
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5551,11 +1678,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=147;
 			type="Land_HBarrier_01_big_4_green_F";
 		};
-		class Item33
+		class Item32
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5567,11 +1695,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=148;
 			type="Land_HBarrier_01_big_4_green_F";
 		};
-		class Item34
+		class Item33
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5583,11 +1712,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=149;
 			type="Land_HBarrier_01_big_4_green_F";
 		};
-		class Item35
+		class Item34
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5599,11 +1729,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=150;
 			type="Land_HBarrier_01_big_4_green_F";
 		};
-		class Item36
+		class Item35
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5615,12 +1746,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=151;
 			type="Land_HBarrier_01_big_4_green_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item37
+		class Item36
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5632,11 +1764,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=152;
 			type="Land_HBarrier_01_big_4_green_F";
 		};
-		class Item38
+		class Item37
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5648,11 +1781,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=153;
 			type="Land_HBarrier_01_big_4_green_F";
 		};
-		class Item39
+		class Item38
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5664,12 +1798,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=154;
 			type="Land_HBarrier_01_big_4_green_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item40
+		class Item39
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5681,11 +1816,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=155;
 			type="Land_HBarrier_01_big_4_green_F";
 		};
-		class Item41
+		class Item40
 		{
 			dataType="Marker";
 			position[]={3022.4458,30.182636,4398.3501};
@@ -5695,7 +1831,7 @@ class Mission
 			id=160;
 			atlOffset=15.667421;
 		};
-		class Item42
+		class Item41
 		{
 			dataType="Marker";
 			position[]={6562.4707,-21.497236,9898.9805};
@@ -5705,7 +1841,7 @@ class Mission
 			id=163;
 			atlOffset=-3.1900005;
 		};
-		class Item43
+		class Item42
 		{
 			dataType="Marker";
 			position[]={9445.8291,-12.703266,8644.8096};
@@ -5715,7 +1851,7 @@ class Mission
 			id=164;
 			atlOffset=-3.1899996;
 		};
-		class Item44
+		class Item43
 		{
 			dataType="Marker";
 			position[]={10633.654,-23.818001,5667.353};
@@ -5726,7 +1862,7 @@ class Mission
 			id=165;
 			atlOffset=-3.1903534;
 		};
-		class Item45
+		class Item44
 		{
 			dataType="Marker";
 			position[]={8909.3896,-87.276695,1407.0038};
@@ -5736,7 +1872,7 @@ class Mission
 			id=166;
 			atlOffset=-3.1900024;
 		};
-		class Item46
+		class Item45
 		{
 			dataType="Marker";
 			position[]={282.76001,-22.028179,9522.668};
@@ -5746,7 +1882,7 @@ class Mission
 			id=167;
 			atlOffset=-3.1899986;
 		};
-		class Item47
+		class Item46
 		{
 			dataType="Marker";
 			position[]={-1235.7861,-57.114273,6836.1953};
@@ -5757,7 +1893,7 @@ class Mission
 			id=168;
 			atlOffset=-3.1903534;
 		};
-		class Item48
+		class Item47
 		{
 			dataType="Marker";
 			position[]={-1427.7869,-15.071719,1498.1366};
@@ -5768,7 +1904,7 @@ class Mission
 			id=169;
 			atlOffset=-3.1903534;
 		};
-		class Item49
+		class Item48
 		{
 			dataType="Marker";
 			position[]={2167.8496,-21.41099,-944.11133};
@@ -5779,7 +1915,7 @@ class Mission
 			id=170;
 			atlOffset=-3.1903534;
 		};
-		class Item50
+		class Item49
 		{
 			dataType="Marker";
 			position[]={6426.7598,-24.055374,-961.5564};
@@ -5790,7 +1926,7 @@ class Mission
 			id=171;
 			atlOffset=-3.1903534;
 		};
-		class Item51
+		class Item50
 		{
 			dataType="Marker";
 			position[]={2001.4104,-4.2427058,4919.978};
@@ -5798,7 +1934,7 @@ class Mission
 			type="Empty";
 			id=172;
 		};
-		class Item52
+		class Item51
 		{
 			dataType="Marker";
 			position[]={5697.2114,-93.79702,6299.3027};
@@ -5807,7 +1943,7 @@ class Mission
 			id=173;
 			atlOffset=-79.747086;
 		};
-		class Item53
+		class Item52
 		{
 			dataType="Marker";
 			position[]={6030.4009,-86.154274,4879.6748};
@@ -5816,7 +1952,7 @@ class Mission
 			id=174;
 			atlOffset=-79.747086;
 		};
-		class Item54
+		class Item53
 		{
 			dataType="Marker";
 			position[]={3435.8516,-1.8395869,3494.8071};
@@ -5824,7 +1960,7 @@ class Mission
 			type="mil_objective";
 			id=175;
 		};
-		class Item55
+		class Item54
 		{
 			dataType="Marker";
 			position[]={5639.0195,-8.2921238,5511.5728};
@@ -5833,7 +1969,7 @@ class Mission
 			id=176;
 			atlOffset=-3.1900001;
 		};
-		class Item56
+		class Item55
 		{
 			dataType="Marker";
 			position[]={4461.9888,-9.0299997,3057.8823};
@@ -5841,7 +1977,7 @@ class Mission
 			type="Empty";
 			id=178;
 		};
-		class Item57
+		class Item56
 		{
 			dataType="Marker";
 			position[]={1381.9493,-0.64816922,5374.3203};
@@ -5849,7 +1985,7 @@ class Mission
 			type="mil_objective";
 			id=179;
 		};
-		class Item58
+		class Item57
 		{
 			dataType="Marker";
 			position[]={1334.0188,-3.2399633,7678.1855};
@@ -5857,7 +1993,7 @@ class Mission
 			type="mil_objective";
 			id=180;
 		};
-		class Item59
+		class Item58
 		{
 			dataType="Marker";
 			position[]={5854.8267,-2.4443359,1890.6775};
@@ -5865,7 +2001,7 @@ class Mission
 			type="mil_objective";
 			id=181;
 		};
-		class Item60
+		class Item59
 		{
 			dataType="Marker";
 			position[]={2805.1284,-1.8965716,3252.46};
@@ -5873,7 +2009,7 @@ class Mission
 			type="mil_objective";
 			id=182;
 		};
-		class Item61
+		class Item60
 		{
 			dataType="Marker";
 			position[]={5241.4707,-7.0143108,5754.8188};
@@ -5882,7 +2018,7 @@ class Mission
 			id=183;
 			atlOffset=-3.1899993;
 		};
-		class Item62
+		class Item61
 		{
 			dataType="Marker";
 			position[]={6015.7021,-8.6722107,6663.0298};
@@ -5891,7 +2027,7 @@ class Mission
 			id=184;
 			atlOffset=-3.1899991;
 		};
-		class Item63
+		class Item62
 		{
 			dataType="Marker";
 			position[]={6738.6128,-7.073514,5323.6289};
@@ -5900,7 +2036,7 @@ class Mission
 			id=185;
 			atlOffset=-3.1899996;
 		};
-		class Item64
+		class Item63
 		{
 			dataType="Marker";
 			position[]={5734.9243,-2.1778834,8252.6475};
@@ -5908,7 +2044,7 @@ class Mission
 			type="mil_objective";
 			id=186;
 		};
-		class Item65
+		class Item64
 		{
 			dataType="Marker";
 			position[]={1312.3444,-5.2672153,8756.4482};
@@ -5917,7 +2053,7 @@ class Mission
 			id=187;
 			atlOffset=-3.1899996;
 		};
-		class Item66
+		class Item65
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5929,12 +2065,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=213;
 			type="Land_HBarrier_01_big_4_green_F";
 			atlOffset=0.032302856;
 		};
-		class Item67
+		class Item66
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5946,11 +2083,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=214;
 			type="Land_HBarrier_01_big_4_green_F";
 		};
-		class Item68
+		class Item67
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5962,11 +2100,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=215;
 			type="Land_HBarrier_01_big_4_green_F";
 		};
-		class Item69
+		class Item68
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5983,7 +2122,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=0.2731781;
 		};
-		class Item70
+		class Item69
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5998,7 +2137,7 @@ class Mission
 			id=218;
 			type="Land_WoodenCrate_01_stack_x5_F";
 		};
-		class Item71
+		class Item70
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6014,7 +2153,7 @@ class Mission
 			id=219;
 			type="Land_WoodenCrate_01_stack_x5_F";
 		};
-		class Item72
+		class Item71
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6030,7 +2169,7 @@ class Mission
 			id=220;
 			type="Land_WoodenCrate_01_stack_x5_F";
 		};
-		class Item73
+		class Item72
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6046,7 +2185,7 @@ class Mission
 			id=221;
 			type="Land_WoodenCrate_01_stack_x5_F";
 		};
-		class Item74
+		class Item73
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6062,7 +2201,7 @@ class Mission
 			id=222;
 			type="Land_WoodenCrate_01_stack_x5_F";
 		};
-		class Item75
+		class Item74
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6079,7 +2218,7 @@ class Mission
 			type="Land_WaterTank_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item76
+		class Item75
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6095,7 +2234,7 @@ class Mission
 			id=224;
 			type="Land_WaterBarrel_F";
 		};
-		class Item77
+		class Item76
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6111,7 +2250,7 @@ class Mission
 			id=225;
 			type="Land_WoodenCrate_01_F";
 		};
-		class Item78
+		class Item77
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6127,7 +2266,7 @@ class Mission
 			id=226;
 			type="Land_MetalCase_01_small_F";
 		};
-		class Item79
+		class Item78
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6139,11 +2278,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=227;
 			type="Land_Cargo10_grey_F";
 		};
-		class Item80
+		class Item79
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6155,12 +2296,14 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=228;
 			type="Land_Cargo20_grey_F";
 			atlOffset=-0.00018310547;
 		};
-		class Item81
+		class Item80
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6172,12 +2315,14 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=229;
 			type="Land_Cargo20_grey_F";
 			atlOffset=-0.00016784668;
 		};
-		class Item82
+		class Item81
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6188,44 +2333,14 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
+				createAsSimpleObject=1;
+				disableSimulation=1;
 			};
 			id=230;
 			type="Land_Cargo20_light_blue_F";
 			atlOffset=2.6228638;
 		};
-		class Item83
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={5262.5132,202.99638,7813.4194};
-				angles[]={0.011246439,0,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=231;
-			type="Land_DeconTent_01_white_F";
-		};
-		class Item84
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={5286.1895,203.01427,7812.4131};
-				angles[]={0.018749893,0,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=232;
-			type="Land_MedicalTent_01_white_generic_outer_F";
-		};
-		class Item85
+		class Item82
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -6282,23 +2397,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item86
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={385.73734,8.7600002,552.797};
-				angles[]={0,2.3661182,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=235;
-			type="Land_HelipadSquare_F";
-		};
-		class Item87
+		class Item83
 		{
 			dataType="Marker";
 			position[]={587.15283,-85.946854,523.54248};
@@ -6307,7 +2406,7 @@ class Mission
 			id=236;
 			atlOffset=-79.747086;
 		};
-		class Item88
+		class Item84
 		{
 			dataType="Marker";
 			position[]={417.36566,-83.491501,174.42444};
@@ -6316,135 +2415,7 @@ class Mission
 			id=237;
 			atlOffset=-79.747086;
 		};
-		class Item89
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={1811.0693,12.41,4835.5352};
-				angles[]={0,3.1415927,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=238;
-			type="Land_HelipadSquare_F";
-		};
-		class Item90
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={1777.9683,12.41,4835.4785};
-				angles[]={0,3.1415927,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=239;
-			type="Land_HelipadSquare_F";
-		};
-		class Item91
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={1745.5701,12.41,4836.251};
-				angles[]={0,3.1415927,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=240;
-			type="Land_HelipadSquare_F";
-		};
-		class Item92
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={1714.0297,12.41,4836.3008};
-				angles[]={0,3.1415927,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=241;
-			type="Land_HelipadSquare_F";
-		};
-		class Item93
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={3062.5676,14.69,4317.0547};
-				angles[]={0,2.1329734,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=249;
-			type="Land_HelipadSquare_F";
-		};
-		class Item94
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={3044.9717,14.69,4289.0176};
-				angles[]={0,2.1329734,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=250;
-			type="Land_HelipadSquare_F";
-		};
-		class Item95
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={3027.0491,14.69,4262.0176};
-				angles[]={0,2.1329734,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=251;
-			type="Land_HelipadSquare_F";
-		};
-		class Item96
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={3010.1948,14.69,4235.3579};
-				angles[]={0,2.1329734,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=252;
-			type="Land_HelipadSquare_F";
-		};
-		class Item97
+		class Item85
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6461,7 +2432,7 @@ class Mission
 			type="Land_Cargo_Tower_V4_F";
 			atlOffset=0.27638435;
 		};
-		class Item98
+		class Item86
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6477,7 +2448,7 @@ class Mission
 			id=254;
 			type="Land_Cargo_Patrol_V4_F";
 		};
-		class Item99
+		class Item87
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6494,7 +2465,7 @@ class Mission
 			type="Land_Cargo_Patrol_V4_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item100
+		class Item88
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6511,7 +2482,7 @@ class Mission
 			type="Land_Cargo_Patrol_V4_F";
 			atlOffset=0.0026073456;
 		};
-		class Item101
+		class Item89
 		{
 			dataType="Layer";
 			name="Outposts";
@@ -6786,39 +2757,7 @@ class Mission
 			id=258;
 			atlOffset=141.31024;
 		};
-		class Item102
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={2800.8835,150.04987,7837.4761};
-				angles[]={6.2791886,1.5746711,6.2491965};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=265;
-			type="Land_HelipadSquare_F";
-		};
-		class Item103
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={5727.5259,54.110001,4292.5586};
-				angles[]={0,3.1410565,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=266;
-			type="Land_HelipadSquare_F";
-		};
-		class Item104
+		class Item90
 		{
 			dataType="Layer";
 			name="Resources";
@@ -7009,7 +2948,7 @@ class Mission
 							colorName="ColorOrange";
 							a=61.469276;
 							b=91.140617;
-							angle=28.15921;
+							angle=28.159206;
 							id=134;
 							atlOffset=-1.1736374;
 						};
@@ -7037,7 +2976,7 @@ class Mission
 							colorName="ColorGreen";
 							a=14.496;
 							b=11.538742;
-							angle=28.279594;
+							angle=28.279591;
 							id=274;
 							atlOffset=-0.071720123;
 						};
@@ -7082,7 +3021,7 @@ class Mission
 					colorName="ColorBrown";
 					a=69.968704;
 					b=76.622749;
-					angle=228.59036;
+					angle=228.59033;
 					id=158;
 					atlOffset=25.352036;
 				};
@@ -7090,23 +3029,7 @@ class Mission
 			id=268;
 			atlOffset=53.832367;
 		};
-		class Item105
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={4853.9849,33.866829,7132.9248};
-				angles[]={6.261188,4.0101862,6.251195};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=273;
-			type="Land_HelipadSquare_F";
-		};
-		class Item106
+		class Item91
 		{
 			dataType="Layer";
 			name="Airfports";
@@ -7432,7 +3355,7 @@ class Mission
 			id=276;
 			atlOffset=13.611166;
 		};
-		class Item107
+		class Item92
 		{
 			dataType="Layer";
 			name="Seaports";
@@ -7511,7 +3434,7 @@ class Mission
 			id=277;
 			atlOffset=27.005886;
 		};
-		class Item108
+		class Item93
 		{
 			dataType="Layer";
 			name="Roadblocks";
@@ -7767,23 +3690,7 @@ class Mission
 			id=278;
 			atlOffset=52.915527;
 		};
-		class Item109
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={576.50085,8.7600002,425.40857};
-				angles[]={0,4.7175293,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=279;
-			type="Land_HelipadSquare_F";
-		};
-		class Item110
+		class Item94
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -7794,7 +3701,7 @@ class Mission
 			id=280;
 			type="HighCommand";
 		};
-		class Item111
+		class Item95
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -7804,7 +3711,7 @@ class Mission
 			id=281;
 			type="HighCommandSubordinate";
 		};
-		class Item112
+		class Item96
 		{
 			dataType="Marker";
 			position[]={3468.0591,7.256,4396.9609};
@@ -7813,37 +3720,7 @@ class Mission
 			id=282;
 			atlOffset=4.2438507e-005;
 		};
-		class Item113
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={9174.5,5,4872.5};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=301;
-			type="Land_HelipadSquare_F";
-		};
-		class Item114
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={9199.5,5,4872.5};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=302;
-			type="Land_HelipadSquare_F";
-		};
-		class Item115
+		class Item97
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7860,7 +3737,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item116
+		class Item98
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7871,11 +3748,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=304;
 			type="Land_HBarrierWall6_F";
 		};
-		class Item117
+		class Item99
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7886,11 +3764,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=305;
 			type="Land_HBarrierWall6_F";
 		};
-		class Item118
+		class Item100
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7907,7 +3786,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item119
+		class Item101
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7924,7 +3803,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item120
+		class Item102
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7936,11 +3815,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=309;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item121
+		class Item103
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7952,11 +3832,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=310;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item122
+		class Item104
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7973,7 +3854,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item123
+		class Item105
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7985,11 +3866,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=313;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item124
+		class Item106
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8006,7 +3888,7 @@ class Mission
 			type="Land_Cargo_Patrol_V3_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item125
+		class Item107
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8018,11 +3900,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=315;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item126
+		class Item108
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8038,7 +3921,7 @@ class Mission
 			id=316;
 			type="Land_Cargo_Patrol_V3_F";
 		};
-		class Item127
+		class Item109
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8050,12 +3933,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=317;
 			type="Land_HBarrier_Big_F";
 			atlOffset=2.3841858e-007;
 		};
-		class Item128
+		class Item110
 		{
 			dataType="Marker";
 			position[]={4982.8779,17.352125,5946.2769};
@@ -8064,7 +3948,7 @@ class Mission
 			id=318;
 			atlOffset=4.196167e-005;
 		};
-		class Item129
+		class Item111
 		{
 			dataType="Marker";
 			position[]={6186.1226,4.5815167,7140.0923};
@@ -8073,7 +3957,7 @@ class Mission
 			id=319;
 			atlOffset=4.2438507e-005;
 		};
-		class Item130
+		class Item112
 		{
 			dataType="Marker";
 			position[]={6407.4814,27.562088,7624.4834};
@@ -8082,7 +3966,7 @@ class Mission
 			id=320;
 			atlOffset=4.196167e-005;
 		};
-		class Item131
+		class Item113
 		{
 			dataType="Marker";
 			position[]={6755.207,46.149174,6451.499};
@@ -8091,7 +3975,7 @@ class Mission
 			id=321;
 			atlOffset=4.196167e-005;
 		};
-		class Item132
+		class Item114
 		{
 			dataType="Marker";
 			position[]={6669.332,9.7615795,7019.2314};
@@ -8100,7 +3984,7 @@ class Mission
 			id=322;
 			atlOffset=4.196167e-005;
 		};
-		class Item133
+		class Item115
 		{
 			dataType="Marker";
 			position[]={6487.5713,5.1223044,6285.8096};
@@ -8109,7 +3993,7 @@ class Mission
 			id=323;
 			atlOffset=4.2438507e-005;
 		};
-		class Item134
+		class Item116
 		{
 			dataType="Marker";
 			position[]={6076.0132,36.164722,5983.7061};
@@ -8118,7 +4002,7 @@ class Mission
 			id=324;
 			atlOffset=4.196167e-005;
 		};
-		class Item135
+		class Item117
 		{
 			dataType="Marker";
 			position[]={5709.9146,9.3883533,5943.8403};
@@ -8127,7 +4011,7 @@ class Mission
 			id=325;
 			atlOffset=4.2915344e-005;
 		};
-		class Item136
+		class Item118
 		{
 			dataType="Marker";
 			position[]={5800.8984,5.9700422,5545.0903};
@@ -8136,7 +4020,7 @@ class Mission
 			id=326;
 			atlOffset=4.2438507e-005;
 		};
-		class Item137
+		class Item119
 		{
 			dataType="Marker";
 			position[]={6332.7788,22.075169,5732.4326};
@@ -8145,7 +4029,7 @@ class Mission
 			id=327;
 			atlOffset=4.196167e-005;
 		};
-		class Item138
+		class Item120
 		{
 			dataType="Marker";
 			position[]={7389.5063,55.06031,6148.1665};
@@ -8154,7 +4038,7 @@ class Mission
 			id=328;
 			atlOffset=4.196167e-005;
 		};
-		class Item139
+		class Item121
 		{
 			dataType="Marker";
 			position[]={7105.0298,12.872475,5777.6113};
@@ -8163,7 +4047,7 @@ class Mission
 			id=329;
 			atlOffset=4.2915344e-005;
 		};
-		class Item140
+		class Item122
 		{
 			dataType="Marker";
 			position[]={8727.0811,105.12666,6250.9473};
@@ -8172,7 +4056,7 @@ class Mission
 			id=330;
 			atlOffset=5.3405762e-005;
 		};
-		class Item141
+		class Item123
 		{
 			dataType="Marker";
 			position[]={8909.3047,23.660042,5291.5479};
@@ -8181,7 +4065,7 @@ class Mission
 			id=331;
 			atlOffset=4.196167e-005;
 		};
-		class Item142
+		class Item124
 		{
 			dataType="Marker";
 			position[]={8264.3213,18.447327,5824.7241};
@@ -8190,7 +4074,7 @@ class Mission
 			id=332;
 			atlOffset=4.196167e-005;
 		};
-		class Item143
+		class Item125
 		{
 			dataType="Marker";
 			position[]={7639.145,47.649624,4703.9355};
@@ -8199,7 +4083,7 @@ class Mission
 			id=333;
 			atlOffset=4.196167e-005;
 		};
-		class Item144
+		class Item126
 		{
 			dataType="Marker";
 			position[]={6851.7676,42.503872,4757.21};
@@ -8208,7 +4092,7 @@ class Mission
 			id=334;
 			atlOffset=4.196167e-005;
 		};
-		class Item145
+		class Item127
 		{
 			dataType="Marker";
 			position[]={6373.2373,38.162395,4359.1152};
@@ -8217,7 +4101,7 @@ class Mission
 			id=335;
 			atlOffset=4.196167e-005;
 		};
-		class Item146
+		class Item128
 		{
 			dataType="Marker";
 			position[]={5335.3003,7.1832151,3627.9927};
@@ -8226,7 +4110,7 @@ class Mission
 			id=336;
 			atlOffset=4.2438507e-005;
 		};
-		class Item147
+		class Item129
 		{
 			dataType="Marker";
 			position[]={4986.2813,25.105524,2205.9534};
@@ -8235,7 +4119,7 @@ class Mission
 			id=337;
 			atlOffset=4.196167e-005;
 		};
-		class Item148
+		class Item130
 		{
 			dataType="Marker";
 			position[]={4195.4937,15.27523,5266.2251};
@@ -8244,7 +4128,7 @@ class Mission
 			id=338;
 			atlOffset=4.2915344e-005;
 		};
-		class Item149
+		class Item131
 		{
 			dataType="Marker";
 			position[]={1545.5944,7.1300426,5697.5244};
@@ -8253,7 +4137,7 @@ class Mission
 			id=339;
 			atlOffset=4.2438507e-005;
 		};
-		class Item150
+		class Item132
 		{
 			dataType="Marker";
 			position[]={1740.4181,40.745392,6775.5947};
@@ -8262,7 +4146,7 @@ class Mission
 			id=340;
 			atlOffset=4.196167e-005;
 		};
-		class Item151
+		class Item133
 		{
 			dataType="Marker";
 			position[]={2241.3816,19.702797,7326.8418};
@@ -8271,7 +4155,7 @@ class Mission
 			id=341;
 			atlOffset=4.196167e-005;
 		};
-		class Item152
+		class Item134
 		{
 			dataType="Marker";
 			position[]={2298.2693,2.9884403,8497.6543};
@@ -8280,7 +4164,7 @@ class Mission
 			id=342;
 			atlOffset=4.2438507e-005;
 		};
-		class Item153
+		class Item135
 		{
 			dataType="Marker";
 			position[]={3297.8071,19.438557,6441.5225};
@@ -8289,7 +4173,7 @@ class Mission
 			id=343;
 			atlOffset=4.196167e-005;
 		};
-		class Item154
+		class Item136
 		{
 			dataType="Marker";
 			position[]={4271.5156,20.920042,6582.3096};
@@ -8298,7 +4182,7 @@ class Mission
 			id=344;
 			atlOffset=4.196167e-005;
 		};
-		class Item155
+		class Item137
 		{
 			dataType="Marker";
 			position[]={5187.7246,29.679436,7277.5586};
@@ -8307,7 +4191,7 @@ class Mission
 			id=345;
 			atlOffset=4.196167e-005;
 		};
-		class Item156
+		class Item138
 		{
 			dataType="Marker";
 			position[]={5357.751,163.60167,7726.731};
@@ -8316,7 +4200,7 @@ class Mission
 			id=346;
 			atlOffset=4.5776367e-005;
 		};
-		class Item157
+		class Item139
 		{
 			dataType="Marker";
 			position[]={7061.0146,9.0371151,3841.2427};
@@ -8325,7 +4209,7 @@ class Mission
 			id=347;
 			atlOffset=4.196167e-005;
 		};
-		class Item158
+		class Item140
 		{
 			dataType="Marker";
 			position[]={4385.0557,30.939602,1348.6993};
@@ -8335,7 +4219,7 @@ class Mission
 			id=348;
 			atlOffset=15.667422;
 		};
-		class Item159
+		class Item141
 		{
 			dataType="Marker";
 			position[]={1780.5658,28.087421,4922.3477};
@@ -8345,7 +4229,7 @@ class Mission
 			id=349;
 			atlOffset=15.667421;
 		};
-		class Item160
+		class Item142
 		{
 			dataType="Marker";
 			position[]={521.91888,24.427422,333.45093};
@@ -8355,17 +4239,17 @@ class Mission
 			id=350;
 			atlOffset=15.667421;
 		};
-		class Item161
+		class Item143
 		{
 			dataType="Marker";
 			position[]={9207.2539,20.667,4988.5352};
 			name="spawnpoint";
 			type="hd_start";
-			angle=28.146994;
+			angle=28.14699;
 			id=351;
 			atlOffset=15.667;
 		};
-		class Item162
+		class Item144
 		{
 			dataType="Marker";
 			position[]={4920.5439,0.38800001,5730.7168};
@@ -8374,11 +4258,11 @@ class Mission
 			type="rectangle";
 			a=5190.1421;
 			b=5239.7939;
-			angle=55.783993;
+			angle=55.783985;
 			id=353;
 			atlOffset=-19.74058;
 		};
-		class Item163
+		class Item145
 		{
 			dataType="Marker";
 			position[]={479.26917,0,378.30554};
@@ -8390,16 +4274,1342 @@ class Mission
 			id=354;
 			atlOffset=-8.79;
 		};
+		class Item146
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=38;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={898.62616,12.140828,5451.0303};
+					};
+					side="Independent";
+					flags=3;
+					class Attributes
+					{
+						name="commanderX";
+						description="Default Commaner";
+						isPlayer=1;
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=356;
+					type="I_G_officer_F";
+					atlOffset=2.2093887;
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male04GRE";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1;
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={903.42108,11.602518,5448.3271};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=357;
+					type="I_G_officer_F";
+					atlOffset=1.5630188;
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={903.55975,11.574219,5450.563};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=358;
+					type="I_G_officer_F";
+					atlOffset=1.4959488;
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={903.50214,11.502116,5452.8965};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=359;
+					type="I_G_officer_F";
+					atlOffset=1.405426;
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={903.33905,11.400959,5455.21};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=360;
+					type="I_G_officer_F";
+					atlOffset=1.3078613;
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={903.29803,11.274815,5457.6641};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=361;
+					type="I_G_officer_F";
+					atlOffset=1.2042618;
+				};
+				class Item6
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={903.11249,11.151037,5459.98};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=362;
+					type="I_G_officer_F";
+					atlOffset=1.1147766;
+				};
+				class Item7
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={902.90546,10.960851,5461.8755};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=363;
+					type="I_G_officer_F";
+					atlOffset=1.0294113;
+				};
+				class Item8
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={905.78046,11.213944,5448.4507};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=364;
+					type="I_G_Soldier_F";
+					atlOffset=1.1350403;
+				};
+				class Item9
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={905.77948,11.176581,5450.79};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=365;
+					type="I_G_Soldier_F";
+					atlOffset=1.0546341;
+				};
+				class Item10
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={905.67303,11.113951,5453.1636};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=366;
+					type="I_G_Soldier_F";
+					atlOffset=0.96520233;
+				};
+				class Item11
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={905.61444,11.024461,5455.3633};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=367;
+					type="I_G_Soldier_F";
+					atlOffset=0.87738037;
+				};
+				class Item12
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={905.41132,10.894525,5457.7856};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=368;
+					type="I_G_Soldier_F";
+					atlOffset=0.78246307;
+				};
+				class Item13
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={905.22382,10.739998,5460.1167};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=369;
+					type="I_G_Soldier_F";
+					atlOffset=0.67633057;
+				};
+				class Item14
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={907.88885,11.109521,5448.4868};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=370;
+					type="I_G_Soldier_AR_F";
+					atlOffset=1.0090256;
+				};
+				class Item15
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={908.05096,11.069618,5450.9268};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=371;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.91348267;
+				};
+				class Item16
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={907.65057,11.013217,5453.3418};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=372;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.8175354;
+				};
+				class Item17
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={907.62714,10.888342,5455.4907};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=373;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.70054626;
+				};
+				class Item18
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={907.42694,10.703317,5457.7319};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=374;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.56147766;
+				};
+				class Item19
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={907.34003,10.515191,5460.1909};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=375;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.42988586;
+				};
+				class Item20
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={909.97772,10.986938,5448.5664};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=376;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.88265228;
+				};
+				class Item21
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={909.84784,10.95783,5450.8843};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=377;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.79734802;
+				};
+				class Item22
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={909.72382,10.863556,5453.6284};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=378;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.64067841;
+				};
+				class Item23
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={909.54999,10.71688,5455.6372};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=379;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.51522064;
+				};
+				class Item24
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={909.48065,10.50953,5457.8218};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=380;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.35932922;
+				};
+				class Item25
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={909.37518,10.32379,5460.3125};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=381;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.23212433;
+				};
+				class Item26
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={911.50507,10.740455,5448.644};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=382;
+					type="I_G_medic_F";
+					atlOffset=0.64479828;
+				};
+				class Item27
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={911.32928,10.727345,5450.9238};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=383;
+					type="I_G_medic_F";
+					atlOffset=0.57946014;
+				};
+				class Item28
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={911.28729,10.598125,5453.7954};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=384;
+					type="I_G_medic_F";
+					atlOffset=0.40799713;
+				};
+				class Item29
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={911.1994,10.468033,5455.6021};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=385;
+					type="I_G_medic_F";
+					atlOffset=0.28740692;
+				};
+				class Item30
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={911.01581,10.279652,5457.9614};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=386;
+					type="I_G_medic_F";
+					atlOffset=0.14078522;
+				};
+				class Item31
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={911.02655,10.08852,5460.3721};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=387;
+					type="I_G_medic_F";
+					atlOffset=0.0065917969;
+				};
+				class Item32
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={913.30682,10.446096,5448.8091};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=388;
+					type="I_G_engineer_F";
+					atlOffset=0.36595917;
+				};
+				class Item33
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={913.33026,10.394513,5451.1094};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=389;
+					type="I_G_engineer_F";
+					atlOffset=0.27748108;
+				};
+				class Item34
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={913.08807,10.277906,5453.8994};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=390;
+					type="I_G_engineer_F";
+					atlOffset=0.13031006;
+				};
+				class Item35
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={912.83319,10.165681,5455.8472};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=391;
+					type="I_G_engineer_F";
+					atlOffset=0.022331238;
+				};
+				class Item36
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={912.63788,9.9975576,5458.0835};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=392;
+					type="I_G_engineer_F";
+					atlOffset=0.06611824;
+				};
+				class Item37
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={912.53339,9.8152685,5460.5527};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=393;
+					type="I_G_engineer_F";
+					atlOffset=-0.11617088;
+				};
+			};
+			class Attributes
+			{
+			};
+			id=355;
+			atlOffset=2.2093887;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="Guerillas";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item147
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={385.73734,8.7600002,552.797};
+				angles[]={0,2.3661182,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=394;
+			type="Land_HelipadCircle_F";
+		};
+		class Item148
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1811.0693,12.41,4835.5352};
+				angles[]={0,3.1415927,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=395;
+			type="Land_HelipadCircle_F";
+		};
+		class Item149
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1777.9683,12.41,4835.4785};
+				angles[]={0,3.1415927,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=396;
+			type="Land_HelipadCircle_F";
+		};
+		class Item150
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1745.5701,12.41,4836.251};
+				angles[]={0,3.1415927,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=397;
+			type="Land_HelipadCircle_F";
+		};
+		class Item151
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1714.0297,12.41,4836.3008};
+				angles[]={0,3.1415927,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=398;
+			type="Land_HelipadCircle_F";
+		};
+		class Item152
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={3062.5676,14.69,4317.0547};
+				angles[]={0,2.1329734,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=399;
+			type="Land_HelipadCircle_F";
+		};
+		class Item153
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={3044.9717,14.69,4289.0176};
+				angles[]={0,2.1329734,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=400;
+			type="Land_HelipadCircle_F";
+		};
+		class Item154
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={3027.0491,14.69,4262.0176};
+				angles[]={0,2.1329734,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=401;
+			type="Land_HelipadCircle_F";
+		};
+		class Item155
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={3010.1948,14.69,4235.3579};
+				angles[]={0,2.1329734,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=402;
+			type="Land_HelipadCircle_F";
+		};
+		class Item156
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2800.8835,150.04987,7837.4761};
+				angles[]={6.2791886,1.5746711,6.2491965};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=403;
+			type="Land_HelipadCircle_F";
+		};
+		class Item157
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5727.5259,54.110001,4292.5586};
+				angles[]={0,3.1410565,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=404;
+			type="Land_HelipadCircle_F";
+		};
+		class Item158
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={4853.9849,33.866829,7132.9248};
+				angles[]={6.261188,4.0101862,6.251195};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=405;
+			type="Land_HelipadCircle_F";
+		};
+		class Item159
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={576.50085,8.7600002,425.40857};
+				angles[]={0,4.7175293,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=406;
+			type="Land_HelipadCircle_F";
+		};
+		class Item160
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={9174.5,5,4872.5};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=407;
+			type="Land_HelipadCircle_F";
+		};
+		class Item161
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={9199.5,5,4872.5};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=408;
+			type="Land_HelipadCircle_F";
+		};
+		class Item162
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5261.3325,202.914,7811.0913};
+				angles[]={6.2644358,4.6879864,-0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=409;
+			type="CamoNet_BLUFOR_F";
+			atlOffset=0.00082397461;
+		};
+		class Item163
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5286.9395,202.80562,7812.5166};
+				angles[]={0.018749893,1.5355018,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=410;
+			type="CamoNet_BLUFOR_open_F";
+		};
+		class Item164
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={5310.854,202.53488,7811.4009};
+			};
+			areaSize[]={5,0,5};
+			flags=1;
+			id=411;
+			type="ModuleHideTerrainObjects_F";
+			atlOffset=0.45507813;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="#filter";
+					expression="_this setVariable [""#filter"",_value]";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"SCALAR"
+								};
+							};
+							value=15;
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="#hideLocally";
+					expression="_this setVariable [""#hideLocally"",_value]";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=2;
+			};
+		};
+		class Item165
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5313.9712,216.94789,7810.8418};
+			};
+			side="Empty";
+			flags=1;
+			class Attributes
+			{
+				description="Church_of_Bob";
+				disableSimulation=1;
+			};
+			id=415;
+			type="Land_OrthodoxChurch_03_F";
+			atlOffset=0.30000305;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="DoorStates";
+					expression="['init',_this,_value] call bis_fnc_3DENAttributeDoorStates;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"ARRAY"
+								};
+							};
+							class value
+							{
+								items=3;
+								class Item0
+								{
+									class data
+									{
+										class type
+										{
+											type[]=
+											{
+												"SCALAR"
+											};
+										};
+										value=10;
+									};
+								};
+								class Item1
+								{
+									class data
+									{
+										class type
+										{
+											type[]=
+											{
+												"SCALAR"
+											};
+										};
+										value=0;
+									};
+								};
+								class Item2
+								{
+									class data
+									{
+										class type
+										{
+											type[]=
+											{
+												"SCALAR"
+											};
+										};
+										value=0;
+									};
+								};
+							};
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=2;
+			};
+		};
 	};
 	class Connections
 	{
 		class LinkIDProvider
 		{
-			nextID=61;
+			nextID=39;
 		};
 		class Links
 		{
-			items=61;
+			items=39;
 			class Item0
 			{
 				linkID=0;
@@ -8413,7 +5623,7 @@ class Mission
 			class Item1
 			{
 				linkID=1;
-				item0=23;
+				item0=356;
 				item1=280;
 				class CustomData
 				{
@@ -8423,7 +5633,7 @@ class Mission
 			class Item2
 			{
 				linkID=2;
-				item0=27;
+				item0=357;
 				item1=280;
 				class CustomData
 				{
@@ -8433,7 +5643,7 @@ class Mission
 			class Item3
 			{
 				linkID=3;
-				item0=28;
+				item0=358;
 				item1=280;
 				class CustomData
 				{
@@ -8443,7 +5653,7 @@ class Mission
 			class Item4
 			{
 				linkID=4;
-				item0=29;
+				item0=359;
 				item1=280;
 				class CustomData
 				{
@@ -8453,7 +5663,7 @@ class Mission
 			class Item5
 			{
 				linkID=5;
-				item0=30;
+				item0=360;
 				item1=280;
 				class CustomData
 				{
@@ -8463,7 +5673,7 @@ class Mission
 			class Item6
 			{
 				linkID=6;
-				item0=31;
+				item0=361;
 				item1=280;
 				class CustomData
 				{
@@ -8473,7 +5683,7 @@ class Mission
 			class Item7
 			{
 				linkID=7;
-				item0=32;
+				item0=362;
 				item1=280;
 				class CustomData
 				{
@@ -8483,7 +5693,7 @@ class Mission
 			class Item8
 			{
 				linkID=8;
-				item0=33;
+				item0=363;
 				item1=280;
 				class CustomData
 				{
@@ -8493,7 +5703,7 @@ class Mission
 			class Item9
 			{
 				linkID=9;
-				item0=34;
+				item0=364;
 				item1=280;
 				class CustomData
 				{
@@ -8503,7 +5713,7 @@ class Mission
 			class Item10
 			{
 				linkID=10;
-				item0=35;
+				item0=365;
 				item1=280;
 				class CustomData
 				{
@@ -8513,7 +5723,7 @@ class Mission
 			class Item11
 			{
 				linkID=11;
-				item0=36;
+				item0=366;
 				item1=280;
 				class CustomData
 				{
@@ -8523,7 +5733,7 @@ class Mission
 			class Item12
 			{
 				linkID=12;
-				item0=37;
+				item0=367;
 				item1=280;
 				class CustomData
 				{
@@ -8533,7 +5743,7 @@ class Mission
 			class Item13
 			{
 				linkID=13;
-				item0=38;
+				item0=368;
 				item1=280;
 				class CustomData
 				{
@@ -8543,7 +5753,7 @@ class Mission
 			class Item14
 			{
 				linkID=14;
-				item0=39;
+				item0=369;
 				item1=280;
 				class CustomData
 				{
@@ -8553,7 +5763,7 @@ class Mission
 			class Item15
 			{
 				linkID=15;
-				item0=40;
+				item0=370;
 				item1=280;
 				class CustomData
 				{
@@ -8563,7 +5773,7 @@ class Mission
 			class Item16
 			{
 				linkID=16;
-				item0=41;
+				item0=371;
 				item1=280;
 				class CustomData
 				{
@@ -8573,7 +5783,7 @@ class Mission
 			class Item17
 			{
 				linkID=17;
-				item0=42;
+				item0=372;
 				item1=280;
 				class CustomData
 				{
@@ -8583,7 +5793,7 @@ class Mission
 			class Item18
 			{
 				linkID=18;
-				item0=43;
+				item0=373;
 				item1=280;
 				class CustomData
 				{
@@ -8593,7 +5803,7 @@ class Mission
 			class Item19
 			{
 				linkID=19;
-				item0=44;
+				item0=374;
 				item1=280;
 				class CustomData
 				{
@@ -8603,7 +5813,7 @@ class Mission
 			class Item20
 			{
 				linkID=20;
-				item0=45;
+				item0=375;
 				item1=280;
 				class CustomData
 				{
@@ -8613,7 +5823,7 @@ class Mission
 			class Item21
 			{
 				linkID=21;
-				item0=46;
+				item0=376;
 				item1=280;
 				class CustomData
 				{
@@ -8623,7 +5833,7 @@ class Mission
 			class Item22
 			{
 				linkID=22;
-				item0=47;
+				item0=377;
 				item1=280;
 				class CustomData
 				{
@@ -8633,7 +5843,7 @@ class Mission
 			class Item23
 			{
 				linkID=23;
-				item0=48;
+				item0=378;
 				item1=280;
 				class CustomData
 				{
@@ -8643,7 +5853,7 @@ class Mission
 			class Item24
 			{
 				linkID=24;
-				item0=49;
+				item0=379;
 				item1=280;
 				class CustomData
 				{
@@ -8653,7 +5863,7 @@ class Mission
 			class Item25
 			{
 				linkID=25;
-				item0=50;
+				item0=380;
 				item1=280;
 				class CustomData
 				{
@@ -8663,7 +5873,7 @@ class Mission
 			class Item26
 			{
 				linkID=26;
-				item0=51;
+				item0=381;
 				item1=280;
 				class CustomData
 				{
@@ -8673,7 +5883,7 @@ class Mission
 			class Item27
 			{
 				linkID=27;
-				item0=52;
+				item0=382;
 				item1=280;
 				class CustomData
 				{
@@ -8683,7 +5893,7 @@ class Mission
 			class Item28
 			{
 				linkID=28;
-				item0=53;
+				item0=383;
 				item1=280;
 				class CustomData
 				{
@@ -8693,7 +5903,7 @@ class Mission
 			class Item29
 			{
 				linkID=29;
-				item0=54;
+				item0=384;
 				item1=280;
 				class CustomData
 				{
@@ -8703,7 +5913,7 @@ class Mission
 			class Item30
 			{
 				linkID=30;
-				item0=55;
+				item0=385;
 				item1=280;
 				class CustomData
 				{
@@ -8713,7 +5923,7 @@ class Mission
 			class Item31
 			{
 				linkID=31;
-				item0=56;
+				item0=386;
 				item1=280;
 				class CustomData
 				{
@@ -8723,7 +5933,7 @@ class Mission
 			class Item32
 			{
 				linkID=32;
-				item0=57;
+				item0=387;
 				item1=280;
 				class CustomData
 				{
@@ -8733,7 +5943,7 @@ class Mission
 			class Item33
 			{
 				linkID=33;
-				item0=58;
+				item0=388;
 				item1=280;
 				class CustomData
 				{
@@ -8743,7 +5953,7 @@ class Mission
 			class Item34
 			{
 				linkID=34;
-				item0=59;
+				item0=389;
 				item1=280;
 				class CustomData
 				{
@@ -8753,7 +5963,7 @@ class Mission
 			class Item35
 			{
 				linkID=35;
-				item0=60;
+				item0=390;
 				item1=280;
 				class CustomData
 				{
@@ -8763,7 +5973,7 @@ class Mission
 			class Item36
 			{
 				linkID=36;
-				item0=61;
+				item0=391;
 				item1=280;
 				class CustomData
 				{
@@ -8773,7 +5983,7 @@ class Mission
 			class Item37
 			{
 				linkID=37;
-				item0=62;
+				item0=392;
 				item1=280;
 				class CustomData
 				{
@@ -8783,227 +5993,7 @@ class Mission
 			class Item38
 			{
 				linkID=38;
-				item0=63;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item39
-			{
-				linkID=39;
-				item0=64;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item40
-			{
-				linkID=40;
-				item0=65;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item41
-			{
-				linkID=41;
-				item0=66;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item42
-			{
-				linkID=42;
-				item0=67;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item43
-			{
-				linkID=43;
-				item0=68;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item44
-			{
-				linkID=44;
-				item0=69;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item45
-			{
-				linkID=45;
-				item0=70;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item46
-			{
-				linkID=46;
-				item0=71;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item47
-			{
-				linkID=47;
-				item0=72;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item48
-			{
-				linkID=48;
-				item0=73;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item49
-			{
-				linkID=49;
-				item0=74;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item50
-			{
-				linkID=50;
-				item0=75;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item51
-			{
-				linkID=51;
-				item0=76;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item52
-			{
-				linkID=52;
-				item0=77;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item53
-			{
-				linkID=53;
-				item0=78;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item54
-			{
-				linkID=54;
-				item0=79;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item55
-			{
-				linkID=55;
-				item0=80;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item56
-			{
-				linkID=56;
-				item0=81;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item57
-			{
-				linkID=57;
-				item0=82;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item58
-			{
-				linkID=58;
-				item0=83;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item59
-			{
-				linkID=59;
-				item0=84;
-				item1=280;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item60
-			{
-				linkID=60;
-				item0=85;
+				item0=393;
 				item1=280;
 				class CustomData
 				{

--- a/Map-Templates/Antistasi-WotP.Tanoa/mission.sqm
+++ b/Map-Templates/Antistasi-WotP.Tanoa/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=1541;
 	class ItemIDProvider
 	{
-		nextID=878;
+		nextID=917;
 	};
 	class MarkerIDProvider
 	{
@@ -16,24 +16,23 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=328;
+		nextID=338;
 	};
 	class Camera
 	{
-		pos[]={9181.2354,246.07274,8692.4609};
-		dir[]={0,-0.70710683,0.70710683};
-		up[]={0,0.70710677,0.70710677};
-		aside[]={0.99999994,0,-0};
+		pos[]={9216.2598,271.90015,8692.502};
+		dir[]={-0.18412197,-0.74343204,0.64300436};
+		up[]={-0.2046586,0.66879123,0.71472174};
+		aside[]={0.96138626,-1.1124794e-006,0.27529016};
 	};
 };
 binarizationWanted=0;
 addons[]=
 {
-	"A3_Characters_F_Exp",
-	"A3_Weapons_F",
 	"A3_Ui_F",
 	"A3_Weapons_F_Ammoboxes",
 	"A3_Structures_F_EPC_Civ_InfoBoards",
+	"A3_Characters_F_Exp",
 	"A3_Modules_F",
 	"A3_Characters_F",
 	"A3_Structures_F_Exp_Military_Flags",
@@ -48,7 +47,8 @@ addons[]=
 	"A3_Structures_F_Ind_AirPort",
 	"A3_Structures_F_Enoch_Military_Barracks",
 	"A3_Structures_F_Exp_Military_ContainerBases",
-	"A3_Modules_F_Hc"
+	"A3_Modules_F_Hc",
+	"A3_Weapons_F"
 };
 class AddonsMetaData
 {
@@ -57,8 +57,8 @@ class AddonsMetaData
 		items=13;
 		class Item0
 		{
-			className="A3_Characters_F_Exp";
-			name="Arma 3 Apex - Characters and Clothing";
+			className="A3_Ui_F";
+			name="Arma 3 - User Interface";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
@@ -71,15 +71,15 @@ class AddonsMetaData
 		};
 		class Item2
 		{
-			className="A3_Ui_F";
-			name="Arma 3 - User Interface";
+			className="A3_Structures_F_EPC";
+			name="Arma 3 Win Episode - Buildings and Structures";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
 		class Item3
 		{
-			className="A3_Structures_F_EPC";
-			name="Arma 3 Win Episode - Buildings and Structures";
+			className="A3_Characters_F_Exp";
+			name="Arma 3 Apex - Characters and Clothing";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
@@ -166,2744 +166,6 @@ class Mission
 		items=235;
 		class Item0
 		{
-			dataType="Group";
-			side="Independent";
-			class Entities
-			{
-				items=60;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9198.8262,220.12206,8727.9844};
-					};
-					side="Independent";
-					flags=6;
-					class Attributes
-					{
-						skill=1;
-						name="commanderX";
-						description="Default Commander";
-						isPlayer=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=311;
-					type="I_C_Soldier_Para_7_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="speaker";
-							expression="_this setspeaker _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="Male01FRE";
-								};
-							};
-						};
-						class Attribute1
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=2;
-					};
-				};
-				class Item1
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9202.082,219.9032,8724.7266};
-						angles[]={0,6.2412972,0};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=360;
-					type="I_C_Soldier_Para_4_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item2
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9213.0352,219.15091,8715.0146};
-						angles[]={0,6.2412972,0};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=654;
-					type="I_C_Soldier_Para_4_F";
-					atlOffset=-0.046646118;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item3
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9216.1094,218.68268,8715.25};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=656;
-					type="I_C_Soldier_Para_5_F";
-					atlOffset=-0.044662476;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item4
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9219.04,218.23302,8714.9014};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=658;
-					type="I_C_Soldier_Para_3_F";
-					atlOffset=-0.042282104;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item5
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9221.9385,217.76714,8715.0791};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=660;
-					type="I_C_Soldier_Para_8_F";
-					atlOffset=-0.042007446;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item6
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9224.9268,217.29105,8715.2998};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=662;
-					type="I_C_Soldier_Para_6_F";
-					atlOffset=-0.034622192;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item7
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9209.0781,219.71281,8714.7148};
-						angles[]={0,0.090093896,0};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=664;
-					type="I_C_Soldier_Para_7_F";
-					atlOffset=-0.044662476;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item8
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9215.2559,218.97414,8709.7188};
-						angles[]={0,6.2412972,0};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=666;
-					type="I_C_Soldier_Para_4_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item9
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9218.3301,218.41643,8709.9541};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=668;
-					type="I_C_Soldier_Para_5_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item10
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9221.2607,217.9128,8709.6055};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=670;
-					type="I_C_Soldier_Para_3_F";
-					atlOffset=0.010543823;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item11
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9224.1592,217.38159,8709.7832};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=672;
-					type="I_C_Soldier_Para_8_F";
-					atlOffset=0.014144897;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item12
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9227.1475,216.83351,8710.0039};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=674;
-					type="I_C_Soldier_Para_6_F";
-					atlOffset=0.014190674;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item13
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9211.2988,219.7475,8709.4189};
-						angles[]={0,0.090093896,0};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=676;
-					type="I_C_Soldier_Para_7_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item14
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9216.9883,218.56767,8704.8672};
-						angles[]={0,6.2412972,0};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=678;
-					type="I_C_Soldier_Para_4_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item15
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9220.0625,217.93648,8705.1025};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=680;
-					type="I_C_Soldier_Para_5_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item16
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9222.9932,217.33908,8704.7539};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=682;
-					type="I_C_Soldier_Para_3_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item17
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9225.8916,216.78543,8704.9316};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=684;
-					type="I_C_Soldier_Para_8_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item18
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9228.8799,216.22507,8705.1523};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=686;
-					type="I_C_Soldier_Para_6_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item19
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9213.0313,219.41595,8704.5674};
-						angles[]={0,0.090093896,0};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=688;
-					type="I_C_Soldier_Para_7_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item20
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9208.0869,219.59343,8724.6133};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=362;
-					type="I_C_Soldier_Para_3_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item21
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9210.9854,219.25606,8724.791};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=363;
-					type="I_C_Soldier_Para_8_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item22
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9213.9736,218.826,8725.0117};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=364;
-					type="I_C_Soldier_Para_6_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item23
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9208.7842,219.58228,8732.6152};
-						angles[]={0,6.2412972,0};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=459;
-					type="I_C_Soldier_Para_4_F";
-					atlOffset=-0.0206604;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item24
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9211.8584,219.21495,8732.8506};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=461;
-					type="I_C_Soldier_Para_5_F";
-					atlOffset=-0.012680054;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item25
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9214.7891,218.84361,8732.502};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=463;
-					type="I_C_Soldier_Para_3_F";
-					atlOffset=-0.0090179443;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item26
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9217.6875,218.58643,8732.6797};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=465;
-					type="I_C_Soldier_Para_8_F";
-					atlOffset=0.0059967041;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item27
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9220.6758,218.37024,8732.9004};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=467;
-					type="I_C_Soldier_Para_6_F";
-					atlOffset=0.0019989014;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item28
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9209.4844,220.00462,8736.8926};
-						angles[]={0,6.2412972,0};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=471;
-					type="I_C_Soldier_Para_4_F";
-					atlOffset=-1.5258789e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item29
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9212.5586,219.77544,8737.1279};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=473;
-					type="I_C_Soldier_Para_5_F";
-					atlOffset=0.013320923;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item30
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9215.4893,219.43719,8736.7793};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=475;
-					type="I_C_Soldier_Para_3_F";
-					atlOffset=0.010314941;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item31
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9218.3877,219.21072,8736.957};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=477;
-					type="I_C_Soldier_Para_8_F";
-					atlOffset=0.010665894;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item32
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9221.376,219.07388,8737.1777};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=479;
-					type="I_C_Soldier_Para_6_F";
-					atlOffset=0.011184692;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item33
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9205.5273,220.3063,8736.5928};
-						angles[]={0,0.090093896,0};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=481;
-					type="I_C_Soldier_Para_7_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item34
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9209.9092,220.56894,8740.293};
-						angles[]={0,6.2412972,0};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=483;
-					type="I_C_Soldier_Para_4_F";
-					atlOffset=-1.5258789e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item35
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9212.9834,220.45323,8740.5283};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=485;
-					type="I_C_Soldier_Para_5_F";
-					atlOffset=-1.5258789e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item36
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9215.9141,220.16454,8740.1797};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=487;
-					type="I_C_Soldier_Para_3_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item37
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9218.8125,220.01382,8740.3574};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=489;
-					type="I_C_Soldier_Para_8_F";
-					atlOffset=-1.5258789e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item38
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9221.8008,219.81172,8740.5781};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=491;
-					type="I_C_Soldier_Para_6_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item39
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9205.9521,220.69756,8739.9932};
-						angles[]={0,0.090093896,0};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=493;
-					type="I_C_Soldier_Para_7_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item40
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9210.8184,221.38371,8744.166};
-						angles[]={0,6.2412972,0};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=495;
-					type="I_C_Soldier_Para_4_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item41
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9213.8926,221.44388,8744.4014};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=497;
-					type="I_C_Soldier_Para_5_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item42
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9216.8232,221.22467,8744.0527};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=499;
-					type="I_C_Soldier_Para_3_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item43
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9219.7217,221.07176,8744.2305};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=501;
-					type="I_C_Soldier_Para_8_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item44
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9222.71,220.85945,8744.4512};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=503;
-					type="I_C_Soldier_Para_6_F";
-					atlOffset=1.5258789e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item45
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9206.8613,221.35008,8743.8662};
-						angles[]={0,0.090093896,0};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=505;
-					type="I_C_Soldier_Para_7_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item46
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9210.0391,219.40041,8729.0645};
-						angles[]={0,6.2412972,0};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=630;
-					type="I_C_Soldier_Para_4_F";
-					atlOffset=0.03465271;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item47
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9213.1133,218.95108,8729.2998};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=632;
-					type="I_C_Soldier_Para_5_F";
-					atlOffset=0.028015137;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item48
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9216.0439,218.50383,8728.9512};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=634;
-					type="I_C_Soldier_Para_3_F";
-					atlOffset=0.0073394775;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item49
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9218.9424,218.19337,8729.1289};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=636;
-					type="I_C_Soldier_Para_8_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item50
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9221.9307,217.97067,8729.3496};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=638;
-					type="I_C_Soldier_Para_6_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item51
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9206.082,219.82283,8728.7646};
-						angles[]={0,0.090093896,0};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=640;
-					type="I_C_Soldier_Para_7_F";
-					atlOffset=0.024963379;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item52
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9223.043,217.66847,8724.5742};
-						angles[]={0,6.2412972,0};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Machinegunner";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=642;
-					type="I_C_Soldier_Para_4_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.97000003;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item53
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9226.1172,217.35556,8724.8096};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=644;
-					type="I_C_Soldier_Para_5_F";
-					atlOffset=0.0020141602;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item54
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9229.0479,217.05486,8724.4609};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Paramedic";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=646;
-					type="I_C_Soldier_Para_3_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1.02;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item55
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9231.9463,216.79662,8724.6387};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Engineer";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=648;
-					type="I_C_Soldier_Para_8_F";
-					atlOffset=0.0082244873;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.95999998;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item56
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9234.9346,216.52435,8724.8594};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="Grenadier";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=650;
-					type="I_C_Soldier_Para_6_F";
-					atlOffset=0.014678955;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item57
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9219.0859,218.09396,8724.2744};
-						angles[]={0,0.090093896,0};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=652;
-					type="I_C_Soldier_Para_7_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item58
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9205.1563,219.80769,8724.9619};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						description="AT Launcher";
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=361;
-					type="I_C_Soldier_Para_5_F";
-					atlOffset=-1.5258789e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=1;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-				class Item59
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={9204.8271,219.99605,8732.3154};
-						angles[]={0,0.090093896,0};
-					};
-					side="Independent";
-					flags=5;
-					class Attributes
-					{
-						isPlayable=1;
-						class Inventory
-						{
-							map="ItemMap";
-						};
-					};
-					id=468;
-					type="I_C_Soldier_Para_7_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="pitch";
-							expression="_this setpitch _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"SCALAR"
-										};
-									};
-									value=0.98000002;
-								};
-							};
-						};
-						nAttributes=1;
-					};
-				};
-			};
-			class Attributes
-			{
-			};
-			id=0;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="groupID";
-					expression="_this setGroupID [_value];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"STRING"
-								};
-							};
-							value="Command";
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item1
-		{
 			dataType="Marker";
 			position[]={9197.1318,220.47301,8731.667};
 			name="Synd_HQ";
@@ -2915,7 +177,7 @@ class Mission
 			id=2;
 			atlOffset=0.00028991699;
 		};
-		class Item2
+		class Item1
 		{
 			dataType="Marker";
 			position[]={9198.4648,2.7037606e+012,8733.8457};
@@ -2926,7 +188,7 @@ class Mission
 			id=3;
 			atlOffset=2.7037606e+012;
 		};
-		class Item3
+		class Item2
 		{
 			dataType="Object";
 			class PositionInfo
@@ -2986,7 +248,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item4
+		class Item3
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3027,7 +289,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item5
+		class Item4
 		{
 			dataType="Group";
 			side="Independent";
@@ -3122,7 +384,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item6
+		class Item5
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -3134,7 +396,7 @@ class Mission
 			id=11;
 			type="Logic";
 		};
-		class Item7
+		class Item6
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -3146,7 +408,7 @@ class Mission
 			id=12;
 			type="Logic";
 		};
-		class Item8
+		class Item7
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -3158,7 +420,7 @@ class Mission
 			id=13;
 			type="Logic";
 		};
-		class Item9
+		class Item8
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -3172,7 +434,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item10
+		class Item9
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -3184,7 +446,7 @@ class Mission
 			id=17;
 			type="Logic";
 		};
-		class Item11
+		class Item10
 		{
 			dataType="Marker";
 			position[]={11310.948,20.257759,5900.9492};
@@ -3195,7 +457,7 @@ class Mission
 			b=50;
 			id=30;
 		};
-		class Item12
+		class Item11
 		{
 			dataType="Marker";
 			position[]={11383.694,2.8701169e+036,5275.6128};
@@ -3207,7 +469,7 @@ class Mission
 			id=31;
 			atlOffset=2.8701169e+036;
 		};
-		class Item13
+		class Item12
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3224,7 +486,7 @@ class Mission
 			type="Flag_Syndikat_F";
 			atlOffset=-0.031982422;
 		};
-		class Item14
+		class Item13
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -3237,7 +499,7 @@ class Mission
 			type="Logic";
 			atlOffset=1.5258789e-005;
 		};
-		class Item15
+		class Item14
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3297,7 +559,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item16
+		class Item15
 		{
 			dataType="Marker";
 			position[]={6773.5918,1.2565496e+029,7555.8301};
@@ -3307,7 +569,7 @@ class Mission
 			id=336;
 			atlOffset=1.2565496e+029;
 		};
-		class Item17
+		class Item16
 		{
 			dataType="Marker";
 			position[]={1736.8215,1.2565496e+029,12781.881};
@@ -3317,7 +579,7 @@ class Mission
 			id=337;
 			atlOffset=1.2565496e+029;
 		};
-		class Item18
+		class Item17
 		{
 			dataType="Marker";
 			position[]={11473.074,1.2565496e+029,13115.996};
@@ -3327,7 +589,7 @@ class Mission
 			id=338;
 			atlOffset=1.2565496e+029;
 		};
-		class Item19
+		class Item18
 		{
 			dataType="Marker";
 			position[]={11553.529,1.2565496e+029,3081.9141};
@@ -3337,7 +599,7 @@ class Mission
 			id=339;
 			atlOffset=1.2565496e+029;
 		};
-		class Item20
+		class Item19
 		{
 			dataType="Marker";
 			position[]={2265.8037,1.2565496e+029,3407.0894};
@@ -3347,7 +609,7 @@ class Mission
 			id=340;
 			atlOffset=1.2565496e+029;
 		};
-		class Item21
+		class Item20
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3364,7 +626,7 @@ class Mission
 			type="Flag_NATO_F";
 			atlOffset=0.056999207;
 		};
-		class Item22
+		class Item21
 		{
 			dataType="Marker";
 			position[]={12752.037,40.074604,14199.098};
@@ -3372,7 +634,7 @@ class Mission
 			type="flag_CTRG";
 			id=345;
 		};
-		class Item23
+		class Item22
 		{
 			dataType="Group";
 			side="West";
@@ -3753,7 +1015,7 @@ class Mission
 			};
 			id=346;
 		};
-		class Item24
+		class Item23
 		{
 			dataType="Object";
 			class PositionInfo
@@ -3770,7 +1032,7 @@ class Mission
 			type="Land_TTowerBig_2_F";
 			atlOffset=-0.0070114136;
 		};
-		class Item25
+		class Item24
 		{
 			dataType="Marker";
 			position[]={6600.8726,10.616028,7316.522};
@@ -3782,7 +1044,7 @@ class Mission
 			id=386;
 			atlOffset=0.56116867;
 		};
-		class Item26
+		class Item25
 		{
 			dataType="Marker";
 			position[]={8978.1318,2.9196179,6711.1514};
@@ -3794,7 +1056,7 @@ class Mission
 			id=387;
 			atlOffset=-0.0047571659;
 		};
-		class Item27
+		class Item26
 		{
 			dataType="Marker";
 			position[]={4554.4268,3.3344629,8796.4805};
@@ -3806,7 +1068,7 @@ class Mission
 			id=388;
 			atlOffset=0.0053319931;
 		};
-		class Item28
+		class Item27
 		{
 			dataType="Marker";
 			position[]={5010.2993,6.9463086,9717.1338};
@@ -3818,7 +1080,7 @@ class Mission
 			id=389;
 			atlOffset=-0.0013327599;
 		};
-		class Item29
+		class Item28
 		{
 			dataType="Marker";
 			position[]={6783.1919,66.965408,10516.366};
@@ -3830,7 +1092,7 @@ class Mission
 			id=390;
 			atlOffset=0.030654907;
 		};
-		class Item30
+		class Item29
 		{
 			dataType="Marker";
 			position[]={5477.9604,4.1778955,11384.883};
@@ -3841,7 +1103,7 @@ class Mission
 			b=50;
 			id=391;
 		};
-		class Item31
+		class Item30
 		{
 			dataType="Marker";
 			position[]={6619.8584,15.548132,13042.848};
@@ -3853,7 +1115,7 @@ class Mission
 			id=392;
 			atlOffset=0.030707359;
 		};
-		class Item32
+		class Item31
 		{
 			dataType="Marker";
 			position[]={8926.5557,151.49054,11748.316};
@@ -3865,7 +1127,7 @@ class Mission
 			id=393;
 			atlOffset=0.086380005;
 		};
-		class Item33
+		class Item32
 		{
 			dataType="Marker";
 			position[]={8269.2715,7.7076759,13659.497};
@@ -3877,7 +1139,7 @@ class Mission
 			id=394;
 			atlOffset=-0.017329216;
 		};
-		class Item34
+		class Item33
 		{
 			dataType="Marker";
 			position[]={11271.37,9.6891108,13114.998};
@@ -3889,7 +1151,7 @@ class Mission
 			id=395;
 			atlOffset=0.025326729;
 		};
-		class Item35
+		class Item34
 		{
 			dataType="Marker";
 			position[]={14146.736,14.14368,11823.99};
@@ -3901,7 +1163,7 @@ class Mission
 			id=396;
 			atlOffset=0.011997223;
 		};
-		class Item36
+		class Item35
 		{
 			dataType="Marker";
 			position[]={12579.705,43.978226,8079.9775};
@@ -3913,7 +1175,7 @@ class Mission
 			id=397;
 			atlOffset=0.061321259;
 		};
-		class Item37
+		class Item36
 		{
 			dataType="Marker";
 			position[]={11795.972,8.2485685,6705.1025};
@@ -3925,7 +1187,7 @@ class Mission
 			id=398;
 			atlOffset=0.018662453;
 		};
-		class Item38
+		class Item37
 		{
 			dataType="Marker";
 			position[]={11243.428,22.984892,3305.29};
@@ -3937,7 +1199,7 @@ class Mission
 			id=399;
 			atlOffset=-0.011983871;
 		};
-		class Item39
+		class Item38
 		{
 			dataType="Marker";
 			position[]={4815.9033,13.932686,5106.6157};
@@ -3949,7 +1211,7 @@ class Mission
 			id=400;
 			atlOffset=-0.0066642761;
 		};
-		class Item40
+		class Item39
 		{
 			dataType="Marker";
 			position[]={3993.7673,23.998205,5735.2402};
@@ -3961,7 +1223,7 @@ class Mission
 			id=401;
 			atlOffset=0.0093154907;
 		};
-		class Item41
+		class Item40
 		{
 			dataType="Marker";
 			position[]={10773.011,107.41172,9557.2959};
@@ -3973,7 +1235,7 @@ class Mission
 			id=402;
 			atlOffset=-0.061325073;
 		};
-		class Item42
+		class Item41
 		{
 			dataType="Marker";
 			position[]={8341.5801,18.074375,9767.4131};
@@ -3985,7 +1247,7 @@ class Mission
 			id=403;
 			atlOffset=0.010663986;
 		};
-		class Item43
+		class Item42
 		{
 			dataType="Marker";
 			position[]={1831.4775,15.602764,12332.693};
@@ -3997,7 +1259,7 @@ class Mission
 			id=404;
 			atlOffset=0.018662453;
 		};
-		class Item44
+		class Item43
 		{
 			dataType="Marker";
 			position[]={10050.675,-3.9290747e+009,8565.627};
@@ -4009,7 +1271,7 @@ class Mission
 			id=405;
 			atlOffset=-3.9290749e+009;
 		};
-		class Item45
+		class Item44
 		{
 			dataType="Marker";
 			position[]={9156.2266,242.70625,9204.126};
@@ -4020,7 +1282,7 @@ class Mission
 			b=400;
 			id=406;
 		};
-		class Item46
+		class Item45
 		{
 			dataType="Marker";
 			position[]={8663.5928,-3.9290749e+009,7137.2651};
@@ -4032,7 +1294,7 @@ class Mission
 			id=407;
 			atlOffset=-3.9290749e+009;
 		};
-		class Item47
+		class Item46
 		{
 			dataType="Marker";
 			position[]={10020.399,-3.9290749e+009,7098.7363};
@@ -4044,7 +1306,7 @@ class Mission
 			id=408;
 			atlOffset=-3.9290749e+009;
 		};
-		class Item48
+		class Item47
 		{
 			dataType="Marker";
 			position[]={12015.701,-3.9290749e+009,7428.9941};
@@ -4056,7 +1318,7 @@ class Mission
 			id=409;
 			atlOffset=-3.9290752e+009;
 		};
-		class Item49
+		class Item48
 		{
 			dataType="Marker";
 			position[]={11727.472,-3.9290747e+009,8859.6553};
@@ -4068,7 +1330,7 @@ class Mission
 			id=410;
 			atlOffset=-3.9290749e+009;
 		};
-		class Item50
+		class Item49
 		{
 			dataType="Marker";
 			position[]={12605.63,-3.9290747e+009,9548.5293};
@@ -4080,7 +1342,7 @@ class Mission
 			id=411;
 			atlOffset=-3.9290749e+009;
 		};
-		class Item51
+		class Item50
 		{
 			dataType="Marker";
 			position[]={13530.334,-3.9290747e+009,10324.287};
@@ -4092,7 +1354,7 @@ class Mission
 			id=412;
 			atlOffset=-3.9290749e+009;
 		};
-		class Item52
+		class Item51
 		{
 			dataType="Marker";
 			position[]={12481.513,-3.9290747e+009,11047.294};
@@ -4104,7 +1366,7 @@ class Mission
 			id=413;
 			atlOffset=-3.9290749e+009;
 		};
-		class Item53
+		class Item52
 		{
 			dataType="Marker";
 			position[]={11649.902,-3.9290747e+009,11922.351};
@@ -4116,7 +1378,7 @@ class Mission
 			id=414;
 			atlOffset=-3.9290749e+009;
 		};
-		class Item54
+		class Item53
 		{
 			dataType="Marker";
 			position[]={8944.0605,-3.9290747e+009,12552.267};
@@ -4128,7 +1390,7 @@ class Mission
 			id=415;
 			atlOffset=-3.9290749e+009;
 		};
-		class Item55
+		class Item54
 		{
 			dataType="Marker";
 			position[]={7929.3696,-3.9290747e+009,11683.418};
@@ -4140,7 +1402,7 @@ class Mission
 			id=416;
 			atlOffset=-3.9290749e+009;
 		};
-		class Item56
+		class Item55
 		{
 			dataType="Marker";
 			position[]={6486.46,-3.9290747e+009,11832.364};
@@ -4152,7 +1414,7 @@ class Mission
 			id=417;
 			atlOffset=-3.9290749e+009;
 		};
-		class Item57
+		class Item56
 		{
 			dataType="Marker";
 			position[]={6874.3394,-3.9290747e+009,9703.6836};
@@ -4164,7 +1426,7 @@ class Mission
 			id=418;
 			atlOffset=-3.9290749e+009;
 		};
-		class Item58
+		class Item57
 		{
 			dataType="Marker";
 			position[]={5785.7461,0,8326.9873};
@@ -4176,7 +1438,7 @@ class Mission
 			id=419;
 			atlOffset=-73.637177;
 		};
-		class Item59
+		class Item58
 		{
 			dataType="Marker";
 			position[]={1388.0699,4.3460913e+018,7795.9229};
@@ -4188,7 +1450,7 @@ class Mission
 			id=420;
 			atlOffset=4.3460913e+018;
 		};
-		class Item60
+		class Item59
 		{
 			dataType="Marker";
 			position[]={5457.0317,4.3460913e+018,3490.8818};
@@ -4200,7 +1462,7 @@ class Mission
 			id=421;
 			atlOffset=4.3460913e+018;
 		};
-		class Item61
+		class Item60
 		{
 			dataType="Marker";
 			position[]={2160.438,5.6670865e+024,2712.7371};
@@ -4212,7 +1474,7 @@ class Mission
 			id=422;
 			atlOffset=5.6670865e+024;
 		};
-		class Item62
+		class Item61
 		{
 			dataType="Marker";
 			position[]={10814.768,4.3460913e+018,10971.475};
@@ -4224,7 +1486,7 @@ class Mission
 			id=423;
 			atlOffset=4.3460913e+018;
 		};
-		class Item63
+		class Item62
 		{
 			dataType="Marker";
 			position[]={9996.4326,4.3460913e+018,10809.105};
@@ -4236,7 +1498,7 @@ class Mission
 			id=424;
 			atlOffset=4.3460913e+018;
 		};
-		class Item64
+		class Item63
 		{
 			dataType="Marker";
 			position[]={10416.426,4.3460913e+018,10257.053};
@@ -4248,7 +1510,7 @@ class Mission
 			id=425;
 			atlOffset=4.3460913e+018;
 		};
-		class Item65
+		class Item64
 		{
 			dataType="Marker";
 			position[]={7509.6929,4.3460913e+018,10823.432};
@@ -4260,7 +1522,7 @@ class Mission
 			id=426;
 			atlOffset=4.3460913e+018;
 		};
-		class Item66
+		class Item65
 		{
 			dataType="Marker";
 			position[]={8739.9014,4.3460913e+018,8277.6982};
@@ -4272,7 +1534,7 @@ class Mission
 			id=427;
 			atlOffset=4.3460913e+018;
 		};
-		class Item67
+		class Item66
 		{
 			dataType="Marker";
 			position[]={11365.444,4.3460913e+018,6725.4893};
@@ -4284,7 +1546,7 @@ class Mission
 			id=428;
 			atlOffset=4.3460913e+018;
 		};
-		class Item68
+		class Item67
 		{
 			dataType="Marker";
 			position[]={13033.241,4.3460913e+018,8255.6816};
@@ -4296,7 +1558,7 @@ class Mission
 			id=429;
 			atlOffset=4.3460913e+018;
 		};
-		class Item69
+		class Item68
 		{
 			dataType="Marker";
 			position[]={13803.839,4.3460913e+018,11241.76};
@@ -4308,7 +1570,7 @@ class Mission
 			id=430;
 			atlOffset=4.3460913e+018;
 		};
-		class Item70
+		class Item69
 		{
 			dataType="Marker";
 			position[]={7913.7773,4.3460913e+018,12797.205};
@@ -4320,7 +1582,7 @@ class Mission
 			id=431;
 			atlOffset=4.3460913e+018;
 		};
-		class Item71
+		class Item70
 		{
 			dataType="Marker";
 			position[]={6636.9756,4.3460913e+018,8634.1777};
@@ -4332,7 +1594,7 @@ class Mission
 			id=432;
 			atlOffset=4.3460913e+018;
 		};
-		class Item72
+		class Item71
 		{
 			dataType="Marker";
 			position[]={5481.6724,4.3460913e+018,9581.9346};
@@ -4344,7 +1606,7 @@ class Mission
 			id=433;
 			atlOffset=4.3460913e+018;
 		};
-		class Item73
+		class Item72
 		{
 			dataType="Marker";
 			position[]={2963.6758,4.3460913e+018,5885.062};
@@ -4356,7 +1618,7 @@ class Mission
 			id=434;
 			atlOffset=4.3460913e+018;
 		};
-		class Item74
+		class Item73
 		{
 			dataType="Marker";
 			position[]={4366.7974,4.3460913e+018,4221.1406};
@@ -4368,7 +1630,7 @@ class Mission
 			id=435;
 			atlOffset=4.3460913e+018;
 		};
-		class Item75
+		class Item74
 		{
 			dataType="Marker";
 			position[]={7331.5747,5.7289289e+023,7982.5522};
@@ -4377,7 +1639,7 @@ class Mission
 			id=509;
 			atlOffset=5.7289289e+023;
 		};
-		class Item76
+		class Item75
 		{
 			dataType="Marker";
 			position[]={8899.6436,5.7289289e+023,10191.442};
@@ -4386,7 +1648,7 @@ class Mission
 			id=510;
 			atlOffset=5.7289289e+023;
 		};
-		class Item77
+		class Item76
 		{
 			dataType="Marker";
 			position[]={8301.5781,5.7289289e+023,13578.238};
@@ -4395,7 +1657,7 @@ class Mission
 			id=511;
 			atlOffset=5.7289289e+023;
 		};
-		class Item78
+		class Item77
 		{
 			dataType="Marker";
 			position[]={10214.967,5.7289289e+023,13433.782};
@@ -4404,7 +1666,7 @@ class Mission
 			id=512;
 			atlOffset=5.7289289e+023;
 		};
-		class Item79
+		class Item78
 		{
 			dataType="Marker";
 			position[]={11369.707,5.7289289e+023,13113.29};
@@ -4413,7 +1675,7 @@ class Mission
 			id=513;
 			atlOffset=5.7289289e+023;
 		};
-		class Item80
+		class Item79
 		{
 			dataType="Marker";
 			position[]={10947.353,5.7289289e+023,9575.9385};
@@ -4422,7 +1684,7 @@ class Mission
 			id=514;
 			atlOffset=5.7289289e+023;
 		};
-		class Item81
+		class Item80
 		{
 			dataType="Marker";
 			position[]={10454.875,5.7289289e+023,11003.146};
@@ -4431,7 +1693,7 @@ class Mission
 			id=515;
 			atlOffset=5.7289289e+023;
 		};
-		class Item82
+		class Item81
 		{
 			dataType="Marker";
 			position[]={9069.6123,5.7289289e+023,7909.2813};
@@ -4440,7 +1702,7 @@ class Mission
 			id=517;
 			atlOffset=5.7289289e+023;
 		};
-		class Item83
+		class Item82
 		{
 			dataType="Marker";
 			position[]={7633.4141,5.7289289e+023,7131.103};
@@ -4449,7 +1711,7 @@ class Mission
 			id=518;
 			atlOffset=5.7289289e+023;
 		};
-		class Item84
+		class Item83
 		{
 			dataType="Marker";
 			position[]={10740.525,5.7289289e+023,6589.7715};
@@ -4458,7 +1720,7 @@ class Mission
 			id=519;
 			atlOffset=5.7289289e+023;
 		};
-		class Item85
+		class Item84
 		{
 			dataType="Marker";
 			position[]={12672.212,5.7289289e+023,6876.0225};
@@ -4467,7 +1729,7 @@ class Mission
 			id=520;
 			atlOffset=5.7289289e+023;
 		};
-		class Item86
+		class Item85
 		{
 			dataType="Marker";
 			position[]={14005.407,5.7289289e+023,8007.8247};
@@ -4476,7 +1738,7 @@ class Mission
 			id=521;
 			atlOffset=5.7289289e+023;
 		};
-		class Item87
+		class Item86
 		{
 			dataType="Marker";
 			position[]={5363.8252,5.7289289e+023,8276.5537};
@@ -4485,7 +1747,7 @@ class Mission
 			id=522;
 			atlOffset=5.7289289e+023;
 		};
-		class Item88
+		class Item87
 		{
 			dataType="Marker";
 			position[]={6443.1035,5.7289289e+023,10687.489};
@@ -4494,7 +1756,7 @@ class Mission
 			id=523;
 			atlOffset=5.7289289e+023;
 		};
-		class Item89
+		class Item88
 		{
 			dataType="Marker";
 			position[]={5380.3657,5.7289289e+023,11796.427};
@@ -4503,7 +1765,7 @@ class Mission
 			id=524;
 			atlOffset=5.7289289e+023;
 		};
-		class Item90
+		class Item89
 		{
 			dataType="Marker";
 			position[]={6805.6309,5.7289289e+023,13251.575};
@@ -4512,7 +1774,7 @@ class Mission
 			id=525;
 			atlOffset=5.7289289e+023;
 		};
-		class Item91
+		class Item90
 		{
 			dataType="Marker";
 			position[]={12758.003,5.7289289e+023,12488.387};
@@ -4521,7 +1783,7 @@ class Mission
 			id=526;
 			atlOffset=5.7289289e+023;
 		};
-		class Item92
+		class Item91
 		{
 			dataType="Marker";
 			position[]={5308.6919,-1.0306302e-022,10124.372};
@@ -4530,7 +1792,7 @@ class Mission
 			id=529;
 			atlOffset=4.71;
 		};
-		class Item93
+		class Item92
 		{
 			dataType="Marker";
 			position[]={5641.4346,0.8378551,10479.436};
@@ -4539,7 +1801,7 @@ class Mission
 			id=530;
 			atlOffset=4.7303185;
 		};
-		class Item94
+		class Item93
 		{
 			dataType="Marker";
 			position[]={6272.2969,2.4648523,12865.763};
@@ -4548,7 +1810,7 @@ class Mission
 			id=531;
 			atlOffset=4.6979456;
 		};
-		class Item95
+		class Item94
 		{
 			dataType="Marker";
 			position[]={6853.5254,2.0206542,13443.509};
@@ -4557,7 +1819,7 @@ class Mission
 			id=532;
 			atlOffset=4.6707497;
 		};
-		class Item96
+		class Item95
 		{
 			dataType="Marker";
 			position[]={7873.2524,1.3554394,13623.727};
@@ -4566,7 +1828,7 @@ class Mission
 			id=533;
 			atlOffset=4.6953979;
 		};
-		class Item97
+		class Item96
 		{
 			dataType="Marker";
 			position[]={8408.4746,1.0033226,13792.548};
@@ -4575,7 +1837,7 @@ class Mission
 			id=534;
 			atlOffset=4.6766748;
 		};
-		class Item98
+		class Item97
 		{
 			dataType="Marker";
 			position[]={9645.5713,2.123208,13640.646};
@@ -4584,7 +1846,7 @@ class Mission
 			id=535;
 			atlOffset=4.6660109;
 		};
-		class Item99
+		class Item98
 		{
 			dataType="Marker";
 			position[]={9945.1426,-0.86934042,13637.755};
@@ -4593,7 +1855,7 @@ class Mission
 			id=536;
 			atlOffset=4.7030864;
 		};
-		class Item100
+		class Item99
 		{
 			dataType="Marker";
 			position[]={13297.544,-11.959624,12461.898};
@@ -4602,7 +1864,7 @@ class Mission
 			id=537;
 			atlOffset=4.7446585;
 		};
-		class Item101
+		class Item100
 		{
 			dataType="Marker";
 			position[]={13577.749,-12.489322,12137.162};
@@ -4611,7 +1873,7 @@ class Mission
 			id=538;
 			atlOffset=4.7007017;
 		};
-		class Item102
+		class Item101
 		{
 			dataType="Marker";
 			position[]={14533.363,2.089431,8877.585};
@@ -4620,7 +1882,7 @@ class Mission
 			id=539;
 			atlOffset=4.6865377;
 		};
-		class Item103
+		class Item102
 		{
 			dataType="Marker";
 			position[]={14071.688,2.3151612,8278.2979};
@@ -4629,7 +1891,7 @@ class Mission
 			id=540;
 			atlOffset=4.6981125;
 		};
-		class Item104
+		class Item103
 		{
 			dataType="Marker";
 			position[]={12923.383,2.3799708,7276.2222};
@@ -4638,7 +1900,7 @@ class Mission
 			id=541;
 			atlOffset=4.7113333;
 		};
-		class Item105
+		class Item104
 		{
 			dataType="Marker";
 			position[]={10809.46,0.0095715523,6147.105};
@@ -4647,7 +1909,7 @@ class Mission
 			id=542;
 			atlOffset=4.7994547;
 		};
-		class Item106
+		class Item105
 		{
 			dataType="Marker";
 			position[]={1676.7452,0.38597298,11951.487};
@@ -4656,7 +1918,7 @@ class Mission
 			id=543;
 			atlOffset=4.7086663;
 		};
-		class Item107
+		class Item106
 		{
 			dataType="Marker";
 			position[]={3146.6555,-1.2572956,10978.803};
@@ -4665,7 +1927,7 @@ class Mission
 			id=544;
 			atlOffset=4.6714544;
 		};
-		class Item108
+		class Item107
 		{
 			dataType="Marker";
 			position[]={2637.2192,2.2185743,7458.7847};
@@ -4674,7 +1936,7 @@ class Mission
 			id=545;
 			atlOffset=4.6379724;
 		};
-		class Item109
+		class Item108
 		{
 			dataType="Marker";
 			position[]={3442.2932,1.0303638,6833.6133};
@@ -4683,7 +1945,7 @@ class Mission
 			id=546;
 			atlOffset=4.753304;
 		};
-		class Item110
+		class Item109
 		{
 			dataType="Marker";
 			position[]={2702.9531,3.4872913,5579.9297};
@@ -4692,7 +1954,7 @@ class Mission
 			id=547;
 			atlOffset=4.6869841;
 		};
-		class Item111
+		class Item110
 		{
 			dataType="Marker";
 			position[]={1624.1685,3.6172795,6185.1455};
@@ -4701,7 +1963,7 @@ class Mission
 			id=548;
 			atlOffset=4.7326717;
 		};
-		class Item112
+		class Item111
 		{
 			dataType="Marker";
 			position[]={888.85211,-1.5593648,7784.0225};
@@ -4710,7 +1972,7 @@ class Mission
 			id=549;
 			atlOffset=4.7259989;
 		};
-		class Item113
+		class Item112
 		{
 			dataType="Marker";
 			position[]={7244.1997,3.1549413,4256.5703};
@@ -4719,7 +1981,7 @@ class Mission
 			id=550;
 			atlOffset=4.6397901;
 		};
-		class Item114
+		class Item113
 		{
 			dataType="Marker";
 			position[]={5615.5518,-1.4814858,3938.2827};
@@ -4728,7 +1990,7 @@ class Mission
 			id=551;
 			atlOffset=4.6607027;
 		};
-		class Item115
+		class Item114
 		{
 			dataType="Marker";
 			position[]={3659.6934,2.4331355,2033.28};
@@ -4737,7 +1999,7 @@ class Mission
 			id=552;
 			atlOffset=4.834157;
 		};
-		class Item116
+		class Item115
 		{
 			dataType="Marker";
 			position[]={1425.8173,4.0735149,3056.3782};
@@ -4746,7 +2008,7 @@ class Mission
 			id=553;
 			atlOffset=4.6793442;
 		};
-		class Item117
+		class Item116
 		{
 			dataType="Marker";
 			position[]={2182.48,3.3729064,4670.2998};
@@ -4755,7 +2017,7 @@ class Mission
 			id=554;
 			atlOffset=4.5817604;
 		};
-		class Item118
+		class Item117
 		{
 			dataType="Marker";
 			position[]={11145.637,-1.5138278,5338.1733};
@@ -4764,7 +2026,7 @@ class Mission
 			id=555;
 			atlOffset=4.7113333;
 		};
-		class Item119
+		class Item118
 		{
 			dataType="Marker";
 			position[]={11833.501,-2.2860084,2692.196};
@@ -4773,7 +2035,7 @@ class Mission
 			id=556;
 			atlOffset=4.7364573;
 		};
-		class Item120
+		class Item119
 		{
 			dataType="Marker";
 			position[]={13020.104,3.3825684,2064.5928};
@@ -4782,7 +2044,7 @@ class Mission
 			id=557;
 			atlOffset=4.71;
 		};
-		class Item121
+		class Item120
 		{
 			dataType="Marker";
 			position[]={10297.78,2.143883,2599.2866};
@@ -4791,7 +2053,7 @@ class Mission
 			id=558;
 			atlOffset=4.7993512;
 		};
-		class Item122
+		class Item121
 		{
 			dataType="Marker";
 			position[]={8807.7529,1.4429951,3579.0894};
@@ -4800,7 +2062,7 @@ class Mission
 			id=559;
 			atlOffset=4.7993507;
 		};
-		class Item123
+		class Item122
 		{
 			dataType="Marker";
 			position[]={8890.8428,-0.14791965,4771.9819};
@@ -4809,7 +2071,7 @@ class Mission
 			id=560;
 			atlOffset=4.6476417;
 		};
-		class Item124
+		class Item123
 		{
 			dataType="Marker";
 			position[]={9450.9326,0.96115494,4252.1318};
@@ -4818,7 +2080,7 @@ class Mission
 			id=561;
 			atlOffset=4.6119142;
 		};
-		class Item125
+		class Item124
 		{
 			dataType="Marker";
 			position[]={7324.7451,-1.9039157e-016,5456.5688};
@@ -4827,7 +2089,7 @@ class Mission
 			id=562;
 			atlOffset=15.577591;
 		};
-		class Item126
+		class Item125
 		{
 			dataType="Marker";
 			position[]={13425.588,-16.980122,5743.4419};
@@ -4836,7 +2098,7 @@ class Mission
 			id=564;
 			atlOffset=15.401009;
 		};
-		class Item127
+		class Item126
 		{
 			dataType="Marker";
 			position[]={14792.189,-42.48135,13713.367};
@@ -4845,7 +2107,7 @@ class Mission
 			id=565;
 			atlOffset=15.637577;
 		};
-		class Item128
+		class Item127
 		{
 			dataType="Marker";
 			position[]={11752.373,-6.2777367,14266.281};
@@ -4854,7 +2116,7 @@ class Mission
 			id=566;
 			atlOffset=15.591917;
 		};
-		class Item129
+		class Item128
 		{
 			dataType="Marker";
 			position[]={9617.6104,-12.346392,14578.438};
@@ -4863,7 +2125,7 @@ class Mission
 			id=567;
 			atlOffset=15.602919;
 		};
-		class Item130
+		class Item129
 		{
 			dataType="Marker";
 			position[]={4766.6724,-12.531301,12960.007};
@@ -4872,7 +2134,7 @@ class Mission
 			id=568;
 			atlOffset=15.577592;
 		};
-		class Item131
+		class Item130
 		{
 			dataType="Marker";
 			position[]={386.15823,-33.727009,12656.868};
@@ -4881,7 +2143,7 @@ class Mission
 			id=569;
 			atlOffset=15.575165;
 		};
-		class Item132
+		class Item131
 		{
 			dataType="Marker";
 			position[]={216.76779,-40.681499,3569.2603};
@@ -4890,7 +2152,7 @@ class Mission
 			id=570;
 			atlOffset=15.597591;
 		};
-		class Item133
+		class Item132
 		{
 			dataType="Marker";
 			position[]={6971.8569,-20.113533,2673.792};
@@ -4899,7 +2161,7 @@ class Mission
 			id=571;
 			atlOffset=15.572243;
 		};
-		class Item134
+		class Item133
 		{
 			dataType="Marker";
 			position[]={13770.102,-7.7526512,3487.022};
@@ -4908,7 +2170,7 @@ class Mission
 			id=572;
 			atlOffset=15.567667;
 		};
-		class Item135
+		class Item134
 		{
 			dataType="Marker";
 			position[]={3626.8403,-3.1850529,10294.673};
@@ -4917,7 +2179,7 @@ class Mission
 			id=573;
 			atlOffset=15.532999;
 		};
-		class Item136
+		class Item135
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -4930,7 +2192,7 @@ class Mission
 			type="Logic";
 			atlOffset=1.5258789e-005;
 		};
-		class Item137
+		class Item136
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -4943,7 +2205,7 @@ class Mission
 			type="Logic";
 			atlOffset=1.5258789e-005;
 		};
-		class Item138
+		class Item137
 		{
 			dataType="Marker";
 			position[]={13539.497,0,922.39398};
@@ -4952,7 +2214,7 @@ class Mission
 			id=601;
 			atlOffset=46.832657;
 		};
-		class Item139
+		class Item138
 		{
 			dataType="Marker";
 			position[]={862.94202,0,14749.403};
@@ -4961,7 +2223,7 @@ class Mission
 			id=602;
 			atlOffset=58.83152;
 		};
-		class Item140
+		class Item139
 		{
 			dataType="Marker";
 			position[]={5347.9351,26.059,14574.517};
@@ -4970,7 +2232,7 @@ class Mission
 			id=607;
 			atlOffset=0.00040054321;
 		};
-		class Item141
+		class Item140
 		{
 			dataType="Group";
 			side="East";
@@ -5344,7 +2606,7 @@ class Mission
 			};
 			id=617;
 		};
-		class Item142
+		class Item141
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5360,7 +2622,7 @@ class Mission
 			id=689;
 			type="Flag_Viper_F";
 		};
-		class Item143
+		class Item142
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5374,7 +2636,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=-0.02305603;
 		};
-		class Item144
+		class Item143
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5388,7 +2650,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=-0.024688721;
 		};
-		class Item145
+		class Item144
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5429,7 +2691,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item146
+		class Item145
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5519,7 +2781,7 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item147
+		class Item146
 		{
 			dataType="Marker";
 			position[]={1841.3149,102.9043,12046.82};
@@ -5534,7 +2796,7 @@ class Mission
 			id=712;
 			atlOffset=98.114136;
 		};
-		class Item148
+		class Item147
 		{
 			dataType="Marker";
 			position[]={5478.9111,3.6075108,4052.4224};
@@ -5548,7 +2810,7 @@ class Mission
 			drawBorder=1;
 			id=713;
 		};
-		class Item149
+		class Item148
 		{
 			dataType="Marker";
 			position[]={11311.72,65.052895,5980.4702};
@@ -5563,7 +2825,7 @@ class Mission
 			id=715;
 			atlOffset=45.788303;
 		};
-		class Item150
+		class Item149
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5574,7 +2836,7 @@ class Mission
 			id=716;
 			type="Logic";
 		};
-		class Item151
+		class Item150
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5591,7 +2853,7 @@ class Mission
 			type="Land_TentHangar_V1_F";
 			atlOffset=-2.3841858e-007;
 		};
-		class Item152
+		class Item151
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5608,7 +2870,7 @@ class Mission
 			type="Land_TentHangar_V1_F";
 			atlOffset=-2.3841858e-007;
 		};
-		class Item153
+		class Item152
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5620,11 +2882,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=719;
 			type="Land_HelipadCircle_F";
 		};
-		class Item154
+		class Item153
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5636,11 +2899,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=720;
 			type="Land_HelipadCircle_F";
 		};
-		class Item155
+		class Item154
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5652,11 +2916,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=721;
 			type="Land_HelipadCircle_F";
 		};
-		class Item156
+		class Item155
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5668,11 +2933,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=722;
 			type="Land_HelipadSquare_F";
 		};
-		class Item157
+		class Item156
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5684,11 +2950,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=723;
 			type="Land_HelipadSquare_F";
+			atlOffset=-1.6450882e-005;
 		};
-		class Item158
+		class Item157
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5705,7 +2973,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=2.3841858e-007;
 		};
-		class Item159
+		class Item158
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5722,7 +2990,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=2.3841858e-007;
 		};
-		class Item160
+		class Item159
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5739,7 +3007,7 @@ class Mission
 			type="Land_Hangar_F";
 			atlOffset=-9.5367432e-007;
 		};
-		class Item161
+		class Item160
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5751,11 +3019,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=732;
 			type="Land_HelipadCircle_F";
 		};
-		class Item162
+		class Item161
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5767,11 +3036,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=733;
 			type="Land_HelipadCircle_F";
 		};
-		class Item163
+		class Item162
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5783,11 +3053,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=734;
 			type="Land_HelipadCircle_F";
 		};
-		class Item164
+		class Item163
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5799,11 +3070,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=735;
 			type="Land_HelipadCircle_F";
 		};
-		class Item165
+		class Item164
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5815,11 +3087,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=740;
 			type="Land_HelipadCircle_F";
 		};
-		class Item166
+		class Item165
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5831,11 +3104,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=741;
 			type="Land_HelipadCircle_F";
 		};
-		class Item167
+		class Item166
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5847,11 +3121,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=742;
 			type="Land_HelipadCircle_F";
 		};
-		class Item168
+		class Item167
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5863,11 +3138,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=743;
 			type="Land_HelipadSquare_F";
 		};
-		class Item169
+		class Item168
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5879,11 +3155,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=744;
 			type="Land_HelipadSquare_F";
 		};
-		class Item170
+		class Item169
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5895,11 +3172,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=748;
 			type="Land_HelipadCircle_F";
 		};
-		class Item171
+		class Item170
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5911,11 +3189,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=749;
 			type="Land_HelipadCircle_F";
 		};
-		class Item172
+		class Item171
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5927,12 +3206,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=750;
 			type="Land_HelipadCircle_F";
 			atlOffset=1.2874603e-005;
 		};
-		class Item173
+		class Item172
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5944,11 +3224,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=751;
 			type="Land_HelipadSquare_F";
 		};
-		class Item174
+		class Item173
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5960,11 +3241,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=752;
 			type="Land_HelipadSquare_F";
 		};
-		class Item175
+		class Item174
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5981,7 +3263,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=-0.0015764236;
 		};
-		class Item176
+		class Item175
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5998,7 +3280,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=-0.0015764236;
 		};
-		class Item177
+		class Item176
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6014,7 +3296,7 @@ class Mission
 			id=757;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item178
+		class Item177
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6030,7 +3312,7 @@ class Mission
 			id=758;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item179
+		class Item178
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6042,11 +3324,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=760;
 			type="Land_HelipadCircle_F";
 		};
-		class Item180
+		class Item179
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6058,11 +3341,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=761;
 			type="Land_HelipadCircle_F";
 		};
-		class Item181
+		class Item180
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6074,11 +3358,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=762;
 			type="Land_HelipadSquare_F";
 		};
-		class Item182
+		class Item181
 		{
 			dataType="Layer";
 			name="Airports";
@@ -6383,14 +3668,14 @@ class Mission
 					colorName="ColorYellow";
 					a=8.2089996;
 					b=6.594471;
-					angle=349.46942;
+					angle=349.46936;
 					id=870;
 				};
 			};
 			id=764;
 			atlOffset=23.520565;
 		};
-		class Item183
+		class Item182
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6402,11 +3687,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=767;
 			type="Land_HelipadCircle_F";
 		};
-		class Item184
+		class Item183
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6418,11 +3704,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=768;
 			type="Land_HelipadCircle_F";
 		};
-		class Item185
+		class Item184
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6434,11 +3721,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=773;
 			type="Land_HelipadCircle_F";
+			atlOffset=-3.361702e-005;
 		};
-		class Item186
+		class Item185
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6450,11 +3739,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=774;
 			type="Land_HelipadCircle_F";
+			atlOffset=-3.361702e-005;
 		};
-		class Item187
+		class Item186
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6466,11 +3757,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=782;
 			type="Land_HelipadCircle_F";
 		};
-		class Item188
+		class Item187
 		{
 			dataType="Layer";
 			name="Factories";
@@ -6709,7 +4001,7 @@ class Mission
 			id=783;
 			atlOffset=1.2091998e+026;
 		};
-		class Item189
+		class Item188
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6720,11 +4012,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=784;
 			type="Land_HelipadCircle_F";
 		};
-		class Item190
+		class Item189
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6736,11 +4029,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=785;
 			type="Land_HelipadCircle_F";
 		};
-		class Item191
+		class Item190
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6752,11 +4046,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=786;
 			type="Land_HelipadCircle_F";
 		};
-		class Item192
+		class Item191
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6768,11 +4063,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=792;
 			type="Land_HelipadCircle_F";
+			atlOffset=-1.5258789e-005;
 		};
-		class Item193
+		class Item192
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6784,12 +4081,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=794;
 			type="Land_HelipadCircle_F";
 			atlOffset=0.00010633469;
 		};
-		class Item194
+		class Item193
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6801,11 +4099,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=795;
 			type="Land_HelipadCircle_F";
 		};
-		class Item195
+		class Item194
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6822,7 +4121,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=-0.04157877;
 		};
-		class Item196
+		class Item195
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6838,7 +4137,7 @@ class Mission
 			id=799;
 			type="Land_Cargo_HQ_V1_F";
 		};
-		class Item197
+		class Item196
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6855,7 +4154,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=0.15754938;
 		};
-		class Item198
+		class Item197
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6872,7 +4171,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=4.7683716e-007;
 		};
-		class Item199
+		class Item198
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6884,11 +4183,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=803;
 			type="Land_HelipadSquare_F";
+			atlOffset=-7.6293945e-006;
 		};
-		class Item200
+		class Item199
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6900,11 +4201,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=806;
 			type="Land_HelipadCircle_F";
 		};
-		class Item201
+		class Item200
 		{
 			dataType="Layer";
 			name="Outposts";
@@ -7306,7 +4608,7 @@ class Mission
 			id=810;
 			atlOffset=3.5775875e+016;
 		};
-		class Item202
+		class Item201
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7318,11 +4620,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=811;
 			type="Land_HelipadCircle_F";
+			atlOffset=-0.0001449585;
 		};
-		class Item203
+		class Item202
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7334,11 +4638,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=812;
 			type="Land_HelipadCircle_F";
 		};
-		class Item204
+		class Item203
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7350,11 +4655,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=817;
 			type="Land_HelipadCircle_F";
 		};
-		class Item205
+		class Item204
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7366,12 +4672,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=819;
 			type="Land_HelipadCircle_F";
 			atlOffset=6.1035156e-005;
 		};
-		class Item206
+		class Item205
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7383,12 +4690,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=820;
 			type="Land_HelipadCircle_F";
 			atlOffset=6.1035156e-005;
 		};
-		class Item207
+		class Item206
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7400,11 +4708,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=821;
 			type="Land_HelipadCircle_F";
 		};
-		class Item208
+		class Item207
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7416,11 +4725,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=822;
 			type="Land_HelipadCircle_F";
 		};
-		class Item209
+		class Item208
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7432,11 +4742,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=826;
 			type="Land_HelipadCircle_F";
+			atlOffset=-2.0027161e-005;
 		};
-		class Item210
+		class Item209
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7448,11 +4760,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=827;
 			type="Land_HelipadCircle_F";
 		};
-		class Item211
+		class Item210
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7464,11 +4777,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=829;
 			type="Land_HelipadSquare_F";
+			atlOffset=-3.8146973e-006;
 		};
-		class Item212
+		class Item211
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7480,11 +4795,13 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=832;
 			type="Land_HelipadSquare_F";
+			atlOffset=-3.3378601e-006;
 		};
-		class Item213
+		class Item212
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7496,11 +4813,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=833;
 			type="Land_HelipadCircle_F";
 		};
-		class Item214
+		class Item213
 		{
 			dataType="Layer";
 			name="Resources";
@@ -7789,7 +5107,7 @@ class Mission
 			id=836;
 			atlOffset=3.3649598e+036;
 		};
-		class Item215
+		class Item214
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7801,11 +5119,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=839;
 			type="Land_HelipadSquare_F";
 		};
-		class Item216
+		class Item215
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7817,11 +5136,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=840;
 			type="Land_HelipadSquare_F";
 		};
-		class Item217
+		class Item216
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7833,11 +5153,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=843;
 			type="Land_HelipadSquare_F";
 		};
-		class Item218
+		class Item217
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7849,11 +5170,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=847;
 			type="Land_HelipadSquare_F";
 		};
-		class Item219
+		class Item218
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7865,11 +5187,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=848;
 			type="Land_HelipadSquare_F";
 		};
-		class Item220
+		class Item219
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7881,11 +5204,12 @@ class Mission
 			flags=4;
 			class Attributes
 			{
+				disableSimulation=1;
 			};
 			id=849;
 			type="Land_HelipadSquare_F";
 		};
-		class Item221
+		class Item220
 		{
 			dataType="Layer";
 			name="Seaports";
@@ -7944,7 +5268,7 @@ class Mission
 					colorName="ColorGreen";
 					a=48.355259;
 					b=6;
-					angle=201.90482;
+					angle=201.9048;
 					id=852;
 					atlOffset=0.78600001;
 				};
@@ -8155,7 +5479,7 @@ class Mission
 			id=858;
 			atlOffset=-33.276302;
 		};
-		class Item222
+		class Item221
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8171,7 +5495,7 @@ class Mission
 			type="Land_ControlTower_01_F";
 			atlOffset=0.022064209;
 		};
-		class Item223
+		class Item222
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8187,7 +5511,7 @@ class Mission
 			id=860;
 			type="Land_Cargo_Patrol_V4_F";
 		};
-		class Item224
+		class Item223
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8203,7 +5527,7 @@ class Mission
 			id=861;
 			type="Land_Cargo_Patrol_V4_F";
 		};
-		class Item225
+		class Item224
 		{
 			dataType="Marker";
 			position[]={2113,4.3460913e+018,8374};
@@ -8215,7 +5539,7 @@ class Mission
 			id=864;
 			atlOffset=4.3460913e+018;
 		};
-		class Item226
+		class Item225
 		{
 			dataType="Marker";
 			position[]={4903.9785,4.3228164,8530.4082};
@@ -8224,7 +5548,7 @@ class Mission
 			id=865;
 			atlOffset=4.7259989;
 		};
-		class Item227
+		class Item226
 		{
 			dataType="Marker";
 			position[]={5010.6436,4.7579079,8473.7617};
@@ -8233,7 +5557,7 @@ class Mission
 			id=866;
 			atlOffset=4.7259989;
 		};
-		class Item228
+		class Item227
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8249,7 +5573,7 @@ class Mission
 			id=871;
 			type="Land_Cargo_Patrol_V4_F";
 		};
-		class Item229
+		class Item228
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -8304,7 +5628,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item230
+		class Item229
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8321,7 +5645,7 @@ class Mission
 			type="Land_Cargo_Patrol_V4_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item231
+		class Item230
 		{
 			dataType="Marker";
 			position[]={12588.62,12.005551,12606.07};
@@ -8333,7 +5657,7 @@ class Mission
 			id=874;
 			atlOffset=0.025326729;
 		};
-		class Item232
+		class Item231
 		{
 			dataType="Object";
 			class PositionInfo
@@ -8349,7 +5673,7 @@ class Mission
 			type="Land_Communication_F";
 			atlOffset=0.0031356812;
 		};
-		class Item233
+		class Item232
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -8360,7 +5684,7 @@ class Mission
 			id=876;
 			type="HighCommand";
 		};
-		class Item234
+		class Item233
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -8370,16 +5694,896 @@ class Mission
 			id=877;
 			type="HighCommandSubordinate";
 		};
+		class Item234
+		{
+			dataType="Group";
+			side="Independent";
+			class Entities
+			{
+				items=38;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9203.3613,222.14798,8730.3389};
+					};
+					side="Independent";
+					flags=3;
+					class Attributes
+					{
+						name="commanderX";
+						description="Default Commaner";
+						isPlayer=1;
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=879;
+					type="I_G_officer_F";
+					atlOffset=2.2093964;
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="speaker";
+							expression="_this setspeaker _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="Male04GRE";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="pitch";
+							expression="_this setpitch _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"SCALAR"
+										};
+									};
+									value=1;
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9208.1563,221.14172,8727.6357};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=880;
+					type="I_G_officer_F";
+					atlOffset=1.5630188;
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9208.2949,221.06287,8729.8711};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=881;
+					type="I_G_officer_F";
+					atlOffset=1.4959564;
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9208.2373,221.05836,8732.2041};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=882;
+					type="I_G_officer_F";
+					atlOffset=1.405426;
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9208.0742,221.1158,8734.5186};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=883;
+					type="I_G_officer_F";
+					atlOffset=1.3078613;
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9208.0332,221.33676,8736.9717};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=884;
+					type="I_G_officer_F";
+					atlOffset=1.2042694;
+				};
+				class Item6
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9207.8477,221.58014,8739.2881};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=885;
+					type="I_G_officer_F";
+					atlOffset=1.1147766;
+				};
+				class Item7
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9207.6406,221.82883,8741.1836};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=886;
+					type="I_G_officer_F";
+					atlOffset=1.0294037;
+				};
+				class Item8
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9210.5156,220.43211,8727.7588};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=887;
+					type="I_G_Soldier_F";
+					atlOffset=1.1350403;
+				};
+				class Item9
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9210.5146,220.35355,8730.0986};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=888;
+					type="I_G_Soldier_F";
+					atlOffset=1.0546265;
+				};
+				class Item10
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9210.4082,220.36182,8732.4717};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=889;
+					type="I_G_Soldier_F";
+					atlOffset=0.9651947;
+				};
+				class Item11
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9210.3496,220.46887,8734.6709};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=890;
+					type="I_G_Soldier_F";
+					atlOffset=0.87738037;
+				};
+				class Item12
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9210.1465,220.75891,8737.0938};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=891;
+					type="I_G_Soldier_F";
+					atlOffset=0.7824707;
+				};
+				class Item13
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9209.959,221.08394,8739.4248};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=892;
+					type="I_G_Soldier_F";
+					atlOffset=0.67633057;
+				};
+				class Item14
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9212.624,220.00247,8727.7949};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=893;
+					type="I_G_Soldier_AR_F";
+					atlOffset=1.0090179;
+				};
+				class Item15
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9212.7861,219.89005,8730.2354};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=894;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.91348267;
+				};
+				class Item16
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9212.3857,219.9718,8732.6494};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=895;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.8175354;
+				};
+				class Item17
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9212.3623,220.08032,8734.7988};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=896;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.70054626;
+				};
+				class Item18
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9212.1621,220.34303,8737.04};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=897;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.56147766;
+				};
+				class Item19
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9212.0752,220.68071,8739.499};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=898;
+					type="I_G_Soldier_AR_F";
+					atlOffset=0.42988586;
+				};
+				class Item20
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9214.7129,219.5574,8727.874};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=899;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.88264465;
+				};
+				class Item21
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9214.583,219.52907,8730.1924};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=900;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.79734802;
+				};
+				class Item22
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9214.459,219.56421,8732.9365};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=901;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.64067078;
+				};
+				class Item23
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9214.2852,219.73557,8734.9453};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=902;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.51522827;
+				};
+				class Item24
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9214.2158,219.9711,8737.1299};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=903;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.35932922;
+				};
+				class Item25
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9214.1104,220.40939,8739.6201};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=904;
+					type="I_G_Soldier_GL_F";
+					atlOffset=0.23213196;
+				};
+				class Item26
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9216.2402,219.08359,8727.9521};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=905;
+					type="I_G_medic_F";
+					atlOffset=0.64479065;
+				};
+				class Item27
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9216.0645,219.12,8730.2314};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=906;
+					type="I_G_medic_F";
+					atlOffset=0.57945251;
+				};
+				class Item28
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9216.0225,219.18832,8733.1035};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=907;
+					type="I_G_medic_F";
+					atlOffset=0.4079895;
+				};
+				class Item29
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9215.9346,219.33868,8734.9102};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=908;
+					type="I_G_medic_F";
+					atlOffset=0.28741455;
+				};
+				class Item30
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9215.751,219.63004,8737.2695};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=909;
+					type="I_G_medic_F";
+					atlOffset=0.14077759;
+				};
+				class Item31
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9215.7617,220.05086,8739.6807};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=910;
+					type="I_G_medic_F";
+					atlOffset=0.0065917969;
+				};
+				class Item32
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9218.042,218.59781,8728.1172};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=911;
+					type="I_G_engineer_F";
+					atlOffset=0.3659668;
+				};
+				class Item33
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9218.0654,218.61351,8730.417};
+					};
+					side="Independent";
+					flags=1;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=912;
+					type="I_G_engineer_F";
+					atlOffset=0.27748108;
+				};
+				class Item34
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9217.8232,218.75163,8733.208};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=913;
+					type="I_G_engineer_F";
+					atlOffset=0.13031006;
+				};
+				class Item35
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9217.5684,218.96051,8735.1553};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=914;
+					type="I_G_engineer_F";
+					atlOffset=0.022323608;
+				};
+				class Item36
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9217.373,219.23962,8737.3916};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=915;
+					type="I_G_engineer_F";
+					atlOffset=-0.11579895;
+				};
+				class Item37
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={9217.2686,219.73956,8739.8604};
+					};
+					side="Independent";
+					flags=5;
+					class Attributes
+					{
+						isPlayable=1;
+						class Inventory
+						{
+							map="ItemMap";
+						};
+					};
+					id=916;
+					type="I_G_engineer_F";
+					atlOffset=-0.25114441;
+				};
+			};
+			class Attributes
+			{
+			};
+			id=878;
+			atlOffset=2.2093964;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="_this setGroupID [_value];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="Guerillas";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
 	};
 	class Connections
 	{
 		class LinkIDProvider
 		{
-			nextID=61;
+			nextID=39;
 		};
 		class Links
 		{
-			items=61;
+			items=39;
 			class Item0
 			{
 				linkID=0;
@@ -8393,7 +6597,7 @@ class Mission
 			class Item1
 			{
 				linkID=1;
-				item0=311;
+				item0=879;
 				item1=876;
 				class CustomData
 				{
@@ -8403,7 +6607,7 @@ class Mission
 			class Item2
 			{
 				linkID=2;
-				item0=360;
+				item0=880;
 				item1=876;
 				class CustomData
 				{
@@ -8413,7 +6617,7 @@ class Mission
 			class Item3
 			{
 				linkID=3;
-				item0=654;
+				item0=881;
 				item1=876;
 				class CustomData
 				{
@@ -8423,7 +6627,7 @@ class Mission
 			class Item4
 			{
 				linkID=4;
-				item0=656;
+				item0=882;
 				item1=876;
 				class CustomData
 				{
@@ -8433,7 +6637,7 @@ class Mission
 			class Item5
 			{
 				linkID=5;
-				item0=658;
+				item0=883;
 				item1=876;
 				class CustomData
 				{
@@ -8443,7 +6647,7 @@ class Mission
 			class Item6
 			{
 				linkID=6;
-				item0=660;
+				item0=884;
 				item1=876;
 				class CustomData
 				{
@@ -8453,7 +6657,7 @@ class Mission
 			class Item7
 			{
 				linkID=7;
-				item0=662;
+				item0=885;
 				item1=876;
 				class CustomData
 				{
@@ -8463,7 +6667,7 @@ class Mission
 			class Item8
 			{
 				linkID=8;
-				item0=664;
+				item0=886;
 				item1=876;
 				class CustomData
 				{
@@ -8473,7 +6677,7 @@ class Mission
 			class Item9
 			{
 				linkID=9;
-				item0=666;
+				item0=887;
 				item1=876;
 				class CustomData
 				{
@@ -8483,7 +6687,7 @@ class Mission
 			class Item10
 			{
 				linkID=10;
-				item0=668;
+				item0=888;
 				item1=876;
 				class CustomData
 				{
@@ -8493,7 +6697,7 @@ class Mission
 			class Item11
 			{
 				linkID=11;
-				item0=670;
+				item0=889;
 				item1=876;
 				class CustomData
 				{
@@ -8503,7 +6707,7 @@ class Mission
 			class Item12
 			{
 				linkID=12;
-				item0=672;
+				item0=890;
 				item1=876;
 				class CustomData
 				{
@@ -8513,7 +6717,7 @@ class Mission
 			class Item13
 			{
 				linkID=13;
-				item0=674;
+				item0=891;
 				item1=876;
 				class CustomData
 				{
@@ -8523,7 +6727,7 @@ class Mission
 			class Item14
 			{
 				linkID=14;
-				item0=676;
+				item0=892;
 				item1=876;
 				class CustomData
 				{
@@ -8533,7 +6737,7 @@ class Mission
 			class Item15
 			{
 				linkID=15;
-				item0=678;
+				item0=893;
 				item1=876;
 				class CustomData
 				{
@@ -8543,7 +6747,7 @@ class Mission
 			class Item16
 			{
 				linkID=16;
-				item0=680;
+				item0=894;
 				item1=876;
 				class CustomData
 				{
@@ -8553,7 +6757,7 @@ class Mission
 			class Item17
 			{
 				linkID=17;
-				item0=682;
+				item0=895;
 				item1=876;
 				class CustomData
 				{
@@ -8563,7 +6767,7 @@ class Mission
 			class Item18
 			{
 				linkID=18;
-				item0=684;
+				item0=896;
 				item1=876;
 				class CustomData
 				{
@@ -8573,7 +6777,7 @@ class Mission
 			class Item19
 			{
 				linkID=19;
-				item0=686;
+				item0=897;
 				item1=876;
 				class CustomData
 				{
@@ -8583,7 +6787,7 @@ class Mission
 			class Item20
 			{
 				linkID=20;
-				item0=688;
+				item0=898;
 				item1=876;
 				class CustomData
 				{
@@ -8593,7 +6797,7 @@ class Mission
 			class Item21
 			{
 				linkID=21;
-				item0=362;
+				item0=899;
 				item1=876;
 				class CustomData
 				{
@@ -8603,7 +6807,7 @@ class Mission
 			class Item22
 			{
 				linkID=22;
-				item0=363;
+				item0=900;
 				item1=876;
 				class CustomData
 				{
@@ -8613,7 +6817,7 @@ class Mission
 			class Item23
 			{
 				linkID=23;
-				item0=364;
+				item0=901;
 				item1=876;
 				class CustomData
 				{
@@ -8623,7 +6827,7 @@ class Mission
 			class Item24
 			{
 				linkID=24;
-				item0=459;
+				item0=902;
 				item1=876;
 				class CustomData
 				{
@@ -8633,7 +6837,7 @@ class Mission
 			class Item25
 			{
 				linkID=25;
-				item0=461;
+				item0=903;
 				item1=876;
 				class CustomData
 				{
@@ -8643,7 +6847,7 @@ class Mission
 			class Item26
 			{
 				linkID=26;
-				item0=463;
+				item0=904;
 				item1=876;
 				class CustomData
 				{
@@ -8653,7 +6857,7 @@ class Mission
 			class Item27
 			{
 				linkID=27;
-				item0=465;
+				item0=905;
 				item1=876;
 				class CustomData
 				{
@@ -8663,7 +6867,7 @@ class Mission
 			class Item28
 			{
 				linkID=28;
-				item0=467;
+				item0=906;
 				item1=876;
 				class CustomData
 				{
@@ -8673,7 +6877,7 @@ class Mission
 			class Item29
 			{
 				linkID=29;
-				item0=471;
+				item0=907;
 				item1=876;
 				class CustomData
 				{
@@ -8683,7 +6887,7 @@ class Mission
 			class Item30
 			{
 				linkID=30;
-				item0=473;
+				item0=908;
 				item1=876;
 				class CustomData
 				{
@@ -8693,7 +6897,7 @@ class Mission
 			class Item31
 			{
 				linkID=31;
-				item0=475;
+				item0=909;
 				item1=876;
 				class CustomData
 				{
@@ -8703,7 +6907,7 @@ class Mission
 			class Item32
 			{
 				linkID=32;
-				item0=477;
+				item0=910;
 				item1=876;
 				class CustomData
 				{
@@ -8713,7 +6917,7 @@ class Mission
 			class Item33
 			{
 				linkID=33;
-				item0=479;
+				item0=911;
 				item1=876;
 				class CustomData
 				{
@@ -8723,7 +6927,7 @@ class Mission
 			class Item34
 			{
 				linkID=34;
-				item0=481;
+				item0=912;
 				item1=876;
 				class CustomData
 				{
@@ -8733,7 +6937,7 @@ class Mission
 			class Item35
 			{
 				linkID=35;
-				item0=483;
+				item0=913;
 				item1=876;
 				class CustomData
 				{
@@ -8743,7 +6947,7 @@ class Mission
 			class Item36
 			{
 				linkID=36;
-				item0=485;
+				item0=914;
 				item1=876;
 				class CustomData
 				{
@@ -8753,7 +6957,7 @@ class Mission
 			class Item37
 			{
 				linkID=37;
-				item0=487;
+				item0=915;
 				item1=876;
 				class CustomData
 				{
@@ -8763,227 +6967,7 @@ class Mission
 			class Item38
 			{
 				linkID=38;
-				item0=489;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item39
-			{
-				linkID=39;
-				item0=491;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item40
-			{
-				linkID=40;
-				item0=493;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item41
-			{
-				linkID=41;
-				item0=495;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item42
-			{
-				linkID=42;
-				item0=497;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item43
-			{
-				linkID=43;
-				item0=499;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item44
-			{
-				linkID=44;
-				item0=501;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item45
-			{
-				linkID=45;
-				item0=503;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item46
-			{
-				linkID=46;
-				item0=505;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item47
-			{
-				linkID=47;
-				item0=630;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item48
-			{
-				linkID=48;
-				item0=632;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item49
-			{
-				linkID=49;
-				item0=634;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item50
-			{
-				linkID=50;
-				item0=636;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item51
-			{
-				linkID=51;
-				item0=638;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item52
-			{
-				linkID=52;
-				item0=640;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item53
-			{
-				linkID=53;
-				item0=642;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item54
-			{
-				linkID=54;
-				item0=644;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item55
-			{
-				linkID=55;
-				item0=646;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item56
-			{
-				linkID=56;
-				item0=648;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item57
-			{
-				linkID=57;
-				item0=650;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item58
-			{
-				linkID=58;
-				item0=652;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item59
-			{
-				linkID=59;
-				item0=361;
-				item1=876;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item60
-			{
-				linkID=60;
-				item0=468;
+				item0=916;
 				item1=876;
 				class CustomData
 				{


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Enhancement

### What have you changed and why?
Information:
All maps got overhauled in terms of:
- changed playable rebel slots to:
	- 8 officers
	- 6 riflemen
	- 6 autoriflemen
	- 6 grenadiers
	- 6 combat life savers
	- 6 engineers    
- Disabled simulation for helipads

Some maps got overhauled in terms of:
- Disabled simulation for Portable Helipad Lights and turned into simple objects
- Disabled simulation for H-barriers
- Disabled simulation for containers and turned into simple objects
- removed the large tents



### Please specify which Issue this PR Resolves.
closes #643 
closes #645 


### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:
This needs to be merged BEFORE #648 