### PR TITLE
Fix bad classnames in 3CB templates

### DIFF
--- a/A3-Antistasi/Templates/BAF_Occ_BAF_Arid.sqf
+++ b/A3-Antistasi/Templates/BAF_Occ_BAF_Arid.sqf
@@ -126,14 +126,14 @@ groupsNATOGen = [policeOfficer,policeGrunt];
 //Lite
 vehNATOBike = "B_T_Quadbike_01_F";
 vehNATOLightArmed = ["UK3CB_BAF_LandRover_WMIK_HMG_FFR_Sand_A_DDPM","UK3CB_BAF_LandRover_WMIK_GMG_FFR_Sand_A_DDPM","UK3CB_BAF_LandRover_WMIK_Milan_FFR_Sand_A_DDPM","UK3CB_BAF_Jackal2_L2A1_D_DDPM","UK3CB_BAF_Coyote_Logistics_L111A1_D_DDPM","UK3CB_BAF_Coyote_Passenger_L111A1_D_DDPM"];
-vehNATOLightUnarmed = ["UK3CB_BAF_MAN_HX60_Container_Servicing_Air_Sand","UK3CB_BAF_LandRover_Hard_FFR_Sand_A_DDPM","UK3CB_BAF_LandRover_Snatch_FFR_Sand_A_DDPM","UK3CB_BAF_LandRover_Soft_FFR_Sand_A_DDPM"];
+vehNATOLightUnarmed = ["UK3CB_BAF_LandRover_Hard_FFR_Sand_A_DDPM","UK3CB_BAF_LandRover_Snatch_FFR_Sand_A_DDPM","UK3CB_BAF_LandRover_Soft_FFR_Sand_A_DDPM"];
 vehNATOTrucks = ["UK3CB_BAF_MAN_HX58_Transport_Sand_DDPM","UK3CB_BAF_MAN_HX60_Transport_Sand_DDPM"];
 vehNATOCargoTrucks = ["UK3CB_BAF_MAN_HX58_Cargo_Sand_A_DDPM","UK3CB_BAF_MAN_HX60_Cargo_Sand_A_DDPM"];
 vehNATOAmmoTruck = "rhsusf_M977A4_AMMO_usarmy_d";
 vehNATORepairTruck = "UK3CB_BAF_MAN_HX58_Repair_Sand_DDPM";
 vehNATOLight = vehNATOLightArmed + vehNATOLightUnarmed;
 //Armored
-vehNATOAPC = ["RHS_M2A3_BUSKIII_d","RHS_M2A3_BUSKI_d","RHS_M2A3_d","RHS_M2A3_d","UK3CB_BAF_FV432_Mk3_GPMG_Sand_DDPM","UK3CB_BAF_FV432_Mk3_RWS_Sand_DDPM"];
+vehNATOAPC = ["RHS_M2A3_BUSKIII","RHS_M2A3_BUSKI","RHS_M2A3","RHS_M2A3","UK3CB_BAF_FV432_Mk3_GPMG_Sand_DDPM","UK3CB_BAF_FV432_Mk3_RWS_Sand_DDPM"];
 vehNATOTank = "rhsusf_m1a2sep1d_usarmy";
 vehNATOAA = "RHS_M6";
 vehNATOAttack = vehNATOAPC + [vehNATOTank];
@@ -156,7 +156,7 @@ vehNATOUAVSmall = "B_UAV_01_F";
 vehNATOMRLS = "rhsusf_m109d_usarmy";
 vehNATOMRLSMags = "rhs_mag_155mm_m795_28";
 //Combined Arrays
-vehNATONormal = vehNATOLight + vehNATOTrucks + [vehNATOAmmoTruck, "UK3CB_BAF_MAN_HX58_Fuel_Green_DDPM", "UK3CB_BAF_LandRover_Amb_FFR_Sand_A_DDPM", vehNATORepairTruck,"UK3CB_BAF_FV432_Mk3_RWS_Sand_DDPM"];
+vehNATONormal = vehNATOLight + vehNATOTrucks + [vehNATOAmmoTruck, "UK3CB_BAF_MAN_HX58_Fuel_Sand_DDPM", "UK3CB_BAF_LandRover_Amb_FFR_Sand_A_DDPM", vehNATORepairTruck,"UK3CB_BAF_FV432_Mk3_RWS_Sand_DDPM"];
 vehNATOAir = vehNATOTransportHelis + vehNATOAttackHelis + [vehNATOPlane,vehNATOPlaneAA] + vehNATOTransportPlanes;
 
 //Militia Vehicles

