### PR TITLE
Re-enable spawning fuel trucks as civilian vehicles

### DIFF
--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -221,8 +221,8 @@ private _vehicleIsSpecial = {
 
 	   (getNumber (_vehConfig >> "transportRepair") > 0)
 	|| (getNumber (_vehConfig >> "transportAmmo") > 0)
-	|| (getNumber (_vehConfig >> "transportFuel") > 0)
-	|| (getNumber (_vehConfig >> "ace_refuel_fuelCargo") > 0)
+//	|| (getNumber (_vehConfig >> "transportFuel") > 0)
+//	|| (getNumber (_vehConfig >> "ace_refuel_fuelCargo") > 0)
 	|| (getNumber (_vehConfig >> "ace_repair_canRepair") > 0)
 	|| (getNumber (_vehConfig >> "ace_rearm_defaultSupply") > 0)
 		//Medical vehicle


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Enhancement

### What have you changed and why?
Fuel trucks are no longer blocked from being automatically added to the civilian vehicles list.

### Please specify which Issue this PR Resolves.
closes #768 

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
