### PR TITLE
Move radio tower repair to server side, fix bugs

### DIFF
--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -84,6 +84,7 @@ class A3A
 		class prestige {};
 		class radioCheck {};
 		class rebuildAssets {};
+		class rebuildRadioTower {};
 		class relocateHQObjects {};
 		class repairRuinedBuilding {};
 		class resourceCheckSkipTime {};

--- a/A3-Antistasi/functions/Base/fn_rebuildAssets.sqf
+++ b/A3-Antistasi/functions/Base/fn_rebuildAssets.sqf
@@ -64,29 +64,6 @@ if (isNull _antennaDead) then
 else
 	{
 	hint "Radio Tower rebuilt";
-	antennasDead = antennasDead - [_antennaDead]; publicVariable "antennasDead";
-	[_antennaDead] call A3A_fnc_repairRuinedBuilding;
-	antennas pushBack _antennaDead; publicVariable "antennas";
-
-	{if ([antennas,_x] call BIS_fnc_nearestPosition == _antennaDead) then {[_x,true] spawn A3A_fnc_blackout}} forEach citiesX;
-	_mrkFinal = createMarker [format ["Ant%1", mapGridPosition _antennaDead], getPos _antennaDead];
-	_mrkFinal setMarkerShape "ICON";
-	_mrkFinal setMarkerType "loc_Transmitter";
-	_mrkFinal setMarkerColor "ColorBlack";
-	_mrkFinal setMarkerText "Radio Tower";
-	mrkAntennas pushBack _mrkFinal;
-	publicVariable "mrkAntennas";
-	_antennaDead addEventHandler ["Killed",
-		{
-		_antenna = _this select 0;
-		_antenna removeAllEventHandlers "Killed";
-		{if ([antennas,_x] call BIS_fnc_nearestPosition == _antenna) then {[_x,false] spawn A3A_fnc_blackout}} forEach citiesX;
-		_mrk = [mrkAntennas, _antenna] call BIS_fnc_nearestPosition;
-		antennas = antennas - [_antenna]; antennasDead = antennasDead + [_antenna]; deleteMarker _mrk;
-		["TaskSucceeded",["", "Radio Tower Destroyed"]] remoteExec ["BIS_fnc_showNotification",teamPlayer];
-		["TaskFailed",["", "Radio Tower Destroyed"]] remoteExec ["BIS_fnc_showNotification",Occupants];
-		publicVariable "antennas"; publicVariable "antennasDead";
-		}
-		];
+	[_antennaDead] remoteExec ["A3A_fnc_rebuildRadioTower", 2];
 	};
 [0,-5000] remoteExec ["A3A_fnc_resourcesFIA",2];

--- a/A3-Antistasi/functions/Base/fn_rebuildRadioTower.sqf
+++ b/A3-Antistasi/functions/Base/fn_rebuildRadioTower.sqf
@@ -1,0 +1,38 @@
+// Repairs a radio tower. 
+// Parameter should be present in antennasDead array
+private _file = "fn_rebuildRadioTower";
+if (!isServer) exitWith { [1, "Server-only function miscalled", _file] call A3A_fnc_log };
+
+params ["_antenna"];
+
+if !(_antenna in antennasDead) exitWith { [1, "Attempted to rebuild invalid radio tower", _file] call A3A_fnc_log };
+[2, format["Repairing Antenna %1", str _antenna], _file] call A3A_fnc_log;
+
+antennasDead = antennasDead - [_antenna]; publicVariable "antennasDead";
+[_antenna] call A3A_fnc_repairRuinedBuilding;
+antennas pushBack _antenna; publicVariable "antennas";
+
+{if ([antennas,_x] call BIS_fnc_nearestPosition == _antenna) then {[_x,true] spawn A3A_fnc_blackout}} forEach citiesX;
+
+private _mrkFinal = createMarker [format ["Ant%1", mapGridPosition _antenna], getPos _antenna];
+_mrkFinal setMarkerShape "ICON";
+_mrkFinal setMarkerType "loc_Transmitter";
+_mrkFinal setMarkerColor "ColorBlack";
+_mrkFinal setMarkerText "Radio Tower";
+mrkAntennas pushBack _mrkFinal;
+publicVariable "mrkAntennas";
+
+_antenna addEventHandler ["Killed",
+	{
+	params ["_antenna"];
+	_antenna removeAllEventHandlers "Killed";
+	{if ([antennas,_x] call BIS_fnc_nearestPosition == _antenna) then {[_x,false] spawn A3A_fnc_blackout}} forEach citiesX;
+	_mrk = [mrkAntennas, _antenna] call BIS_fnc_nearestPosition;
+	mrkAntennas = mrkAntennas - [_mrk]; deleteMarker _mrk;
+	antennas = antennas - [_antenna]; antennasDead = antennasDead + [_antenna]; 
+	publicVariable "antennas"; publicVariable "antennasDead"; publicVariable "mrkAntennas";
+	["TaskSucceeded",["", "Radio Tower Destroyed"]] remoteExec ["BIS_fnc_showNotification",teamPlayer];
+	["TaskFailed",["", "Radio Tower Destroyed"]] remoteExec ["BIS_fnc_showNotification",Occupants];
+	}
+	];
+

