### PR TITLE
Remove AA planes from random pool in patrolCA

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_patrolCA.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_patrolCA.sqf
@@ -421,7 +421,11 @@ else
 	_vehPool = [];
 	_countX = if (!_super) then {if (_isMarker) then {2} else {1}} else {round ((tierWar + difficultyCoef) / 2) + 1};
 	_typeVehX = "";
-	_vehPool = if (_sideX == Occupants) then {(vehNATOAir - [vehNATOPlane]) select {[_x] call A3A_fnc_vehAvailable}} else {(vehCSATAir - [vehCSATPlane]) select {[_x] call A3A_fnc_vehAvailable}};
+	_vehPool = if (_sideX == Occupants) then {
+		(vehNATOAir - [vehNATOPlane,vehNATOPlaneAA]) select {[_x] call A3A_fnc_vehAvailable}
+	} else {
+		(vehCSATAir - [vehCSATPlane,vehCSATPlaneAA]) select {[_x] call A3A_fnc_vehAvailable}
+	};
 	if (_isSDK) then
 		{
 		_rnd = random 100;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Removed AA planes from the random-aircraft pool in patrolCA. They'll still be used in the case where the rebels are using air vehicles.

I think the inclusion of AA planes here was a bug in the first place, as ground aircraft are already removed from the random pool. The AA planes often just circle at high altitude, unnecessarily spawning in rebel garrisons (at high perf cost) and confusing your AIs.   

### Please specify which Issue this PR Resolves.
closes #774

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
