### PR TITLE
Equipment category manual overrides

### DIFF
--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -337,6 +337,7 @@ class A3A
 		class ACEpvpReDress {};
 		class ammunitionTransfer {};
 		class arsenalManage {};
+		class categoryOverrides {};
 		class checkRadiosUnlocked {};
 		class configSort {};
 		class crateLootParams {};

--- a/A3-Antistasi/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_categoryOverrides.sqf
@@ -1,0 +1,107 @@
+
+//asval, Mk17 and SCAR-H arguable
+
+private _categoryOverrideTable = [
+["rhs_weap_vss", ["SniperRifles","Weapons"]],
+["rhs_weap_vss_grip", ["SniperRifles","Weapons"]],
+["rhs_weap_vss_npz", ["SniperRifles","Weapons"]],
+["rhs_weap_vss_grip_npz", ["SniperRifles","Weapons"]],
+["rhs_weap_svdp", ["SniperRifles","Weapons"]],
+["rhs_weap_svdp_npz", ["SniperRifles","Weapons"]],
+["rhs_weap_svdp_wd", ["SniperRifles","Weapons"]],
+["rhs_weap_svdp_wd_npz", ["SniperRifles","Weapons"]],
+["rhs_weap_svds", ["SniperRifles","Weapons"]],
+["rhs_weap_svds_npz", ["SniperRifles","Weapons"]],
+["rhs_weap_t5000", ["SniperRifles","Weapons"]],
+["rhs_weap_pp2000", ["SMGs","Weapons"]],
+["rhs_weap_XM2010", ["SniperRifles","Weapons"]],
+["rhs_weap_XM2010_d", ["SniperRifles","Weapons"]],
+["rhs_weap_XM2010_wd", ["SniperRifles","Weapons"]],
+["rhs_weap_XM2010_sa", ["SniperRifles","Weapons"]],
+["rhs_weap_m24sws", ["SniperRifles","Weapons"]],
+["rhs_weap_m24sws_d", ["SniperRifles","Weapons"]],
+["rhs_weap_m24sws_wd", ["SniperRifles","Weapons"]],
+["rhs_weap_m40a5", ["SniperRifles","Weapons"]],
+["rhs_weap_m40a5_d", ["SniperRifles","Weapons"]],
+["rhs_weap_m40a5_wd", ["SniperRifles","Weapons"]],
+["rhs_weap_M590_5RD", ["Shotguns","Weapons"]],
+["rhs_weap_M590_8RD", ["Shotguns","Weapons"]],
+["rhs_weap_kar98k", ["SniperRifles","Weapons"]],
+["rhs_weap_m38", ["SniperRifles","Weapons"]],
+["rhs_weap_m38_rail", ["SniperRifles","Weapons"]],
+["rhs_weap_mosin_sbr", ["SniperRifles","Weapons"]],
+["rhs_weap_mg42", ["MachineGuns","Weapons"]],
+["rhs_weap_Izh18", ["Shotguns","Weapons"]],
+
+["rhs_weap_M320", ["GrenadeLaunchers","Weapons"]],
+["rhs_weap_m27iar", ["MachineGuns","Weapons"]],
+["rhs_weap_m27iar_grip", ["MachineGuns","Weapons"]],
+["rhs_weap_m32", ["GrenadeLaunchers","Weapons"]],
+["rhs_weap_m79", ["GrenadeLaunchers","Weapons"]],
+
+["UK3CB_Enfield", ["SniperRifles","Weapons"]],
+["UK3CB_Enfield_rail", ["SniperRifles","Weapons"]],
+["UK3CB_M14DMR", ["SniperRifles","Weapons"]],
+["UK3CB_M21", ["SniperRifles","Weapons"]],
+["UK3CB_SVD_OLD", ["SniperRifles","Weapons"]],
+["UK3CB_M16A1_LSW", ["MachineGuns","Weapons"]],
+
+["UK3CB_BAF_Javelin_CLU", ["Binoculars","Items"]],
+["UK3CB_BAF_Javelin_Slung_Tube", ["MissileLaunchers","Weapons","AT"]],
+["UK3CB_M79", ["GrenadeLaunchers","Weapons"]],
+["UK3CB_BAF_AT4_CS_AT_Launcher", ["RocketLaunchers","Weapons","AT"]],
+["UK3CB_BAF_AT4_CS_AP_Launcher", ["RocketLaunchers","Weapons","AT"]],
+
+["launch_NLAW_F", ["MissileLaunchers","Weapons","AT"]],
+
+["UK3CB_BAF_L86A2", ["MachineGuns","Weapons"]],
+["UK3CB_BAF_L86A3", ["MachineGuns","Weapons"]],
+
+["UK3CB_BAF_Tripod", ["StaticWeaponParts","Items"]],
+["UK3CB_BAF_L16_Tripod", ["StaticWeaponParts","Items"]],
+["UK3CB_BAF_L111A1", ["StaticWeaponParts","Items"]],
+["UK3CB_BAF_L134A1", ["StaticWeaponParts","Items"]],
+["UK3CB_BAF_L16", ["StaticWeaponParts","Items"]],
+["UK3CB_BAF_M6", ["StaticWeaponParts","Items"]],
+
+["UK3CB_M14_Rail", ["SniperRifles","Weapons"]],
+["UK3CB_M21_Bipod_Railed", ["SniperRifles","Weapons"]],
+["UK3CB_M14DMR_Railed", ["SniperRifles","Weapons"]],
+
+["ace_csw_m3CarryTripod", ["StaticWeaponParts","Items"]],
+["ace_csw_m3CarryTripodLow", ["StaticWeaponParts","Items"]],
+["ace_csw_kordCarryTripod", ["StaticWeaponParts","Items"]],
+["ace_csw_kordCarryTripodLow", ["StaticWeaponParts","Items"]],
+["ace_csw_m220CarryTripod", ["StaticWeaponParts","Items"]],
+["ace_csw_spg9CarryTripod", ["StaticWeaponParts","Items"]],
+["ace_csw_sag30CarryTripod", ["StaticWeaponParts","Items"]],
+["ace_csw_carryMortarBaseplate", ["StaticWeaponParts","Items"]],
+["ace_csw_staticATCarry", ["StaticWeaponParts","Items"]],
+["ace_csw_staticAACarry", ["StaticWeaponParts","Items"]],
+["ace_csw_staticHMGCarry", ["StaticWeaponParts","Items"]],
+["ace_csw_staticGMGCarry", ["StaticWeaponParts","Items"]],
+["ace_csw_staticMortarCarry", ["StaticWeaponParts","Items"]],
+
+["ace_compat_rhs_afrf3_2b14_carry", ["StaticWeaponParts","Items"]],
+["ace_compat_rhs_afrf3_nsv_carry" , ["StaticWeaponParts","Items"]],
+["ace_compat_rhs_afrf3_kord_carry" , ["StaticWeaponParts","Items"]],
+["ace_compat_rhs_afrf3_ags30_carry" , ["StaticWeaponParts","Items"]],
+["ace_compat_rhs_afrf3_spg9_carry" , ["StaticWeaponParts","Items"]],
+["ace_compat_rhs_afrf3_spg9m_carry" , ["StaticWeaponParts","Items"]],
+["ace_compat_rhs_afrf3_metis_carry" , ["StaticWeaponParts","Items"]],
+["ace_compat_rhs_afrf3_kornet_carry" , ["StaticWeaponParts","Items"]],
+["ace_compat_rhs_usf3_m252_carry" , ["StaticWeaponParts","Items"]],
+["ace_compat_rhs_usf3_m2_carry" , ["StaticWeaponParts","Items"]],
+["ace_compat_rhs_usf3_mk19_carry" , ["StaticWeaponParts","Items"]],
+["ace_compat_rhs_usf3_tow_carry" , ["StaticWeaponParts","Items"]],
+["ace_compat_rhs_gref3_dshkm_carry" , ["StaticWeaponParts","Items"]],
+
+["ace_dragon_super", ["MissileLaunchers","Weapons","AT"]],
+["ace_dragon_sight", ["Binoculars","Items"]]	];
+
+categoryOverrides = (group timer) createUnit ["logic", [0, 0], [], 0, "NONE"];
+{
+	categoryOverrides setVariable [_x select 0, _x select 1];
+} forEach _categoryOverrideTable;
+
+

