### PR TITLE
Fix exploit where crates could be loaded into a vehicle while undercover

### DIFF
--- a/A3-Antistasi/JeroenArsenal/JNL/Actions/fn_logistics_addActionLoad.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNL/Actions/fn_logistics_addActionLoad.sqf
@@ -76,6 +76,7 @@ _loadActionID = _object addAction [
 		    };
 		    default
 		    {
+			_player setCaptive false;			// break undercover
 		   	[_nearestVehicle, _cargo, true, true] remoteexec ["jn_fnc_logistics_load", 2];
 		    };
 			};


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Loot crates could be loaded into vehicles without breaking undercover, so it was straightforward to farm them in the early game by driving in with civvie clothes and an offroad/truck. This PR breaks undercover when a JNL crate is loaded.

The local setCaptive should be fine here, as the player is always local to an addAction.

### Please specify which Issue this PR Resolves.
closes #971

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the Mission in Singleplayer?
2. [X] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
