### PR TITLE
Fix bogus classname for 3CB invader flagpole

### DIFF
--- a/A3-Antistasi/Templates/3CB_Inv_TKM_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Inv_TKM_Arid.sqf
@@ -10,7 +10,7 @@ factionMaleInvaders = "UK3CB_TKM_B";
 if (gameMode == 4) then {factionFIA = "UK3CB_TKP_O"};
 
 //Flag Images
-CSATFlag = "Flag_TKM_O_Army";
+CSATFlag = "Flag_TKM_O";
 CSATFlagTexture = "\UK3CB_Factions\addons\UK3CB_Factions_TKM\Flag\tkm_o_flag_co.paa";
 flagCSATmrk = "UK3CB_Marker_O_TKM";
 if (isServer) then {"CSAT_carrier" setMarkerText "Takistani Carrier"};

--- a/A3-Antistasi/Templates/3CB_Inv_UKN_Temp.sqf
+++ b/A3-Antistasi/Templates/3CB_Inv_UKN_Temp.sqf
@@ -10,7 +10,7 @@ factionMaleInvaders = "UK3CB_TKM_B";
 if (gameMode == 4) then {factionFIA = "UK3CB_TKP_O"};
 
 //Flag Images
-CSATFlag = "Flag_TKM_O_Army";
+CSATFlag = "Flag_TKM_O";
 CSATFlagTexture = "\UK3CB_Factions\addons\UK3CB_Factions_TKM\Flag\tkm_o_flag_co.paa";
 flagCSATmrk = "UK3CB_Marker_O_TKM";
 if (isServer) then {"CSAT_carrier" setMarkerText "Takistani Carrier"};

--- a/A3-Antistasi/Templates/3CB_Inv_UKN_Trop.sqf
+++ b/A3-Antistasi/Templates/3CB_Inv_UKN_Trop.sqf
@@ -10,7 +10,7 @@ factionMaleInvaders = "UK3CB_TKM_B";
 if (gameMode == 4) then {factionFIA = "UK3CB_TKP_O"};
 
 //Flag Images
-CSATFlag = "Flag_TKM_O_Army";
+CSATFlag = "Flag_TKM_O";
 CSATFlagTexture = "\UK3CB_Factions\addons\UK3CB_Factions_TKM\Flag\tkm_o_flag_co.paa";
 flagCSATmrk = "UK3CB_Marker_O_TKM";
 if (isServer) then {"CSAT_carrier" setMarkerText "Takistani Carrier"};


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
3CB invader factions had a bogus classname for the flagpole, which caused it not to spawn, often preventing capture of locations.

### Please specify which Issue this PR Resolves.
closes #846

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

Although these templates clearly haven't had much testing, so they may benefit from a second look.