### PR TITLE
Disable StartLR since LRs can be found in loot.

### DIFF
--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -183,7 +183,7 @@ everyEquipmentRelatedArrayName = allEquipmentArrayNames + unlockedEquipmentArray
 DECLARE_SERVER_VAR(startLR, false);
 if (hasTFAR) then
 {
-	startLR = true;																			//set to true to start with LR radios unlocked.
+	startLR = false;																			//set to true to start with LR radios unlocked.
 	if (isServer) then
 	{
 		[] spawn {


### PR DESCRIPTION
This was mentioned in the PR that updated the blufor start LR because the players needed to carry everything but the kitchen sink at all times.

closes #743 