### PR TITLE
Add debug for PostMortem and SurrenderAction Call

### DIFF
--- a/A3-Antistasi/Stringtable.xml
+++ b/A3-Antistasi/Stringtable.xml
@@ -392,7 +392,7 @@
         <Russian>Быть Лидером Сопротивления значит быть героем. </Russian>
       </Key>
       <Key ID="STR_antistasi_credits_generic_version_text">
-        <Original>2.2.2</Original>
+        <Original>2.2.2.Tad-Debug</Original>
       </Key>
     </Container>
     <Container name="dialog_vehicle_purchase">

--- a/A3-Antistasi/Stringtable.xml
+++ b/A3-Antistasi/Stringtable.xml
@@ -392,7 +392,7 @@
         <Russian>Быть Лидером Сопротивления значит быть героем. </Russian>
       </Key>
       <Key ID="STR_antistasi_credits_generic_version_text">
-        <Original>2.2.2.Tad-Debug</Original>
+        <Original>2.2.2</Original>
       </Key>
     </Container>
     <Container name="dialog_vehicle_purchase">

--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -494,7 +494,7 @@ class A3A
 		class rhsModCompat {};
 	};
 
-	class UI 
+	class UI
 	{
 		class customHint {};
 	};

--- a/A3-Antistasi/functions/AI/fn_surrenderAction.sqf
+++ b/A3-Antistasi/functions/AI/fn_surrenderAction.sqf
@@ -2,7 +2,7 @@ private _filename = "fn_surrenderAction";
 params ["_unit"];
 
 if (typeOf _unit == "Fin_random_F") exitWith {};		// dogs do not surrender?
-//https://forums.bohemia.net/forums/topic/107114-script-to-delete-units/
+
 // ACE sometimes calls the wakeup handler when units die
 // Safe code to prevent unit doing anything until we check that they're alive
 _unit stop true;

--- a/A3-Antistasi/functions/AI/fn_surrenderAction.sqf
+++ b/A3-Antistasi/functions/AI/fn_surrenderAction.sqf
@@ -1,3 +1,4 @@
+private _filename = "fn_surrenderAction";
 params ["_unit"];
 
 if (typeOf _unit == "Fin_random_F") exitWith {};		// dogs do not surrender?
@@ -85,7 +86,12 @@ if (!isNil "_markerX") then
 	};
 
 // timed cleanup functions
+unitStr = format["Cleanup called for unit:%1",_unit];
+boxxStr = format["Cleanup called for boxx:%1",_boxX];
+[3,unitStr,_filename] call A3A_fnc_log;
 [_unit] spawn A3A_fnc_postmortem;
+
+[3,boxXStr,_filename] call A3A_fnc_log;
 [_boxX] spawn A3A_fnc_postmortem;
 
 sleep 3;

--- a/A3-Antistasi/functions/AI/fn_surrenderAction.sqf
+++ b/A3-Antistasi/functions/AI/fn_surrenderAction.sqf
@@ -2,7 +2,7 @@ private _filename = "fn_surrenderAction";
 params ["_unit"];
 
 if (typeOf _unit == "Fin_random_F") exitWith {};		// dogs do not surrender?
-
+//https://forums.bohemia.net/forums/topic/107114-script-to-delete-units/
 // ACE sometimes calls the wakeup handler when units die
 // Safe code to prevent unit doing anything until we check that they're alive
 _unit stop true;

--- a/A3-Antistasi/functions/AI/fn_surrenderAction.sqf
+++ b/A3-Antistasi/functions/AI/fn_surrenderAction.sqf
@@ -86,12 +86,10 @@ if (!isNil "_markerX") then
 	};
 
 // timed cleanup functions
-unitStr = format["Cleanup called for unit:%1",_unit];
-boxxStr = format["Cleanup called for boxx:%1",_boxX];
-[3,unitStr,_filename] call A3A_fnc_log;
+[3,format["Cleanup called for unit:%1",_unit],_filename] call A3A_fnc_log;
 [_unit] spawn A3A_fnc_postmortem;
 
-[3,boxXStr,_filename] call A3A_fnc_log;
+[3,format["Cleanup called for boxx:%1",_boxX],_filename] call A3A_fnc_log;
 [_boxX] spawn A3A_fnc_postmortem;
 
 sleep 3;

--- a/A3-Antistasi/functions/REINF/fn_postmortem.sqf
+++ b/A3-Antistasi/functions/REINF/fn_postmortem.sqf
@@ -1,5 +1,8 @@
 private _filename = "fn_postmortem";
+[3,"PostMortem Called",_filename] call A3A_fnc_log;
 params ["_victim"];
+
+if !(_victim)exitwith{[3,"Function failed called with null param.",_filename] call A3A_fnc_log;}
 
 /*  Handles the despawn and cleanup of dead units
 *   Params:
@@ -10,12 +13,12 @@ params ["_victim"];
 */
 
 private _group = group _victim;
