### PR TITLE
Fix error when rebels equip a grenade launcher that's not a rifle

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_randomRifle.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_randomRifle.sqf
@@ -20,7 +20,7 @@ if !(primaryWeapon _unit isEqualTo "") then {
 	_unit removeWeapon (primaryWeapon _unit);
 };
 
-if (_rifleFinal in unlockedGrenadeLaunchers) then {
+if (_rifleFinal in unlockedGrenadeLaunchers && {_rifleFinal in unlockedRifles} ) then {
 	// lookup real underbarrel GL magazine, because not everything is 40mm
 	private _config = configFile >> "CfgWeapons" >> _rifleFinal;
 	private _glmuzzle = getArray (_config >> "muzzles") select 1;		// guaranteed by category


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
randomRifle assumed that all grenade launchers were also rifles, and so have multiple muzzles, which is no longer true since the category override patch where weapons like the M79 and M320 are not classed as grenade launchers. This PR handles the case where the grenade launcher is just a grenade launcher.

### Please specify which Issue this PR Resolves.
closes #913

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

Should really add some better handling for how much ammunition to add though. Five grenades is going to be a bit miserable for a non-rifle GL. Best method is probably weight-based, so it'd take some work.
