### PR TITLE
Allow boats to be placed further from flags, place upright on surface

### DIFF
--- a/A3-Antistasi/functions/Garage/fn_vehPlacementBegin.sqf
+++ b/A3-Antistasi/functions/Garage/fn_vehPlacementBegin.sqf
@@ -173,17 +173,20 @@ addMissionEventHandler ["EachFrame",
 	};
 	
 	// If vehicle is a boat, make sure it spawns at sea level?
-	_shipX = false;
-	if (vehPlace_previewVeh isKindOf "Ship") then {_placementPos set [2,0]; _shipX = true};
-	
-	// Do nothing if destination too far
-	if (_placementPos distance2d player > 100)exitWith {vehPlace_previewVeh setPosASL [0,0,0]};
-	// Ships only spawn on water, and cars can't spawn on water
+
 	_water = surfaceIsWater _placementPos;
-	if (_shipX and {!_water}) exitWith {vehPlace_previewVeh setPosASL [0,0,0]};
-	if (!_shipX and {_water}) exitWith {vehPlace_previewVeh setPosASL [0,0,0]};
-	// If all checks pass, set position of preview and orient it to the ground
-	vehPlace_updatedLookPosition =	_pos;
-	vehPlace_previewVeh setPosATL _placementPos;
-	vehPlace_previewVeh setVectorUp (_chosenIntersection select 1);
+	if (vehPlace_previewVeh isKindOf "Ship") then
+	{
+		_placementPos set [2,0];
+		if (!water || _placementPos distance2d player > 200) exitWith {vehPlace_previewVeh setPosASL [0,0,0]};
+		vehPlace_updatedLookPosition = _pos;
+		vehPlace_previewVeh setPosASL _placementPos;
+		vehPlace_previewVeh setVectorUp [0,0,1];
+	}
+	else {
+		if (_water || _placementPos distance2d player > 100) exitWith {vehPlace_previewVeh setPosASL [0,0,0]};
+		vehPlace_updatedLookPosition = _pos;
+		vehPlace_previewVeh setPosATL _placementPos;
+		vehPlace_previewVeh setVectorUp (_chosenIntersection select 1);
+	};
 	}];

--- a/A3-Antistasi/functions/Garage/fn_vehPlacementCallbacks.sqf
+++ b/A3-Antistasi/functions/Garage/fn_vehPlacementCallbacks.sqf
@@ -33,9 +33,10 @@ switch (_callbackTarget) do {
 			
 			case CALLBACK_VEH_IS_VALID_LOCATION: {
 				private _pos = _callbackParams select 0;
-				if (_pos distance2d (getMarkerPos garage_nearestMarker) > 50) exitWith 
+				private _maxDist = [50,150] select ((_callbackParams select 2) isKindOf "Ship");
+				if (_pos distance2d (getMarkerPos garage_nearestMarker) > _maxDist) exitWith
 				{
-					[false, "Vehicles must be placed within 50m of the flag"];
+					[false, format ["This vehicle must be placed within %1m of the flag", _maxDist]];
 				};
 				[true];
 			};
@@ -105,9 +106,10 @@ switch (_callbackTarget) do {
 			
 			case CALLBACK_VEH_IS_VALID_LOCATION: {
 				private _pos = _callbackParams select 0;
-				if (_pos distance2d (getMarkerPos vehiclePurchase_nearestMarker) > 50) exitWith 
+				private _maxDist = [50,150] select ((_callbackParams select 2) isKindOf "Ship");
+				if (_pos distance2d (getMarkerPos vehiclePurchase_nearestMarker) > _maxDist) exitWith
 				{
-					[false, "Vehicles must be placed within 50m of the flag"];
+					[false, format ["This vehicle must be placed within %1m of the flag", _maxDist]];
 				};
 				[true];
 			};


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Enhancement

### What have you changed and why?
- Both purchased and ungaraged boats can now be placed up to 150m from the marker.
- Boats no longer placed underwater or at non-upright angles.

### Please specify which Issue this PR Resolves.
closes #766

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
