### PR TITLE
New war level calculation

### DIFF
--- a/A3-Antistasi/functions/OrgPlayers/fn_tierCheck.sqf
+++ b/A3-Antistasi/functions/OrgPlayers/fn_tierCheck.sqf
@@ -1,11 +1,29 @@
-_sites = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
-_tierWar = 1 + (floor (((5*({(_x in outposts) or (_x in resourcesX) or (_x in citiesX)} count _sites)) + (10*({_x in seaports} count _sites)) + (20*({_x in airportsX} count _sites)))/10));
+params [["_silent", false]];
+
+private _totalPoints = (8 * count airportsX) + (4 * count seaports) + (2 * count outposts)
+	+ (count citiesX) + (2 * count resourcesX) + (2 * count factories);
+
+private _rebelSites = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
+private _rebelPoints = 0;
+{
+	_rebelPoints = _rebelPoints + call {
+		if (_x in citiesX) exitWith {1};
+		if (_x in outposts or {_x in resourcesX or _x in factories}) exitWith {2};
+		if (_x in seaports) exitWith (4);
+		if (_x in airportsX) then {8} else {0};
+	}
+} forEach _rebelSites;
+
+// war tier 10 = 70% of total points, WT8 = 42%, WT6 = 22%, WT4 = 8%, WT2 = 1%
+private _tierWar = 1 + floor (9 * sqrt (_rebelPoints / (0.7 * _totalPoints)));
 if (_tierWar > 10) then {_tierWar = 10};
+
+//_tierWar = 1 + (floor (((5*({(_x in outposts) or (_x in resourcesX) or (_x in citiesX)} count _sites)) + (10*({_x in seaports} count _sites)) + (20*({_x in airportsX} count _sites)))/10));
 if (_tierWar != tierWar) then
 {
 	tierWar = _tierWar;
 	publicVariable "tierWar";
-	[petros,"tier",""] remoteExec ["A3A_fnc_commsMP",[teamPlayer,civilian]];
+	if (!_silent) then { [petros,"tier",""] remoteExec ["A3A_fnc_commsMP",[teamPlayer,civilian]] };
 	//Updates the vehicles and groups for the sites
 	[] call A3A_fnc_updatePreference;
 	//[] remoteExec ["A3A_fnc_statistics",[teamPlayer,civilian]];

--- a/A3-Antistasi/functions/Save/fn_loadServer.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadServer.sqf
@@ -104,14 +104,17 @@ if (isServer) then {
 	_sites = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
 
 	//Isn't that just tierCheck.sqf?
-	tierWar = 1 + (floor (((5*({(_x in outposts) or (_x in resourcesX) or (_x in citiesX)} count _sites)) + (10*({_x in seaports} count _sites)) + (20*({_x in airportsX} count _sites)))/10));
-	if (tierWar > 10) then {tierWar = 10};
-	publicVariable "tierWar";
+//	tierWar = 1 + (floor (((5*({(_x in outposts) or (_x in resourcesX) or (_x in citiesX)} count _sites)) + (10*({_x in seaports} count _sites)) + (20*({_x in airportsX} count _sites)))/10));
+//	if (tierWar > 10) then {tierWar = 10};
+//	publicVariable "tierWar";
 
 	tierPreference = 1;
 	publicVariable "tierPreference";
 	//Updating the preferences based on war level
-	[] call A3A_fnc_updatePreference;
+//	[] call A3A_fnc_updatePreference;
+
+	// update war tier silently, calls updatePreference if changed
+	[true] call A3A_fnc_tierCheck;
 
 	if (isNil "usesWurzelGarrison") then {
 		//Create the garrison new


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Enhancement

### What have you changed and why?
The old war level calculation is purely dependent on the count of locations captured, with no adjustment for map size. This PR changes the calculation. Features:

1. Hits war level 10 with 70% of the island captured.
2. Calculation is non-linear so that lower war levels are still triggered early.
3. War level contribution of cities reduced to make the mass flips less punishing.
4. Factories now included. Probably an old bug that they weren't.

The non-linearity is currently critical, because until war level 2, reb vs gov vs inv acts like reb vs gov, where every attack will be launched against rebels. Makes it very difficult to hold territory at war level 1. I could disable major attacks at war level 1, but then you'd have people thinking it's a great idea to take one resource and AFK for 24 hours.

### Please specify which Issue this PR Resolves.
closes #877

### Is further testing or are further changes required?
1. [X] Don't ask me.
2. [ ] Yes (Please provide further detail below.)