--- a/A3-Antistasi/Templates/RHS_Inv_AFRF_Arid.sqf
+++ b/A3-Antistasi/Templates/RHS_Inv_AFRF_Arid.sqf
@@ -114,7 +114,7 @@ vehCSATTrucks = ["rhs_kamaz5350_vdv","rhs_kamaz5350_open_vdv","RHS_Ural_Open_VDV
 vehCSATAmmoTruck = "rhs_gaz66_ammo_vmf";
 vehCSATLight = vehCSATLightArmed + vehCSATLightUnarmed;
 //Armored
-vehCSATAPC = ["rhs_bmd1r","rhs_bmp1p_vdv","rhs_bmd1p","rhs_bmd2m","rhs_bmp1p_vdv","rhs_bmp2k_vdv","rhs_btr80a_vdv","rhsbmp3mera_msv","rhs_bmd1PK"];
+vehCSATAPC = ["rhs_bmd1r","rhs_bmp1p_vdv","rhs_bmd1p","rhs_bmd2m","rhs_bmp1p_vdv","rhs_bmp2k_vdv","rhs_btr80a_vdv","rhs_bmp3mera_msv","rhs_bmd1PK"];
 vehCSATTank = "rhs_t90sab_tv";
 vehCSATAA = "rhs_zsu234_aa";
 vehCSATAttack = vehCSATAPC + [vehCSATTank];

--- a/A3-Antistasi/Templates/RHS_Inv_AFRF_Temp.sqf
+++ b/A3-Antistasi/Templates/RHS_Inv_AFRF_Temp.sqf
@@ -114,7 +114,7 @@ vehCSATTrucks = ["rhs_kamaz5350_vdv","rhs_kamaz5350_open_vdv","RHS_Ural_Open_VDV
 vehCSATAmmoTruck = "rhs_gaz66_ammo_vmf";
 vehCSATLight = vehCSATLightArmed + vehCSATLightUnarmed;
 //Armored
-vehCSATAPC = ["rhs_bmd1r","rhs_bmp1p_vdv","rhs_bmd1p","rhs_bmd2m","rhs_bmp1p_vdv","rhs_bmp2k_vdv","rhs_btr80a_vdv","rhsbmp3mera_msv","rhs_bmd1PK"];
+vehCSATAPC = ["rhs_bmd1r","rhs_bmp1p_vdv","rhs_bmd1p","rhs_bmd2m","rhs_bmp1p_vdv","rhs_bmp2k_vdv","rhs_btr80a_vdv","rhs_bmp3mera_msv","rhs_bmd1PK"];
 vehCSATTank = "rhs_t90sab_tv";
 vehCSATAA = "rhs_zsu234_aa";
 vehCSATAttack = vehCSATAPC + [vehCSATTank];

--- a/A3-Antistasi/Templates/RHS_Inv_AFRF_Trop.sqf
+++ b/A3-Antistasi/Templates/RHS_Inv_AFRF_Trop.sqf
@@ -114,7 +114,7 @@ vehCSATTrucks = ["rhs_kamaz5350_vdv","rhs_kamaz5350_open_vdv","RHS_Ural_Open_VDV
 vehCSATAmmoTruck = "rhs_gaz66_ammo_vmf";
 vehCSATLight = vehCSATLightArmed + vehCSATLightUnarmed;
 //Armored
-vehCSATAPC = ["rhs_bmd1r","rhs_bmp1p_vdv","rhs_bmd1p","rhs_bmd2m","rhs_bmp1p_vdv","rhs_bmp2k_vdv","rhs_btr80a_vdv","rhsbmp3mera_msv","rhs_bmd1PK"];
+vehCSATAPC = ["rhs_bmd1r","rhs_bmp1p_vdv","rhs_bmd1p","rhs_bmd2m","rhs_bmp1p_vdv","rhs_bmp2k_vdv","rhs_btr80a_vdv","rhs_bmp3mera_msv","rhs_bmd1PK"];
 vehCSATTank = "rhs_t90sab_tv";
 vehCSATAA = "rhs_zsu234_aa";
 vehCSATAttack = vehCSATAPC + [vehCSATTank];

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -608,6 +608,18 @@ DECLARE_SERVER_VAR(vehUnlimited, _vehUnlimited);
 private _vehFIA = [vehSDKBike,vehSDKLightArmed,SDKMGStatic,vehSDKLightUnarmed,vehSDKTruck,vehSDKBoat,SDKMortar,staticATteamPlayer,staticAAteamPlayer,vehSDKRepair];
 DECLARE_SERVER_VAR(vehFIA, _vehFIA);
 
+// sanity check the lists to catch some serious problems early
+private _badVehs = [];
+{  
+    if !(isClass (configFile >> "CfgVehicles" >> _x)) then {
+        _badVehs pushBackUnique _x;
+    };
+} forEach (vehNormal + vehBoats + vehAttack + vehPlanes + vehAA + vehMRLS + vehUnlimited + vehFIA);
+
+if (count _badVehs > 0) then {
+	[1, format ["Missing vehicle classnames: %1", str _badVehs], _filename] call A3A_fnc_log;
+};
+
 ///////////////////////////
 //     MOD TEMPLATES    ///
 ///////////////////////////


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
1. Replaced references to non-existent RHS M2A3 classnames.
2. Replaced reference to non-existent 3CB fuel truck classname.
3. Removed container from light unarmed vehicles. Assumed unintentional.
4. Added some sanity checking code to make this easier to debug in future.

The sanity checking is probably not complete, but it should be testing the vast majority of vehicle classnames.

### Please specify which Issue this PR Resolves.
closes #771, #772

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
