### PR TITLE
Change TIME_LEFT intel option to return approx time until next attack

### DIFF
--- a/A3-Antistasi/functions/Intel/fn_selectIntel.sqf
+++ b/A3-Antistasi/functions/Intel/fn_selectIntel.sqf
@@ -61,15 +61,14 @@ if(_intelType == "Small") then
         };
         case (TIME_LEFT):
         {
-            private _nextTick = nextTick - time;
-            _nextTick = _nextTick * (0.9 + random 0.2);
-            if(_nextTick < 60) then
+            private _nextAttack = countCA + (random 600) - 300;
+            if(_nextAttack < 300) then
             {
-                _text = format ["%1 will send their next reinforcements shortly!", _sideName];
+                _text = format ["Next enemy attack is imminent!"];
             }
             else
             {
-                _text = format ["%1 is able to send reinforcements in %2 minutes", _sideName, round (_nextTick / 60)];
+                _text = format ["Next enemy attack expected in %1 minutes", round (_nextAttack / 60)];
             };
         };
         case (ACCESS_CAR):


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Enhancement

### What have you changed and why?
The TIME_LEFT intel option attempted to use the non-public time-until-next-tick value (nextTick). This PR changes it to return an approximated version of the time until the next attack (countCA) instead, which is already public and is a bit more useful. The ticks are always 10 minutes apart but the attack timer has much more variation.

Note that the attacking side currently isn't determined until the attack is launched, so the side parameter isn't used.

### Please specify which Issue this PR Resolves.
closes #874

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
