### PR TITLE
Speculative workaround for players losing money & rank on load

### DIFF
--- a/A3-Antistasi/dialogs.hpp
+++ b/A3-Antistasi/dialogs.hpp
@@ -79,7 +79,7 @@ class should_load_personal_save {
 			y = 0.317959 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
-			action = "closeDialog 0; nul = [] spawn A3A_fnc_loadPreviousSession;";
+			action = "closeDialog 0; [true] spawn A3A_fnc_loadPreviousSession;";
 		};
 		class HQ_button_Gstatic: RscButton
 		{
@@ -90,7 +90,7 @@ class should_load_personal_save {
 			y = 0.317959 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
-			action = "closeDialog 0;";
+			action = "closeDialog 0; [false] spawn A3A_fnc_loadPreviousSession;";
 		};
 	};
 };

--- a/A3-Antistasi/functions/Save/fn_loadPreviousSession.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadPreviousSession.sqf
@@ -1,4 +1,9 @@
-[] call A3A_fnc_loadPlayer;
-
-
-
+if (_this select 0) then {
+	[] call A3A_fnc_loadPlayer;
+}
+else {
+	player setVariable ["score",0,true];
+	player setVariable ["moneyX",95,true];
+	player setUnitRank "PRIVATE";
+	player setVariable ["rankX",rank player,true];
+};

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -165,12 +165,13 @@ if (player getVariable ["pvp",false]) exitWith {
 	}];
 };
 
-player setVariable ["score",0,true];
+// keep these local for the moment to avoid fights with the server
+player setVariable ["score",0];
 player setVariable ["owner",player,true];
 player setVariable ["punish",0,true];
-player setVariable ["moneyX",95,true];
-player setUnitRank "PRIVATE";
-player setVariable ["rankX",rank player,true];
+player setVariable ["moneyX",95];
+//player setUnitRank "PRIVATE";
+player setVariable ["rankX",rank player];
 
 stragglers = creategroup teamPlayer;
 (group player) enableAttack false;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Currently global setVariables are used for money, rank and score both on the client side with default values (initClient) and on the server side with saved values (loadPlayer). Depending on timings and how Arma handles this situation, this may lead to desynchronized values or the default value being incorrectly applied over the top of the saved values.

This PR uses an ugly hack of a workaround to avoid global setVariables being used on two machines at the same time.

It's not currently known whether this is a real cause of problems, and the method is horrible, so this PR should only be used for testing and not merged into unstable.

### Please specify which Issue this PR Resolves.
closes #1031

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)
