### PR TITLE
Prevent bogus JNL load action being added to surrender crates

### DIFF
--- a/A3-Antistasi/functions/AI/fn_surrenderAction.sqf
+++ b/A3-Antistasi/functions/AI/fn_surrenderAction.sqf
@@ -38,7 +38,7 @@ _unit addEventHandler ["HandleDamage",
 // create surrender box
 private _boxX = "Box_IND_Wps_F" createVehicle position _unit;
 _boxX allowDamage false;
-_boxX call jn_fnc_logistics_addAction;
+//_boxX call jn_fnc_logistics_addAction;
 clearMagazineCargoGlobal _boxX;
 clearWeaponCargoGlobal _boxX;
 clearItemCargoGlobal _boxX;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
On creation, JNL load actions are currently added to surrender crates. These crates aren't supported by JNL and so using the action generates errors. This PR removes the JNL load action from these crates.

While JNL can be easily adapted to support this crate type, surrender crates are currently automatically deleted after an hour, so using them with JNL could cause serious problems.

### Please specify which Issue this PR Resolves.
closes #910 

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
