### PR TITLE
Fix potential zero-divisor error in fogCheck

### DIFF
--- a/A3-Antistasi/functions/Base/fn_fogCheck.sqf
+++ b/A3-Antistasi/functions/Base/fn_fogCheck.sqf
@@ -63,4 +63,5 @@ if (_dz !=0 && _fogDecay != 0) then
 	};
 private _fogAverage = _fogValue * _fogCoeff;
 private _fogViewDistance = 0.9 * _MaxViewDistance * exp (- _fogAverage * ln(_ViewDistanceDecayRate));
+if (_fogViewDistance == 0) exitWith {0};
 0 max (1.0 - _l/_fogViewDistance)


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
With extreme inputs from fogParams, _fogViewDistance can have a value of zero due to floating-point underflow. This may cause a zero divisor error. This PR skips the final calculation in this case.

### Please specify which Issue this PR Resolves.
closes #810 

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
