### PR TITLE
Changes to items in getLoadout template function

### DIFF
--- a/A3-Antistasi/functions/Templates/fn_getLoadout.sqf
+++ b/A3-Antistasi/functions/Templates/fn_getLoadout.sqf
@@ -3,13 +3,10 @@ params ["_loadoutName"];
 private _basicMedicalSupplies =
 	if (hasACE) then {
 		[
-			["ACE_Tourniquet",3],
-			["ACE_SalineIV_500",1],
-			["ACE_Morphine",2],
-			["ACE_Epinephrine",2],
-			["ACE_Adenosine",2],
-			["ACE_PackingBandage",10],
-			["ACE_ElasticBandage",10],
+			["ACE_Tourniquet",4],
+			["ACE_Morphine",3],
+			["ACE_Epinephrine",3],
+			["ACE_PackingBandage",20],
 			["ACE_Quikclot",10],
 			["ACE_splint", 2]
 		]
@@ -24,7 +21,9 @@ private _basicMiscItems =
 	if (hasACE) then {
 		[
 			["ACE_Earplugs",1],
-			["ACE_Cabletie",3]
+			["ACE_Cabletie",3],
+			["ACE_MapTools"]
+
 		];
 	} else {
 		[
@@ -37,20 +36,13 @@ private _medicSupplies =
 		[
 			["ACE_surgicalKit",1],
 
-			["ACE_PackingBandage",5],
-			["ACE_ElasticBandage",20],
-			["ACE_QuikClot",10],
+			["ACE_ElasticBandage",25],
 
 			["ACE_Morphine",5],
-			["ACE_Epinephrine",5],
-			["ACE_Adenosine",5],
+			["ACE_Epinephrine",10],
 
-			["ACE_PlasmaIV_250",5],
-			["ACE_SalineIV_500",3],
-			["ACE_BloodIV",1],
-
-			["ACE_Tourniquet",3],
-			["ACE_Splint",4]
+			["ACE_BloodIV_500",6],
+			["ACE_Splint",5]
 		]
 		+ ([[["ACE_PersonalAidKit", 2]], [["adv_aceCPR_AED", 1]]] select hasADVCPR)
 		+ ([[], [["adv_aceSplint_splint", 7]]] select hasADVSplint);

--- a/A3-Antistasi/functions/Templates/fn_getLoadout.sqf
+++ b/A3-Antistasi/functions/Templates/fn_getLoadout.sqf
@@ -22,7 +22,7 @@ private _basicMiscItems =
 		[
 			["ACE_Earplugs",1],
 			["ACE_Cabletie",3],
-			["ACE_MapTools"]
+			["ACE_MapTools",1]
 
 		];
 	} else {


### PR DESCRIPTION
I had to move my getLoadout changes out of my PvP Rework PR and make a separate PR for it, as it is still being discussed.

## What type of PR is this.
1. [ ] Bug
2. [x] Enhancement

### What have you changed and why?
Information: 

**_basicMedicalSupplies**
Added one more tourniquet (4 tourniquets for 4 limbs).
Removed IV bag from uniform (doesn't make sense for everyone to carry blood bags, that's the medic's job)
Set morphine and epinephrine count to 3 each
Removed elastic bandages, replaced them with more packing. (Elastics are not good for anyone except for medics, as they reopen in a minute and require you to stitch immediately after bandaging. Packing can last at least 5 times longer without reopening, but are less effective).

**_basicMiscItems**
Added a map tool

**_medicSupplies**
Removed quikclots and packing bandages. Replaced them with 5 elastic bandages (Elastics are around 3 times more effective than quikclots, and are around twice as effective as packing bandages).
Increased amount of epinephrine to 10
Removed tourniquets (all loadouts now get 4 tourniquets in their uniforms)
Removed the 250ml Plasma bags and 500ml Saline bags. (Loadouts already have blood. Having one of each type serves no purpose.)
Replaced the 1000ml blood bag with 6 500ml blood bags

### Please specify which Issue this PR Resolves.
None AFAIK

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the Mission in Singleplayer?
2. [x] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes (Please provide further detail below.)

********************************************************
Notes: Seeing as how we will be discussing this in the dev meeting, this shall be WIP until we all come to an agreement.
