### PR TITLE
Fix towed vehicles left with null attached objects

### DIFF
--- a/A3-Antistasi/Scripts/fn_advancedTowingInit.sqf
+++ b/A3-Antistasi/Scripts/fn_advancedTowingInit.sqf
@@ -412,6 +412,7 @@ SA_Pickup_Tow_Ropes = {
 			{
 				_attachedObj ropeDetach _x;
 			} forEach (_vehicle getVariable ["SA_Tow_Ropes",[]]);
+			detach _attachedObj;
 			deleteVehicle _attachedObj;
 		} forEach ropeAttachedObjects _vehicle;
 		_helper = "Land_Can_V2_F" createVehicle position _player;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
When ropes are detached from a towed vehicle, the helper object wasn't detached from the vehicle before deleting it. This causes the vehicle to be left with null objects in its attachedObjects array. As the vehicle save code doesn't save anything with an attached object, these vehicles would not be saved if left near the HQ.

This fix simply detaches the helper object before it's deleted. I'm fairly sure that there are no side effects.

### Please specify which Issue this PR Resolves.
At least a partial fix for #692.

### Is further testing or are further changes required?
1. [X] No, but...
2. [ ] Yes (Please provide further detail below.)

Could consider making the vehicle save code less restrictive. We'd need a reliable way to determine which objects should and shouldn't be saved, which requires a lot more testing than this bugfix.
