### PR TITLE
Only unlock TFAR items when you are in a MP mission

### DIFF
--- a/A3-Antistasi/Templates/3CB_Reb_CNM_Temp.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_CNM_Temp.sqf
@@ -104,5 +104,7 @@ initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK
 initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular"];
 //TFAR Unlocks
-if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
-if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "UK3CB_B_O_Radio_Backpack"};
+if (isMultiplayer) then {
+	if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
+	if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "UK3CB_B_O_Radio_Backpack"};
+};

--- a/A3-Antistasi/Templates/3CB_Reb_CNM_Trop.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_CNM_Trop.sqf
@@ -104,5 +104,7 @@ initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK
 initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular"];
 //TFAR Unlocks
-if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
-if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "UK3CB_B_O_Radio_Backpack"};
+if (isMultiplayer) then {
+	if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
+	if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "UK3CB_B_O_Radio_Backpack"};
+};

--- a/A3-Antistasi/Templates/3CB_Reb_TPGM_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_TPGM_Arid.sqf
@@ -104,5 +104,7 @@ initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK
 initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular"];
 //TAFR Unlocks
-if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_rf7800str"]};
-if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "UK3CB_B_B_Radio_Backpack"};
+if (isMultiplayer) then {
+	if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_rf7800str"]};
+	if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "UK3CB_B_B_Radio_Backpack"};
+};

--- a/A3-Antistasi/Templates/3CB_Reb_TTF_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_TTF_Arid.sqf
@@ -108,5 +108,7 @@ initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK
 initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular"];
 //TFAR Unlocks
-if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
-if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "UK3CB_B_O_Radio_Backpack"};
+if (isMultiplayer) then {
+	if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
+	if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "UK3CB_B_O_Radio_Backpack"};
+};

--- a/A3-Antistasi/Templates/IFA_Reb_POL_Arct.sqf
+++ b/A3-Antistasi/Templates/IFA_Reb_POL_Arct.sqf
@@ -103,4 +103,6 @@ initialRebelEquipment append ["B_LIB_SOV_RA_Gasbag"];
 initialRebelEquipment append ["V_LIB_WP_OfficerVest","V_LIB_WP_SniperBela","V_LIB_WP_Kar98Vest","V_LIB_SOV_RA_Belt"];
 initialRebelEquipment append ["LIB_Binocular_PL"];
 //TFAR Unlocks
-if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "B_LIB_US_Radio"};
+if (isMultiplayer) then {
+	if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "B_LIB_US_Radio"};
+};

--- a/A3-Antistasi/Templates/IFA_Reb_POL_Arid.sqf
+++ b/A3-Antistasi/Templates/IFA_Reb_POL_Arid.sqf
@@ -103,4 +103,6 @@ initialRebelEquipment append ["B_LIB_SOV_RA_Gasbag"];
 initialRebelEquipment append ["V_LIB_WP_OfficerVest","V_LIB_WP_SniperBela","V_LIB_WP_Kar98Vest","V_LIB_SOV_RA_Belt"];
 initialRebelEquipment append ["LIB_Binocular_PL"];
 //TFAR Unlocks
-if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "B_LIB_US_Radio"};
+if (isMultiplayer) then {
+	if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "B_LIB_US_Radio"};
+};

--- a/A3-Antistasi/Templates/IFA_Reb_POL_Temp.sqf
+++ b/A3-Antistasi/Templates/IFA_Reb_POL_Temp.sqf
@@ -103,4 +103,6 @@ initialRebelEquipment append ["B_LIB_SOV_RA_Gasbag"];
 initialRebelEquipment append ["V_LIB_WP_OfficerVest","V_LIB_WP_SniperBela","V_LIB_WP_Kar98Vest","V_LIB_SOV_RA_Belt"];
 initialRebelEquipment append ["LIB_Binocular_PL"];
 //TFAR Unlocks
-if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "B_LIB_US_Radio"};
+if (isMultiplayer) then {
+	if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "B_LIB_US_Radio"};
+};

