### PR TITLE
Remove patrol heli from attack heli array in 3CB TKA template

### DIFF
--- a/A3-Antistasi/Templates/3CB_Occ_TKA_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Occ_TKA_Arid.sqf
@@ -146,7 +146,7 @@ vehNATOTransportPlanes = [];
 //Heli
 vehNATOPatrolHeli = "UK3CB_TKA_I_UH1H_M240";
 vehNATOTransportHelis = ["UK3CB_TKA_I_Mi8","UK3CB_TKA_I_Mi8AMT",vehNATOPatrolHeli,"UK3CB_TKA_I_UH1H"];
-vehNATOAttackHelis = ["UK3CB_TKA_I_UH1H_M240","UK3CB_TKA_I_Mi_24P","UK3CB_TKA_I_Mi_24V","UK3CB_TKA_I_Mi8AMTSh"];
+vehNATOAttackHelis = ["UK3CB_TKA_I_Mi_24P","UK3CB_TKA_I_Mi_24V","UK3CB_TKA_I_Mi8AMTSh"];
 //UAV
 vehNATOUAV = "B_UAV_02_F";
 vehNATOUAVSmall = "B_UAV_01_F";


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Removed the patrol heli from the attack heli array in the blufor 3CB TKA template. Antistasi makes assumptions in several places that the attack heli array doesn't contain the patrol heli. 

I can't prove that this fixes #905, but it's the only possibility I can find. The theoretical problem is that attack helis are a limited resource, so it was possible for patrolCA to build a _vehPool that contained no air transport vehicles. Normally the patrol heli is guaranteed to be in _vehPool.

### Please specify which Issue this PR Resolves.
closes #905

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
