### PR TITLE
Show injured marker for ACE Unconsciousness & AI Driver bug fix

### DIFF
--- a/A3-Antistasi/functions/init/fn_playerMarkers.sqf
+++ b/A3-Antistasi/functions/init/fn_playerMarkers.sqf
@@ -29,7 +29,7 @@ while {true} do
 				_mrk setMarkerAlphaLocal 1;
 				_mrk setMarkerPosLocal position _playerX;
 				_mrk setMarkerDirLocal getDir _playerX;
-				if (_playerX getVariable ["INCAPACITATED",false]) then
+				if (_playerX getVariable ["INCAPACITATED",false] || _playerX getVariable ["ACE_isUnconscious",false]) then
 					{
 					_mrk setMarkerTextLocal format ["%1 Injured",name _playerX];
 					_mrk setMarkerColorLocal "ColorRed";
@@ -43,7 +43,7 @@ while {true} do
 			else
 				{
 				_veh = vehicle _playerX;
-				if ((isNull driver _veh) or (driver _veh == _playerX)) then
+				if ((!isPlayer driver _veh) or (driver _veh == _playerX)) then
 					{
 					_mrk setMarkerAlphaLocal 1;
 					_mrk setMarkerPosLocal position _veh;


### PR DESCRIPTION
Also show markers for vehicles if the driver is not a player (otherwise no markers will show)

## What type of PR is this.
1. [x] Bug
2. [x] Enhancement

closes #663 
closes #664 

### What have you changed and why?
- Injured player marker condition is extended to check the `ACE_isUnconscious` variable
- Vehicle markers check if the driver is a player, this is needed as having an AI driver causes your marker to become invisible

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the Mission in Singleplayer?
2. [x] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:
