### PR TITLE
Add autoSaveInterval option

### DIFF
--- a/A3-Antistasi/MissionDescription/params.hpp
+++ b/A3-Antistasi/MissionDescription/params.hpp
@@ -16,10 +16,17 @@ class Params
      };
      class autoSave
      {
-          title = "Enable Autosave (every hour)";
+          title = "Enable Autosave (every X minutes)";
           values[] = {1,0};
           texts[] = {"Yes","No"};
           default = 1;
+     };
+     class autoSaveInterval
+     {
+          title = "Time between autosaves (in minutes)";
+          values[] = {600,1200,1800,3600,5400};
+          texts[] = {"10","20","30","60","90"};
+          default = 3600;
      };
      class membership
      {

--- a/A3-Antistasi/functions/init/fn_resourcecheck.sqf
+++ b/A3-Antistasi/functions/init/fn_resourcecheck.sqf
@@ -229,7 +229,7 @@ while {true} do
 			_countSave = _countSave - 600;
 			if (_countSave <= 0) then
 				{
-				_countSave = 3600;
+				_countSave = autoSaveInterval;
 				_nul = [] execVM "statSave\saveLoop.sqf";
 				};
 			};


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Enhancement

### What have you changed and why?
This patch introduces a new option to the parameters exposed to users, "autoSaveInterval".
This option allows the user to specify in minutes how often the host should autosave the mission, starting at 10 minutes (the minimum allowable time) up to 90. 

Whilst I understand the performance implications a user setting the auto-save to 10 minutes, I've found this feature quite useful on my own dedicated server when trying to diagnose a crashing issue and I felt that other members of the Antistasi community may also want this option.

### Please specify which Issue this PR Resolves.
n/a

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the Mission in Singleplayer?
2. [X] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:
