### PR TITLE
Make al_trembling quit silently when run on server/HC

### DIFF
--- a/Map-Templates/Antistasi-ChernarusWinter.chernarus_winter/AL_snowstorm/al_trembling.sqf
+++ b/Map-Templates/Antistasi-ChernarusWinter.chernarus_winter/AL_snowstorm/al_trembling.sqf
@@ -1,6 +1,6 @@
 // by ALIAS
 
-if ((!hasInterface)or(pos_p!="open")) exitWith {};
+if ((!hasInterface)or{pos_p!="open"}) exitWith {};
 params ["_pozitie_x","_pozitie_y"];
 
 drop [["\A3\data_f\cl_basic",1,0,1],"","Billboard",0.5,(snow_gust#1)/2,[_pozitie_x,_pozitie_y,0],[vit_x,vit_y,0],13,1.3,1,0.1,[1,10,15],[[1,1,1,0],[1,1,1,.1],[1,1,1,0]],[1],1,0,"AL_snowstorm\rotocol_drop.sqf","",hunt_alias,0,true,0.1];


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Prevented the snowstorm code in al_trembling from running when executed on servers and HCs. It's not supposed to, but the syntax is botched in the if...exitwith statement.

Caveat: I have little idea what this code does.

### Please specify which Issue this PR Resolves.
closes #689 

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Untested. It won't work any worse at least. Travis will probably fail to due to hash-select syntax.