--- a/A3-Antistasi/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_categoryOverrides.sqf
@@ -97,7 +97,34 @@ private _categoryOverrideTable = [
 ["ace_compat_rhs_gref3_dshkm_carry" , ["StaticWeaponParts","Items"]],
 
 ["ace_dragon_super", ["MissileLaunchers","Weapons","AT"]],
-["ace_dragon_sight", ["Binoculars","Items"]]	];
+["ace_dragon_sight", ["Binoculars","Items"]],
+
+["LIB_PTRD", ["Unknown", "Weapons"]],
+["LIB_M2_Flamethrower", ["Unknown", "Weapons"]],			// don't want these two being chosen randomly by AIs
+["LIB_Bagpipes", ["Unknown","Weapons"]],					// wat
+
+["LIB_M2_Tripod", ["StaticWeaponParts","Items"]],
+["LIB_Laffete_Tripod", ["StaticWeaponParts","Items"]],
+["LIB_BM37_Tripod", ["StaticWeaponParts","Items"]],
+["LIB_BM37_Barrel", ["StaticWeaponParts","Items"]],
+["LIB_GrWr34_Tripod", ["StaticWeaponParts","Items"]],
+["LIB_GrWr34_Tripod_g", ["StaticWeaponParts","Items"]],
+["LIB_GrWr34_Barrel", ["StaticWeaponParts","Items"]],
+["LIB_GrWr34_Barrel_g", ["StaticWeaponParts","Items"]],
+["LIB_M2_60_Tripod", ["StaticWeaponParts","Items"]],
+["LIB_M2_60_Barrel", ["StaticWeaponParts","Items"]]   ];
+
+/* Not sure if these are a problem
+["LIB_GER_Headset",["NVGs","Items"]],
+["LIB_Headwrap",["NVGs","Items"]],
+["LIB_Headwrap_gloves",["NVGs","Items"]],
+["LIB_Mohawk",["NVGs","Items"]],
+["LIB_GER_Gloves1",["NVGs","Items"]],
+["LIB_GER_Gloves2",["NVGs","Items"]],
+["LIB_GER_Gloves3",["NVGs","Items"]],
+["LIB_GER_Gloves4",["NVGs","Items"]],
+["LIB_GER_Gloves5",["NVGs","Items"]],
+*/
 
 categoryOverrides = (group timer) createUnit ["logic", [0, 0], [], 0, "NONE"];
 {

--- a/A3-Antistasi/functions/Ammunition/fn_equipmentClassToCategories.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentClassToCategories.sqf
@@ -10,6 +10,10 @@
 
 params ["_className"];
 
+// First check if the item has hardcoded categories
+private _categories = categoryOverrides getVariable [_className, []];
+if (count _categories > 0) exitWith { _categories };
+
 private _itemType = [_className] call A3A_fnc_itemType;
 
 private _baseCategory =	switch (_itemType select 1) do
@@ -76,8 +80,6 @@ private _baseCategory =	switch (_itemType select 1) do
 
 		default {"Unknown"};
 	};
