### PR TITLE
Remove Ace Interaction on VehicleBox

### DIFF
--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -342,7 +342,7 @@ if (isMultiplayer) then {
 				_isMember = true;
 				["General Info", "You are not in the member's list, but as you are Server Admin, you have been added. Welcome!"] call A3A_fnc_customHint;
 			};
-			
+
 			if (_isMember) then {
 				membersX pushBack (getPlayerUID player);
 				publicVariable "membersX";
@@ -350,7 +350,7 @@ if (isMultiplayer) then {
 				_nonMembers = {(side group _x == teamPlayer) and !([_x] call A3A_fnc_isMember)} count (call A3A_fnc_playableUnits);
 				if (_nonMembers >= (playableSlotsNumber teamPlayer) - bookedSlots) then {["memberSlots",false,1,false,false] call BIS_fnc_endMission};
 				if (memberDistance != 16000) then {[] execVM "orgPlayers\nonMemberDistance.sqf"};
-				
+
 				["General Info", "Welcome Guest<br/><br/>You have joined this server as guest"] call A3A_fnc_customHint;
 			};
 		};
@@ -387,7 +387,7 @@ if (_isJip) then {
 		} forEach missionsX;
 	};
 }
-else 
+else
 {
 	[2,"Not Joining in Progress (JIP)",_filename] call A3A_fnc_log;
 };
@@ -451,6 +451,7 @@ _flagLight setLightAttenuation [7, 0, 0.5, 0.5];
 vehicleBox allowDamage false;
 vehicleBox addAction ["Heal, Repair and Rearm", A3A_fnc_healAndRepair,nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull]) and (side (group _this) == teamPlayer)", 4];
 vehicleBox addAction ["Vehicle Arsenal", JN_fnc_arsenal_handleAction, [], 0, true, false, "", "alive _target && vehicle _this != _this", 10];
+if (hasACE) then { [vehicleBox, VehicleBox] call ace_common_fnc_claim;};			//Disables ALL Ace Interactions
 if (isMultiplayer) then {
 	vehicleBox addAction ["Personal Garage", { [GARAGE_PERSONAL] spawn A3A_fnc_garage },nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull]) and (side (group _this) == teamPlayer)", 4];
 };
@@ -496,7 +497,7 @@ if (isNil "placementDone") then {
 if (isMultiplayer) then {
 	[] spawn A3A_fnc_createDialog_shouldLoadPersonalSave;
 }
-else 
+else
 {
 	if (loadLastSave) then {
 		[] spawn A3A_fnc_loadPlayer;

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -451,7 +451,7 @@ _flagLight setLightAttenuation [7, 0, 0.5, 0.5];
 vehicleBox allowDamage false;
 vehicleBox addAction ["Heal, Repair and Rearm", A3A_fnc_healAndRepair,nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull]) and (side (group _this) == teamPlayer)", 4];
 vehicleBox addAction ["Vehicle Arsenal", JN_fnc_arsenal_handleAction, [], 0, true, false, "", "alive _target && vehicle _this != _this", 10];
-if (hasACE) then { [vehicleBox, VehicleBox] call ace_common_fnc_claim;};			//Disables ALL Ace Interactions
+if (hasACE) then { [vehicleBox, VehicleBox] call ace_common_fnc_claim;};	//Disables ALL Ace Interactions
 if (isMultiplayer) then {
 	vehicleBox addAction ["Personal Garage", { [GARAGE_PERSONAL] spawn A3A_fnc_garage },nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull]) and (side (group _this) == teamPlayer)", 4];
 };


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Enhancement

### What have you changed and why?
Information: Added "ace_common_fnc_claim" to VehicleBox in Fn_InitClient, since its only Important to disable Ace actions on Clients since noone else can Interact with the Box it should work on All Players.
--------> Adding it in the Init of VehicleBox in the Missions could also work but thats pretty annoying to edit and 1 times per Map instead of once in Initclient.

Ignore Line 345,353,390,500 that seems to be Atom fighting random Spaces.
    

### Please specify which Issue this PR Resolves.
closes #948 

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)
I havent had any Errors during my testing and it disabled Ace Interactions completly as intended, in Theory it should work on all Clients (With Ace).
********************************************************
Notes: I Assigned both of you since you know more than me but it seems to be a pretty simple one where i can't have fucked up :D
