### PR TITLE
Various Petros & moveHQObject fixes

### DIFF
--- a/A3-Antistasi/functions/Base/fn_buildHQ.sqf
+++ b/A3-Antistasi/functions/Base/fn_buildHQ.sqf
@@ -6,15 +6,19 @@ if (petros != (leader group petros)) then
 	[petros] join _groupPetros;
 	_groupPetros selectLeader petros;
 };
-[petros,"remove"] remoteExec ["A3A_fnc_flagaction",0,petros];
+[petros,"remove"] remoteExec ["A3A_fnc_flagaction",0];
+
 petros switchAction "PlayerStand";
 petros disableAI "MOVE";
 petros disableAI "AUTOTARGET";
+petros setBehaviour "SAFE";
+
+// Put petros back on the server, otherwise might cause issues on disconnect
+[group petros, 2] remoteExec ["setGroupOwner", 2];
 
 [getPos petros] call A3A_fnc_relocateHQObjects;
 
-petros setBehaviour "SAFE";
 if (isNil "placementDone") then {placementDone = true; publicVariable "placementDone"};
 sleep 5;
-[Petros,"mission"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],petros];
+[Petros,"mission"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian]];
 

--- a/A3-Antistasi/functions/Base/fn_createPetros.sqf
+++ b/A3-Antistasi/functions/Base/fn_createPetros.sqf
@@ -30,9 +30,9 @@ if (petros == leader _groupPetros) then {
 	petros disableAI "MOVE";
 	petros disableAI "AUTOTARGET";
 	petros setBehaviour "SAFE";
-	[Petros,"mission"] remoteExec ["A3A_fnc_flagaction",0]
+	[Petros,"mission"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian]]
 } else {
-	[Petros,"buildHQ"] remoteExec ["A3A_fnc_flagaction",0]
+	[Petros,"buildHQ"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian]]
 };
 
 call A3A_fnc_initPetros;

--- a/A3-Antistasi/functions/Base/fn_moveHQ.sqf
+++ b/A3-Antistasi/functions/Base/fn_moveHQ.sqf
@@ -2,19 +2,23 @@ if (player != theBoss) exitWith {["Move HQ", "Only our Commander has access to t
 
 if ((count weaponCargo boxX >0) or (count magazineCargo boxX >0) or (count itemCargo boxX >0) or (count backpackCargo boxX >0)) exitWith {["Move HQ", "You must first empty your Ammobox in order to move the HQ"] call A3A_fnc_customHint;};
 
-if !(isNull attachedTo petros) then { detach petros };		// in case someone is moving him
+if !(isNull attachedTo petros) exitWith {["Move HQ", "Put Petros down before you move the HQ!"] call A3A_fnc_customHint;};
 
-petros enableAI "MOVE";
-petros enableAI "AUTOTARGET";
 
-[petros,"remove"] remoteExec ["A3A_fnc_flagaction",0,petros];
+[petros,"remove"] remoteExec ["A3A_fnc_flagaction",0];
 //removeAllActions petros;
 private _groupPetros = group petros;
 [petros] join theBoss;
 deleteGroup _groupPetros;
+
 petros setBehaviour "AWARE";
+petros enableAI "MOVE";
+petros enableAI "AUTOTARGET";
+
+/*
 if (isMultiplayer) then
 	{
+	// these would need to be remoteExec'd on the server
 	boxX hideObjectGlobal true;
 	vehicleBox hideObjectGlobal true;
 	mapX hideObjectGlobal true;
@@ -29,6 +33,7 @@ else
 	fireX hideObject true;
 	flagX hideObject true;
 	};
+*/
 
 fireX inflame false;
 

--- a/A3-Antistasi/functions/Dialogs/fn_moveHQObject.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_moveHQObject.sqf
@@ -40,11 +40,27 @@ private _fnc_placeObject = {
 		_playerX removeAction _dropObjectActionIndex;
 	};
 
-	// some objects never lose (and even regain) their velocity when detached, becoming lethal
-	// on a DS, object locality changes when detached, so we have to remoteexec
+	// Can't find a case where this is ever true, but we'll make sure
+	if (local _thingX) then {
+		if (isNull group _thingX) then { [_thingX, 2] remoteExec ["setOwner", 2] }
+		else { [group _thingX, 2] remoteExec ["setGroupOwner", 2] };
+	};
+
+	// Some objects never lose (and even regain) their velocity when detached, becoming lethal
+	// On a DS, object locality changes when detached, so we have to remoteexec
 	[_thingX, [0,0,0]] remoteExec ["setVelocity", _thingX];
+
+	// Without this, non-unit objects often hang in mid-air
 	[_thingX, surfaceNormal position _thingX] remoteExec ["setVectorUp", _thingX];
-	_thingX setPosATL [getPosATL _thingX select 0,getPosATL _thingX select 1,0.1];
+
+	// Place on closest surface
+	private _pos = getPosASL _thingX;
+	private _intersects = lineIntersectsSurfaces [_pos, _pos vectorAdd [0,0,-100], _thingX];
+	if (count _intersects > 0) then {
+		_thingX setPosASL (_intersects select 0 select 0);
+	};
+
+	// _thingX setPosATL [getPosATL _thingX select 0,getPosATL _thingX select 1,0.1];
 
 	_thingX setVariable ["objectBeingMoved", false];
 	_thingX addAction ["Move this asset", A3A_fnc_moveHQObject,nil,0,false,true,"","(_this == theBoss)"];


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Enhancement

### What have you changed and why?
- Enabled placing HQ objects on nearest surface.
- Fixed an issue where Petros remained local to player after building HQ.
- Fixed an issue where attached Petros could disappear if move HQ option was used.
- Fixed an issue where Petros wouldn't move when moving HQ the second time.
- Cleaned up some unnecessary JIPs.

### Please specify which Issue this PR Resolves.
closes #976, plus possibly some reported cases where Petros disappears if the commander disconnects.

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the Mission in Singleplayer?
2. [X] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