-
-private _categories = [];
 
 if (_baseCategory != "") then { _categories pushBack _baseCategory};
 

--- a/A3-Antistasi/functions/Ammunition/fn_randomRifle.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_randomRifle.sqf
@@ -6,6 +6,8 @@ if (_pool isEqualTo []) then {
 	} else {
 		if !(unlockedSMGs isEqualTo []) then {
 			_pool = unlockedSMGs;
+		} else {
+			_pool = unlockedShotguns + unlockedSniperRifles;
 		};
 	};
 };

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -542,6 +542,8 @@ DECLARE_SERVER_VAR(sniperGroups, _sniperGroups);
 //This is all very tightly coupled.
 //Beware when changing these, or doing anything with them, really.
 
+[2,"Initializing hardcoded categories",_fileName] call A3A_fnc_log;
+[] call A3A_fnc_categoryOverrides;
 [2,"Scanning config entries for items",_fileName] call A3A_fnc_log;
 [A3A_fnc_equipmentIsValidForCurrentModset] call A3A_fnc_configSort;
 [2,"Categorizing vehicle classes",_fileName] call A3A_fnc_log;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Enhancement

### What have you changed and why?
This is an example method of adding manual overrides for items that are mis-categorized by mods. From a design perspective it may be preferable to put the table somewhere more obviously editable, or split it into chunks. It may be partially or wholly obsoleted depending on how the template system is implemented.

Table should currently include almost all miscategorized ACE, RHS and 3CB gear. IFA needs to be done. Some debatable decisions:

1. LSWs classified as MGs. Maybe a bit weedy.
2. Marksman rifles (eg M14 DMR) classified as sniper rifles, but battle rifles (eg M14) classified as rifles. Enfield & Kar98 classified as sniper rifles, because you wouldn't want your AI riflemen using them by choice.
3. Missile launchers classified by their primary purpose. Doesn't actually matter atm unless you enable unlockable missile launchers, because it's only used to decide what your AT and AA rebel AIs pick.
4. ACE static weapon parts get a new category so that they don't stomp all over the rocket launchers. Should probably be added to loot crates & public variables.

At least some of the "unknown" ACE items should be given a category and/or included in loot crates. Haven't decided what to do with those yet. List here: https://pastebin.com/p9sEpKRX

### Please specify which Issue this PR Resolves.
closes #491, #651 when IFA stuff is added. Plus several other undocumented issues like ACE static weapon bags dominating the rocket launcher category, 3CB Javelin and PCML being unlockable etc. 

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Comments requested.