### PR TITLE
3CB Loadouts + small PVP Fixes.

### DIFF
--- a/A3-Antistasi/Templates/BAF_Occ_BAF_Arid.sqf
+++ b/A3-Antistasi/Templates/BAF_Occ_BAF_Arid.sqf
@@ -28,21 +28,21 @@ NATOAmmobox = "B_supplyCrate_F";
 //PvP Loadouts
 NATOPlayerLoadouts = [
 	//Team Leader
-	"UK3CB_BAF_SC_DDPM_REC",
+	["3CB_BAF_Teamleader_MTP"] call A3A_fnc_getLoadout,
 	//Medic
-	"UK3CB_BAF_Medic_DDPM_REC",
+	["3CB_BAF_Medic_MTP"] call A3A_fnc_getLoadout,
 	//Autorifleman
-	"UK3CB_BAF_MGLMG_DDPM_REC",
+	["3CB_BAF_MachineGunner_MTP"] call A3A_fnc_getLoadout,
 	//Marksman
-	"UK3CB_BAF_Marksman_DDPM_REC",
+	["3CB_BAF_Marksman_MTP"] call A3A_fnc_getLoadout,
 	//Anti-tank Scout
-	"UK3CB_BAF_Explosive_DDPM_REC",
+	["3CB_BAF_AT_MTP"] call A3A_fnc_getLoadout,
 	//AT2
-	"UK3CB_BAF_FAC_DDPM_REC"
+	["3CB_BAF_AT2_MTP"] call A3A_fnc_getLoadout
 ];
 
 //PVP Player Vehicles
-vehNATOPVP = ["UK3CB_BAF_MAN_HX60_Container_Servicing_Air_Sand","UK3CB_BAF_LandRover_Hard_FFR_Sand_A_DDPM","UK3CB_BAF_LandRover_Snatch_FFR_Sand_A_DDPM","UK3CB_BAF_LandRover_Soft_FFR_Sand_A_DDPM","UK3CB_BAF_LandRover_WMIK_HMG_FFR_Sand_A_DDPM"];
+vehNATOPVP = ["UK3CB_BAF_LandRover_Hard_FFR_Sand_A_DDPM","UK3CB_BAF_LandRover_Snatch_FFR_Sand_A_DDPM","UK3CB_BAF_LandRover_Soft_FFR_Sand_A_DDPM","UK3CB_BAF_LandRover_WMIK_HMG_FFR_Sand_A_DDPM"];
 
 ////////////////////////////////////
 //             UNITS             ///

--- a/A3-Antistasi/Templates/BAF_Occ_BAF_Trop.sqf
+++ b/A3-Antistasi/Templates/BAF_Occ_BAF_Trop.sqf
@@ -26,21 +26,21 @@ NATOAmmobox = "B_supplyCrate_F";
 //PvP Loadouts
 NATOPlayerLoadouts = [
 	//Team Leader
-	["vanilla_blufor_teamLeader"] call A3A_fnc_getLoadout,
+	["3CB_BAF_Teamleader_MTP"] call A3A_fnc_getLoadout,
 	//Medic
-	["vanilla_blufor_medic"] call A3A_fnc_getLoadout,
+	["3CB_BAF_Medic_MTP"] call A3A_fnc_getLoadout,
 	//Autorifleman
-	["vanilla_blufor_machineGunner"] call A3A_fnc_getLoadout,
+	["3CB_BAF_MachineGunner_MTP"] call A3A_fnc_getLoadout,
 	//Marksman
-	["vanilla_blufor_marksman"] call A3A_fnc_getLoadout,
+	["3CB_BAF_Marksman_MTP"] call A3A_fnc_getLoadout,
 	//Anti-tank Scout
-	["vanilla_blufor_AT"] call A3A_fnc_getLoadout,
+	["3CB_BAF_AT_MTP"] call A3A_fnc_getLoadout,
 	//AT2
-	["vanilla_blufor_rifleman"] call A3A_fnc_getLoadout
+	["3CB_BAF_AT2_MTP"] call A3A_fnc_getLoadout
 ];
 
 //PVP Player Vehicles
-vehNATOPVP = ["B_T_MRAP_01_F","B_MRAP_01_hmg_F"];
+vehNATOPVP = ["UK3CB_BAF_LandRover_Hard_FFR_Green_A_MTP","UK3CB_BAF_LandRover_Snatch_FFR_Green_A_MTP","UK3CB_BAF_LandRover_Soft_FFR_Green_A_MTP","UK3CB_BAF_LandRover_WMIK_HMG_FFR_Green_A_MTP"];
 
 ////////////////////////////////////
 //             UNITS             ///

--- a/A3-Antistasi/Templates/Loadouts/3CB_BAF_AT2_MTP.sqf
+++ b/A3-Antistasi/Templates/Loadouts/3CB_BAF_AT2_MTP.sqf
@@ -1,0 +1,81 @@
+[//Loadout
+[//Primary Weapon
+"UK3CB_BAF_L85A3",									//Weapon
+"UK3CB_BAF_SFFH",													//Muzzle     //Flashhider
+"UK3CB_BAF_LLM_Flashlight_Black",													//Rail
+"RKSL_optic_EOT552_C",													//Sight
+["UK3CB_BAF_556_30Rnd",30],		//Primary Magazine
+[],													//Secondary Magazine
+"UK3CB_underbarrel_acc_grippod_t"													//Bipod
+],
+
+[//Launcher
+"UK3CB_BAF_AT4_CS_AP_Launcher",									//Weapon
+"",													//Muzzle
+"",													//Rail
+"",													//Sight
+["UK3CB_BAF_AT4_CS_AP_Mag",1],		//Primary Magazine
+[],													//Secondary Magazine
+""													//Bipod
+],
+
+[//Secondary Weapon
+"UK3CB_BAF_L131A1",								//Weapon
+"",					//Muzzle
+"UK3CB_BAF_Flashlight_L131A1",																//Rail
+"",																//Sight
+["UK3CB_BAF_9_17Rnd",17],			//Primary Magazine
+[],																//Secondary Magazine
+""																//Bipod
+],
+
+[//Uniform
+"UK3CB_BAF_U_CombatUniform_MTP_RM",								//Uniform
+[//Inventory
+ + _basicMedicalSupplies
+ + _basicMiscItems
+]
+],
+
+[//Vest
+"UK3CB_BAF_V_Osprey_Rifleman_D",
+[//Inventory
+["UK3CB_BAF_HMNVS",1],
+["UK3CB_BAF_SmokeShell",2,1],
+["HandGrenade",1,1],
+["UK3CB_BAF_9_17Rnd",1,17],
+["UK3CB_BAF_556_30Rnd",4,30]
+]
++ _aceFlashlight
++ _aceM84
+],
+
+[//Backpack
+"UK3CB_BAF_B_Bergen_MTP_Sapper_L_A",						//Backpack
+[//Inventory
+[]
+]
+],
+
+"UK3CB_BAF_H_Mk7_Camo_ESS_D",				//Headgear
+"UK3CB_BAF_G_Tactical_Grey",       						  //Facewear
+
+[//Binocular
+"Binocular",					//Binocular
+"",
+"",
+"",
+[],
+[],
+""
+],
+
+[//Item
+"ItemMap",											//Map
+"",													//Terminal
+["TF_RF7800STR"] call _fnc_tfarRadio,				//Radio
+"ItemCompass",										//Compass
+_tfarMicroDAGRNoArray,										//Watch
+""													//Goggles
+]
+];

--- a/A3-Antistasi/Templates/Loadouts/3CB_BAF_AT2_MTP.sqf
+++ b/A3-Antistasi/Templates/Loadouts/3CB_BAF_AT2_MTP.sqf
@@ -10,11 +10,11 @@
 ],
 
 [//Launcher
-"UK3CB_BAF_AT4_CS_AP_Launcher",									//Weapon
+"UK3CB_BAF_NLAW_Launcher",									//Weapon
 "",													//Muzzle
 "",													//Rail
 "",													//Sight
-["UK3CB_BAF_AT4_CS_AP_Mag",1],		//Primary Magazine
+[],		//Primary Magazine
 [],													//Secondary Magazine
 ""													//Bipod
 ],

