### PR TITLE
Prevent backpack drones from being used to farm airstrike points

### DIFF
--- a/A3-Antistasi/functions/REINF/fn_addBombRun.sqf
+++ b/A3-Antistasi/functions/REINF/fn_addBombRun.sqf
@@ -22,6 +22,14 @@ if (not(_veh isKindOf "Air")) exitWith {["Airstrike", "Only Air Vehicles can be 
 
 _typeX = typeOf _veh;
 
+if (isClass (configfile >> "CfgVehicles" >> _typeX >> "assembleInfo")) then {
+	if (count getArray (configfile >> "CfgVehicles" >> _typeX >> "assembleInfo" >> "dissasembleTo") > 0) then {
+		_exit = true;
+	};
+};
+if (_exit) exitWith {["Airstrike", "Backpack drones cannot be used to increase Airstrike points"] call A3A_fnc_customHint;};
+
+
 //if (_typeX == vehSDKHeli) exitWith {hint "Syndikat Helicopters cannot be used to increase Airstrike points"};
 
 _pointsX = 2;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
It was possible to farm infinite airstrike points by unlocking a UAV backpack and then converting the assembled UAVs. This PR adds a check for whether an aircraft can be disassembled.    

### Please specify which Issue this PR Resolves.
closes #958

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
