### PR TITLE
Separate release & recruit actions on surrendered enemies

### DIFF
--- a/A3-Antistasi/functions/AI/fn_captureX.sqf
+++ b/A3-Antistasi/functions/AI/fn_captureX.sqf
@@ -50,12 +50,12 @@ else {
 
 	private _mult = if (_interrogated) then { 0.5 } else { 1.0 };
 	if (_sideX == Occupants) then {
-		if (faction _unit == factionFIA) then { _modAggroOcc = -0.5*_mult }
-		else { _modAggroOcc = -1.0*_mult };
+		if (faction _unit == factionFIA) then { _modAggroOcc = -0.3*_mult }
+		else { _modAggroOcc = -0.6*_mult };
 	}
 	else {
-		if (faction _unit == factionFIA) then { _modAggroInv = -0.1*_mult }
-		else { _modAggroInv = -0.2*_mult };
+		if (faction _unit == factionFIA) then { _modAggroInv = -0.05*_mult }
+		else { _modAggroInv = -0.1*_mult };
 	};
 };
 

--- a/A3-Antistasi/functions/AI/fn_captureX.sqf
+++ b/A3-Antistasi/functions/AI/fn_captureX.sqf
@@ -1,57 +1,79 @@
-_unit = _this select 0;
-_playerX = _this select 1;
+private _unit = _this select 0;
+private _playerX = _this select 1;
+private _recruiting = _this select 3;
 
 [_unit,"remove"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_unit];
 
 if (!alive _unit) exitWith {};
-_sideX = side (group _unit);
-_chance = 80;
-if ((_sideX == Occupants) and (faction _unit != factionFIA)) then
-	{
+
+private _sideX = side (group _unit);
+private _interrogated = _unit getVariable ["interrogated", false];
+
+private _modAggroOcc = 0;
+private _modAggroInv = 0;
+private _modHR = false;
+private _response = "";
+private _targetMarker = respawnOccupants;
+
+if (_recruiting) then {
+	_playerX globalChat "How about joining the good guys?";
+
+	private _chance = 0;
+	if (_sideX == Occupants) then {
+		if (faction _unit == factionFIA) then { _chance = 60; _modAggroOcc = 0.1; }
+		else { _chance = 20; _modAggroOcc = 0.5; };
+	}
+	else {
+		if (faction _unit == factionFIA) then { _chance = 60; _modAggroInv = 0.1; }
+		else { _chance = 40; _modAggroInv = 0.5; };
+	};
+	if (_interrogated) then { _chance = _chance / 2 };
+
+	if (random 100 < _chance) then {
+		_response = "Why not? It can't be any worse.";
+		_modHR = true;
+		_targetMarker = respawnTeamPlayer;
+	}
+	else {
+		_response =  "Screw you!";
+		_modAggroOcc = 0;
+		_modAggroInv = 0;
+	};
+}
+else {
 	_playerX globalChat "Go back to your base and tell your comrades we are not enemies. We just want to live in peace";
-	}
-else
-	{
-	_playerX globalChat "Why not join us and make profitable business?";
-	_chance = if (faction _unit != factionFIA) then {100 - prestigeCSAT} else {100 - prestigeNATO};
-	};
+	_response = selectRandom [
+		"Okay, thank you. I owe you my life",
+		"Thank you. I swear you won't regret it!",
+		"Allah bless you!"
+	];
 
-_chance = _chance + 20;
-
-sleep 5;
-if (round random 100 < _chance) then
-	{
-	if (isMultiplayer) then {[_unit,true] remoteExec ["enableSimulationGlobal",2]} else {_unit enableSimulation true};
-	if ((_sideX == Occupants) and (faction _unit != factionFIA)) then
-		{
-		_unit globalChat "Okay, thank you. I owe you my life";
-		}
-	else
-		{
-		if (faction _unit != factionFIA) then {_unit globalChat "Allah bless you!"} else {_unit globalChat "Thank you. I swear you won't regret it!"};
-		};
-	_unit enableAI "ANIM";
-	_unit enableAI "MOVE";
-	_unit stop false;
-	[_unit,""] remoteExec ["switchMove"];
-	_unit doMove (getMarkerPos respawnOccupants);
-	if (_unit getVariable ["spawner",false]) then {_unit setVariable ["spawner",nil,true]};
-	sleep 100;
-	if (alive _unit) then
-		{
-		if ((_sideX == Occupants) and (faction _unit != factionFIA)) then
-			{
-			[-0.5,0] remoteExec ["A3A_fnc_prestige",2];
-			}
-		else
-			{
-			[1,0] remoteExec ["A3A_fnc_resourcesFIA",2];
-			[1,1] remoteExec ["A3A_fnc_prestige",2];
-			};
-		};
-	deleteVehicle _unit;
+	private _mult = if (_interrogated) then { 0.5 } else { 1.0 };
+	if (_sideX == Occupants) then {
+		if (faction _unit == factionFIA) then { _modAggroOcc = -0.5*_mult }
+		else { _modAggroOcc = -1.0*_mult };
 	}
-else
-	{
-	_unit globalChat "Screw you!";
+	else {
+		if (faction _unit == factionFIA) then { _modAggroInv = -0.1*_mult }
+		else { _modAggroInv = -0.2*_mult };
 	};
+};
+
+
+if (isMultiplayer) then {[_unit,true] remoteExec ["enableSimulationGlobal",2]} else {_unit enableSimulation true};
+sleep 3;
+_unit globalChat _response;
+_unit enableAI "ANIM";
+_unit enableAI "MOVE";
+_unit stop false;
+[_unit,""] remoteExec ["switchMove"];
+_unit doMove (getMarkerPos _targetMarker);
+// probably redundant. Should already be done in surrenderAction
+if (_unit getVariable ["spawner",false]) then {_unit setVariable ["spawner",nil,true]};
+sleep 100;
+if (alive _unit) then
+{
+	[_modAggroOcc,_modAggroInv] remoteExec ["A3A_fnc_prestige",2];
+	if (_modHR) then { [1,0] remoteExec ["A3A_fnc_resourcesFIA",2] };
+};
+deleteVehicle _unit;

--- a/A3-Antistasi/functions/AI/fn_interrogate.sqf
+++ b/A3-Antistasi/functions/AI/fn_interrogate.sqf
@@ -1,9 +1,17 @@
 _unit = _this select 0;
 _playerX = _this select 1;
 
-[_unit,"remove"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_unit];
+//[_unit,"remove"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_unit];
+
+// Remove interrogate action but leave release/recruit actions
+{
+	private _actparams = _unit actionParams _x;
+	if (_actparams select 0 == "Interrogate") then { _unit removeAction _x };
+} forEach (actionIDs _unit);
 
 if (!alive _unit) exitWith {};
+if (_unit getVariable ["interrogated", false]) exitWith {};
+_unit setVariable ["interrogated", true, true];
 
 _playerX globalChat "You imperialist! Tell me what you know!";
 _chance = 0;

--- a/A3-Antistasi/functions/AI/fn_surrenderAction.sqf
+++ b/A3-Antistasi/functions/AI/fn_surrenderAction.sqf
@@ -74,5 +74,4 @@ if (!isNil "_markerX") then
 sleep 10;
 _unit allowDamage true;
 if (isMultiplayer) then {[_unit,false] remoteExec ["enableSimulationGlobal",2]} else {_unit enableSimulation false};
-[_unit,"interrogate"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_unit];
-[_unit,"captureX"]remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_unit];
+[_unit,"captureX"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_unit];

--- a/A3-Antistasi/functions/Base/fn_flagaction.sqf
+++ b/A3-Antistasi/functions/Base/fn_flagaction.sqf
@@ -82,8 +82,13 @@ switch _typeX do
 		};
 	case "refugee": {_flag addAction ["<t>Liberate</t> <img image='\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_unbind_ca.paa' size='1.6' shadow=2 />", A3A_fnc_liberaterefugee,nil,6,true,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull])",4]};//"\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_unbind_ca.paa"
 	case "prisonerX": {_flag addAction ["<t>Liberate POW</t> <img image='\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_unbind_ca.paa' size='1.6' shadow=2 />", A3A_fnc_liberatePOW,nil,6,true,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull])",4]};
