### PR TITLE
Remove LAT from RHS AFRF TL

### DIFF
--- a/A3-Antistasi/Templates/Loadouts/rhs_afrf_teamLeader.sqf
+++ b/A3-Antistasi/Templates/Loadouts/rhs_afrf_teamLeader.sqf
@@ -51,7 +51,6 @@
 		],
 
 		[//Backpack
-		"",
 		[//Inventory
 		[]
 		]

--- a/A3-Antistasi/Templates/Loadouts/rhs_afrf_teamLeader.sqf
+++ b/A3-Antistasi/Templates/Loadouts/rhs_afrf_teamLeader.sqf
@@ -11,11 +11,11 @@
 		],
 
 		[//Launcher
-		"rhs_weap_rpg26",									//Weapon
+		"",									//Weapon
 		"",													//Muzzle
 		"",													//Rail
 		"",								//Sight
-		["rhs_rpg26_mag",1],							//Primary Magazine
+		[],							//Primary Magazine
 		[],													//Secondary Magazine
 		""													//Bipod
 		],


### PR DESCRIPTION
No other RHS loadout has the TL with LAT, nor on 3CB.

## What type of PR is this.
1. [ ] Bug
2. [ ] Enhancement
3. [x] Balance tweak
### What have you changed and why?
Information:
    Removed RPG-26 from AFRF TL Loadout

### Please specify which Issue this PR Resolves.
closes none

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:
