### PR TITLE
Add ammo boxes to list of objects that shouldn't be saved near the HQ

### DIFF
--- a/A3-Antistasi/statSave/saveLoop.sqf
+++ b/A3-Antistasi/statSave/saveLoop.sqf
@@ -83,7 +83,7 @@ _arrayEst = [];
 	_veh = _x;
 	_typeVehX = typeOf _veh;
 	if ((_veh distance getMarkerPos respawnTeamPlayer < 50) and !(_veh in staticsToSave) and !(_typeVehX in ["ACE_SandbagObject","Land_PaperBox_01_open_boxes_F","Land_PaperBox_01_open_empty_F"])) then {
-		if (((not (_veh isKindOf "StaticWeapon")) and (not (_veh isKindOf "ReammoBox")) and (not (_veh isKindOf "FlagCarrier")) and (not(_veh isKindOf "Building"))) and (not (_typeVehX == "C_Van_01_box_F")) and (count attachedObjects _veh == 0) and (alive _veh) and ({(alive _x) and (!isPlayer _x)} count crew _veh == 0) and (not(_typeVehX == "WeaponHolderSimulated"))) then {
+		if (((not (_veh isKindOf "StaticWeapon")) and (not (_veh isKindOf "ReammoBox")) and (not (_veh isKindOf "ReammoBox_F")) and (not (_veh isKindOf "FlagCarrier")) and (not(_veh isKindOf "Building"))) and (not (_typeVehX == "C_Van_01_box_F")) and (count attachedObjects _veh == 0) and (alive _veh) and ({(alive _x) and (!isPlayer _x)} count crew _veh == 0) and (not(_typeVehX == "WeaponHolderSimulated"))) then {
 			_posVeh = getPos _veh;
 			_dirVeh = getDir _veh;
 			_arrayEst pushBack [_typeVehX,_posVeh,_dirVeh];


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Ammo boxes left near the HQ were being saved. Because AIVEHInit doesn't touch ammo boxes (as it's also used for the full ones), they were not being cleared of default cargo on load, so were an easy way to unlock some items.

The poor code quality and spaghetti design remain unchanged. This is just a quick fix.

### Please specify which Issue this PR Resolves.
closes #754 

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
