### PR TITLE
Include RHS civilian trucks in civilian vehicle type list

### DIFF
--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -233,7 +233,7 @@ private _vehicleIsSpecial = {
 private _civVehConfigs = "(
 	getNumber (_x >> 'scope') isEqualTo 2 && {
 		getNumber (_x >> 'side') isEqualTo 3 && {
-			getText (_x >> 'vehicleClass') in ['Car','Support'] && {
+			getText (_x >> 'vehicleClass') in ['Car','Support','rhs_vehclass_truck'] && {
 				getText (_x >> 'simulation') == 'carx'
 			}
 		}


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Enhancement
3. [X] Horror

### What have you changed and why?
RHS trucks have a different vehicle class to the vanilla trucks. This PR adds that class to the list, so that the automatic civilian vehicle detection function can see them.

### Please specify which Issue this PR Resolves.
closes #727

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Do not merge this PR unless you want at least 1/3 of civilian vehicles to be Urals. The problem is that each civilian vehicle found has an equal chance to be spawned, and RHS has around 10 slightly different civilian versions of the Ural.

Civilian vehicles really need a curated solution, with a list of classes and weights. 