### PR TITLE
3CB Classname Fixes/Civcar changes

### DIFF
--- a/A3-Antistasi/Templates/3CB_Occ_TKA_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Occ_TKA_Arid.sqf
@@ -16,7 +16,7 @@ NATOFlag = "Flag_TKA_O_Army";
 NATOFlagTexture = "\UK3CB_Factions\addons\UK3CB_Factions_TKA\Flag\tka_o_army_co.paa";
 flagNATOmrk = "UK3CB_MARKER_TKA_O_Army";
 if (isServer) then {"NATO_carrier" setMarkerText "Takistani Carrier"};
-	
+
 //Loot Crate
 NATOAmmobox = "I_supplyCrate_F";
 
@@ -122,7 +122,7 @@ groupsNATOGen = [policeOfficer,policeGrunt];
 ////////////////////////////////////
 //Military Vehicles
 //Lite
-vehNATOBike = "B_T_Quadbike_01_F";
+vehNATOBike = "I_G_Quadbike_01_F";
 vehNATOLightArmed = ["UK3CB_TKA_I_LR_M2","UK3CB_TKA_I_LR_AGS30","UK3CB_TKA_I_LR_SPG9","UK3CB_TKA_I_GAZ_Vodnik_PKT","UK3CB_TKA_I_LR_SF_M2","UK3CB_TKA_I_LR_SF_AGS30","UK3CB_TKA_I_BTR40_MG","UK3CB_TKA_I_BRDM2","UK3CB_TKA_I_BRDM2_ATGM"];
 vehNATOLightUnarmed = ["UK3CB_TKA_I_BTR40","UK3CB_TKA_I_GAZ_Vodnik","UK3CB_TKA_I_LR_Open","UK3CB_TKA_I_Hilux_Closed","UK3CB_TKA_I_BRDM2_HQ"];
 vehNATOTrucks = ["UK3CB_TKA_I_V3S_Closed","UK3CB_TKA_I_V3S_Open","UK3CB_TKA_I_V3S_Recovery"];
@@ -148,8 +148,8 @@ vehNATOPatrolHeli = "UK3CB_TKA_I_UH1H_M240";
 vehNATOTransportHelis = ["UK3CB_TKA_I_Mi8","UK3CB_TKA_I_Mi8AMT",vehNATOPatrolHeli,"UK3CB_TKA_I_UH1H"];
 vehNATOAttackHelis = ["UK3CB_TKA_I_Mi_24P","UK3CB_TKA_I_Mi_24V","UK3CB_TKA_I_Mi8AMTSh"];
 //UAV
-vehNATOUAV = "B_UAV_02_F";
-vehNATOUAVSmall = "B_UAV_01_F";
+vehNATOUAV = "I_UAV_02_dynamicLoadout_F";
+vehNATOUAVSmall = "I_UAV_01_F";
 //Artillery
 vehNATOMRLS = "UK3CB_TKA_I_BM21";
 vehNATOMRLSMags = "rhs_mag_40Rnd_122mm_rockets";

--- a/A3-Antistasi/Templates/3CB_Occ_TKA_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Occ_TKA_Arid.sqf
@@ -148,7 +148,7 @@ vehNATOPatrolHeli = "UK3CB_TKA_I_UH1H_M240";
 vehNATOTransportHelis = ["UK3CB_TKA_I_Mi8","UK3CB_TKA_I_Mi8AMT",vehNATOPatrolHeli,"UK3CB_TKA_I_UH1H"];
 vehNATOAttackHelis = ["UK3CB_TKA_I_Mi_24P","UK3CB_TKA_I_Mi_24V","UK3CB_TKA_I_Mi8AMTSh"];
 //UAV
-vehNATOUAV = "I_UAV_02_dynamicLoadout_F";
+vehNATOUAV = "I_UAV_02_F";
 vehNATOUAVSmall = "I_UAV_01_F";
 //Artillery
 vehNATOMRLS = "UK3CB_TKA_I_BM21";

--- a/A3-Antistasi/Templates/3CB_Reb_CNM_Temp.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_CNM_Temp.sqf
@@ -43,7 +43,7 @@ soldiersSDK = sdkTier1 + sdkTier2 + sdkTier3;
 //           VEHICLES            ///
 ////////////////////////////////////
 //Military Vehicles
-vehSDKBike = "UK3CB_CCM_I_Golf";
+vehSDKBike = "I_G_Quadbike_01_F";
 vehSDKLightArmed = "UK3CB_CCM_I_Datsun_Pkm";
 vehSDKAT = "UK3CB_CCM_I_Hilux_Spg";
 vehSDKLightUnarmed = "UK3CB_CCM_I_Datsun_Open";
@@ -54,7 +54,7 @@ vehSDKBoat = "I_C_Boat_Transport_01_F";
 vehSDKRepair = "UK3CB_CCM_I_V3S_Repair";
 
 //Civilian Vehicles
-civCar = "UK3CB_CHC_C_Ikarus";
+civCar = "UK3CB_C_Hilux_Open";
 civTruck = "UK3CB_CHC_C_V3S_Recovery";
 civHeli = "UK3CB_CHC_C_Mi8AMT";
 civBoat = "C_Rubberboat";

--- a/A3-Antistasi/Templates/3CB_Reb_CNM_Trop.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_CNM_Trop.sqf
@@ -43,7 +43,7 @@ soldiersSDK = sdkTier1 + sdkTier2 + sdkTier3;
 //           VEHICLES            ///
 ////////////////////////////////////
 //Military Vehicles
-vehSDKBike = "UK3CB_CCM_I_Golf";
+vehSDKBike = "I_G_Quadbike_01_F";
 vehSDKLightArmed = "UK3CB_CCM_I_Datsun_Pkm";
 vehSDKAT = "UK3CB_CCM_I_Hilux_Spg";
 vehSDKLightUnarmed = "UK3CB_CCM_I_Datsun_Open";
@@ -54,7 +54,7 @@ vehSDKBoat = "I_C_Boat_Transport_01_F";
 vehSDKRepair = "UK3CB_CCM_I_V3S_Repair";
 
 //Civilian Vehicles
-civCar = "UK3CB_CHC_C_Ikarus";
+civCar = "UK3CB_C_Hilux_Open";
 civTruck = "UK3CB_CHC_C_V3S_Recovery";
 civHeli = "UK3CB_CHC_C_Mi8AMT";
 civBoat = "C_Rubberboat";

--- a/A3-Antistasi/Templates/3CB_Reb_TPGM_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_TPGM_Arid.sqf
@@ -43,7 +43,7 @@ soldiersSDK = sdkTier1 + sdkTier2 + sdkTier3;
 //           VEHICLES            ///
 ////////////////////////////////////
 //Military Vehicles
-vehSDKBike = "UK3CB_UN_B_UAZ_Closed";
+vehSDKBike = "B_G_Quadbike_01_F";
 vehSDKLightArmed = "UK3CB_UN_B_Hilux_Pkm";
 vehSDKAT = "UK3CB_UN_B_LR_SPG9";
 vehSDKLightUnarmed = "UK3CB_UN_B_Hilux_Closed";
@@ -54,7 +54,7 @@ vehSDKBoat = "I_C_Boat_Transport_01_F";
 vehSDKRepair = "UK3CB_UN_B_V3S_Repair";
 
 //Civilian Vehicles
-civCar = "UK3CB_CHC_C_Ikarus";
+civCar = "UK3CB_C_Hilux_Open";
 civTruck = "UK3CB_CHC_C_V3S_Recovery";
 civHeli = "UK3CB_CHC_C_Mi8AMT";
 civBoat = "C_Rubberboat";

--- a/A3-Antistasi/Templates/3CB_Reb_TPGM_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_TPGM_Arid.sqf
@@ -3,7 +3,7 @@
 ////////////////////////////////////
 nameTeamPlayer = "UN";
 SDKFlag = "Flag_CCM_B";
