### PR TITLE
Fix picture endings for intel laptops

### DIFF
--- a/A3-Antistasi/functions/Intel/fn_searchIntelOnLaptop.sqf
+++ b/A3-Antistasi/functions/Intel/fn_searchIntelOnLaptop.sqf
@@ -246,7 +246,7 @@ _intel setVariable ["ActionNeeded", nil, true];
 
 if(_pointSum >= _neededPoints) then
 {
-    _intel setObjectTextureGlobal [0, "Pictures\laptop_completed.paa"];
+    _intel setObjectTextureGlobal [0, "Pictures\laptop_complete.paa"];
     {
         [petros,"hint","You managed to download the intel!"] remoteExec ["A3A_fnc_commsMP",_x];
         [10,_x] call A3A_fnc_playerScoreAdd;
@@ -257,6 +257,7 @@ if(_pointSum >= _neededPoints) then
 else
 {
     //Players failed to retrieve the intel
+    _intel setObjectTextureGlobal [0, "a3\structures_f\items\electronics\data\electronics_screens_laptop_co.paa"];
     _intel remoteExec ["removeAllActions", [teamPlayer, civilian], _intel];
     [_intel, "Intel_Large"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian], _intel];
 };

--- a/A3-Antistasi/functions/Intel/fn_searchIntelOnLaptop.sqf
+++ b/A3-Antistasi/functions/Intel/fn_searchIntelOnLaptop.sqf
@@ -17,7 +17,7 @@ private _bomb = _intel getVariable ["trapBomb", objNull];
 private _isTrap = !(isNull _bomb);
 if(_isTrap) exitWith
 {
-    _intel setObjectTextureGlobal [0, "Pictures\laptop_die.jpg"];
+    _intel setObjectTextureGlobal [0, "Pictures\laptop_die.paa"];
     {
         [petros,"hint","The screen says:\nPrepare to die!"] remoteExec ["A3A_fnc_commsMP",_x];
     } forEach ([50,0,_intel,teamPlayer] call A3A_fnc_distanceUnits);
@@ -105,7 +105,7 @@ if(!(_attack == "No")) then
 _intel setVariable ["ActionNeeded", false, true];
 ["", 0, 0] params ["_errorText", "_errorChance", "_enemyCounter"];
 
-_intel setObjectTextureGlobal [0, "Pictures\laptop_downloading.jpg"];
+_intel setObjectTextureGlobal [0, "Pictures\laptop_downloading.paa"];
 private _lastTime = time;
 private _timeDiff = 0;
 while {_pointSum <= _neededPoints} do
@@ -184,7 +184,7 @@ while {_pointSum <= _neededPoints} do
                     _picturePath = "error6";
                 };
             };
-            _picturePath = format ["Pictures\laptop_%1.jpg", _picturePath];
+            _picturePath = format ["Pictures\laptop_%1.paa", _picturePath];
             _intel setObjectTextureGlobal [0, _picturePath];
             [
                 _intel,
@@ -193,7 +193,7 @@ while {_pointSum <= _neededPoints} do
                     {
                         (_this select 0) setVariable ["ActionNeeded", false, true];
                         (_this select 0) removeAction (_this select 2);
-                        (_this select 0) setObjectTextureGlobal [0, "Pictures\laptop_downloading.jpg"];
+                        (_this select 0) setObjectTextureGlobal [0, "Pictures\laptop_downloading.paa"];
                     },nil,4,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull])",4
                 ]
             ] remoteExec ["addAction", [teamPlayer, civilian], _intel];
@@ -246,7 +246,7 @@ _intel setVariable ["ActionNeeded", nil, true];
 
 if(_pointSum >= _neededPoints) then
 {
-    _intel setObjectTextureGlobal [0, "Pictures\laptop_completed.jpg"];
+    _intel setObjectTextureGlobal [0, "Pictures\laptop_completed.paa"];
     {
         [petros,"hint","You managed to download the intel!"] remoteExec ["A3A_fnc_commsMP",_x];
         [10,_x] call A3A_fnc_playerScoreAdd;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Information:
- Fixed the ending of pictures from .jpg to .paa
- Fixed a typo in the path of the complete.paa picture
- Reset the texture to the default one, if the players fail to download it

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:
