### PR TITLE
Fix misleading descriptions of fast travel and unlock count params

### DIFF
--- a/A3-Antistasi/MissionDescription/params.hpp
+++ b/A3-Antistasi/MissionDescription/params.hpp
@@ -78,7 +78,7 @@ class Params
      };
      class unlockItem
      {
-          title = "Number of the same weapons required to unlock";
+          title = "Number of the same item required to unlock";
           values[] = {15,25,40};
           default = 25;
      };
@@ -118,9 +118,9 @@ class Params
      };
      class allowFT
      {
-          title = "Limited Fast Travel";
+          title = "Fast Travel Targets Allowed";
           values[] = {0,1};
-          texts[] = {"No","Yes"};
+          texts[] = {"Anywhere","Airports & HQ"};
           default = 1;
      };
      class napalmEnabled

--- a/A3-Antistasi/MissionDescription/params.hpp
+++ b/A3-Antistasi/MissionDescription/params.hpp
@@ -120,7 +120,7 @@ class Params
      {
           title = "Fast Travel Targets Allowed";
           values[] = {0,1};
-          texts[] = {"Anywhere","Airports & HQ"};
+          texts[] = {"Any friendly position","Only Airports & HQ"};
           default = 1;
      };
      class napalmEnabled


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Enhancement
3. [X] Something

### What have you changed and why?
Changed the fast travel and unlock count parameter descriptions as they confused a lot of people.

"Anywhere" isn't really ideal as it's actually "any rebel-held location", but the latter is a bit long for a parameter value. Couldn't think of a better way to phrase this. Someone else might.

### Please specify which Issue this PR Resolves.
closes #869 

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

Params could do with a reorganisation, but now is not the time.