-
-groupStr = format["Group for victim:%1 assigned:%2.",_victim, _group];
-[3,unitStr,_filename] call A3A_fnc_log;
-
-if (isNull _group) then
+if (isNull _group || isNil "_group" ) then
 {
+
+    groupStr = format["Group for victim :: %1, assigned :: %2.",_victim, _group];
+    [3,groupStr,_filename] call A3A_fnc_log;
+
 	if (_victim in staticsToSave) then
     {
         staticsToSave = staticsToSave - [_victim];
@@ -23,6 +26,8 @@ if (isNull _group) then
     };
 };
 
-sleep cleantime;
-deleteVehicle _victim;
-deleteGroup _group;
+[] spawn {
+    sleep cleantime;
+    deleteVehicle _victim;
+    deleteGroup _group;
+}

--- a/A3-Antistasi/functions/REINF/fn_postmortem.sqf
+++ b/A3-Antistasi/functions/REINF/fn_postmortem.sqf
@@ -1,9 +1,3 @@
-private _filename = "fn_postmortem";
-[3,"PostMortem Called",_filename] call A3A_fnc_log;
-params ["_victim"];
-
-if !(_victim)exitwith{[3,"Function failed called with null param.",_filename] call A3A_fnc_log;}
-
 /*  Handles the despawn and cleanup of dead units
 *   Params:
 *       _victim : OBJECT : The dead unit
@@ -12,12 +6,16 @@ if !(_victim)exitwith{[3,"Function failed called with null param.",_filename] ca
 *       Nothing
 */
 
+params ["_victim"];
+private _filename = "fn_postmortem";
 private _group = group _victim;
-if (isNull _group || isNil "_group" ) then
-{
 
-    groupStr = format["Group for victim :: %1, assigned :: %2.",_victim, _group];
-    [3,groupStr,_filename] call A3A_fnc_log;
+[3,"PostMortem Called",_filename] call A3A_fnc_log;
+if (isnull _victim)exitwith{[3,"Function failed called with null param.",_filename] call A3A_fnc_log;};
+
+if (isNull _group) then
+{
+    [3,format["Group for victim :: %1, no group found! Removing from Statics list.",_victim],_filename] call A3A_fnc_log;
 
 	if (_victim in staticsToSave) then
     {
@@ -26,8 +24,18 @@ if (isNull _group || isNil "_group" ) then
     };
 };
 
-[] spawn {
-    sleep cleantime;
+cleanSTR = format ["Pausing for %1 minutes before cleaning victim: %2 and group: %3", round cleantime/60, _victim, _group];
+[3,cleanSTR, _filename] call A3A_fnc_log;
+sleep cleantime;
+
+if !(isnull _victim) then
+{
+    [3,format["Cleanup complete for %1 victim.", _victim],_filename] call A3A_fnc_log;
     deleteVehicle _victim;
+};
+
+if !(isnull _group) then
+{
+    [3,format["Cleanup complete for %1 group.", _group],_filename] call A3A_fnc_log;
     deleteGroup _group;
-}
+};

--- a/A3-Antistasi/functions/REINF/fn_postmortem.sqf
+++ b/A3-Antistasi/functions/REINF/fn_postmortem.sqf
@@ -11,7 +11,7 @@ private _filename = "fn_postmortem";
 private _group = group _victim;
 
 [3,"PostMortem Called",_filename] call A3A_fnc_log;
-if (isnull _victim)exitwith{[3,"Function failed called with null param.",_filename] call A3A_fnc_log;};
+if (isnull _victim)exitwith{[1,"Function failed called with null param.",_filename] call A3A_fnc_log;};
 
 if (isNull _group) then
 {

--- a/A3-Antistasi/functions/REINF/fn_postmortem.sqf
+++ b/A3-Antistasi/functions/REINF/fn_postmortem.sqf
@@ -1,3 +1,4 @@
+private _filename = "fn_postmortem";
 params ["_victim"];
 
 /*  Handles the despawn and cleanup of dead units
@@ -9,6 +10,10 @@ params ["_victim"];
 */
 
 private _group = group _victim;
+
+groupStr = format["Group for victim:%1 assigned:%2.",_victim, _group];
+[3,unitStr,_filename] call A3A_fnc_log;
+
 if (isNull _group) then
 {
 	if (_victim in staticsToSave) then


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Information:
Added Debug logging and some null catches to determine if bad UNIT's are being passed to the script.

### Please specify which Issue this PR Resolves.
closes #589 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the Mission in Singleplayer?
2. [X] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes (Please provide further detail below.)

********************************************************
Notes:
In my testing something did pass through a null unit value to the Postmortem script, however it was caught by the new `exitwith` I have added early on. Finding out what is causing this would be ideal.