### PR TITLE
Fix arsenal loadouts

### DIFF
--- a/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_init.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_init.sqf
@@ -43,9 +43,11 @@ IDC_RSCDISPLAYARSENAL_TAB_CARGOPUT		23
 IDC_RSCDISPLAYARSENAL_TAB_CARGOMISC		24
 IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL		26
 */
-//jna_minItemMember = [-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1];
-jna_minItemMember = [24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,memberOnlyMagLimit,24,24,24,24,memberOnlyMagLimit];
-
+jna_minItemMember = [-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1];
+//jna_minItemMember = [24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,memberOnlyMagLimit,24,24,24,24,memberOnlyMagLimit];
+jna_minItemMember = jna_minItemMember apply { minWeaps };
+jna_minItemMember set [IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG, memberOnlyMagLimit];
+jna_minItemMember set [IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL, memberOnlyMagLimit];
 //preload the ammobox so you dont need to wait the first time
 ["Preload"] call jn_fnc_arsenal;
 

--- a/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_loadInventory.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_loadInventory.sqf
@@ -63,6 +63,17 @@ _isItemBino = {
 	getNumber(configFile >> "CfgWeapons" >> _this >> "type") == 4096;
 };
 
+// because addItemCargo doesn't enable grenades
+_addItemToContainer = {
+	params ["_container", "_item"];
+	switch (_container) do {
+		case 0: { player addItemToUniform _item };
+		case 1: { player addItemToVest _item };
+		default { player addItemToBackpack _item };
+	};
+};
+
+
 //name that needed to be loaded
 _saveName = _this;
 _saveData = profilenamespace getvariable ["bis_fnc_saveInventory_data",[]];
@@ -353,6 +364,8 @@ private _addContainerFuncs = [
 	};
 } forEach _containers;
 
