### PR TITLE
Restrict vehicle box repair to unoccupied and rebel vehicles

### DIFF
--- a/A3-Antistasi/functions/Base/fn_healAndRepair.sqf
+++ b/A3-Antistasi/functions/Base/fn_healAndRepair.sqf
@@ -33,10 +33,13 @@ boxX setVariable ["lastUsed", _time, true];
 {
 	if ((_x distance _posHQ < 150) and (alive _x) and (isNull(attachedTo _x))) then
 	{
-		_x setDamage 0;
-		if (_x getVariable ["incapacitated",false]) then {_x setVariable ["incapacitated",false,true]};
-		[_x,1] remoteExec ["setVehicleAmmo",_x];
-		if (_x in reportedVehs) then {reportedVehs = reportedVehs - [_x]; publicVariable "reportedVehs"};
+		private _vehSide = side group _x;
+		if (_vehSide == sideUnknown || _vehSide == teamPlayer) then {
+			_x setDamage 0;
+			if (_x getVariable ["incapacitated",false]) then {_x setVariable ["incapacitated",false,true]};
+			[_x,1] remoteExec ["setVehicleAmmo",_x];
+			if (_x in reportedVehs) then {reportedVehs = reportedVehs - [_x]; publicVariable "reportedVehs"};
+		};
 	};
 } forEach vehicles;
 


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug, probably
2. [ ] Enhancement

### What have you changed and why?
The vehicle box would repair occupied enemy vehicles, which is weird and probably unintentional. This PR restricts it to unoccupied vehicles and those currently controlled by the player team.

This depends on `side group _vehicle` working in a reasonable manner, which it seems to.

### Please specify which Issue this PR Resolves.
closes #824

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
