### PR TITLE
Add surrender crate to JNL cargo list

### DIFF
--- a/A3-Antistasi/JeroenArsenal/JNL/fn_logistics_init.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNL/fn_logistics_init.sqf
@@ -534,9 +534,9 @@ jnl_attachmentOffset = [
 	["\A3\Weapons_F\Ammoboxes\Supplydrop.p3d",						[0, 0, 0.95],			[1,0,0],				1],		//Ammodrop crate
 	["\A3\Soft_F\Quadbike_01\Quadbike_01_F.p3d",					[0, 0, 1.4],			[0,1,0],				1],		//Quadbike
 	["\WW2\Assets_m\Weapons\Ammoboxes_m\IF_GER_Ammo.p3d",			[0,0,0.85],				[1,0,0],				1],		//ifa ammo
-	["\WW2\Assets_m\Weapons\Ammoboxes_m\IF_SU_Ammo.p3d",			[0,0,0.85],				[1,0,0],				1]		//ifa ammo
+	["\WW2\Assets_m\Weapons\Ammoboxes_m\IF_SU_Ammo.p3d",			[0,0,0.85],				[1,0,0],				1],		//ifa ammo
+	["\A3\weapons_F\AmmoBoxes\WpnsBox_F",							[0,0,0.85],				[1,0,0],				1]
 ];
-
 
 //todo replace with real items that are avalable
 jng_staticWeaponList = [];


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Antistasi adds the JNL load action to surrender crates, but JNL doesn't have their model listed in jnl_attachmentOffset, which causes RPT errors. This PR adds these crates to the array.

Questionable whether we want surrender crates to be loadable, or whether JNL should have a default for objects not in the list (it uses boundingArea for positioning these anyway), but this fixes the immediate problem.

### Please specify which Issue this PR Resolves.
closes #910 

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
