### PR TITLE
Fix boss loss on respawn and clean up logging

### DIFF
--- a/A3-Antistasi/functions/OrgPlayers/fn_assignBossIfNone.sqf
+++ b/A3-Antistasi/functions/OrgPlayers/fn_assignBossIfNone.sqf
@@ -3,28 +3,20 @@ private _filename = "fn_assignBossIfNone";
 
 // Don't run if a Boss exists and is still eligible
 if (!isNil "theBoss" && {!isNull theBoss && (theBoss getVariable ["eligible", false])}) exitWith {
-	[3, format ["Not attempting to assign new boss - player %1 is the boss", name theBoss],_filename] call A3A_fnc_log;
+	[3, format ["Not attempting to assign new boss - player %1 is the boss", theBoss],_filename] call A3A_fnc_log;
 };
 
-private _members = [];
+private _members = (call A3A_fnc_playableUnits) select { [_x] call A3A_fnc_isMember };
+[3, format ["Attempting to assign new boss, checking %1 members for next Boss.", count _members],_filename] call A3A_fnc_log;
+
 private _nextBoss = objNull;
-
-[3, format ["Attempting to assign new boss, checking %1 members for next Boss.", count membersX],_filename] call A3A_fnc_log;
-// Are there any members online.
-
-private _BossRank = 0;
+private _bossRank = 0;
 {
-	private _isMember = [_x] call A3A_fnc_isMember;
-	if (_isMember) then {
-		_members pushBack _x;
-	};
-	
-	if ((_x getVariable ["eligible", false]) && (side (group _x) == teamPlayer) && _isMember) then {
-		[3, format ["Player %1 is eligible", name _x],_filename] call A3A_fnc_log;
-		[3, format ["Current Boss Rank: %1.", _BossRank],_filename] call A3A_fnc_log;
+	if ((_x getVariable ["eligible", false]) && (side group _x == teamPlayer)) then {
+		[3, format ["Player %1 is eligible", _x],_filename] call A3A_fnc_log;
 		private _dataX = [_x] call A3A_fnc_numericRank;
 		private _playerRank = _dataX select 0;
-		[3, format ["Players rank is: %1", _playerRank],_filename] call A3A_fnc_log;
+		[3, format ["Current boss rank: %1, player rank: %2", _bossRank, _playerRank],_filename] call A3A_fnc_log;
 		if (_playerRank > _BossRank) then
 		{
 			_nextBoss = _x;
@@ -32,13 +24,13 @@ private _BossRank = 0;
 		};
 	}
 	else {
-		[3, format ["Player is not eligible: %1", name _x],_filename] call A3A_fnc_log;
+		[3, format ["Player %1 is not eligible", _x],_filename] call A3A_fnc_log;
 	};
-} forEach (call A3A_fnc_playableUnits);
+} forEach _members;
 
 if (!isNull _nextBoss) then
 {
-	[2, format ["Player chosen for Boss: %1", name _nextBoss],_filename] call A3A_fnc_log;
+	[2, format ["Player chosen for Boss: %1", _nextBoss],_filename] call A3A_fnc_log;
 	[_nextBoss] call A3A_fnc_theBossTransfer;
 }
 else

--- a/A3-Antistasi/functions/OrgPlayers/fn_makePlayerBossIfEligible.sqf
+++ b/A3-Antistasi/functions/OrgPlayers/fn_makePlayerBossIfEligible.sqf
@@ -2,7 +2,7 @@ private _filename = "fn_makePlayerBossIfEligible";
 
 params ["_player"];
 
-[3, format ["Attempting to make %1 the boss", name _player], _filename] call A3A_fnc_log;
+[3, format ["Attempting to make %1 the boss", _player], _filename] call A3A_fnc_log;
 
 if (_player getVariable ["eligible",false] && (side (group _player) == teamPlayer) && [_player] call A3A_fnc_isMember) exitWith {
 	[3, "Player is eligible, making them the boss", _filename] call A3A_fnc_log;

--- a/A3-Antistasi/functions/OrgPlayers/fn_theBossTransfer.sqf
+++ b/A3-Antistasi/functions/OrgPlayers/fn_theBossTransfer.sqf
@@ -1,10 +1,10 @@
 if !(isServer) exitWith {};
 private _filename = "fn_theBossTransfer";
-params [["_newBoss", objNull]];
+params [["_newBoss", objNull], ["_silent", false]];
 
 if (!isNil "theBoss" and {!isNull theBoss}) then
 {
-	[3, format ["Removing %1 from Boss roles.", name theBoss], _filename] call A3A_fnc_log;
+	[3, format ["Removing %1 from Boss roles.", theBoss], _filename] call A3A_fnc_log;
 	
 	bossHCGroupsTransfer = hcAllGroups theBoss;
 	hcRemoveAllGroups theBoss;
@@ -17,10 +17,11 @@ theBoss = _newBoss;
 publicVariable "theBoss";
 
 if (isNull _newBoss) exitWith { 
-	[] spawn {
+	[_silent] spawn {
+		params ["_silent"];
 		sleep 5;
 		private _textX = format ["The commander has resigned. There is no eligible commander."];
-		[petros,"hint",_textX, "New Commander"] remoteExec ["A3A_fnc_commsMP", 0];
+		if (!_silent) then {[petros,"hint",_textX, "New Commander"] remoteExec ["A3A_fnc_commsMP", 0]};
 		[] remoteExec ["A3A_fnc_statistics",[teamPlayer,civilian]];
 	};
 };
@@ -39,6 +40,7 @@ if (!isNil "bossHCGroupsTransfer") then
 }
 else {
 	// Boss got lost somewhere, try to find HC groups by scanning
+	[3, "No previous HC groups found, scanning all groups.",_filename] call A3A_fnc_log;
 	{
 		if ((leader _x getVariable ["spawner",false]) and (!isPlayer leader _x) and (side _x == teamPlayer)) then
 		{
@@ -47,11 +49,12 @@ else {
 	} forEach allGroups;
 };
 
-[3, format ["New boss %1 (%2) set.", str theBoss, name theBoss], _filename] call A3A_fnc_log;
+[3, format ["New boss %1 set.", theBoss], _filename] call A3A_fnc_log;
 
-[] spawn {
+[_silent] spawn {
+	params ["_silent"];
 	sleep 5;
 	private _textX = format ["%1 is the new commander of our forces. Greet them!", name theBoss];
-	[petros,"hint",_textX, "New Commander"] remoteExec ["A3A_fnc_commsMP", 0];
+	if (!_silent) then {[petros,"hint",_textX, "New Commander"] remoteExec ["A3A_fnc_commsMP", 0]};
 	[] remoteExec ["A3A_fnc_statistics",[teamPlayer,civilian]];
 };

--- a/A3-Antistasi/onPlayerRespawn.sqf
+++ b/A3-Antistasi/onPlayerRespawn.sqf
@@ -68,7 +68,7 @@ if (side group player == teamPlayer) then
 	//_newUnit enableSimulation true;
 	if (_oldUnit == theBoss) then
 		{
-		[_newUnit] call A3A_fnc_theBossTransfer;
+		[_newUnit, true] remoteExec ["A3A_fnc_theBossTransfer", 2];
 		};
 
 


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
- Fixed bug where theBossTransfer wasn't being remoteExec'd in onPlayerRespawn, causing the commander role to end up on a corpse after a respawn.
- Added silent mode to theBossTransfer so that corpse transfers aren't broadcast.
- Improved logging output of commander transfer functions.

### Please specify which Issue this PR Resolves.
closes #995

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the Mission in Singleplayer?
2. [X] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
