### PR TITLE
Change bogus remoteExecCalls to remoteExec

### DIFF
--- a/A3-Antistasi/Scripts/UPSMON/MODULES/UPSMON_RESPAWN.sqf
+++ b/A3-Antistasi/Scripts/UPSMON/MODULES/UPSMON_RESPAWN.sqf
@@ -111,7 +111,7 @@ If (!_removeunit) then
 
 			if (isMultiplayer) then
 			{
-				[netid _newunit, _initstr] remoteExecCall ["UPSMON_fnc_setVehicleInit", 0,true];
+				[netid _newunit, _initstr] remoteExec ["UPSMON_fnc_setVehicleInit", 0,true];
 			} else
 			{
 				_unitstr = "_newunit";

--- a/A3-Antistasi/Scripts/UPSMON/MODULES/UPSMON_spawn.sqf
+++ b/A3-Antistasi/Scripts/UPSMON/MODULES/UPSMON_spawn.sqf
@@ -90,7 +90,7 @@ if (UPSMON_Debug>0) then {diag_log format["Spawning %3 copies of template %1 on 
 					
 			if (isMultiplayer) then 
 			{
-				[netid _newunit, _initstr] remoteExecCall ["UPSMON_fnc_setVehicleInit", 0,true];
+				[netid _newunit, _initstr] remoteExec ["UPSMON_fnc_setVehicleInit", 0,true];
 			} else 
 			{
 				_unitstr = "_newunit";

--- a/A3-Antistasi/functions/Base/fn_garbageCleaner.sqf
+++ b/A3-Antistasi/functions/Base/fn_garbageCleaner.sqf
@@ -1,6 +1,6 @@
 private ["_toDelete"];
 
-[petros,"hint","Deleting Garbage. Please wait"] remoteExecCall ["A3A_fnc_commsMP", 0];
+[petros,"hint","Deleting Garbage. Please wait"] remoteExec ["A3A_fnc_commsMP", 0];
 
 /*
 _toDelete = nearestObjects [markerPos "base_4", ["WeaponHolderSimulated", "GroundWeaponHolder", "WeaponHolder"], 16000];
@@ -13,4 +13,4 @@ for "_i" from 0 to ((count _toDelete) - 1) do
 {deleteVehicle _x} forEach (allMissionObjects "WeaponHolder");
 {deleteVehicle _x} forEach (allMissionObjects "WeaponHolderSimulated");
 
-[petros,"hint","Garbage deleted"] remoteExecCall ["A3A_fnc_commsMP", 0];
+[petros,"hint","Garbage deleted"] remoteExec ["A3A_fnc_commsMP", 0];

--- a/A3-Antistasi/functions/Base/fn_outpostDialog.sqf
+++ b/A3-Antistasi/functions/Base/fn_outpostDialog.sqf
@@ -60,4 +60,4 @@ if (_typeX != "delete") then
 	[-_hr,-_costs] remoteExec ["A3A_fnc_resourcesFIA",2];
 	};
 
- [_typeX,_positionTel] remoteExecCall ["A3A_fnc_createOutpostsFIA", 2];
+ [_typeX,_positionTel] remoteExec ["A3A_fnc_createOutpostsFIA", 2];

--- a/A3-Antistasi/functions/CREATE/fn_createFIAOutposts2.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createFIAOutposts2.sqf
@@ -67,11 +67,11 @@ if ({alive _x} count units _groupX == 0) then
 	deleteMarker _markerX;
 	if (_isRoad) then
 		{
-		["TaskFailed", ["", "Roadblock Lost"]] remoteExecCall ["BIS_fnc_showNotification", 0];
+		["TaskFailed", ["", "Roadblock Lost"]] remoteExec ["BIS_fnc_showNotification", 0];
 		}
 	else
 		{
-		["TaskFailed", ["", "Watchpost Lost"]] remoteExecCall ["BIS_fnc_showNotification", 0];
+		["TaskFailed", ["", "Watchpost Lost"]] remoteExec ["BIS_fnc_showNotification", 0];
 		};
 	};
 

--- a/A3-Antistasi/functions/Dialogs/fn_skiptime.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_skiptime.sqf
@@ -20,6 +20,6 @@ if ((_x distance _posHQ > 100) and (side _x == teamPlayer)) then {_checkX = true
 
 if (_checkX) exitWith {hint "All players must be in a 100m radius from HQ to be able to rest"};
 
-remoteExecCall ["A3A_fnc_resourcecheckSkipTime", 0];
+remoteExec ["A3A_fnc_resourcecheckSkipTime", 0];
 
 

--- a/A3-Antistasi/functions/Garage/fn_vehPlacementCallbacks.sqf
+++ b/A3-Antistasi/functions/Garage/fn_vehPlacementCallbacks.sqf
@@ -140,7 +140,7 @@ switch (_callbackTarget) do {
 					{
 					if (player ==	theBoss && ((_typeVehX == SDKMortar) or (_typeVehX == staticATteamPlayer) or (_typeVehX == staticAAteamPlayer) or (_typeVehX == SDKMGStatic))) then
 						{
-						_nul = [0,(-1 * vehiclePurchase_cost)] remoteExecCall ["A3A_fnc_resourcesFIA",2]
+						_nul = [0,(-1 * vehiclePurchase_cost)] remoteExec ["A3A_fnc_resourcesFIA",2]
 						}
 					else
 						{

--- a/A3-Antistasi/functions/OrgPlayers/fn_assignBossIfNone.sqf
+++ b/A3-Antistasi/functions/OrgPlayers/fn_assignBossIfNone.sqf
@@ -42,7 +42,7 @@ if (!isNull _nextBoss) then
 	_textX = format ["%1 is the new leader of our forces. Greet them!", name _nextBoss];
 	[_nextBoss] call A3A_fnc_theBossInit;
 	sleep 5;
-	[petros,"hint",_textX] remoteExecCall ["A3A_fnc_commsMP", 0];
+	[petros,"hint",_textX] remoteExec ["A3A_fnc_commsMP", 0];
 }
 else
 {

--- a/A3-Antistasi/functions/OrgPlayers/fn_makePlayerBossIfEligible.sqf
+++ b/A3-Antistasi/functions/OrgPlayers/fn_makePlayerBossIfEligible.sqf
@@ -10,7 +10,7 @@ if (_player getVariable ["eligible",true] && ({(side (group _player) == teamPlay
 	[3, "Player is eligible, making them the boss", _filename] call A3A_fnc_log;
 	_textX = format ["%1 is the new leader of our forces. Greet them!", name _player];
 	[_player] call A3A_fnc_theBossInit;
-	[petros,"hint",_textX] remoteExecCall ["A3A_fnc_commsMP", 0];
+	[petros,"hint",_textX] remoteExec ["A3A_fnc_commsMP", 0];
 	true;
 };
 

--- a/A3-Antistasi/functions/REINF/fn_buildMinefield.sqf
+++ b/A3-Antistasi/functions/REINF/fn_buildMinefield.sqf
@@ -6,7 +6,7 @@ _typeX = _this select 0;
 _positionTel = _this select 1;
 _quantity = _this select 2;
 _costs = (2*(server getVariable (SDKExp select 0))) + ([vehSDKTruck] call A3A_fnc_vehiclePrice);
-[-2,(-1*_costs)] remoteExecCall ["A3A_fnc_resourcesFIA",2];
+[-2,(-1*_costs)] remoteExec ["A3A_fnc_resourcesFIA",2];
 
 if (_typeX == "ATMine") then
 	{

--- a/A3-Antistasi/functions/init/fn_initServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initServer.sqf
@@ -169,7 +169,7 @@ if !(loadLastSave) then {
 };
 call A3A_fnc_createPetros;
 
-[petros,"hint","Server load finished"] remoteExecCall ["A3A_fnc_commsMP", 0];
+[petros,"hint","Server load finished"] remoteExec ["A3A_fnc_commsMP", 0];
 
 //HandleDisconnect doesn't get 'owner' param, so we can't use it to handle headless client disconnects.
 addMissionEventHandler ["HandleDisconnect",{_this call A3A_fnc_onPlayerDisconnect;false}];

--- a/A3-Antistasi/statSave/saveLoop.sqf
+++ b/A3-Antistasi/statSave/saveLoop.sqf
@@ -206,5 +206,5 @@ _controlsX = controlsX select {(sidesX getVariable [_x,sideUnknown] == teamPlaye
 
 savingServer = false;
 _saveHintText = format ["Savegame Done.\n\nYou won't lose your stats in the event of a game update.\n\nRemember: if you want to preserve any vehicle, it must be near the HQ Flag with no AI inside.\nIf AI are inside, you will save the funds you spent on it.\n\nAI will be refunded\n\nStolen and purchased Static Weapons need to be ASSEMBLED in order to be saved. You can save disassembled Static Weapons in the ammo box.\n\nMounted Statics (Mortar/AA/AT squads) won't get saved, but you will be able to recover the cost.\n\nSame for assigned vehicles more than 50m away from HQ.\n\n%1 fund count:\nHR: %2\nMoney: %3 €",nameTeamPlayer,_hrBackground,_resourcesBackground];
-[petros,"hint",_saveHintText] remoteExecCall ["A3A_fnc_commsMP", 0];
+[petros,"hint",_saveHintText] remoteExec ["A3A_fnc_commsMP", 0];
 diag_log format ["%1: [Antistasi] | INFO | Persistent Save Completed.",servertime];


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Changed a lot of remoteExecCalls to remoteExec, mostly introduced erroneously by #620. None of the BIS_fnc_MP calls replaced there were unscheduled, and in some cases they call code that needs to be scheduled due to use of sleep or waituntil. Some detail:
1. UPSMON_fnc_setVehicleInit: Most of these were set to remoteExec anyway. I didn't check what it does, but it was scheduled before so it stays scheduled.
2. A3A_fnc_commsMP: Needs to be scheduled due to sleeps & waituntil. Not critical as it only spams text, but still a bug.
3. A3A_fnc_createOutpostsFIA: Needs to be scheduled due to sleeps. If not, FIA roadblocks break (see #710).
4. A3A_fnc_resourcesFIA: Uses waituntil to synchronize updates. Broken because other calls are scheduled, so they may overlap with the unscheduled calls.
5. A3A_fnc_resourceCheckSkipTime: Has a sleep, so must be scheduled.

I left the remoteExecCalls in JNx and towing as they're old and the authors probably know what they're doing.

### Please specify which Issue this PR Resolves.
closes #710 

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

