### PR TITLE
Reimplement contact reports with timeout

### DIFF
--- a/A3-Antistasi/functions/Missions/fn_underAttack.sqf
+++ b/A3-Antistasi/functions/Missions/fn_underAttack.sqf
@@ -2,10 +2,7 @@ private ["_markerX","_nameDest","_nameENY"];
 
 params ["_markerX", "_sideEny", "_sideX", ["_roadblockTemp", true]];
 
-if ([_markerX] call BIS_fnc_taskExists) exitWith {
-	[3, "Task already active for marker " + _markerX, "underAttack"] call A3A_fnc_log;
-};
-[3, "Creating task for marker " + _markerX, "underAttack"] call A3A_fnc_log;
+if ([_markerX] call BIS_fnc_taskExists) exitWith {};
 
 _nameDest = [_markerX] call A3A_fnc_localizar;
 _nameENY = if (_sideEny == teamPlayer) then
@@ -29,7 +26,5 @@ waitUntil {
 	(_roadblockTemp && {spawner getVariable _markerX == 2}) or
 	((garrison getVariable [_markerX + "_lastAttack", 0]) + 600 < serverTime)
 };
-
-[3, "Terminating task for marker " + _markerX, "underAttack"] call A3A_fnc_log;
 
 [_markerX] call BIS_fnc_deleteTask;

--- a/A3-Antistasi/functions/Missions/fn_underAttack.sqf
+++ b/A3-Antistasi/functions/Missions/fn_underAttack.sqf
@@ -1,6 +1,12 @@
 private ["_markerX","_nameDest","_nameENY"];
 
 params ["_markerX", "_sideEny", "_sideX", ["_roadblockTemp", true]];
+
+if ([_markerX] call BIS_fnc_taskExists) exitWith {
+	[3, "Task already active for marker " + _markerX, "underAttack"] call A3A_fnc_log;
+};
+[3, "Creating task for marker " + _markerX, "underAttack"] call A3A_fnc_log;
+
 _nameDest = [_markerX] call A3A_fnc_localizar;
 _nameENY = if (_sideEny == teamPlayer) then
 {
@@ -12,10 +18,18 @@ else
 };
 if (_sideX == teamPlayer) then {_sideX = [teamPlayer,civilian]};
 
-[_sideX,_markerX,[format ["%2 is attacking us in %1. Help the defense if you can",_nameDest,_nameENY],format ["%1 Contact Rep",_nameENY],_markerX],getMarkerPos _markerX,false,0,true,"Defend",true] call BIS_fnc_taskCreate;
+[_sideX,_markerX,[format ["%2 is attacking us in %1. Help the defense if you can",_nameDest,_nameENY],format ["%1 Contact Report",_nameENY],_markerX],getMarkerPos _markerX,false,0,true,"Defend",true] call BIS_fnc_taskCreate;
 
 if (_sideX isEqualType []) then {_sideX = teamPlayer};
 
-waitUntil {sleep 10; (sidesX getVariable [_markerX,sideUnknown] != _sideX) or (_roadblockTemp && {spawner getVariable _markerX == 2})};
+// Terminate on despawn, capture or ten minutes since last injury
+waitUntil {
+	sleep 10;
+	(sidesX getVariable [_markerX,sideUnknown] != _sideX) or
+	(_roadblockTemp && {spawner getVariable _markerX == 2}) or
+	((garrison getVariable [_markerX + "_lastAttack", 0]) + 600 < serverTime)
+};
 
-[0,_markerX] spawn A3A_fnc_deleteTask;
+[3, "Terminating task for marker " + _markerX, "underAttack"] call A3A_fnc_log;
+
+[_markerX] call BIS_fnc_deleteTask;

--- a/A3-Antistasi/functions/Revive/fn_handleDamage.sqf
+++ b/A3-Antistasi/functions/Revive/fn_handleDamage.sqf
@@ -31,7 +31,24 @@ if (_part == "" && _damage > 0.1) then
 		//if (_damage > 0.6) then {[_unit,_unit,_injurer] spawn A3A_fnc_chargeWithSmoke};
 		if (_damage > 0.6) then {[_unit,_injurer] spawn A3A_fnc_unitGetToCover};
 	};
+
+	// Contact report generation for rebels
+	if (side group _injurer == Occupants or side group _injurer == Invaders) then
+	{
+		// Check if unit is part of a rebel garrison
+		private _marker = _unit getVariable ["markerX",""];
+		if (_marker != "" && {sidesX getVariable [_marker,sideUnknown] == teamPlayer}) then
+		{
+			// Limit last attack var changes and task updates to once per 30 seconds
+			private _lastAttackTime = garrison getVariable [_marker + "_lastAttack", -30];
+			if (_lastAttackTime + 30 < serverTime) then {
+				garrison setVariable [_marker + "_lastAttack", serverTime, true];
+				[_marker, side group _injurer, side group _unit] remoteExec ["A3A_fnc_underAttack", 2];
+			};
+		};
+	};
 };