-SDKFlagTexture = "\UK3CB_Factions\addons\UK3CB_Factions_CCM\Flag\ccm_i_flag_co.paa";
+SDKFlagTexture = "uk3cb_factions\addons\uk3cb_factions_ccm\flag\ccm_b_flag_co.paa";
 typePetros = "UK3CB_UN_B_OFF";
 
 ////////////////////////////////////
@@ -46,7 +46,7 @@ soldiersSDK = sdkTier1 + sdkTier2 + sdkTier3;
 vehSDKBike = "UK3CB_UN_B_UAZ_Closed";
 vehSDKLightArmed = "UK3CB_UN_B_Hilux_Pkm";
 vehSDKAT = "UK3CB_UN_B_LR_SPG9";
-vehSDKLightUnarmed = "UK3CB_CCM_I_Hilux_Closed";
+vehSDKLightUnarmed = "UK3CB_UN_B_Hilux_Closed";
 vehSDKTruck = "UK3CB_UN_B_V3S_Closed";
 //vehSDKHeli = "rhsgref_ins_g_Mi8amt";
 vehSDKPlane = "UK3CB_UN_B_C130J";
@@ -66,7 +66,7 @@ civBoat = "C_Rubberboat";
 SDKMGStatic = "UK3CB_UN_B_NSV";
 staticATteamPlayer = "UK3CB_UN_B_SPG9";
 staticAAteamPlayer = "UK3CB_UN_B_ZU23";
-SDKMortar = "rhsgref_UN_B_2b14_82mm";
+SDKMortar = "UK3CB_UN_B_2b14_82mm";
 SDKMortarHEMag = "rhs_mag_3vo18_10";
 SDKMortarSmokeMag = "rhs_mag_d832du_10";
 

--- a/A3-Antistasi/Templates/3CB_Reb_TTF_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_TTF_Arid.sqf
@@ -47,7 +47,7 @@ soldiersSDK = sdkTier1 + sdkTier2 + sdkTier3;
 //           VEHICLES            ///
 ////////////////////////////////////
 //Military Vehicles
-vehSDKBike = "UK3CB_CCM_I_Golf";
+vehSDKBike = "I_G_Quadbike_01_F";
 vehSDKLightArmed = "UK3CB_CCM_I_Datsun_Pkm";
 vehSDKAT = "UK3CB_CCM_I_Hilux_Spg";
 vehSDKLightUnarmed = "UK3CB_CCM_I_Datsun_Open";
@@ -58,7 +58,7 @@ vehSDKBoat = "I_C_Boat_Transport_01_F";
 vehSDKRepair = "UK3CB_CCM_I_V3S_Repair";
 
 //Civilian Vehicles
-civCar = "UK3CB_CHC_C_Ikarus";
+civCar = "UK3CB_C_Hilux_Open";
 civTruck = "UK3CB_CHC_C_V3S_Recovery";
 civHeli = "UK3CB_CHC_C_Mi8AMT";
 civBoat = "C_Rubberboat";


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [x] Enhancement

### What have you changed and why?
Information:
### Reb TPGM Template:
vehSDKLightUnarmed to an existing classname , fitting to the rest of the UN Vehicles.
Fixed the Typo in SDKMortar
changed Flag texture to be the same as on the Flag.
Changed Civcar from Bus to Open Hilux.
Changed SDKbike from Golf to Quadbike.

### REB CMN/TTF Template:
Changed Civcar from Bus to Open Hilux.
Changed SDKbike from Golf to Quadbike.

### OCC TKA Template:
Swaped Blue UAVs for Greenfor onces.
Changed Bluefors Tropical Quadbike to an Independant one.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:
Fixes this report from 2.2.2 Bugs report channel

![grafik](https://user-images.githubusercontent.com/57111907/78377509-fbb75e80-75cf-11ea-80ae-1ba935f02e66.png)
