### PR TITLE
Speculative workaround for remaining schrodinger's buildings

### DIFF
--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -90,12 +90,14 @@ class A3A
 		class rebuildRadioTower {};
 		class relocateHQObjects {};
 		class repairRuinedBuilding {};
+		class requestDataFromServer {};
 		class resourceCheckSkipTime {};
 		class resourcesFIA {};
 		class returnMuzzle {};
 		class revealToPlayer {};
 		class scheduler {};
 		class sellVehicle {};
+		class setDataOnClient {};
 		class setMarkerAlphaForSide {};
 		class sizeMarker {};
 		class splitVehicleCrewIntoOwnGroups {};

--- a/A3-Antistasi/functions/Base/fn_repairRuinedBuilding.sqf
+++ b/A3-Antistasi/functions/Base/fn_repairRuinedBuilding.sqf
@@ -39,4 +39,6 @@ _buildingToRepair setPos [_oldPos select 0, _oldPos select 1, 0];
 //Make sure we unhide, in case it was hidden by BIS_fnc_createRuin
 [_buildingToRepair, false] remoteExec ["hideObject", 0, _buildingToRepair];
 
+destroyedBuildings = destroyedBuildings - [_buildingToRepair];
+
 true;

--- a/A3-Antistasi/functions/Base/fn_requestDataFromServer.sqf
+++ b/A3-Antistasi/functions/Base/fn_requestDataFromServer.sqf
@@ -1,0 +1,15 @@
+_filename = "fn_requestDataFromServer";
+
+if (!isServer) exitWith { [1, "Server-only function miscalled", _filename] call A3A_fnc_log };
+if (!isRemoteExecuted) exitWith { [1, "Function not remote executed", _filename] call A3A_fnc_log };
+
+if (isNil "serverInitDone") then { waitUntil {sleep 1; !(isNil "serverInitDone")} };
+
+params ["_varName"];
+
+_varValue = missionNamespace getVariable _varName;
+if (isNil "_varValue") exitWith {
+	[1, format ["Var %1 not defined on server", _varName], _filename] call A3A_fnc_log
+};
+
+[_varName, _varValue] remoteExec ["A3A_fnc_setDataOnClient", remoteExecutedOwner];

--- a/A3-Antistasi/functions/Base/fn_setDataOnClient.sqf
+++ b/A3-Antistasi/functions/Base/fn_setDataOnClient.sqf
@@ -1,0 +1,16 @@
+_filename = "fn_setDataOnClient";
+
+if (isServer) exitWith {[1, "Client-only function miscalled", _filename] call A3A_fnc_log};
+
+params ["_varName", "_varValue"];
+
+switch (_varName) do {
+	case "destroyedBuildings": {
+		destroyedBuildings = _varValue;
+		{ hideObject _x } forEach destroyedBuildings;
+	};
+	default {
+		missionNamespace setVariable ["_varName", "_varValue"];
+	};
+};
+

--- a/A3-Antistasi/functions/Save/fn_loadServer.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadServer.sqf
@@ -92,13 +92,14 @@ if (isServer) then {
     [true] call A3A_fnc_calculateAggression;
 
 	["chopForest"] call A3A_fnc_getStatVariable;
-	["destroyedBuildings"] call A3A_fnc_getStatVariable;
+
 	/*
 	{
 	_buildings = nearestObjects [_x, listMilBld, 25, true];
 	(_buildings select 1) setDamage 1;
 	} forEach destroyedBuildings;
 	*/
+
 	["posHQ"] call A3A_fnc_getStatVariable;
 	["nextTick"] call A3A_fnc_getStatVariable;
 	["staticsX"] call A3A_fnc_getStatVariable;

--- a/A3-Antistasi/functions/Save/fn_loadStat.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadStat.sqf
@@ -95,11 +95,11 @@ if (_varName in specialVarLoads) then {
 	if (_varName == 'destroyedBuildings') then {
 		destroyedBuildings= +_varValue;
 		//publicVariable "destroyedBuildings";
-		private _building = objNull;
 		{
 			// nearestObject sometimes picks the wrong building and is several times slower
-			_building = nearestObjects [_x, ["House"], 1, true] select 0;
-			if !(_building in antennas) then {
+			// Example: Livonia Land_Cargo_Tower_V2_F at [6366.63,3880.88,0] ATL
+			private _building = nearestObjects [_x, ["House"], 1, true] select 0;
+			if (!isNil "_building" && {!(_building in antennas)} ) then {
 				private _ruin = [_building] call BIS_fnc_createRuin;
 				//JIP on the _ruin, as repairRuinedBuilding will delete the ruin.
 				if !(isNull _ruin) then {

--- a/A3-Antistasi/functions/Save/fn_loadStat.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadStat.sqf
@@ -93,22 +93,23 @@ if (_varName in specialVarLoads) then {
 	if (_varName == 'maxUnits') then {maxUnits=_varValue; publicVariable "maxUnits"};
 	if (_varName == 'vehInGarage') then {vehInGarage= +_varValue; publicVariable "vehInGarage"};
 	if (_varName == 'destroyedBuildings') then {
-		destroyedBuildings= +_varValue;
-		//publicVariable "destroyedBuildings";
 		{
 			// nearestObject sometimes picks the wrong building and is several times slower
 			// Example: Livonia Land_Cargo_Tower_V2_F at [6366.63,3880.88,0] ATL
+
 			private _building = nearestObjects [_x, ["House"], 1, true] select 0;
-			if (!isNil "_building" && {!(_building in antennas)} ) then {
+			call {
+				if (isNil "_building") exitWith { diag_log format ["No building found at %1", _x] };
+				if (_building in antennas) exitWith { diag_log "Antenna in destroyed building list, ignoring" };
+
 				private _ruin = [_building] call BIS_fnc_createRuin;
-				//JIP on the _ruin, as repairRuinedBuilding will delete the ruin.
-				if !(isNull _ruin) then {
-					[_building, true] remoteExec ["hideObject", 0, _ruin];
-				} else {
+				if (isNull _ruin) exitWith {
 					diag_log format ["Loading Destroyed Buildings: Unable to create ruin for %1", typeOf _building];
 				};
+
+				destroyedBuildings pushBack _building;
 			};
-		} forEach destroyedBuildings;
+		} forEach _varValue;
 	};
 	if (_varName == 'minesX') then {
 		for "_i" from 0 to (count _varvalue) - 1 do {

--- a/A3-Antistasi/functions/Save/fn_loadStat.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadStat.sqf
@@ -97,7 +97,8 @@ if (_varName in specialVarLoads) then {
 		//publicVariable "destroyedBuildings";
 		private _building = objNull;
 		{
-			_building = nearestObject [_x, "House"];
+			// nearestObject sometimes picks the wrong building and is several times slower
+			_building = nearestObjects [_x, ["House"], 1, true] select 0;
 			if !(_building in antennas) then {
 				private _ruin = [_building] call BIS_fnc_createRuin;
 				//JIP on the _ruin, as repairRuinedBuilding will delete the ruin.

--- a/A3-Antistasi/functions/Save/fn_saveLoop.sqf
+++ b/A3-Antistasi/functions/Save/fn_saveLoop.sqf
@@ -31,7 +31,8 @@ private _antennasDeadPositions = [];
 ["maxUnits", maxUnits] call A3A_fnc_setStatVariable;
 ["nextTick", nextTick - time] call A3A_fnc_setStatVariable;
 ["weather",[fogParams,rain]] call A3A_fnc_setStatVariable;
-["destroyedBuildings",destroyedBuildings] call A3A_fnc_setStatVariable;
+private _destroyedPositions = destroyedBuildings apply { getPosATL _x };
+["destroyedBuildings",_destroyedPositions] call A3A_fnc_setStatVariable;
 
 //Save aggression values
 ["aggressionOccupants", [aggressionLevelOccupants, aggressionStackOccupants]] call A3A_fnc_setStatVariable;

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -9,6 +9,8 @@ if (isNil "logLevel") then { logLevel = 2 };scriptName "initClient.sqf";
 
 call A3A_fnc_installSchrodingersBuildingFix;
 
+if (!isServer) then { ["destroyedBuildings"] remoteExec ["A3A_fnc_requestDataFromServer", 2] };
+
 if (hasInterface) then {
 	waitUntil {!isNull player};
 	waitUntil {player == player};

--- a/A3-Antistasi/functions/init/fn_initServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initServer.sqf
@@ -192,7 +192,7 @@ addMissionEventHandler ["BuildingChanged", {
 
 		// Antenna dead/alive status is handled separately
 		if !(_oldBuilding in antennas || _oldBuilding in antennasDead) then {
-			destroyedBuildings pushBack (getPosATL _oldBuilding);
+			destroyedBuildings pushBack _oldBuilding;
 		};
 	};
 }];

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -97,7 +97,7 @@ DECLARE_SERVER_VAR(haveRadio, hasTFAR || hasACRE);
 //List of vehicles that are reported (I.e - Players can't go undercover in them)
 DECLARE_SERVER_VAR(reportedVehs, []);
 //Currently destroyed buildings.
-DECLARE_SERVER_VAR(destroyedBuildings, []);
+//DECLARE_SERVER_VAR(destroyedBuildings, []);
 //Initial HR
 server setVariable ["hr",8,true];
 //Initial faction money pool
@@ -127,6 +127,8 @@ movingMarker = false;
 markersChanging = [];
 
 playerHasBeenPvP = [];
+
+destroyedBuildings = [];		// synced only on join, to avoid spam on change
 
 ///////////////////////////////////////////
 //     INITIALISING ITEM CATEGORIES     ///


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Enhancement
3. [X] Armaaaaa

### What have you changed and why?
A speculative workaround for a potential Arma bug with the synchronization of destroyed buildings. Currently we JIP-remoteExec hideObject for each building that was destroyed at server start, and we have an additional fix (`fn_installSchrodingersBuildingFix`) for the case where a building is destroyed while a client is connected but not correctly updated on all clients.

This PR covers a third case where a building is destroyed after server load but before a specific client joins. The current destroyedBuildings list is sent to each client on connection, and the client then hides those buildings. The list is sent using a request/send system to avoid unnecessary publicVariable spam on building destruction. As the remoteExec count is much lower, this may also dodge a potential issue where the hideObject remoteExecs were lost due to network spam.

### Please specify which Issue this PR Resolves.
closes #1001 if it works. It may not.

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the Mission in Singleplayer?
2. [X] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

I don't know if this is going to help. I can't replicate the observed problems on my DS, and the quality of the reports isn't high enough to identify a likely cause. All we can do is cover all plausible Arma bugs and hope.