--- a/A3-Antistasi/Templates/Loadouts/3CB_BAF_AT_MTP.sqf
+++ b/A3-Antistasi/Templates/Loadouts/3CB_BAF_AT_MTP.sqf
@@ -1,0 +1,81 @@
+[//Loadout
+[//Primary Weapon
+"UK3CB_BAF_L85A3",									//Weapon
+"UK3CB_BAF_SFFH",													//Muzzle     //Flashhider
+"UK3CB_BAF_LLM_Flashlight_Black",													//Rail
+"RKSL_optic_EOT552_C",													//Sight
+["UK3CB_BAF_556_30Rnd",30],		//Primary Magazine
+[],													//Secondary Magazine
+"UK3CB_underbarrel_acc_grippod_t"													//Bipod
+],
+
+[//Launcher
+"UK3CB_BAF_AT4_CS_AP_Launcher",									//Weapon
+"",													//Muzzle
+"",													//Rail
+"",													//Sight
+["UK3CB_BAF_AT4_CS_AP_Mag",1],		//Primary Magazine
+[],													//Secondary Magazine
+""													//Bipod
+],
+
+[//Secondary Weapon
+"UK3CB_BAF_L131A1",								//Weapon
+"",					//Muzzle
+"UK3CB_BAF_Flashlight_L131A1",																//Rail
+"",																//Sight
+["UK3CB_BAF_9_17Rnd",17],			//Primary Magazine
+[],																//Secondary Magazine
+""																//Bipod
+],
+
+[//Uniform
+"UK3CB_BAF_U_CombatUniform_MTP_RM",								//Uniform
+[//Inventory
+ + _basicMedicalSupplies
+ + _basicMiscItems
+]
+],
+
+[//Vest
+"UK3CB_BAF_V_Osprey_Rifleman_D",
+[//Inventory
+["UK3CB_BAF_HMNVS",1],
+["UK3CB_BAF_SmokeShell",2,1],
+["HandGrenade",1,1],
+["UK3CB_BAF_9_17Rnd",1,17],
+["UK3CB_BAF_556_30Rnd",4,30]
+]
++ _aceFlashlight
++ _aceM84
+],
+
+[//Backpack
+"UK3CB_BAF_B_Bergen_MTP_Sapper_L_A",						//Backpack
+[//Inventory
+[]
+]
+],
+
+"UK3CB_BAF_H_Mk7_Camo_ESS_D",				//Headgear
+"UK3CB_BAF_G_Tactical_Grey",       						  //Facewear
+
+[//Binocular
+"Binocular",					//Binocular
+"",
+"",
+"",
+[],
+[],
+""
+],
+
+[//Item
+"ItemMap",											//Map
+"",													//Terminal
+["TF_RF7800STR"] call _fnc_tfarRadio,				//Radio
+"ItemCompass",										//Compass
+_tfarMicroDAGRNoArray,										//Watch
+""													//Goggles
+]
+];

--- a/A3-Antistasi/Templates/Loadouts/3CB_BAF_AT_MTP.sqf
+++ b/A3-Antistasi/Templates/Loadouts/3CB_BAF_AT_MTP.sqf
@@ -10,11 +10,11 @@
 ],
 
 [//Launcher
-"UK3CB_BAF_AT4_CS_AP_Launcher",									//Weapon
+"UK3CB_BAF_NLAW_Launcher",									//Weapon
 "",													//Muzzle
 "",													//Rail
 "",													//Sight
-["UK3CB_BAF_AT4_CS_AP_Mag",1],		//Primary Magazine
+[],		//Primary Magazine
 [],													//Secondary Magazine
 ""													//Bipod
 ],

--- a/A3-Antistasi/Templates/Loadouts/3CB_BAF_MachineGunner_MTP.sqf
+++ b/A3-Antistasi/Templates/Loadouts/3CB_BAF_MachineGunner_MTP.sqf
@@ -1,0 +1,82 @@
+[//Loadout
+[//Primary Weapon
+"UK3CB_BAF_L110A3",									//Weapon
+"UK3CB_BAF_SFFH",													//Muzzle     //Flashhider
+"UK3CB_BAF_LLM_Flashlight_Black",													//Rail
+"RKSL_optic_EOT552_C",													//Sight
+["UK3CB_BAF_556_200Rnd",200],		//Primary Magazine
+[],													//Secondary Magazine
+"UK3CB_underbarrel_acc_grippod_t"													//Bipod
+],
+
+[//Launcher
+"",									//Weapon
+"",													//Muzzle
+"",													//Rail
+"",													//Sight
+[],		//Primary Magazine
+[],													//Secondary Magazine
+""													//Bipod
+],
+
+[//Secondary Weapon
+"UK3CB_BAF_L131A1",								//Weapon
+"",					//Muzzle
+"UK3CB_BAF_Flashlight_L131A1",																//Rail
+"",																//Sight
+["UK3CB_BAF_9_17Rnd",17],			//Primary Magazine
+[],																//Secondary Magazine
+""																//Bipod
+],
+
+[//Uniform
+"UK3CB_BAF_U_CombatUniform_MTP_RM",								//Uniform
+[//Inventory
+ + _basicMedicalSupplies
+ + _basicMiscItems
+]
+],
+
+[//Vest
+"UK3CB_BAF_V_Osprey_Rifleman_D",
+[//Inventory
+["UK3CB_BAF_HMNVS",1],
+["UK3CB_BAF_SmokeShell",2,1],
+["HandGrenade",1,1],
+["UK3CB_BAF_9_17Rnd",1,17],
+["UK3CB_BAF_556_200Rnd",1,200]
+]
++ _aceFlashlight
++ _aceM84
+],
+
+[//Backpack
+"UK3CB_BAF_B_Kitbag_MTP",						//Backpack
+[//Inventory
+["UK3CB_BAF_556_200Rnd_T",2,200]
+]
+
+],
+
+"UK3CB_BAF_H_Mk7_Camo_ESS_D",				//Headgear
+"UK3CB_BAF_G_Tactical_Grey",       						  //Facewear
+
+[//Binocular
+"Binocular",					//Binocular
+"",
+"",
+"",
+[],
+[],
+""
+],
+
+[//Item
+"ItemMap",											//Map
+"",													//Terminal
+["TF_RF7800STR"] call _fnc_tfarRadio,				//Radio
+"ItemCompass",										//Compass
+_tfarMicroDAGRNoArray,										//Watch
+""													//Goggles
+]
+];

--- a/A3-Antistasi/Templates/Loadouts/3CB_BAF_Marksman_MTP.sqf
+++ b/A3-Antistasi/Templates/Loadouts/3CB_BAF_Marksman_MTP.sqf
@@ -1,0 +1,82 @@
+[//Loadout
+[//Primary Weapon
+"UK3CB_BAF_L129A1",									//Weapon
+"",													//Muzzle
+"UK3CB_BAF_LLM_Flashlight_Black",													//Rail
+"UK3CB_BAF_SpecterLDS",													//Sight
+["UK3CB_BAF_762_L42A1_20Rnd",20],		//Primary Magazine
+[],													//Secondary Magazine
+"UK3CB_underbarrel_acc_bipod"													//Bipod
+],
+
+[//Launcher
+"",									//Weapon
+"",													//Muzzle
+"",													//Rail
+"",													//Sight
+[],		//Primary Magazine
+[],													//Secondary Magazine
+""													//Bipod
+],
+
+[//Secondary Weapon
+"UK3CB_BAF_L131A1",								//Weapon
+"",					//Muzzle
+"UK3CB_BAF_Flashlight_L131A1",																//Rail
+"",																//Sight
+["UK3CB_BAF_9_17Rnd",17],			//Primary Magazine
+[],																//Secondary Magazine
+""																//Bipod
+],
+
+[//Uniform
+"UK3CB_BAF_U_CombatUniform_MTP_RM",								//Uniform
+[//Inventory
+ + _basicMedicalSupplies
+ + _basicMiscItems
+]
+],
+
+[//Vest
+"UK3CB_BAF_V_Osprey_Rifleman_D",
+[//Inventory
+["UK3CB_BAF_HMNVS",1],
+["UK3CB_BAF_SmokeShell",2,1],
+["HandGrenade",1,1],
+["UK3CB_BAF_9_17Rnd",1,17],
+["UK3CB_BAF_762_L42A1_20Rnd",5,20]
+]
++ _aceFlashlight
++ _aceM84
+],
+
+[//Backpack
+"",						//Backpack
+[//Inventory
+[]
+]
+
+],
+
+"UK3CB_BAF_H_Boonie_MTP_PRR",				//Headgear
+"UK3CB_BAF_G_Tactical_Grey",       						  //Facewear
+
+[//Binocular
+"Binocular",					//Binocular
+"",
+"",
+"",
+[],
+[],
+""
+],
+
+[//Item
+"ItemMap",											//Map
+"",													//Terminal
+["TF_RF7800STR"] call _fnc_tfarRadio,				//Radio
+"ItemCompass",										//Compass
+_tfarMicroDAGRNoArray,										//Watch
+""													//Goggles
+]
+];

