### PR TITLE
Fixed missing startWithLongRangeRadio parameter

### DIFF
--- a/A3-Antistasi/functions/init/fn_initServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initServer.sqf
@@ -68,6 +68,7 @@ if (isMultiplayer) then {
 	teamSwitchDelay = 0;
 	playerMarkersEnabled = true;
 	minPlayersRequiredforPVP = 2;
+    startWithLongRangeRadio = true;
 };
 
 [] call A3A_fnc_crateLootParams;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Information: Added a default value for startWithLongRangeRadio for SP games Assumed to true due to two reasons

1) Default value in params.hpp is true

2) LR radios in SP are kinda useless anyways, so no need to block them

### Please specify which Issue this PR Resolves.
closes #799 

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:
