### PR TITLE
Create new category for cargo backpacks, use it for rebel AIs

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_equipmentClassToCategories.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentClassToCategories.sqf
@@ -138,4 +138,11 @@ if (_basecategory == "Headgear") then {
 	};
 };
 
+if (_basecategory == "Backpacks") then {
+	// 160 = assault pack. Just a way to limit which backpacks friendly AI are using.
+	if (getNumber (configFile >> "CfgVehicles" >> _className >> "maximumLoad") >= 160) then {
+		_categories pushBack "BackpacksCargo";
+	};
+};
+
 _categories;

--- a/A3-Antistasi/functions/REINF/fn_equipRebel.sqf
+++ b/A3-Antistasi/functions/REINF/fn_equipRebel.sqf
@@ -38,8 +38,7 @@ if !(unlockedVests isEqualTo []) then {
 	if (count unlockedArmoredVests * 20 < random(100)) then { _unit addVest (selectRandom unlockedVests) }
 	else { _unit addVest (selectRandom unlockedArmoredVests); };
 };
-if !(unlockedBackpacks isEqualTo []) then { _unit addBackpack (selectRandom unlockedBackpacks) };
-
+if !(unlockedBackpacksCargo isEqualTo []) then { _unit addBackpack (selectRandom unlockedBackpacksCargo) };
 
 _unit addItemToUniform "FirstAidKit";
 _unit addItemToUniform "FirstAidKit";

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -131,7 +131,7 @@ playerHasBeenPvP = [];
 
 //We initialise a LOT of arrays based on the categories. Every category gets a 'allX' variables and an 'unlockedX' variable.
 
-private _unlockableCategories = allCategoriesExceptSpecial + ["AA", "AT", "GrenadeLaunchers", "ArmoredVests", "ArmoredHeadgear"];
+private _unlockableCategories = allCategoriesExceptSpecial + ["AA", "AT", "GrenadeLaunchers", "ArmoredVests", "ArmoredHeadgear", "BackpacksCargo"];
 
 //Build list of 'allX' variables, such as 'allWeapons'
 DECLARE_SERVER_VAR(allEquipmentArrayNames, allCategories apply {"all" + _x});


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
unlockedBackpacks includes static weapon, UAV and parachute backpacks. This is not suitable for the rebel AI backpack list, as they need to put gear in backpacks. I created a new subcategory (backpacksCargo) which generates allBackpacksCargo and unlockedBackpacksCargo lists.

`fn_equipmentSort` has some backpack sorting, but it doesn't use categories and so doesn't generate unlockedXXX lists. The method used also doesn't pick out small-cap backpacks or parachutes, so I used a maximumLoad threshold instead. I left the equipmentSort code unmodified, so there won't be any side effects.

Checked the new code against all RHS and vanilla backpacks, works as intended.

### Please specify which Issue this PR Resolves.
closes #722

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

`fn_equipRebel` may have line ending issues. Not sure how to resolve these.