### PR TITLE
Remove TK uniform check due to uniform inconsistency

### DIFF
--- a/A3-Antistasi/functions/Revive/fn_handleDamage.sqf
+++ b/A3-Antistasi/functions/Revive/fn_handleDamage.sqf
@@ -17,12 +17,13 @@ if (_part == "" && _damage > 0.1) then
 	// Player vs rebel TK check
 	if (isPlayer _instigator && _unit != _instigator && {side group _instigator == teamPlayer && side group _unit == teamPlayer}) then
 	{
-		_uniform = uniform _unit;
-		if (_uniform in allRebelUniforms || {_uniform in allCivilianUniforms}) then
-		{
+// Removed uniform check because neither allRebelUniforms or uniform side is currently sufficient
+//		_uniform = uniform _unit;
+//		if (_uniform in allRebelUniforms || {_uniform in allCivilianUniforms}) then
+//		{
 			[_instigator, 20, (_damage min 0.34), _unit] remoteExec ["A3A_fnc_punishment",_instigator];
 			[format ["%1 was injured by %2 (UID: %3), %4m from HQ",name _unit,name _instigator,getPlayerUID _instigator,_unit distance2D posHQ]] remoteExec ["diag_log",2];
-		};
+//		};
 	};
 
 	// this will not work the same with ACE, as damage isn't accumulated


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Enhancement
3. [X] Feature removal

### What have you changed and why?
The TK check had a check for whether the player was wearing an enemy uniform. However, none of the current data is sufficient for an accurate test:
- allRebelUniforms does not always contain uniforms of the player units or rebel AIs.
- Blufor guerrilla uniforms are currently used for greenfor, so uniform side is not a valid check.

This PR removes the uniform check so that all rebel TK incidents are now considered a TK, regardless of uniform worn.

Alternative solutions that don't remove the uniform check are possible, but would require feedback:
1. Fix allRebelUniforms so that it includes all valid rebel uniforms for each case, preferably without using both greenfor and blufor guerrilla uniforms (to avoid arsenal dupes). Ensure that all rebel players and AI have one of these uniforms on spawn. I'm fairly sure it's not my decision what counts as a valid rebel uniform, so this would need extensive feedback. 
2. Use greenfor guerrilla uniforms rather than blufor guerrilla uniforms for greenfor and switch the TK check to uniform side. The comments suggest that the scope of the greenfor uniforms is a problem, but as far as I can tell, it isn't. Relevant code:
https://github.com/official-antistasi-community/A3-Antistasi/blob/f4657fe4a3d0c2f1b6940524d781f5c68cc22515/A3-Antistasi/functions/Ammunition/fn_equipmentSort.sqf#L24-L26

Option 1 would be necessary for the template project, as rebel uniforms would no longer be related to the side of the unit.

### Please specify which Issue this PR Resolves.
closes #862

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)
See above.
