### PR TITLE
Mission generation script generates smaller mission

### DIFF
--- a/PrepareMissionForPacking.ps1
+++ b/PrepareMissionForPacking.ps1
@@ -17,9 +17,11 @@ $formattedVersionId = $versionId.Split("\.") -join "-";
 
 ForEach ($templateFolder in $missionTemplateFolders) {
 	$folderName = $templateFolder.Name;
-	$pair = $folderName.Split("\.");
+    $pair = $folderName.Split("\.");
 	$missionFolderName = $pair[0] + "-" + $formattedVersionId + "." + $pair[1]; 
 	$destinationPath = $(Join-Path $folderForPreparedMissions.FullName $missionFolderName);
 	Copy-Item -Path $mainDataPath -Destination $destinationPath -Recurse;
+    $exclude = "NavGrid"+ $pair[1] + ".sqf";
+    Get-ChildItem $destinationPath\NavGrids -Exclude $exclude | Remove-Item -Force;
 	Copy-Item -Path $(Join-Path $templateFolder.FullName "*") -Destination $destinationPath -Recurse -Force;
 }


### PR DESCRIPTION
Currently missions after generation with PrepareMissionForPacking.ps1 has about 7,2 MB because NavGrids of all maps are copied to each output mission folder.
This change removes not necessary grids from each mission NavGrids directory. This reduces output size to about 4,6 MB.