### PR TITLE
Update start money

### DIFF
--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -168,7 +168,7 @@ if (player getVariable ["pvp",false]) exitWith {
 player setVariable ["score",0,true];
 player setVariable ["owner",player,true];
 player setVariable ["punish",0,true];
-player setVariable ["moneyX",100,true];
+player setVariable ["moneyX",95,true];
 player setUnitRank "PRIVATE";
 player setVariable ["rankX",rank player,true];
 


### PR DESCRIPTION
Changes the start money from 100 to 95 to prevent endless money exploit.

## What type of PR is this.
1. [x] Bug
2. [ ] Enhancement

### What have you changed and why?
Information:
 Changes start money value from 100 to 95 to avoid the money exploid. Now people have to go kill first before they have enough money to give it away.   

### Please specify which Issue this PR Resolves.
closes #1021 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:
