### PR TITLE
Fix case where an airstrike targets an airport with no runway

### DIFF
--- a/A3-Antistasi/functions/AI/fn_airstrike.sqf
+++ b/A3-Antistasi/functions/AI/fn_airstrike.sqf
@@ -30,9 +30,12 @@ if (_isMarker) then
 	if (_markerX in airportsX) then
 		{
 		private _runwayTakeoff = [_markerX] call A3A_fnc_getRunwayTakeoffForAirportMarker;
-		_positionX = _runwayTakeoff select 0;
-		_angOrig = (_runwayTakeoff select 1) + (random 20 - 10);
-		_ang = _angOrig + 180;
+		if (count _runwayTakeoff > 0) then
+			{
+			_positionX = _runwayTakeoff select 0;
+			_angOrig = (_runwayTakeoff select 1) + (random 20 - 10);
+			_ang = _angOrig + 180;
+			};
 		};
 	_pos1 = [_positionX, 400, _angorig] call BIS_Fnc_relPos;
 	_origpos = [_positionX, 3*distanceSPWN, _angorig] call BIS_fnc_relPos;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
When fn_airstrike is called with an airport marker as the target, it adjusts the target position based on the runway. As some airports on smaller maps (eg Malden airport_2) do not have runways, this breaks. I added a check for whether the airport has a runway, in which case the adjustment is bypassed.

### Please specify which Issue this PR Resolves.
closes #704 

### Is further testing or are further changes required?
1. [X] No, but
2. [ ] Yes (Please provide further detail below.)

The runway detection functionality should really be moved into init code, and the data stored. Doesn't much matter for any current uses though.