### PR TITLE
Airstrike sanity

### DIFF
--- a/A3-Antistasi/dialogs.hpp
+++ b/A3-Antistasi/dialogs.hpp
@@ -1894,18 +1894,18 @@ class carpet_bombing 			{
 		class HQ_button_Gstatic: RscButton
 		{
 			idc = -1;
-			text = "Carpet Bombing"; //--- ToDo: Localize;
+			text = "Cluster Bombs"; //--- ToDo: Localize;
 			x = 0.482498 * safezoneW + safezoneX;
 			y = 0.317959 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			tooltip = "Cost: 1 point";
-			action = "closeDialog 0;[""CARPET""] spawn A3A_fnc_NATObomb;";
+			action = "closeDialog 0;[""CLUSTER""] spawn A3A_fnc_NATObomb;";
 		};
 		class 4slots_L2: RscButton
 		{
 			idc = -1;
-			text = "NAPALM Bomb"; //--- ToDo: Localize;
+			text = "NAPALM Bombs"; //--- ToDo: Localize;
 			x = 0.272481 * safezoneW + safezoneX;
 			y = 0.415981 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;

--- a/A3-Antistasi/dialogs.hpp
+++ b/A3-Antistasi/dialogs.hpp
@@ -2514,13 +2514,13 @@ class tu_madre 				{
 		class HQ_button_Gstatic: RscButton
 		{
 			idc = -1;
-			text = "Carpet Bombing"; //--- ToDo: Localize;
+			text = "Cluster Bombing"; //--- ToDo: Localize;
 			x = 0.482498 * safezoneW + safezoneX;
 			y = 0.317959 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			tooltip = "Cost: 10 points";
-			action = "closeDialog 0;[""CARPET""] spawn A3A_fnc_NATObomb;";
+			action = "closeDialog 0;[""CLUSTER""] spawn A3A_fnc_NATObomb;";
 		};
 
 		class HQ_button_Gremove: RscButton

--- a/A3-Antistasi/functions/AI/fn_airbomb.sqf
+++ b/A3-Antistasi/functions/AI/fn_airbomb.sqf
@@ -1,53 +1,57 @@
 if (not isServer and hasInterface) exitWith {};
-private ["_countX","_plane","_typeX","_ammo","_cluster","_carpet","_sleep","_bomb"];
+private _filename = "fn_airbomb";
+private ["_countX","_plane","_typeX","_ammo","_cluster","_sleep","_bomb"];
 _plane = _this select 0;
 _typeX = _this select 1;
-_ammo = "Bomb_03_F";
-_countX = 8;
+_countX = 4;
 _cluster = false;
-_carpet = false;
-if (_typeX != "HE") then
-	{
-	_ammo = "G_40mm_HEDP";
-	if (_this select 1 == "NAPALM") then {_countX = 24} else {_countX = 48; _carpet = true};
-	_cluster = true;
-	};
+
+switch (_typeX) do {
+    case ("HE"): {
+        _ammo = "Bo_Mk82";
+				_sleep = 0.25
+    };
+		case ("CLUSTER"): {
+			_ammo = "BombCluster_03_Ammo_F";
+			_sleep = 0.5
+		};
+		case ("NAPALM"): {
+			_ammo = "ammo_Bomb_SDB";
+			_sleep = 0.5
+		};
+		default {
+			[1, "Invalid bomb type", _filename] call A3A_fnc_log;
+		};
+};
+
 if (typeOf _plane == vehSDKPlane) then {_countX = round (_countX / 2)};
 sleep random 5;
-_sleep = if (!_cluster) then {0.6} else {if (!_carpet) then {0.1} else {0.05}};
 
 for "_i" from 1 to _countX do
 	{
 	sleep _sleep;
 	if (alive _plane) then
 		{
-		_bomb = _ammo createvehicle ([getPos _plane select 0,getPos _plane select 1,(getPos _plane select 2)- 4]);
+		_bomb = _ammo createvehicle ([getPos _plane select 0,getPos _plane select 1,(getPos _plane select 2)- 5]);
 		waituntil {!isnull _bomb};
 		_bomb setDir (getDir _plane);
-		if (!_cluster) then
+		if (_typeX != "NAPALM") then
 			{
 			_bomb setVelocity [0,0,-50]
 			}
 		else
 			{
-			if (_this select 1 == "NAPALM") then
-				{
-				_bomb setVelocity [-5 + (random 10),-5 + (random 10),-50];
+				_bomb setVelocity [0,0,-50];
 				_nul = [_bomb] spawn
-					{
+				{
 					_bomba = _this select 0;
 					_pos = [];
 					while {!isNull _bomba} do
-						{
+					{
 						_pos = getPosASL _bomba;
 						sleep 0.1;
-						};
-					[_pos] remoteExec  ["A3A_fnc_napalm"];
 					};
-				}
-			else
-				{
-				_bomb setVelocity [-35 + (random 70),-35 + (random 70),-50];
+					[_pos] remoteExec  ["A3A_fnc_napalm"];
 				};
 			};
 		};

--- a/A3-Antistasi/functions/AI/fn_airbomb.sqf
+++ b/A3-Antistasi/functions/AI/fn_airbomb.sqf
@@ -35,13 +35,9 @@ for "_i" from 1 to _countX do
 		_bomb = _ammo createvehicle ([getPos _plane select 0,getPos _plane select 1,(getPos _plane select 2)- 5]);
 		waituntil {!isnull _bomb};
 		_bomb setDir (getDir _plane);
-		if (_typeX != "NAPALM") then
+		_bomb setVelocity [0,0,-50];
+		if (_typeX == "NAPALM") then
 			{
-			_bomb setVelocity [0,0,-50]
-			}
-		else
-			{
-				_bomb setVelocity [0,0,-50];
 				_nul = [_bomb] spawn
 				{
 					_bomba = _this select 0;
@@ -56,3 +52,4 @@ for "_i" from 1 to _countX do
 			};
 		};
 	};
+//_bomba is used to track when napalm bombs hit the ground in order to call the napalm script on the correct position

--- a/A3-Antistasi/functions/REINF/fn_NATObomb.sqf
+++ b/A3-Antistasi/functions/REINF/fn_NATObomb.sqf
@@ -70,7 +70,7 @@ _wp1 setWaypointSpeed "LIMITED";
 _wp1 setWaypointBehaviour "CARELESS";
 
 if (_typeX == "NAPALM" && napalmEnabled) then {_wp1 setWaypointStatements ["true", "[this,""NAPALM""] spawn A3A_fnc_airbomb"]} else {_typeX = "HE"};
-if (_typeX == "CARPET") then {_wp1 setWaypointStatements ["true", "[this,""CARPET""] spawn A3A_fnc_airbomb"]};
+if (_typeX == "CARPET") then {_wp1 setWaypointStatements ["true", "[this,""CLUSTER""] spawn A3A_fnc_airbomb"]};
 if (_typeX == "HE") then {_wp1 setWaypointStatements ["true", "[this,""HE""] spawn A3A_fnc_airbomb"]};
 
 

--- a/A3-Antistasi/functions/REINF/fn_NATObomb.sqf
+++ b/A3-Antistasi/functions/REINF/fn_NATObomb.sqf
@@ -70,7 +70,7 @@ _wp1 setWaypointSpeed "LIMITED";
 _wp1 setWaypointBehaviour "CARELESS";
 
 if (_typeX == "NAPALM" && napalmEnabled) then {_wp1 setWaypointStatements ["true", "[this,""NAPALM""] spawn A3A_fnc_airbomb"]} else {_typeX = "HE"};
-if (_typeX == "CARPET") then {_wp1 setWaypointStatements ["true", "[this,""CLUSTER""] spawn A3A_fnc_airbomb"]};
+if (_typeX == "CLUSTER") then {_wp1 setWaypointStatements ["true", "[this,""CLUSTER""] spawn A3A_fnc_airbomb"]};
 if (_typeX == "HE") then {_wp1 setWaypointStatements ["true", "[this,""HE""] spawn A3A_fnc_airbomb"]};
 
 


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Enhancement
3. [x] Change
### What have you changed and why?
Information:
    Halved the bomb count, now 4 for AI and 2 for rebel.
    Rework bomb type detection, it is now modular if we get more ideas.
    Removed redundant drop inaccuracy, was only used because the plane was dropping the 
    sub-munitions directly.
    Removed 2 unused variables, _carpet and _cluster.
    Adds comment explaining the point of _bomba
### Please specify which Issue this PR Resolves.
closes:
#524 
#546 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:
