### PR TITLE
Add ifa to mod not allowed description

### DIFF
--- a/A3-Antistasi/MissionDescription/endMission.hpp
+++ b/A3-Antistasi/MissionDescription/endMission.hpp
@@ -3,7 +3,7 @@ class modUnautorized
 {
 	title = "Incompatible Mods";
 	subtitle = "Incompatible Mods detected";
-	description = "An incompatible mod installed on the server or your PC has been detected. To avoid support problems the mission is finished. Please uninstall unsupported (ASR AI, aLIVE, MCC or any AI behaviour) mods from your computer or server to be able to play Antistasi.";
+	description = "An incompatible mod installed on the server or your PC has been detected. To avoid support problems the mission is finished. Please uninstall unsupported (IFA, ASR AI, aLIVE, MCC or any AI behaviour) mods from your computer or server to be able to play Antistasi.";
 	picture = "b_unknown";
 	pictureColor[] = {0.0,0.5,0.0,1};
 };
@@ -62,4 +62,3 @@ class hcDown
 	picture = "b_unknown";
 	pictureColor[] = {0.0,0.5,0.0,1};
 };
-


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Enhancement

### What have you changed and why?
Information:
Added IFA to the text shown to the players when the load an incompatible mod.

### Which issue does this closes?
None, it is linked to #1000

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes: Just a change in a string, it literally can't break anything