+
 
 // Let ACE medical handle the rest (inc return value) if it's running 
 if (hasACEMedical) exitWith {};

--- a/A3-Antistasi/functions/Revive/fn_handleDamageAAF.sqf
+++ b/A3-Antistasi/functions/Revive/fn_handleDamageAAF.sqf
@@ -3,7 +3,7 @@
 params ["_unit","_part","_damage","_injurer","_projectile","_hitIndex","_instigator","_hitPoint"];
 
 // Functionality unrelated to Antistasi revive
-if (side _injurer == teamPlayer) then
+if (side group _injurer == teamPlayer) then
 {
 	// Helmet popping: use _hitpoint rather than _part to work around ACE calling its fake hitpoint "head"
 	if (_damage >= 1 && {_hitPoint == "hithead"}) then
@@ -27,6 +27,22 @@ if (side _injurer == teamPlayer) then
 	if (_part == "" && _damage < 1) then 
 	{
 		if (_damage > 0.6) then {[_unit,_injurer] spawn A3A_fnc_unitGetToCover};
+	};
+
+	// Contact report generation for PvP players
+	if (_part == "" && side group _unit == Occupants) then
+	{
+		// Check if unit is part of a garrison
+		private _marker = _unit getVariable ["markerX",""];
+		if (_marker != "" && {sidesX getVariable [_marker,sideUnknown] == Occupants}) then
+		{
+			// Limit last attack var changes and task updates to once per 30 seconds
+			private _lastAttackTime = garrison getVariable [_marker + "_lastAttack", -30];
+			if (_lastAttackTime + 30 < serverTime) then {
+				garrison setVariable [_marker + "_lastAttack", serverTime, true];
+				[_marker, teamPlayer, side group _unit] remoteExec ["A3A_fnc_underAttack", 2];
+			};
+		};
 	};
 };
 

--- a/A3-Antistasi/functions/Revive/fn_unconscious.sqf
+++ b/A3-Antistasi/functions/Revive/fn_unconscious.sqf
@@ -61,14 +61,6 @@ else
 			[_unit,"heal"] remoteExec ["A3A_fnc_flagaction",0,_unit];
 			if (_unit != petros) then {if (_injurer != Invaders) then {[_unit,true] remoteExec ["setCaptive",0,_unit]; _unit setCaptive true}};
 			};
-		if ((_injurer  == Occupants) or (_injurer  == Invaders)) then
-			{
-			_markerX = _unit getVariable ["markerX",""];
-			if (_markerX != "") then
-				{
-				if (!([_markerX] call BIS_fnc_taskExists) and (sidesX getVariable [_markerX,sideUnknown] == teamPlayer)) then {[_markerX,_injurer,teamPlayer] remoteExec ["A3A_fnc_underAttack",2]};
-				};
-			};
 		};
 	};
 

--- a/A3-Antistasi/functions/Revive/fn_unconsciousAAF.sqf
+++ b/A3-Antistasi/functions/Revive/fn_unconsciousAAF.sqf
@@ -5,18 +5,6 @@ private _playerNear = false;
 private _group = group _unit;
 private _side = side _group;
 
-if ((side _injurer == teamPlayer) and (_side == Occupants)) then
-{
-	_marker = _unit getVariable ["markerX",""];
-	if (_marker != "") then
-	{
-		if (!([_marker] call BIS_fnc_taskExists) and (sidesX getVariable [_marker,sideUnknown] == Occupants)) then
-        {
-            [_marker, teamPlayer,_side] remoteExec ["A3A_fnc_underAttack",2]
-        };
-	};
-};
-
 if ({if ((isPlayer _x) and (_x distance _unit < distanceSPWN2)) exitWith {1}} count allUnits != 0) then
 {
 	_playerNear = true;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Enhancement

### What have you changed and why?
Contact report tasks for locations were triggered by the unconscious handlers, which are no longer called when ACE medical is running. This PR moves them to the damage handlers instead, and adds a timeout so that they no longer stick around on the map until the location is despawned.    

Because the damage handler and task update are often running on different machines, the synchronization is not perfect and the occasional shooting incident will be missed. There are more accurate methods than I used here, but as alert accuracy isn't important or even realistic, I prioritized complexity and performance.

### Please specify which Issue this PR Resolves.
closes #882

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
