### PR TITLE
Fix loading of destroyed buildings

### DIFF
--- a/A3-Antistasi/functions/Save/fn_loadServer.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadServer.sqf
@@ -92,13 +92,14 @@ if (isServer) then {
     [true] call A3A_fnc_calculateAggression;
 
 	["chopForest"] call A3A_fnc_getStatVariable;
-	["destroyedBuildings"] call A3A_fnc_getStatVariable;
+
 	/*
 	{
 	_buildings = nearestObjects [_x, listMilBld, 25, true];
 	(_buildings select 1) setDamage 1;
 	} forEach destroyedBuildings;
 	*/
+
 	["posHQ"] call A3A_fnc_getStatVariable;
 	["nextTick"] call A3A_fnc_getStatVariable;
 	["staticsX"] call A3A_fnc_getStatVariable;

--- a/A3-Antistasi/functions/Save/fn_loadStat.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadStat.sqf
@@ -95,11 +95,11 @@ if (_varName in specialVarLoads) then {
 	if (_varName == 'destroyedBuildings') then {
 		destroyedBuildings= +_varValue;
 		//publicVariable "destroyedBuildings";
-		private _building = objNull;
 		{
 			// nearestObject sometimes picks the wrong building and is several times slower
-			_building = nearestObjects [_x, ["House"], 1, true] select 0;
-			if !(_building in antennas) then {
+			// Example: Livonia Land_Cargo_Tower_V2_F at [6366.63,3880.88,0] ATL
+			private _building = nearestObjects [_x, ["House"], 1, true] select 0;
+			if (!isNil "_building" && {!(_building in antennas)} ) then {
 				private _ruin = [_building] call BIS_fnc_createRuin;
 				//JIP on the _ruin, as repairRuinedBuilding will delete the ruin.
 				if !(isNull _ruin) then {

--- a/A3-Antistasi/functions/Save/fn_loadStat.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadStat.sqf
@@ -97,7 +97,8 @@ if (_varName in specialVarLoads) then {
 		//publicVariable "destroyedBuildings";
 		private _building = objNull;
 		{
-			_building = nearestObject [_x, "House"];
+			// nearestObject sometimes picks the wrong building and is several times slower
+			_building = nearestObjects [_x, ["House"], 1, true] select 0;
 			if !(_building in antennas) then {
 				private _ruin = [_building] call BIS_fnc_createRuin;
 				//JIP on the _ruin, as repairRuinedBuilding will delete the ruin.


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Fixed a couple of errors in the destroyed buildings loading code:
1. nearestObject sometimes picks the wrong building, probably due to using a 3d model-centre check. This occasionally causes the wrong building to be destroyed on load. nearestObjects is accurate and much faster.
2. destroyedBuildings was being loaded twice, causing an RPT error for each building loaded.

### Please specify which Issue this PR Resolves.
Fixes the RPT errors in #1001 but not the actual problem.

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the Mission in Singleplayer?
2. [X] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