--- a/A3-Antistasi/Templates/Loadouts/3CB_BAF_Marksman_MTP.sqf
+++ b/A3-Antistasi/Templates/Loadouts/3CB_BAF_Marksman_MTP.sqf
@@ -3,7 +3,7 @@
 "UK3CB_BAF_L129A1",									//Weapon
 "",													//Muzzle
 "UK3CB_BAF_LLM_Flashlight_Black",													//Rail
-"UK3CB_BAF_SpecterLDS",													//Sight
+"UK3CB_BAF_TA648_308",													//Sight
 ["UK3CB_BAF_762_L42A1_20Rnd",20],		//Primary Magazine
 [],													//Secondary Magazine
 "UK3CB_underbarrel_acc_bipod"													//Bipod

--- a/A3-Antistasi/Templates/Loadouts/3CB_BAF_Medic_MTP.sqf
+++ b/A3-Antistasi/Templates/Loadouts/3CB_BAF_Medic_MTP.sqf
@@ -1,0 +1,84 @@
+[//Loadout
+[//Primary Weapon
+"UK3CB_BAF_L119A1_FG",					//Weapon
+"UK3CB_BAF_SFFH",											//Muzzel
+"UK3CB_BAF_LLM_Flashlight_Black",									//Rail
+"RKSL_optic_EOT552",																	//Sight
+["UK3CB_BAF_556_30Rnd",30],	//Primary Magazine
+[],										//Secondary Magazine
+"" 	//Grip
+
+],
+
+[//Launcher
+"",													//Weapon
+"",													//Muzzle
+"",													//Rail
+"",													//Sight
+[],													//Primary Magazine
+[],													//Secondary Magazine
+""													//Bipod
+],
+
+[//Secondary Weapon
+"UK3CB_BAF_L131A1",								//Weapon
+"",					//Muzzle
+"UK3CB_BAF_Flashlight_L131A1",																//Rail
+"",																//Sight
+["UK3CB_BAF_9_17Rnd",17],			//Primary Magazine
+[],																//Secondary Magazine
+""																//Bipod
+],
+
+[//Uniform
+"UK3CB_BAF_U_CombatUniform_MTP_RM",								//Uniform
+[//Inventory
+ + _basicMedicalSupplies
+ + _basicMiscItems
+]
+],
+
+[//Vest
+"UK3CB_BAF_V_Osprey_Medic_B",
+[//Inventory
+["UK3CB_BAF_HMNVS",1],
+["UK3CB_BAF_SmokeShell",2,1],
+["HandGrenade",1,1],
+["UK3CB_BAF_9_17Rnd",1,17],
+["UK3CB_BAF_556_30Rnd",4,30]
+]
++ _aceFlashlight
++ _aceM84
+],
+
+[//Backpack
+"UK3CB_BAF_B_Bergen_MTP_Medic_L_B",
+[//Inventory
+[]
++ _medicSupplies
+]
+],
+
+"UK3CB_BAF_H_CrewHelmet_ESS_A",				//Headgear
+
+"UK3CB_BAF_G_Tactical_Grey",		//Facewear
+
+[//Binocular
+"",										//Binocular
+"",
+"",
+"",
+[],
+[],
+""
+],
+
+[//Item
+"ItemMap",											//Map
+"",													//Terminal
+["TF_RF7800STR"] call _fnc_tfarRadio,				//Radio
+"ItemCompass",										//Compass
+_tfarMicroDAGRNoArray,										//Watch
+""													//Goggles
+]
+];

