### PR TITLE
Fix negative laptop search time diff

### DIFF
--- a/A3-Antistasi/functions/Intel/fn_searchIntelOnLaptop.sqf
+++ b/A3-Antistasi/functions/Intel/fn_searchIntelOnLaptop.sqf
@@ -112,7 +112,7 @@ while {_pointSum <= _neededPoints} do
 {
 
     sleep 1;
-    _timeDiff = (_lastTime - time);
+    _timeDiff = (time - _lastTime) max 1;		// unclear whether time is monotonic, so cap to minimum 1
     _lastTime = time;
 
     //Checking for players in range


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Fixes a bug where the timeDiff calculation was reversed in the laptop search loop, causing the completion percentage to count backwards.

Also ensured that the diff value is at least 1 second, just in case `time` doesn't behave nicely in some situations. Documentation is insufficient to know whether it's necessary, but it won't hurt.

### Please specify which Issue this PR Resolves.
Quick fix for testing bug report.

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
