### PR TITLE
Convoy depart timer fix

### DIFF
--- a/A3-Antistasi/functions/Missions/fn_convoy.sqf
+++ b/A3-Antistasi/functions/Missions/fn_convoy.sqf
@@ -62,8 +62,7 @@ else
 
 _typeConvoyX = selectRandom _typeConvoy;
 
-_timeLimit = if (_difficultX) then {0} else {round random 10};// timeX for the convoy to come out, we should put a random round 15
-_timeLimit = 0;
+_timeLimit = if (_difficultX) then {0} else { (round random 5)+5 }; // 0 or 5-10 minute limit - there's already good a chance for 0 seconds, why have a double chance (0-10)?
 _dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + _timeLimit];
 _dateLimitNum = dateToNumber _dateLimit;
 _dateLimit = numberToDate [date select 0, _dateLimitNum];//converts datenumber back to date array so that time formats correctly when put through the function


### PR DESCRIPTION
## What type of PR is this.
1. [ X ] Bug

### What have you changed and why?
- Fixed convoys _always_ immediately departing. There was a line (maybe left over from debugging?) setting the timer to 0 every time.
- The chance of immediately departing was also seemingly double the intended one - the base chance calculated from the war level, on top of the 0-10 minute rnd. I modified that to 5-10 minutes, but of course that can be omitted if it was actually intentional!
    
closes #1064 

### Please verify the following and ensure all checks are completed.
1. [ X ] Have you loaded the Mission in Singleplayer?
2. [ X ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [ X ] No