### PR TITLE
Make petros movable, fix several petros bugs

### DIFF
--- a/A3-Antistasi/functions/Base/fn_buildHQ.sqf
+++ b/A3-Antistasi/functions/Base/fn_buildHQ.sqf
@@ -1,12 +1,11 @@
 private ["_pos","_rnd","_posFire"];
 _movedX = false;
 if (petros != (leader group petros)) then
-	{
-	groupPetros = createGroup teamPlayer;
-	publicVariable "groupPetros";
-	[petros] join groupPetros;
-	groupPetros selectLeader petros;
-	};
+{
+	private _groupPetros = createGroup teamPlayer;
+	[petros] join _groupPetros;
+	_groupPetros selectLeader petros;
+};
 [petros,"remove"] remoteExec ["A3A_fnc_flagaction",0,petros];
 petros switchAction "PlayerStand";
 petros disableAI "MOVE";

--- a/A3-Antistasi/functions/Base/fn_createPetros.sqf
+++ b/A3-Antistasi/functions/Base/fn_createPetros.sqf
@@ -16,7 +16,7 @@ private _position = if (count _location > 0) then {
 	};
 };
 
-petros = groupPetros createUnit [typePetros, _position, [], 10, "NONE"];
+petros = _groupPetros createUnit [typePetros, _position, [], 10, "NONE"];
 publicVariable "petros";
 
 deleteVehicle _oldPetros;		// Petros should now be leader unless there's a player in the group

--- a/A3-Antistasi/functions/Base/fn_createPetros.sqf
+++ b/A3-Antistasi/functions/Base/fn_createPetros.sqf
@@ -1,9 +1,10 @@
 params [["_location", []]];
 
-_oldPetros = if (isNil "petros") then {objNull}	else {petros};
+private _oldPetros = if (isNil "petros") then {objNull} else {petros};
+private _groupPetros = if (!isNull _oldPetros && {side group _oldPetros == teamPlayer}) then {group _oldPetros} else {createGroup teamPlayer};
 
-groupPetros = if (! isNull _oldPetros && {side group _oldPetros == teamPlayer}) then {group _oldPetros} else {createGroup teamPlayer};
-publicVariable "groupPetros";
+// Hack-fix for bugged case where petros is killed by enemy while being moved
+if (count _location > 0 && count units _groupPetros > 1) then { _groupPetros = createGroup teamPlayer };
 
 private _position = if (count _location > 0) then {
 	_location
@@ -18,20 +19,20 @@ private _position = if (count _location > 0) then {
 petros = groupPetros createUnit [typePetros, _position, [], 10, "NONE"];
 publicVariable "petros";
 
-groupPetros setGroupIdGlobal ["Petros","GroupColor4"];
-petros setIdentity "friendlyX";
+deleteVehicle _oldPetros;		// Petros should now be leader unless there's a player in the group
 
-if (worldName == "Tanoa") then {petros setName "Maru"} else {petros setName "Petros"};
+private _name = if (worldName == "Tanoa") then {"Maru"} else {"Petros"};
+[petros, "friendlyX"] remoteExec ["setIdentity", 0];
+[petros, _name] remoteExec ["setName", 0];
 
-petros disableAI "MOVE";
-petros disableAI "AUTOTARGET";
-
-if (petros == leader groupPetros) then {
-	[Petros,"mission"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],petros]
+if (petros == leader _groupPetros) then {
+	_groupPetros setGroupIdGlobal ["Petros","GroupColor4"];
+	petros disableAI "MOVE";
+	petros disableAI "AUTOTARGET";
+	petros setBehaviour "SAFE";
+	[Petros,"mission"] remoteExec ["A3A_fnc_flagaction",0]
 } else {
-	[Petros,"buildHQ"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],petros]
+	[Petros,"buildHQ"] remoteExec ["A3A_fnc_flagaction",0]
 };
 
 call A3A_fnc_initPetros;
-
-deleteVehicle _oldPetros;

--- a/A3-Antistasi/functions/Base/fn_flagaction.sqf
+++ b/A3-Antistasi/functions/Base/fn_flagaction.sqf
@@ -20,6 +20,7 @@ switch _typeX do
 	case "mission": {
 		petros addAction ["Mission Request", {CreateDialog "mission_menu";},nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull]) and ([_this] call A3A_fnc_isMember) and (petros == leader group petros)",4];
 		petros addAction ["HQ Management", A3A_fnc_dialogHQ,nil,0,false,true,"","(_this == theBoss) and (petros == leader group petros)", 4];
+		petros addAction ["Move this asset", A3A_fnc_moveHQObject,nil,0,false,true,"","(_this == theBoss)"];
 	};
 	case "truckX": {actionX = _flag addAction ["<t>Transfer Ammobox to Truck<t> <img image='\A3\ui_f\data\igui\cfg\actions\unloadVehicle_ca.paa' size='1.8' shadow=2 />", A3A_fnc_transfer,nil,6,true,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull])"]};
 	//case "heal": {if (player != _flag) then {_flag addAction [format ["Revive %1",name _flag], { _this spawn A3A_fnc_actionRevive; },nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull])"]}};