--- a/A3-Antistasi/Templates/RHS_Reb_CDF_Arid.sqf
+++ b/A3-Antistasi/Templates/RHS_Reb_CDF_Arid.sqf
@@ -104,5 +104,7 @@ initialRebelEquipment append ["B_FieldPack_oli","B_FieldPack_blk","B_FieldPack_o
 initialRebelEquipment append ["rhsgref_chestrig","rhsgref_chicom","rhs_vydra_3m","rhs_vest_pistol_holster","rhs_vest_commander","rhs_6sh46","rhsgref_alice_webbing"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular"];
 //TFAR Unlocks
-if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_rf7800str"]};
-if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_rt1523g_big_rhs"};
+if (isMultiplayer) then {
+	if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_rf7800str"]};
+	if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_rt1523g_big_rhs"};
+};

--- a/A3-Antistasi/Templates/RHS_Reb_CDF_Wdl.sqf
+++ b/A3-Antistasi/Templates/RHS_Reb_CDF_Wdl.sqf
@@ -104,5 +104,7 @@ initialRebelEquipment append ["B_FieldPack_oli","B_FieldPack_blk","B_FieldPack_o
 initialRebelEquipment append ["rhsgref_chestrig","rhsgref_chicom","rhs_vydra_3m","rhs_vest_pistol_holster","rhs_vest_commander","rhs_6sh46","rhsgref_alice_webbing"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular"];
 //TFAR Unlocks
-if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_rf7800str"]};
-if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_rt1523g_big_rhs"};
+if (isMultiplayer) then {
+	if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_rf7800str"]};
+	if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_rt1523g_big_rhs"};
+};

--- a/A3-Antistasi/Templates/RHS_Reb_NAPA_Arid.sqf
+++ b/A3-Antistasi/Templates/RHS_Reb_NAPA_Arid.sqf
@@ -103,5 +103,7 @@ initialRebelEquipment append ["B_FieldPack_oli","B_FieldPack_blk","B_FieldPack_o
 initialRebelEquipment append ["rhsgref_chestrig","rhsgref_chicom","rhs_vydra_3m","rhs_vest_pistol_holster","rhs_vest_commander","rhs_6sh46","rhsgref_alice_webbing"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular"];
 //TAFR Unlocks
-if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
-if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_anprc155_coyote"};
+if (isMultiplayer) then {
+	if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
+	if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_anprc155_coyote"};
+};

--- a/A3-Antistasi/Templates/RHS_Reb_NAPA_Wdl.sqf
+++ b/A3-Antistasi/Templates/RHS_Reb_NAPA_Wdl.sqf
@@ -103,5 +103,7 @@ initialRebelEquipment append ["B_FieldPack_oli","B_FieldPack_blk","B_FieldPack_o
 initialRebelEquipment append ["rhsgref_chestrig","rhsgref_chicom","rhs_vydra_3m","rhs_vest_pistol_holster","rhs_vest_commander","rhs_6sh46","rhsgref_alice_webbing"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular"];
 //TAFR Unlocks
-if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
-if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_anprc155_coyote"};
+if (isMultiplayer) then {
+	if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
+	if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_anprc155_coyote"};
+};

--- a/A3-Antistasi/Templates/Vanilla_Reb_FIA_Altis.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_FIA_Altis.sqf
@@ -106,5 +106,7 @@ initialRebelEquipment append ["B_FieldPack_oli","B_FieldPack_blk","B_FieldPack_o
 initialRebelEquipment append ["V_Chestrig_blk","V_Chestrig_rgr","V_Chestrig_khk","V_Chestrig_oli","V_BandollierB_blk","V_BandollierB_cbr","V_BandollierB_rgr","V_BandollierB_khk","V_BandollierB_oli","V_Rangemaster_belt"];
 initialRebelEquipment append ["Binocular","acc_flashlight"];
 //TFAR Unlocks
-if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
-if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_anprc155"};
+if (isMultiplayer) then {
+	if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
+	if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_anprc155"};
+};

--- a/A3-Antistasi/Templates/Vanilla_Reb_FIA_B_Altis.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_FIA_B_Altis.sqf
@@ -103,5 +103,7 @@ initialRebelEquipment append ["B_FieldPack_oli","B_FieldPack_blk","B_FieldPack_o
 initialRebelEquipment append ["V_Chestrig_blk","V_Chestrig_rgr","V_Chestrig_khk","V_Chestrig_oli","V_BandollierB_blk","V_BandollierB_cbr","V_BandollierB_rgr","V_BandollierB_khk","V_BandollierB_oli","V_Rangemaster_belt"];
 initialRebelEquipment append ["Binocular","acc_flashlight"];
 //TFAR Unlocks
-if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_rf7800str"]};
-if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_rt1523g_big_rhs"};
+if (isMultiplayer) then {
+	if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_rf7800str"]};
+	if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_rt1523g_big_rhs"};
+};

--- a/A3-Antistasi/Templates/Vanilla_Reb_FIA_Enoch.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_FIA_Enoch.sqf
@@ -105,5 +105,7 @@ initialRebelEquipment append ["B_FieldPack_blk","B_FieldPack_oucamo","B_FieldPac
 initialRebelEquipment append ["V_Chestrig_blk","V_Chestrig_rgr","V_Chestrig_khk","V_Chestrig_oli","V_BandollierB_blk","V_SmershVest_01_F","V_BandollierB_rgr","V_SmershVest_01_radio_F","V_BandollierB_oli","V_Rangemaster_belt"];
 initialRebelEquipment append ["Binocular","acc_flashlight"];
 //TFAR Unlocks
-if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
-if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_anprc155"};
+if (isMultiplayer) then {
+	if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
+	if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_anprc155"};
+};

--- a/A3-Antistasi/Templates/Vanilla_Reb_SDK_Tanoa.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_SDK_Tanoa.sqf
@@ -105,5 +105,7 @@ initialRebelEquipment append ["B_FieldPack_blk","B_FieldPack_oucamo","B_FieldPac
 initialRebelEquipment append ["V_Chestrig_blk","V_Chestrig_rgr","V_Chestrig_khk","V_Chestrig_oli","V_BandollierB_blk","V_BandollierB_ghex","V_BandollierB_rgr","V_BandollierB_oli","V_Rangemaster_belt","V_TacChestrig_cbr_F","V_TacChestrig_oli_F","V_TacChestrig_grn_F"];
 initialRebelEquipment append ["Binocular","acc_flashlight"];
 //TFAR unlocks
-if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
-if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_anprc155"};
+if (isMultiplayer) then {
+	if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
+	if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_anprc155"};
+};


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Enhancement

### What have you changed and why?
Information:
When the mission is started in a SP (SinglePlayer) environment, the code still tries to "unlock" TFAR items in the arsenal. It does this by checking the `startWithLongRangeRadio` global variable which is not set. I fixed this by adding a `isMultiplayer` check around the "unlocking" code.

### Please specify which Issue this PR Resolves.
closes #799 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the Mission in Singleplayer?
2. [x] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes (Please provide further detail below.)

********************************************************
Notes:

I have tested this in the `Antistasi-Chernarus-2-2-2.chernarus_summer` mission, but not the others. So in my case only `RHS_Reb_NAPA_Arid.sqf` was triggered and not the other files..

~~The changes aren't to complex so we might get away by not testing the other missions~~
