### PR TITLE
"SDKMortarSmokeMag" Fix for Reb_CDF

### DIFF
--- a/A3-Antistasi/Templates/RHS_Reb_CDF_Arid.sqf
+++ b/A3-Antistasi/Templates/RHS_Reb_CDF_Arid.sqf
@@ -68,7 +68,7 @@ staticATteamPlayer = "rhsgref_cdf_b_SPG9";
 staticAAteamPlayer = "rhsgref_cdf_b_ZU23";
 SDKMortar = "rhsgref_cdf_b_reg_M252";
 SDKMortarHEMag = "rhs_12Rnd_m821_HE";
-SDKMortarSmokeMag = "rhs_12Rnd_m821_HE";
+SDKMortarSmokeMag = "8Rnd_82mm_Mo_Smoke_white";
 
 //Static Weapon Bags
 MGStaticSDKB = "RHS_DShkM_Gun_Bag";

--- a/A3-Antistasi/Templates/RHS_Reb_CDF_Wdl.sqf
+++ b/A3-Antistasi/Templates/RHS_Reb_CDF_Wdl.sqf
@@ -68,7 +68,7 @@ staticATteamPlayer = "rhsgref_cdf_b_SPG9";
 staticAAteamPlayer = "rhsgref_cdf_b_ZU23";
 SDKMortar = "rhsgref_cdf_b_reg_M252";
 SDKMortarHEMag = "rhs_12Rnd_m821_HE";
-SDKMortarSmokeMag = "rhs_12Rnd_m821_HE";
+SDKMortarSmokeMag = "8Rnd_82mm_Mo_Smoke_white";
 
 //Static Weapon Bags
 MGStaticSDKB = "RHS_DShkM_Gun_Bag";


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [x] Enhancement

### What have you changed and why?
Information: Changed SDKMortarSmokeMag from HE to a Smoke Mortar Round
The 8 Rounds are the highest amount possible in that Mortar, there is no RHS Variant it uses Vanilla

### Please specify which Issue this PR Resolves.
closes #1005 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:
It only has Happend in Reb_CDF Templates.