### PR TITLE
Fix bug in spawn distance reduction button

### DIFF
--- a/A3-Antistasi/dialogs.hpp
+++ b/A3-Antistasi/dialogs.hpp
@@ -1092,7 +1092,7 @@ class spawn_config 			{
 			y = 0.317959 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
-			action = "if (player == theBoss) then {if (distanceSPWN > 600) then {distanceSPWN = distanceSPWN - 100; if (distanceSPWN < 600) then {distanceSPWN = 600}; distanceSPWN1 = distanceSPWN * 1.3; distanceSPWN2 = distanceSPWN /2; if (distanceSPWN < 600) then {distanceSPWN = 600};publicVariable ""distanceSPWN"";publicVariable ""distanceSPWN1"";publicVariable ""distanceSPWN2"";}; [""Spawn Distance"", ""format [""Spawn Distance Set to %1 meters"",distanceSPWN]""] call A3A_fnc_customHint;} else {[""Spawn Distance"", ""Only Player Commander has access to this function""] call A3A_fnc_customHint;};";
+			action = "if (player == theBoss) then {if (distanceSPWN > 600) then {distanceSPWN = distanceSPWN - 100; distanceSPWN1 = distanceSPWN * 1.3; distanceSPWN2 = distanceSPWN /2; publicVariable ""distanceSPWN"";publicVariable ""distanceSPWN1"";publicVariable ""distanceSPWN2"";}; [""Spawn Distance"", format [""Spawn Distance Set to %1 meters"",distanceSPWN]] call A3A_fnc_customHint;} else {[""Spawn Distance"", ""Only Player Commander has access to this function""] call A3A_fnc_customHint;};";
 		};
 	};
 };


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Spawn distance reduction button was broken in the customHint patch by misplaced quotes. Fixed that, and removed some redundant checks to make it slightly less unreadable.

### Please specify which Issue this PR Resolves.
closes #884

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