--- a/A3-Antistasi/Templates/Loadouts/3CB_BAF_Teamleader_MTP.sqf
+++ b/A3-Antistasi/Templates/Loadouts/3CB_BAF_Teamleader_MTP.sqf
@@ -1,0 +1,84 @@
+[//Loadout
+[//Primary Weapon
+"UK3CB_BAF_L85A3",									//Weapon
+"UK3CB_BAF_SFFH",													//Muzzle     //Flashhider
+"UK3CB_BAF_LLM_Flashlight_Black",													//Rail
+"RKSL_optic_LDS_C",													//Sight
+["UK3CB_BAF_556_30Rnd",30],		//Primary Magazine
+[],													//Secondary Magazine
+"UK3CB_underbarrel_acc_grippod_t"													//Bipod
+],
+
+[//Launcher
+"",									//Weapon
+"",													//Muzzle
+"",													//Rail
+"",													//Sight
+[],		//Primary Magazine
+[],													//Secondary Magazine
+""													//Bipod
+],
+
+[//Secondary Weapon
+"UK3CB_BAF_L131A1",								//Weapon
+"",					//Muzzle
+"UK3CB_BAF_Flashlight_L131A1",																//Rail
+"",																//Sight
+["UK3CB_BAF_9_17Rnd",17],			//Primary Magazine
+[],																//Secondary Magazine
+""																//Bipod
+],
+
+[//Uniform
+"UK3CB_BAF_U_CombatUniform_MTP_RM",								//Uniform
+[//Inventory
+ + _basicMedicalSupplies
+ + _basicMiscItems
+]
+],
+
+[//Vest
+"UK3CB_BAF_V_Osprey_SL_A",
+[//Inventory
+["UK3CB_BAF_HMNVS",1],
+["UK3CB_BAF_SmokeShell",2,1],
+["HandGrenade",1,1],
+["UK3CB_BAF_9_17Rnd",1,17],
+["UK3CB_BAF_556_30Rnd",4,30]
+]
++ _aceFlashlight
++ _aceM84
+],
+
+[//Backpack
+"UK3CB_BAF_B_Bergen_MTP_SL_L_A",						//Backpack
+[//Inventory
+["SmokeShellGreen",1,1],
+["SmokeShellOrange",1,1],
+["SmokeShellRed",1,1]
+]
+
+],
+
+"UK3CB_BAF_H_Mk7_Camo_ESS_A",				//Headgear
+"UK3CB_BAF_G_Tactical_Grey",       						  //Facewear
+
+[//Binocular
+"rhsusf_bino_lrf_Vector21",					//Binocular
+"",
+"",
+"",
+[],
+[],
+""
+],
+
+[//Item
+"ItemMap",											//Map
+"ItemGPS",													//Terminal
+["TF_RF7800STR"] call _fnc_tfarRadio,				//Radio
+"ItemCompass",										//Compass
+_tfarMicroDAGRNoArray,										//Watch
+""													//Goggles
+]
+];


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [x] Enhancement

### What have you changed and why?
Information:
Added 3CB MTP Loadouts:
AT/AT2/Teamleader get a L85A3, Holosights for AT, LDS x4 Scope for TL.
Marksman gets a weirdly named British DMR chambered in 7.62 and a x4 Scope.
Medics gets a weirdly British M4 with Holosight.
Machinegunner gets a British M249.

Added Calls for Loadouts in Both Templates.
Fixes 3CB BAF PVP for Tanoa:
Changed PVP vehicles to avoid Vanilla vehicles, they are the same as in Arid Template just in Green.
### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the Mission in Local host?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:

