### PR TITLE
Change logging function to default to logging to server

### DIFF
--- a/A3-Antistasi/functions/Utility/fn_log.sqf
+++ b/A3-Antistasi/functions/Utility/fn_log.sqf
@@ -6,16 +6,18 @@
 		Log Message: string - Message to log
 		File (optional): string - File in which the log message originated
 		Log to server (optional): bool - true for logging to server RPT instead of client
-		The example below would output an error to the console.
+			Defaults to true for all HC logs, and errors (level 1) on clients
 
+		The example below would output an error to the console.
 		private _filename = "fn_log";
 		[1, "Message", _filename] call A3A_fnc_log;
 **/
 
-params ["_level", "_message", ["_file", "No File Specified"], ["_toServer", false]];
+params ["_level", "_message", ["_file", "No File Specified"]];
+private _toServer = param [3, !(hasInterface && _level > 1)];
 private _filename = "fn_log";
 
-//This ignores the log event if it's above the
+//This ignores the log event if it's above the global threshold
 if (_level > LogLevel) exitwith {};
 
 // Sets up the actual log event.
@@ -38,8 +40,7 @@ switch (_level) do {
 	};
 };
 
-// Lazy evaluation should be removed if default value of _toServer is changed
-if (_toServer && {!isServer}) then {
+if (isNil "blockServerLogging" && _toServer && !isServer) then {
 	_logLine remoteExec ["diag_log", 2];
 } else {
 	diag_log _logLine;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Enhancement
3. [X] Whatever

### What have you changed and why?
Implemented design specified in #891. It doesn't actually do much yet because most of the HC functions currently use direct diag_log calls rather than A3A_fnc_log.

### Please specify which Issue this PR Resolves.
closes #757, #891.

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

