### PR TITLE
Work around probable Arma bug causing mortar unpack/repack loop

### DIFF
--- a/A3-Antistasi/functions/AI/fn_mortyAI.sqf
+++ b/A3-Antistasi/functions/AI/fn_mortyAI.sqf
@@ -23,7 +23,11 @@ while {(alive _morty0) and (alive _morty1)} do
 	_mortarX = _typeX createVehicle _pos;
 	removeBackpackGlobal _morty0;
 	removeBackpackGlobal _morty1;
-	_groupX addVehicle _mortarX;
+
+// Removed as workaround for probable Arma AI bug with Podnos mortar + long distance (~200m) moves
+// After a long move, non-gunner will attempt to move into the second mortar seat unless this is removed
+//	_groupX addVehicle _mortarX;
+
 	_morty1 assignAsGunner _mortarX;
 	[_morty1] orderGetIn true;
 	[_morty1] allowGetIn true;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
In some cases, the non-gunner of a mortar team will attempt to board the mortar, causing the Antistasi mortar loop to think the squad has been given a move order. How to reproduce:
- Buy a two-man mortar team with no quadbike in RHS greenfor. Might also happen with other cases where the mortar has two seats.
- Using high command, order them to move to a position at least 300m away (minimum not known, probably closer to 200m, but short distances do not work).
- Once they arrive, the mortar team will now continually unpack and repack the mortar (they're actually creating a new mortar vehicle each time, but that's what it looks like). Once in this state, they'll never set up the mortar correctly regardless of future move distances or waypoint clearance.

Removing the addVehicle on the mortar prevents the problem, which suggests to me that it's actually an Arma AI bug, where it thinks boarding the mortar will help it to move long distances. Antistasi actually runs very little AI code on 2-man mortar teams: Just this spawned function, no UPSMON or attackDrillAI.

I think the only downside to removing the addVehicle is that the enemy won't consider the mortar a valid target unless it's occupied. Would mean that they may occasionally leave a mortar intact that they should probably destroy or capture.

### Please specify which Issue this PR Resolves.
closes #845

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
