### PR TITLE
Fix HQ objects becoming lethal if dropped while moving

### DIFF
--- a/A3-Antistasi/functions/Dialogs/fn_moveHQObject.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_moveHQObject.sqf
@@ -36,6 +36,7 @@ private _fnc_placeObject = {
 		_playerX removeAction _dropObjectActionIndex;
 	};
 
+	_thingX setVelocity [0,0,0];		// some objects never lose their velocity when detached, becoming lethal
 	_thingX setVectorUp surfaceNormal position _thingX;
 	_thingX setPosATL [getPosATL _thingX select 0,getPosATL _thingX select 1,0.1];
 


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Apparently non-PhysX objects retain their current velocity forever when detached from another object, becoming lethal on contact. This could happen by dropping some HQ assets (tent, flag) while moving.

### Please specify which Issue this PR Resolves.
closes #834 

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