--- a/A3-Antistasi/functions/Base/fn_repairRuinedBuilding.sqf
+++ b/A3-Antistasi/functions/Base/fn_repairRuinedBuilding.sqf
@@ -1,6 +1,8 @@
 //Repairs a destroyed building.
 //Parameter can either be the ruin of a building, or the building itself buried underneath the ruins.
 
+if (!isServer) exitWith { [1, "Server-only function miscalled", "fn_repairRuinedBuilding"] call A3A_fnc_log };
+
 params ["_target"];
 
 private _buildingToRepair = objNull;

--- a/A3-Antistasi/functions/Missions/fn_REP_Antenna.sqf
+++ b/A3-Antistasi/functions/Missions/fn_REP_Antenna.sqf
@@ -105,30 +105,7 @@ if (dateToNumber date > _dateLimitNum) then
 		[-600] remoteExec ["A3A_fnc_timingCA",2];
 		[-10,theBoss] call A3A_fnc_playerScoreAdd;
 		};
-	antennasDead = antennasDead - [_antennaDead]; publicVariable "antennasDead";
-	diag_log format ["%1: [Antistasi] | DEBUG | Repairing Antenna %2.",servertime, typeOf _antennaDead];
-	[_antennaDead] call A3A_fnc_repairRuinedBuilding;
-	antennas pushBack _antennaDead; publicVariable "antennas";
-	{if ([antennas,_x] call BIS_fnc_nearestPosition == _antennaDead) then {[_x,true] spawn A3A_fnc_blackout}} forEach citiesX;
-	_mrkFinal = createMarker [format ["Ant%1", mapGridPosition _antennaDead], getPos _antennaDead];
-	_mrkFinal setMarkerShape "ICON";
-	_mrkFinal setMarkerType "loc_Transmitter";
-	_mrkFinal setMarkerColor "ColorBlack";
-	_mrkFinal setMarkerText "Radio Tower";
-	mrkAntennas pushBack _mrkFinal;
-	publicVariable "mrkAntennas";
-	_antennaDead addEventHandler ["Killed",
-		{
-		_antenna = _this select 0;
-		_antenna removeAllEventHandlers "Killed";
-		{if ([antennas,_x] call BIS_fnc_nearestPosition == _antenna) then {[_x,false] spawn A3A_fnc_blackout}} forEach citiesX;
-		_mrk = [mrkAntennas, _antenna] call BIS_fnc_nearestPosition;
-		antennas = antennas - [_antenna]; antennasDead = antennasDead + [_antenna]; deleteMarker _mrk;
-		["TaskSucceeded",["", "Radio Tower Destroyed"]] remoteExec ["BIS_fnc_showNotification",teamPlayer];
-		["TaskFailed",["", "Radio Tower Destroyed"]] remoteExec ["BIS_fnc_showNotification",Occupants];
-		publicVariable "antennas"; publicVariable "antennasDead";
-		}
-		];
+	[_antennaDead] remoteExec ["A3A_fnc_rebuildRadioTower", 2];
 	};
 
 _nul = [30,"REP"] spawn A3A_fnc_deleteTask;

--- a/A3-Antistasi/functions/init/fn_initServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initServer.sqf
@@ -183,7 +183,10 @@ addMissionEventHandler ["BuildingChanged", {
 		_oldBuilding setVariable ["ruins", _newBuilding];
 		_newBuilding setVariable ["building", _oldBuilding];
 
-		destroyedBuildings pushBack (getPosATL _oldBuilding);
+		// Antenna dead/alive status is handled separately
+		if !(_oldBuilding in antennas || _oldBuilding in antennasDead) then {
+			destroyedBuildings pushBack (getPosATL _oldBuilding);
+		};
 	};
 }];
 


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Three bugs related to radio tower rebuilding:
1. A3A_fnc_repairRuinedBuilding only works when run on the server, because it accesses non-public variables, so neither the repair mission or the boss rebuild option actually rebuilt the tower object. One option was to make those variables public, but given what the function does I chose to move radio tower rebuilding onto the server, rather than clients and HCs mangling several different public arrays and setVariables.
2. Markers for dead radio towers were being deleted, but not removed from mrkAntennas. Minor issue that may have caused some missing-object RPT spam.
3. Radio towers were being added to destroyedBuildings, when they're specifically excluded from that mechanic. Probably minor.

### Please specify which Issue this PR Resolves.
closes #673

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