+
+
 //add items to containers
 {
 	_container = call (_x select 0);
@@ -385,11 +398,11 @@ private _addContainerFuncs = [
 				_amount = 1;
 				call {
 					if ([_itemCounts select _index, _item] call jn_fnc_arsenal_itemCount == -1) exitWith {
-						_container addItemCargo [_item, 1];
+						[_forEachIndex, _item] call _addItemToContainer;
 					};
 
 					if (_amountAvailable >= _amount) then {
-						_container addItemCargo [_item,_amount];
+						[_forEachIndex, _item] call _addItemToContainer;
 						[_arrayTaken,_index,_item,_amount] call _addToArray;
 						[_availableItems,_index,_item,_amount] call _removeFromArray;
 					} else {

--- a/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_loadInventory.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_loadInventory.sqf
@@ -63,17 +63,6 @@ _isItemBino = {
 	getNumber(configFile >> "CfgWeapons" >> _this >> "type") == 4096;
 };
 
-// because addItemCargo doesn't enable grenades
-_addItemToContainer = {
-	params ["_container", "_item"];
-	switch (_container) do {
-		case 0: { player addItemToUniform _item };
-		case 1: { player addItemToVest _item };
-		default { player addItemToBackpack _item };
-	};
-};
-
-
 //name that needed to be loaded
 _saveName = _this;
 _saveData = profilenamespace getvariable ["bis_fnc_saveInventory_data",[]];
@@ -371,7 +360,15 @@ private _addContainerFuncs = [
 	};
 } forEach _containers;
 
-
+// because addItemCargo doesn't enable grenades
+_addItemToContainer = {
+	params ["_containerIndex", "_item"];
+	switch (_containerIndex) do {
+		case 0: { player addItemToUniform _item };
+		case 1: { player addItemToVest _item };
+		default { player addItemToBackpack _item };
+	};
+};
 
 //add items to containers
 {

--- a/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_loadInventory.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_loadInventory.sqf
@@ -165,16 +165,23 @@ removebackpack player;
 _isMember = [player] call A3A_fnc_isMember;
 _availableItems = [jna_dataList, _arrayPlaced] call _addArrays;
 _itemCounts =+ _availableItems;
+// reduce available items by guest limits for non-members
 {
 	_index = _foreachindex;
 	_subArray = _x;
+	_isMagArray = (_index == IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG) || (_index == IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL);
 	{
 		_item = _x select 0;
 		_amount = (_x select 1);
-		if (_amount != -1) then {
-			_amount = [(_x select 1) - (jna_minItemMember select _index),(_x select 1)] select _isMember;
+		if (_amount != -1 && !_isMember) then {
+			if !(_isMagArray) then { _amount = _amount - minWeaps }
+			else {
+				// Magazines are counted in bullets
+				_ammoCount = getNumber (configfile >> "CfgMagazines" >> _item >> "count");
+				_amount = _amount - memberOnlyMagLimit * _ammoCount;
+			};
+			_subArray set [_foreachindex, [_item,_amount]];
 		};
-		_subArray set [_foreachindex, [_item,_amount]];
 	} forEach _subArray;
 	_availableItems set [_index, _subArray];
 } forEach _availableItems;

--- a/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_loadInventory.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_loadInventory.sqf
@@ -238,7 +238,7 @@ _weapons = [_inventory select 6,_inventory select 7,_inventory select 8];
 			if (_amountMagAvailable > 0) then {
 				if (_amountMagAvailable < _amountMag) then {
 					_arrayMissing = [_arrayMissing,[_itemMag,_amountMag]] call jn_fnc_arsenal_addToArray;
-					_amountMag = _amountMagAvailable;
+					_amountMag = _amountMagAvailable max 0;
 				};
 			[_arrayTaken,_indexMag,_itemMag,_amountMag] call _addToArray;
 			[_availableItems,_indexMag,_itemMag,_amountMag] call _removeFromArray;
@@ -283,7 +283,7 @@ _weapons = [_inventory select 6,_inventory select 7,_inventory select 8];
 						};
 					};
 
-					if ((_indexAcc != -1) AND {[_availableItems select _indexAcc, _itemAcc] call jn_fnc_arsenal_itemCount != 0}) then {
+					if ((_indexAcc != -1) AND {[_availableItems select _indexAcc, _itemAcc] call jn_fnc_arsenal_itemCount > 0}) then {
 						switch _index do{
 							case IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON:{player addPrimaryWeaponItem _itemAcc;};
 							case IDC_RSCDISPLAYARSENAL_TAB_SECONDARYWEAPON:{player addSecondaryWeaponItem _itemAcc;};
@@ -374,14 +374,12 @@ private _addContainerFuncs = [
 					};
 
 					if(_amountAvailable < _amount) then {
-						_amount = _amountAvailable;
 						_arrayMissing = [_arrayMissing,[_item,(_amount - _amountAvailable)]] call jn_fnc_arsenal_addToArray;
+						_amount = _amountAvailable max 0;
 					};
 					[_arrayTaken,_index,_item,_amount] call _addToArray;
 					[_availableItems,_index,_item,_amount] call _removeFromArray;
-					if (_amount>0) then {//prevent empty mags
-						_container addMagazineAmmoCargo  [_item,1, _amount];
-					};
+					_container addMagazineAmmoCargo  [_item,1, _amount];
 				};
 			} else {
 				_amount = 1;
@@ -390,7 +388,7 @@ private _addContainerFuncs = [
 						_container addItemCargo [_item, 1];
 					};
 
-					if (_amountAvailable > _amount) then {
+					if (_amountAvailable >= _amount) then {
 						_container addItemCargo [_item,_amount];
 						[_arrayTaken,_index,_item,_amount] call _addToArray;
 						[_availableItems,_index,_item,_amount] call _removeFromArray;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Several arsenal bugs, mostly related to loading loadouts:
1. Fixed a bug where the arsenal used 24 rather than Antistasi's minWeaps param as the guest limit.
2. Fixed a bug where weapon accessories bypassed the guest limit.
3. Fixed some potential bugs with negative bullet counts and off-by-ones.
4. Fixed a bug where grenades wouldn't be throwable after loading a loadout.
5. Fixed a bug where the magazine guest limit was counting in mags rather than bullets.

4 is arguably an Arma bug. `(vestContainer player) addItemCargo "HandGrenade"` demonstrates the problem, at least in vanilla. Not difficult to work around, but rather spoiled the attempt at code reduction.

### Please specify which Issue this PR Resolves.
closes #721, maybe others

### Is further testing or are further changes required?
1. [X] No, but:
2. [ ] Yes (Please provide further detail below.)

I reckon this file could be rewritten a lot cleaner by stripping out most of the check-and-remove code into a local function. This is a bugfix PR though, so I'm keeping it to minimum changes for the moment.