--- a/A3-Antistasi/functions/Base/fn_initPetros.sqf
+++ b/A3-Antistasi/functions/Base/fn_initPetros.sqf
@@ -6,7 +6,8 @@ removeGoggles petros;
 petros setSkill 1;
 petros setVariable ["respawning",false];
 petros allowDamage false;
-[petros,(selectRandom unlockedRifles), 8, 0] call BIS_fnc_addWeapon;
+
+[petros,unlockedRifles] call A3A_fnc_randomRifle;
 petros selectWeapon (primaryWeapon petros);
 petros addEventHandler
 [

--- a/A3-Antistasi/functions/Base/fn_moveHQ.sqf
+++ b/A3-Antistasi/functions/Base/fn_moveHQ.sqf
@@ -2,6 +2,8 @@ if (player != theBoss) exitWith {hint "Only our Commander has access to this fun
 
 if ((count weaponCargo boxX >0) or (count magazineCargo boxX >0) or (count itemCargo boxX >0) or (count backpackCargo boxX >0)) exitWith {hint "You must first empty your Ammobox in order to move the HQ"};
 
+if !(isNull attachedTo petros) then { detach petros };		// in case someone is moving him
+
 petros enableAI "MOVE";
 petros enableAI "AUTOTARGET";
 

--- a/A3-Antistasi/functions/Base/fn_moveHQ.sqf
+++ b/A3-Antistasi/functions/Base/fn_moveHQ.sqf
@@ -9,7 +9,9 @@ petros enableAI "AUTOTARGET";
 
 [petros,"remove"] remoteExec ["A3A_fnc_flagaction",0,petros];
 //removeAllActions petros;
+private _groupPetros = group petros;
 [petros] join theBoss;
+deleteGroup _groupPetros;
 petros setBehaviour "AWARE";
 if (isMultiplayer) then
 	{

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -473,13 +473,15 @@ mapX addAction ["Map Info", A3A_fnc_cityinfo,nil,0,false,true,"","(isPlayer _thi
 mapX addAction ["Move this asset", A3A_fnc_moveHQObject,nil,0,false,true,"","(_this == theBoss)", 4];
 if (isMultiplayer) then {mapX addAction ["AI Load Info", { [] remoteExec ["A3A_fnc_AILoadInfo",4];},nil,0,false,true,"","((_this == theBoss) || (serverCommandAvailable ""#logout""))"]};
 _nul = [player] execVM "OrgPlayers\unitTraits.sqf";
-groupPetros = group petros;
-groupPetros setGroupIdGlobal ["Petros","GroupColor4"];
+
+// only add petros actions if he's static
+if (petros == leader group petros) then {
+	group petros setGroupId ["Petros","GroupColor4"];
+	[petros,"remove"] call A3A_fnc_flagaction;		// in case we already created them in initserver
+	[petros,"mission"] call A3A_fnc_flagaction;
+};
 petros setIdentity "friendlyX";
-petros setName "Petros";
-petros disableAI "MOVE";
-petros disableAI "AUTOTARGET";
-[petros,"mission"] call A3A_fnc_flagaction;
+if (worldName == "Tanoa") then {petros setName "Maru"} else {petros setName "Petros"};
 
 disableSerialization;
 //1 cutRsc ["H8erHUD","PLAIN",0,false];


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Enhancement

### What have you changed and why?
- Made petros movable, like the other HQ objects. The original moving code was actually solid and didn't need much work.
- Fixed a bug where Petros would still be in the boss's group after death & placement.
- Fixed a bug where Petros would have "build HQ" incorrectly in the action menu.
- Fixed a bug where Petros could have duplicate action menu entries.
- Fixed a bug where Petros would lose his identity on DS clients after death.

The HQ management code is quite spaghetti and could probably do with a refactor, but it was just about fixable as-is, so I left the structure alone.

Currently it doesn't save or load Petros's position, but that doesn't really matter when it's so easy to move him around.

### Please specify which Issue this PR Resolves.
closes #769 and #644 

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the Mission in Singleplayer?
2. [X] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

