### PR TITLE
Fix savePlayer error caused by group member without a value

### DIFF
--- a/A3-Antistasi/functions/Save/fn_savePlayer.sqf
+++ b/A3-Antistasi/functions/Save/fn_savePlayer.sqf
@@ -62,11 +62,9 @@ if (isMultiplayer) then
 	_friendX = _x;
 	if ((!isNull _friendX) and (!isPlayer _friendX) and (alive _friendX)) then
 		{
-		private _valueOfFriend = (server getVariable (typeOf _friendX));
-		//If we don't get a number (which can happen if _friendX becomes null, for example) we lose the value of _resourcesBackground;
-		if (_valueOfFriend isEqualType _resourcesBackground) then {
-			_resourcesBackground = _resourcesBackground + (server getVariable (typeOf _friendX));
-		};
+		private _valueOfFriend = server getVariable [typeOf _friendX, 0];
+		_resourcesBackground = _resourcesBackground + _valueOfFriend;
+
 		if (vehicle _friendX != _friendX) then
 			{
 			_veh = vehicle _friendX;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
The savePlayer code attempts to determine the monetary value of each unit in the player's group, but doesn't correctly handle the nil case where a unit has no value. This could be caused by abusing ACE group join, or possibly by other methods.

### Please specify which Issue this PR Resolves.
closes #908 

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

This functionality appears to be a giant exploit. Players gain the monetary value of any non-player units and vehicles in their group, regardless of who purchased them. This might make some sense if the player saves were simultaneous and the group leader received the resources, but currently players are only saved on disconnection or when personally using the map board.
