### PR TITLE
Updated airbase markers to be default colour

### DIFF
--- a/A3-Antistasi/functions/Base/fn_mrkUpdate.sqf
+++ b/A3-Antistasi/functions/Base/fn_mrkUpdate.sqf
@@ -13,6 +13,7 @@ if (sidesX getVariable [_markerX,sideUnknown] == teamPlayer) then
 		[_mrkD,format ["%1 Airbase",nameTeamPlayer]] remoteExec ["setMarkerTextLocal",[Occupants,Invaders],true];
 		//_mrkD setMarkerText format ["SDK Airbase%1",_textX];
 		if (markerType _mrkD != "flag_Syndicat") then {_mrkD setMarkerType "flag_Syndicat"};
+		_mrkD setMarkerColor "Default";
 		}
 	else
 		{
@@ -48,7 +49,8 @@ else
 		{
 		if (_markerX in airportsX) then
 			{_mrkD setMarkerText format ["%1 Airbase",nameOccupants];
-			_mrkD setMarkerType flagNATOmrk
+			_mrkD setMarkerType flagNATOmrk;
+			_mrkD setMarkerColor "Default";
 			}
 		else
 			{
@@ -63,7 +65,7 @@ else
 		{
 		if (_markerX in airportsX) then {_mrkD setMarkerText format ["%1 Airbase",nameInvaders];_mrkD setMarkerType flagCSATmrk} else {
 		if (_markerX in outposts) then {_mrkD setMarkerText format ["%1 Outpost",nameInvaders]}};
-		_mrkD setMarkerColor colorInvaders;
+		if !(_markerX in airportsX) then {__mrkD setMarkerColor colorInvaders;} else {_mrkD setMarkerColor "Default"};
 		};
 	if (_markerX in resourcesX) then
 	 	{

--- a/A3-Antistasi/functions/init/fn_initGarrisons.sqf
+++ b/A3-Antistasi/functions/init/fn_initGarrisons.sqf
@@ -40,12 +40,12 @@ _fnc_initMarker =
 
 		if (_x in _mrkCSAT) then
 		{
-			_mrk setMarkerColor colorInvaders;
+			if !(_x in airportsX) then {_mrk setMarkerColor colorInvaders;} else {_mrk setMarkerColor "Default"};
 			sidesX setVariable [_x, Invaders, true];
 		}
 		else
 		{
-			_mrk setMarkerColor colorOccupants;
+			if !(_x in airportsX) then {_mrk setMarkerColor colorOccupants;} else {_mrk setMarkerColor "Default"};
 			sidesX setVariable [_x, Occupants, true];
 		};
 


### PR DESCRIPTION
Updated airbase markers to be deafult color, this is done to improve "readability" of the markers

## What type of PR is this.
1. [ ] Bug
2. [x] Enhancement

### What have you changed and why?
Information:Updated airbase markers to be deafult color, this is done to improve "readability" of the markers
    https://drive.google.com/open?id=1XxQFud57tw4hQiBgZyNY_BNA6J5eD8u2

### Please specify which Issue this PR Resolves.
closes #901

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:
