### PR TITLE
Fix outpost and airport markers initializing with wrong side name

### DIFF
--- a/A3-Antistasi/functions/init/fn_initGarrisons.sqf
+++ b/A3-Antistasi/functions/init/fn_initGarrisons.sqf
@@ -7,11 +7,10 @@ private _fileName = "fn_initGarrisons";
 _fnc_initMarker =
 {
 	params ["_mrkCSAT", "_target", "_mrkType", "_mrkText", ["_useSideName", false]];
-	private ["_pos", "_mrk", "_garrNum", "_garrison", "_groupsRandom"];
 
 	{
-		_pos = getMarkerPos _x;
-		_mrk = createMarker [format ["Dum%1", _x], _pos];
+		private _pos = getMarkerPos _x;
+		private _mrk = createMarker [format ["Dum%1", _x], _pos];
 		//TODO Multilanguage variable insted text
 		_mrk setMarkerShape "ICON";
 
@@ -20,22 +19,22 @@ _fnc_initMarker =
 			killZones setVariable [_x, [], true];
 			server setVariable [_x, 0, true];
 
-			if (_x in _mrkCSAT) then
-			{
-				_mrkText = format [_mrkText, nameInvaders];
-				if(_x in airportsX) then
-				{
-					_mrkType = flagCSATmrk;
-				};
-			}
-			else
-			{
-				_mrkText = format [_mrkText, nameOccupants];
-				if(_x in airportsX) then
-				{
-					_mrkType = flagNATOmrk;
-				};
-			};
+			private _sideName = if (_x in _mrkCSAT) then {nameInvaders} else {nameOccupants};
+			_mrk setMarkerText format [_mrkText, _sideName];
+		}
+		else
+		{
+			_mrk setMarkerText _mrkText;
+		};
+
+		if (_x in airportsX) then
+		{
+			private _flagType = if (_x in _mrkCSAT) then {flagCSATmrk} else {flagNATOmrk};
+			_mrk setMarkerType _flagType;
+		}
+		else
+		{
+			_mrk setMarkerType _mrkType;
 		};
 
 		if (_x in _mrkCSAT) then
@@ -48,9 +47,6 @@ _fnc_initMarker =
 			if !(_x in airportsX) then {_mrk setMarkerColor colorOccupants;} else {_mrk setMarkerColor "Default"};
 			sidesX setVariable [_x, Occupants, true];
 		};
-
-		_mrk setMarkerType _mrkType;
-		_mrk setMarkerText _mrkText;
 
 		[_x] call A3A_fnc_createControls;
 	} forEach _target;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Bad algorithm in initGarrisons (overwriting of input params) caused some outpost and airport markers to have the wrong side name on initialization. This PR fixes it. There were no side effects, so this wouldn't have been causing any of the mixed-side bugs.

### Please specify which Issue this PR Resolves.
closes #756

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
