### PR TITLE
Fixed multiple bugs in intel rework

### DIFF
--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -167,6 +167,7 @@ class A3A
 
 	class Convoy
 	{
+        class cleanConvoyMarker {};
 		class convoyDebug {};
 		class convoyMovement {};
 		class createAIAction {};

--- a/A3-Antistasi/functions/Convoy/fn_cleanConvoyMarker.sqf
+++ b/A3-Antistasi/functions/Convoy/fn_cleanConvoyMarker.sqf
@@ -1,0 +1,18 @@
+/*  Checks the convoy markers and cleans out deleted convoys
+*
+*   Scope: Internal
+*
+*   Params:
+*       Nothing
+*
+*   Returns:
+*       Nothing
+*/
+
+private _convoysOccupants = server getVariable ["convoyMarker_Occupants", [""]];
+_convoysOccupants = _convoysOccupants select {(getMarkerColor _x) != ""};
+server setVariable ["convoyMarker_Occupants", _convoysOccupants, true];
+
+private _convoysInvaders = server getVariable ["convoyMarker_Invaders", [""]];
+_convoysInvaders = _convoysInvaders select {(getMarkerColor _x) != ""};
+server setVariable ["convoyMarker_Invaders", _convoysInvaders, true];

--- a/A3-Antistasi/functions/Intel/fn_searchIntelOnLeader.sqf
+++ b/A3-Antistasi/functions/Intel/fn_searchIntelOnLeader.sqf
@@ -68,6 +68,7 @@ if(_wasCancelled) exitWith
 {
     hint "Search cancelled";
     _caller setVariable ["intelFound", nil];
+    [_squadLeader, "Small_Intel"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_squadLeader];
 };
 
 if(_caller getVariable ["intelFound", false]) then

--- a/A3-Antistasi/functions/Intel/fn_searchIntelOnLeader.sqf
+++ b/A3-Antistasi/functions/Intel/fn_searchIntelOnLeader.sqf
@@ -68,7 +68,7 @@ if(_wasCancelled) exitWith
 {
     hint "Search cancelled";
     _caller setVariable ["intelFound", nil];
-    [_squadLeader, "Small_Intel"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_squadLeader];
+    [_squadLeader, "Intel_Small"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_squadLeader];
 };
 
 if(_caller getVariable ["intelFound", false]) then
@@ -86,6 +86,6 @@ if(_caller getVariable ["intelFound", false]) then
 }
 else
 {
-    [_squadLeader, "Small_Intel"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_squadLeader];
+    [_squadLeader, "Intel_Small"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_squadLeader];
 };
 _caller setVariable ["intelFound", nil];

--- a/A3-Antistasi/functions/Intel/fn_selectIntel.sqf
+++ b/A3-Antistasi/functions/Intel/fn_selectIntel.sqf
@@ -79,13 +79,14 @@ if(_intelType == "Small") then
         case (CONVOY):
         {
             private _convoyMarker = "";
+            [] call A3A_fnc_cleanConvoyMarker;
             if(_side == Occupants) then
             {
                 _convoyMarker = selectRandom (server getVariable ["convoyMarker_Occupants", [""]]);
             }
             else
             {
-                _convoyMarker = selectRandom (server getVariable ["convoyMarker_Occupants", [""]]);
+                _convoyMarker = selectRandom (server getVariable ["convoyMarker_Invaders", [""]]);
             };
             if(_convoyMarker != "") then
             {
@@ -118,6 +119,7 @@ if(_intelType == "Medium") then
         };
         case (CONVOYS):
         {
+            [] call A3A_fnc_cleanConvoyMarker;
             private _convoyMarkers = [];
             if(_side == Occupants) then
             {

--- a/A3-Antistasi/functions/init/fn_resourcecheck.sqf
+++ b/A3-Antistasi/functions/init/fn_resourcecheck.sqf
@@ -128,7 +128,8 @@ while {true} do
 	bombRuns = bombRuns + (({sidesX getVariable [_x,sideUnknown] == teamPlayer} count airportsX) * 0.25);
 	[petros,"taxRep",_textX] remoteExec ["A3A_fnc_commsMP",[teamPlayer,civilian]];
 	[] call A3A_fnc_economicsAI;
-	
+    [] call A3A_fnc_cleanConvoyMarker;
+
 	if (isMultiplayer) then
 	{
 		[] spawn A3A_fnc_promotePlayer;
@@ -136,7 +137,7 @@ while {true} do
 		difficultyCoef = floor ((({side group _x == teamPlayer} count (call A3A_fnc_playableUnits)) - ({side group _x != teamPlayer} count (call A3A_fnc_playableUnits))) / 5);
 		publicVariable "difficultyCoef";
 	};
-	
+
 	if ((!bigAttackInProgress) and (random 100 < 50)) then {[] call A3A_fnc_missionRequestAUTO};
 	//Removed from scheduler for now, as it errors on Headless Clients.
 	//[[],"A3A_fnc_reinforcementsAI"] call A3A_fnc_scheduler;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Information:
Fixed multiple bugs in and around the intel system.
1) Added a function to clean the convoy marker array every tick or before a intel convoy reward is issued. The A3A_fnc_cleanConvoyMarker function checks all markers by checking if `getMarkerColor` returns anything besides "". The still existing markers are then saved again. This fixes an issue with a single convoy reward, which selected a marker that isn't there anymore and therefor doesn't show anything on the map. Furthermore it should stop the array from growing the whole time.

2) Fixed a missing call to add the "Search for Intel" action on squadleaders if the action has been aborted by the player. If the players abort the search now, the action is getting readded correctly.

3) Fixed the parameter in searchIntelOnLeader for the flagaction remoteExec. Parameter changed from "Small_Intel" to "Intel_Small" and is now actually working. We might want to add a default case in flagAction which prints out unknown command to the rpt so we see when the parameter for it is unknown.

4) Fixed a type in selectIntel which retrieved the Occupant convoy marker instead of the Invader convoy marker. Bad copy paste happened there.
    
### Please specify which Issue this PR Resolves.
No issues, but the errors mentioned on discord in the testing channel.

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

********************************************************
Notes: Please merge it unto unstable and upload the new unstable to the test server
