### PR TITLE
Workaround for Zeus link lost when old corpse is deleted

### DIFF
--- a/A3-Antistasi/onPlayerRespawn.sqf
+++ b/A3-Antistasi/onPlayerRespawn.sqf
@@ -11,7 +11,6 @@ waitUntil {alive player};
 //This is a workaround that re-assigns curator to the player if their body is deleted.
 //It will only run on LAN hosted MP, where the hoster is *always* admin, so we shouldn't run into any issues.
 if (isServer) then {
-	// workaround for BIS bug where zeus link is broken in MP hosted when old corpse is deleted
 	_oldUnit addEventHandler ["Deleted", {
 		[] spawn {
 			sleep 1;		// should ensure that the bug unassigns first

--- a/A3-Antistasi/onPlayerRespawn.sqf
+++ b/A3-Antistasi/onPlayerRespawn.sqf
@@ -7,6 +7,9 @@ if (isNull _oldUnit) exitWith {};
 
 waitUntil {alive player};
 
+//When LAN hosting, Bohemia's Zeus module code will cause the player lose Zeus access if the body is deleted after respawning.
+//This is a workaround that re-assigns curator to the player if their body is deleted.
+//It will only run on LAN hosted MP, where the hoster is *always* admin, so we shouldn't run into any issues.
 if (isServer) then {
 	// workaround for BIS bug where zeus link is broken in MP hosted when old corpse is deleted
 	_oldUnit addEventHandler ["Deleted", {

--- a/A3-Antistasi/onPlayerRespawn.sqf
+++ b/A3-Antistasi/onPlayerRespawn.sqf
@@ -7,6 +7,16 @@ if (isNull _oldUnit) exitWith {};
 
 waitUntil {alive player};
 
+if (isServer) then {
+	// workaround for BIS bug where zeus link is broken in MP hosted when old corpse is deleted
+	_oldUnit addEventHandler ["Deleted", {
+		[] spawn {
+			sleep 1;		// should ensure that the bug unassigns first
+			{ player assignCurator _x } forEach allCurators;
+		}
+	} ];
+};
+
 _nul = [_oldUnit] spawn A3A_fnc_postmortem;
 
 _oldUnit setVariable ["incapacitated",false,true];


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
There's a bug in BIS's curator script related to the #adminlogged mode where a link is retained to the player's old corpse, and when that's deleted, the (real) curator is unassigned. Only applies to hosted MP.

This patch works around the problem with a fairly direct route: Reassigning the curator to the hosting player shortly after the corpse is deleted. It can be removed if BIS fix their bug, or if we switch to creating and/or assigning the curator by script rather than relying on #adminlogged. The latter option would probably require a fair amount of work, including a UI.

### Please specify which Issue this PR Resolves.
closes #835

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
