### PR TITLE
Fix marker colour-setting typo in mrkUpdate

### DIFF
--- a/A3-Antistasi/functions/Base/fn_mrkUpdate.sqf
+++ b/A3-Antistasi/functions/Base/fn_mrkUpdate.sqf
@@ -65,7 +65,7 @@ else
 		{
 		if (_markerX in airportsX) then {_mrkD setMarkerText format ["%1 Airbase",nameInvaders];_mrkD setMarkerType flagCSATmrk} else {
 		if (_markerX in outposts) then {_mrkD setMarkerText format ["%1 Outpost",nameInvaders]}};
-		if !(_markerX in airportsX) then {__mrkD setMarkerColor colorInvaders;} else {_mrkD setMarkerColor "Default"};
+		if !(_markerX in airportsX) then {_mrkD setMarkerColor colorInvaders;} else {_mrkD setMarkerColor "Default"};
 		};
 	if (_markerX in resourcesX) then
 	 	{


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Fixed typo in #925 that throws RPT errors and prevents some invader markers from having their colours set correctly.

### Please specify which Issue this PR Resolves.
Possibly related to #954. Not clear.

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
