### PR TITLE
Fix savegame player money exploits and profilenamespace spam

### DIFF
--- a/A3-Antistasi/functions/Garage/fn_vehPlacementCallbacks.sqf
+++ b/A3-Antistasi/functions/Garage/fn_vehPlacementCallbacks.sqf
@@ -147,7 +147,6 @@ switch (_callbackTarget) do {
 					else
 						{
 						[-1 * vehiclePurchase_cost] call A3A_fnc_resourcesPlayer;
-						["moneyX",player getVariable ["moneyX",0]] call A3A_fnc_setStatVariable;
 						_purchasedVeh setVariable ["ownerX",getPlayerUID player,true];
 						};
 					};

--- a/A3-Antistasi/functions/OrgPlayers/fn_donateMoney.sqf
+++ b/A3-Antistasi/functions/OrgPlayers/fn_donateMoney.sqf
@@ -4,23 +4,16 @@ if (_resourcesPlayer < 100) exitWith {["Donate Money", "You have less than 100 �
 
 if (count _this == 0) exitWith
 	{
-	[-100] call A3A_fnc_resourcesPlayer;
 	[0,100] remoteExec ["A3A_fnc_resourcesFIA",2];
 	_pointsXJ = (player getVariable "score") + 1;
 	player setVariable ["score",_pointsXJ,true];
+	[-100] call A3A_fnc_resourcesPlayer;
 	["Donate Money", "You have donated 100 € to the cause. This will raise your status among our forces"] call A3A_fnc_customHint;
-	[] spawn A3A_fnc_statistics;
-	["moneyX",player getVariable ["moneyX",0]] call A3A_fnc_setStatVariable;
 	};
 _target = cursortarget;
 
 if (!isPlayer _target) exitWith {["Donate Money", "You must be looking to a player in order to give him money"] call A3A_fnc_customHint;};
 
 [-100] call A3A_fnc_resourcesPlayer;
-_money = player getVariable "moneyX";
-["moneyX",_money] call A3A_fnc_setStatVariable;
-_moneyX = _target getVariable "moneyX";
-_target setVariable ["moneyX",_moneyX + 100, true];
+[100] remoteExec ["A3A_fnc_resourcesPlayer", _target];
 ["Donate Money", format ["You have donated 100 € to %1", name _target]] call A3A_fnc_customHint;
-[] remoteExec ["A3A_fnc_statistics",_target];
-[] spawn A3A_fnc_statistics;

--- a/A3-Antistasi/functions/OrgPlayers/fn_playerScoreAdd.sqf
+++ b/A3-Antistasi/functions/OrgPlayers/fn_playerScoreAdd.sqf
@@ -32,4 +32,3 @@ if (_pointsX > 0) then
 	{
 	if (_pointsX != 1) then {[0,(_pointsX * 5)] remoteExec ["A3A_fnc_resourcesFIA",2]} else {[0,20-(tierWar * 2)] remoteExec ["A3A_fnc_resourcesFIA",2]};
 	};
-

--- a/A3-Antistasi/functions/OrgPlayers/fn_resourcesPlayer.sqf
+++ b/A3-Antistasi/functions/OrgPlayers/fn_resourcesPlayer.sqf
@@ -4,5 +4,4 @@ _moneyX = _moneyX + (player getVariable "moneyX");
 if (_moneyX < 0) then {_moneyX = 0};
 player setVariable ["moneyX",_moneyX,true];
 [] spawn A3A_fnc_statistics;
-["moneyX",_moneyX] call A3A_fnc_setStatVariable;
 true

--- a/A3-Antistasi/functions/OrgPlayers/fn_theBossSteal.sqf
+++ b/A3-Antistasi/functions/OrgPlayers/fn_theBossSteal.sqf
@@ -1,9 +1,7 @@
 _resourcesFIA = server getVariable "resourcesFIA";
 if (_resourcesFIA < 100) exitWith {["Money Grab", "FIA has not enough resources to grab"] call A3A_fnc_customHint;};
-[100] call A3A_fnc_resourcesPlayer;
 server setvariable ["resourcesFIA",_resourcesFIA - 100, true];
-[] remoteExec ["A3A_fnc_statistics",theBoss];
 [-2,theBoss] call A3A_fnc_playerScoreAdd;
-["scorePlayer", player getVariable "score"] call A3A_fnc_setStatVariable;
+[100] call A3A_fnc_resourcesPlayer;
 
 ["Money Grab", format ["You grabbed 100 € from the %1 Money Pool.<br/><br/>This will affect your prestige and status among %1 forces",nameTeamPlayer]] call A3A_fnc_customHint;

--- a/A3-Antistasi/functions/REINF/fn_buildCreateVehicleCallback.sqf
+++ b/A3-Antistasi/functions/REINF/fn_buildCreateVehicleCallback.sqf
@@ -47,7 +47,6 @@ if (build_cost > 0) then
 	else
 		{
 		[-build_cost] call A3A_fnc_resourcesPlayer;
-		["moneyX",player getVariable ["moneyX",0]] call A3A_fnc_setStatVariable;
 		};
 	};
 

--- a/A3-Antistasi/functions/REINF/fn_reinfPlayer.sqf
+++ b/A3-Antistasi/functions/REINF/fn_reinfPlayer.sqf
@@ -28,7 +28,6 @@ if (!isMultiPlayer) then {
 } else {
 	_nul = [-1, 0] remoteExec ["A3A_fnc_resourcesFIA",2];
 	[- _costs] call A3A_fnc_resourcesPlayer;
-	["moneyX",player getVariable ["moneyX",0]] call A3A_fnc_setStatVariable;
 	["AI Recruitment", "Soldier Recruited.<br/><br/>Remember: if you use the group menu to switch groups you will lose control of your recruited AI"] call A3A_fnc_customHint;
 };
 

--- a/A3-Antistasi/functions/Save/fn_saveLoop.sqf
+++ b/A3-Antistasi/functions/Save/fn_saveLoop.sqf
@@ -1,10 +1,15 @@
 if (hasInterface) then {
 	if (!isNil "savingClient" && {savingClient}) exitWith {["Save", "Your personal stats are being saved"] call A3A_fnc_customHint;};
-	[] call A3A_fnc_savePlayer;
+	[getPlayerUID player, player] call A3A_fnc_savePlayer;
 };
 
 //Server only from here on out.
 if (!isServer) exitWith {};
+
+// Save each player with global flag
+{
+	[getPlayerUID _x, _x, true] call A3A_fnc_savePlayer;
+} forEach (call A3A_fnc_playableUnits);
 
 if (savingServer) exitWith {["Save Game", "Server data save is still in progress"] remoteExecCall ["A3A_fnc_customHint",theBoss]};
 savingServer = true;

--- a/A3-Antistasi/functions/Save/fn_saveLoop.sqf
+++ b/A3-Antistasi/functions/Save/fn_saveLoop.sqf
@@ -207,6 +207,7 @@ _dataX = [];
 _controlsX = controlsX select {(sidesX getVariable [_x,sideUnknown] == teamPlayer) and (controlsX find _x < defaultControlIndex)};
 ["controlsSDK",_controlsX] call A3A_fnc_setStatVariable;
 
+saveProfileNamespace;
 savingServer = false;
 _saveHintText = format ["Savegame Done.<br/><br/>You won't lose your stats in the event of a game update.<br/><br/>Remember: if you want to preserve any vehicle, it must be near the HQ Flag with no AI inside.<br/>If AI are inside, you will save the funds you spent on it.<br/><br/>AI will be refunded<br/><br/>Stolen and purchased Static Weapons need to be ASSEMBLED in order to be saved. You can save disassembled Static Weapons in the ammo box.<br/><br/>Mounted Statics (Mortar/AA/AT squads) won't get saved, but you will be able to recover the cost.<br/><br/>Same for assigned vehicles more than 50m away from HQ.<br/><br/>%1 fund count:<br/>HR: %2<br/>Money: %3 €",nameTeamPlayer,_hrBackground,_resourcesBackground];
 [petros,"hint",_saveHintText, "Save"] remoteExec ["A3A_fnc_commsMP", 0];

--- a/A3-Antistasi/functions/Save/fn_savePlayer.sqf
+++ b/A3-Antistasi/functions/Save/fn_savePlayer.sqf
@@ -1,16 +1,10 @@
-private _playerId =	param [0];
-private _playerUnit = param [1];
-
-if (hasInterface) then {
-	if (isNil "_playerId" || isNil "_playerUnit") then {
-		_playerId = getPlayerUID player;
-		_playerUnit = player;
-	};
-};
+params ["_playerId", "_playerUnit", ["_globalSave", false]];
 
 if (isMultiplayer && !isServer) exitwith {
-	[_playerId, _playerUnit] remoteExec ["A3A_fnc_savePlayer", 2];
+	[_playerId, _playerUnit, _globalSave] remoteExec ["A3A_fnc_savePlayer", 2];
 };
+
+_playerUnit = _playerUnit getVariable ["owner", _playerUnit];		// save the real player, not remote controlled AIs
 
 if (isNil "_playerId" || {_playerId == ""}) exitWith {
 	diag_log format ["[Antistasi] Not saving player of unit %1 due to missing playerID", _playerUnit];
@@ -53,47 +47,40 @@ if (_shouldStripLoadout) then {
 };
 
 if (isMultiplayer) then
-	{
+{
 	[_playerId, "scorePlayer", _playerUnit getVariable "score"] call A3A_fnc_savePlayerStat;
 	[_playerId, "rankPlayer", rank _playerUnit] call A3A_fnc_savePlayerStat;
-	[_playerId, "personalGarage",[_playerUnit] call A3A_fnc_getPersonalGarage] call A3A_fnc_savePlayerStat;
-	_resourcesBackground = _playerUnit getVariable ["moneyX", 0];
-	{
-	_friendX = _x;
-	if ((!isNull _friendX) and (!isPlayer _friendX) and (alive _friendX)) then
-		{
-		private _valueOfFriend = server getVariable [typeOf _friendX, 0];
-		_resourcesBackground = _resourcesBackground + _valueOfFriend;
+	[_playerId, "personalGarage", [_playerUnit] call A3A_fnc_getPersonalGarage] call A3A_fnc_savePlayerStat;
 
-		if (vehicle _friendX != _friendX) then
+	_totalMoney = _playerUnit getVariable ["moneyX", 0];
+	if (_shouldStripLoadout) then { _totalMoney = round (_totalMoney * 0.85) };
+
+	if (_globalSave) then 
+	{
+		// Add value of live AIs owned by player
+		// plus cost of vehicles driven by player-owned units, including self
+		// plus cost of unsaved static weapons aimed by player-owned units, including self
+		{
+			if (alive _x && (_x getVariable ["owner", objNull] == _playerUnit)) then
 			{
-			_veh = vehicle _friendX;
-			_typeVehX = typeOf _veh;
-			if (not(_veh in staticsToSave)) then
-				{
-					if ((_veh isKindOf "StaticWeapon") or (driver _veh == _friendX)) then
-					{
-						private _vehPrice = ([_typeVehX] call A3A_fnc_vehiclePrice);
-						if (_vehPrice isEqualType _resourcesBackground) then {
-							_resourcesBackground = _resourcesBackground + _vehPrice;
-						};
-						if (count attachedObjects _veh != 0) then {
-							{
-								private _attachmentPrice = ([typeOf _x] call A3A_fnc_vehiclePrice);
-								if (_vehPrice isEqualType _resourcesBackground) then {
-									_resourcesBackground = _resourcesBackground + _attachmentPrice;
-								};
-							} 
-							forEach attachedObjects _veh;
-						};
-					};
+				if (_x != _playerUnit) then {
+					private _unitPrice = server getVariable [typeOf _x, 0];
+					_totalMoney = _totalMoney + _unitPrice;
+				};
+				private _veh = vehicle _x;
+				if (_veh == _x || {_veh in staticsToSave}) exitWith {};
+				if (_x == driver _veh || {_x == gunner _veh && _veh isKindOf "StaticWeapon"}) then {
+					private _vehPrice = [typeof _veh] call A3A_fnc_vehiclePrice;
+					_totalMoney = _totalMoney + _vehPrice;
 				};
 			};
-		};
-	} forEach (units group _playerUnit) - [_playerUnit]; //Can't have player unit in here, as it'll get nulled out if called on disconnect.
-	[_playerId, "moneyX",_resourcesBackground] call A3A_fnc_savePlayerStat;
+
+		} forEach (units group _playerUnit);
 	};
 
-saveProfileNamespace;
+	[_playerId, "moneyX", _totalMoney] call A3A_fnc_savePlayerStat;
+};
+
+if (!_globalSave) then { saveProfileNamespace };
 savingClient = false;
 true;

--- a/A3-Antistasi/functions/Save/fn_savePlayer.sqf
+++ b/A3-Antistasi/functions/Save/fn_savePlayer.sqf
@@ -93,6 +93,7 @@ if (isMultiplayer) then
 	} forEach (units group _playerUnit) - [_playerUnit]; //Can't have player unit in here, as it'll get nulled out if called on disconnect.
 	[_playerId, "moneyX",_resourcesBackground] call A3A_fnc_savePlayerStat;
 	};
-	
+
+saveProfileNamespace;
 savingClient = false;
 true;

--- a/A3-Antistasi/functions/Save/fn_setStatVariable.sqf
+++ b/A3-Antistasi/functions/Save/fn_setStatVariable.sqf
@@ -6,5 +6,4 @@ _varValue = _this select 1;
 if (!isNil "_varValue") then {
 	_varSaveName = [_varName] call A3A_fnc_varNameToSaveName;
 	profileNameSpace setVariable [_varSaveName, _varValue];
-	if (isDedicated) then {saveProfileNamespace};
 };

--- a/A3-Antistasi/onPlayerRespawn.sqf
+++ b/A3-Antistasi/onPlayerRespawn.sqf
@@ -61,6 +61,12 @@ if (side group player == teamPlayer) then
 	{
     _newUnit addOwnedMine _x;
     } count (getAllOwnedMines (_oldUnit));
+	{
+		if (_x getVariable ["owner", ObjNull] == _oldUnit) then {
+			_x setVariable ["owner", _newUnit, true];
+		};
+	} forEach (units group player);
+
 
 	// don't reinit revive because damage handlers are respawn-persistent
 	//if (!hasACEMedical) then {[_newUnit] call A3A_fnc_initRevive};


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Fix various player money exploits involving saving with AIs and vehicles. Players used to have their squad-owned vehicles and AIs refunded whenever they disconnected or saved, but these vehicles were not deleted so you could simply disconnect and reconnect to farm money.

Players are now saved during a global save (they weren't before), and their owned units are refunded during that save, but not if they disconnect or save manually. I think it's still a bit generous to players (you get full purchase value for vehicles, not sale value), but it'll be lightly used and it'll do for now. There's a fair argument for simply removing the refund code entirely.

As it'll be saving some extra data, I sorted out the saveProfileNamespace usage in the first commit. This was previously writing back the entire profile every time a variable was written, causing massive server performance hitches and probably save/profile corruption. Now it only writes after a global save or a player save. I'm not sure if it ever had an attached issue, but it should have.

Also removed a bunch of dead code that was still saving player money locally.

### Please specify which Issue this PR Resolves.
closes #919 

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the Mission in Singleplayer?
2. [X] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
