### PR TITLE
[Save/Load] Changed how vehicle re-spawn orientation is handled to avoid clipping

### DIFF
--- a/A3-Antistasi/statSave/saveFuncs.sqf
+++ b/A3-Antistasi/statSave/saveFuncs.sqf
@@ -329,11 +329,19 @@ fn_SetStat = {
 			for "_i" from 0 to (count _varvalue) - 1 do {
 				_typeVehX = _varvalue select _i select 0;
 				_posVeh = _varvalue select _i select 1;
-				_dirVeh = _varvalue select _i select 2;
-				_veh = createVehicle [_typeVehX,[0,0,1000],[],0,"NONE"];
-				_veh setDir _dirVeh;_veh setDir _dirVeh;
-				_veh setVectorUp surfaceNormal (_posVeh);
-				_veh setPosATL _posVeh;
+				_xVectorUp = _varvalue select _i select 2;
+				_xVectorDir = _varvalue select _i select 3;
+				private _veh = createVehicle [_typeVehX,[0,0,1000],[],0,"NONE"];
+				// This is only here to handle old save states. Could be removed after a few version itterations. -Hazey
+				if ((_varvalue select _i select 2) isEqualType 0) then { // We have to check number because old save state might still be using getDir. -Hazey
+					_dirVeh = _varvalue select _i select 2;
+					_veh setDir _dirVeh;
+					_veh setVectorUp surfaceNormal (_posVeh);
+					_veh setPosATL _posVeh;
+				} else {
+					_veh setPosATL _posVeh;
+					_veh setVectorDirAndUp [_xVectorDir,_xVectorUp];
+				};
 				if ((_veh isKindOf "StaticWeapon") or (_veh isKindOf "Building")) then {
 					staticsToSave pushBack _veh;
 				};

--- a/A3-Antistasi/statSave/saveLoop.sqf
+++ b/A3-Antistasi/statSave/saveLoop.sqf
@@ -85,8 +85,9 @@ _arrayEst = [];
 	if ((_veh distance getMarkerPos respawnTeamPlayer < 50) and !(_veh in staticsToSave) and !(_typeVehX in ["ACE_SandbagObject","Land_PaperBox_01_open_boxes_F","Land_PaperBox_01_open_empty_F"])) then {
 		if (((not (_veh isKindOf "StaticWeapon")) and (not (_veh isKindOf "ReammoBox")) and (not (_veh isKindOf "ReammoBox_F")) and (not (_veh isKindOf "FlagCarrier")) and (not(_veh isKindOf "Building"))) and (not (_typeVehX == "C_Van_01_box_F")) and (count attachedObjects _veh == 0) and (alive _veh) and ({(alive _x) and (!isPlayer _x)} count crew _veh == 0) and (not(_typeVehX == "WeaponHolderSimulated"))) then {
 			_posVeh = getPos _veh;
-			_dirVeh = getDir _veh;
-			_arrayEst pushBack [_typeVehX,_posVeh,_dirVeh];
+			_xVectorUp = vectorUp _veh;
+			_xVectorDir = vectorDir _veh;
+			_arrayEst pushBack [_typeVehX,_posVeh,_xVectorUp,_xVectorDir];
 		};
 	};
 } forEach vehicles - [boxX,flagX,fireX,vehicleBox,mapX];


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [x] Enhancement

### What have you changed and why?
Information: 

Vehicles now take into account its direction and rotation. This will help make sure vehicles don't explode if parked on another object.

### Please specify which Issue this PR Resolves.
closes #804

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the Mission in Singleplayer?
2. [x] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes (Please provide further detail below.)

********************************************************
Notes:
Park vehicle on a brick wall or in a weird position. 
Save and reload.
Vehicle should spawn back in position without exploding. (should...)