-	case "interrogate": {_flag addAction ["Interrogate", { _this spawn A3A_fnc_interrogate; },nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull])",4]};
-	case "captureX": {_flag addAction ["<t>Release POW</t> <img image='\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_unbind_ca.paa' size='1.6' shadow=2 />", A3A_fnc_captureX,nil,6,true,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull])",4]};
+	case "captureX":
+		{
+		// Uses the optional param to determine whether the call of captureX is a release or a recruit
+		_flag addAction ["<t>Release POW</t> <img image='\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_unbind_ca.paa' size='1.6' shadow=2 />", { _this spawn A3A_fnc_captureX; },false,6,true,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull])",4];
+		_flag addAction ["Recruit", { _this spawn A3A_fnc_captureX; },true,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull])",4];
+		_flag addAction ["Interrogate", { _this spawn A3A_fnc_interrogate; },nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull])",4];
+		};
 	case "buildHQ": {_flag addAction ["Build HQ here", A3A_fnc_buildHQ,nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull])",4]};
 	case "seaport": {_flag addAction ["Buy Boat", {[vehSDKBoat] spawn A3A_fnc_addFIAVeh},nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull])",4]};
 	case "steal": {_flag addAction ["Steal Static", A3A_fnc_stealStatic,nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull])",4]};


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Enhancement

### What have you changed and why?
Releasing a surrendered enemy used to work as described in #739. Non-militia occupants would reduce occupant aggro by 0.5 points each, while militia occupants and invaders would instead be given an offer to join the rebels, causing +1/+1 aggro and +1 HR.

This PR instead splits the release and recruit actions in the action menu, so either can be used on any surrendered enemy. Aggro reduction from releasing varies by faction (militia cause less than non-militia, invaders have little effect, as it's supposed to be very difficult to reduce invader aggro). Recruit chance also varies by faction (militia much easier than regular troops) while the aggro penalty is reduced to make it a more attractive early-game option.

I also made releasing or recruiting possible (but less beneficial) after an interrogation, to make that a slightly more useful and intuitive option.

### Please specify which Issue this PR Resolves.
closes #739

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)
3. [X] Maybe

On an ACE server, the aggro reduction values will seem quite low because revive -> surrender doesn't work there. I kept the values to "safe" levels because without ACE it's already not difficult to keep aggro low. I am intending to fix revive -> surrender with ACE, so that would change the equation.

Ideally we'd have lists of potential responses in the faction templates, and released enemies might actually join a garrison rather than being deleted after 100 seconds, but that's fancy stuff for the future.