### PR TITLE
Starting Gear for Night/Removed ADV

### DIFF
--- a/A3-Antistasi/Templates/3CB_Reb_CNM_Temp.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_CNM_Temp.sqf
@@ -96,13 +96,13 @@ breachingExplosivesAPC = [["rhs_ec200_mag", 1], ["rhs_ec200_sand_mag", 1], ["rhs
 breachingExplosivesTank = [["rhs_ec400_mag", 1], ["rhs_ec400_sand_mag", 1], ["rhs_ec200_mag", 2], ["rhs_ec200_sand_mag", 2], ["rhsusf_m112x4_mag", 1], ["rhs_charge_M2tet_x2_mag", 1]];
 
 //Starting Unlocks
-initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L107A1","UK3CB_Enfield","UK3CB_Enfield_rail","rhs_weap_rpg75"];
+initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L117A2","UK3CB_Enfield","UK3CB_Enfield_rail","rhs_weap_rpg75"];
 initialRebelEquipment append ["UK3CB_Enfield","UK3CB_Enfield_rail"];
 initialRebelEquipment append ["rhs_weap_rpg75"];
 initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enfield_mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK3CB_TKC_C_B_Sidor_MED","UK3CB_CW_SOV_O_LATE_B_Sidor_RIF","UK3CB_CW_SOV_O_EARLY_B_Sidor_RIF"];
 initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
-initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular"];
+initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular","UK3CB_BAF_Flashlight_L105A1"];
 //TFAR Unlocks
 if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
 if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "UK3CB_B_O_Radio_Backpack"};

--- a/A3-Antistasi/Templates/3CB_Reb_CNM_Trop.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_CNM_Trop.sqf
@@ -96,13 +96,13 @@ breachingExplosivesAPC = [["rhs_ec200_mag", 1], ["rhs_ec200_sand_mag", 1], ["rhs
 breachingExplosivesTank = [["rhs_ec400_mag", 1], ["rhs_ec400_sand_mag", 1], ["rhs_ec200_mag", 2], ["rhs_ec200_sand_mag", 2], ["rhsusf_m112x4_mag", 1], ["rhs_charge_M2tet_x2_mag", 1]];
 
 //Starting Unlocks
-initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L107A1","UK3CB_Enfield","UK3CB_Enfield_rail","rhs_weap_rpg75"];
+initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L117A2","UK3CB_Enfield","UK3CB_Enfield_rail","rhs_weap_rpg75"];
 initialRebelEquipment append ["UK3CB_Enfield","UK3CB_Enfield_rail"];
 initialRebelEquipment append ["rhs_weap_rpg75"];
 initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enfield_mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK3CB_TKC_C_B_Sidor_MED","UK3CB_CW_SOV_O_LATE_B_Sidor_RIF","UK3CB_CW_SOV_O_EARLY_B_Sidor_RIF"];
 initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
-initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular"];
+initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular","UK3CB_BAF_Flashlight_L105A1"];
 //TFAR Unlocks
 if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
 if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "UK3CB_B_O_Radio_Backpack"};

--- a/A3-Antistasi/Templates/3CB_Reb_TPGM_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_TPGM_Arid.sqf
@@ -96,13 +96,13 @@ breachingExplosivesAPC = [["rhs_ec200_mag", 1], ["rhs_ec200_sand_mag", 1], ["rhs
 breachingExplosivesTank = [["rhs_ec400_mag", 1], ["rhs_ec400_sand_mag", 1], ["rhs_ec200_mag", 2], ["rhs_ec200_sand_mag", 2], ["rhsusf_m112x4_mag", 1], ["rhs_charge_M2tet_x2_mag", 1]];
 
 //Starting Unlocks
-initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L107A1","UK3CB_Enfield","UK3CB_Enfield_rail","rhs_weap_rpg75"];
+initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L117A2","UK3CB_Enfield","UK3CB_Enfield_rail","rhs_weap_rpg75"];
 initialRebelEquipment append ["UK3CB_Enfield","UK3CB_Enfield_rail"];
 initialRebelEquipment append ["rhs_weap_rpg75"];
 initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enfield_mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK3CB_TKC_C_B_Sidor_MED","UK3CB_CW_SOV_O_LATE_B_Sidor_RIF","UK3CB_CW_SOV_O_EARLY_B_Sidor_RIF"];
 initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
-initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular"];
+initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular","UK3CB_BAF_Flashlight_L105A1"];
 //TAFR Unlocks
 if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_rf7800str"]};
 if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "UK3CB_B_B_Radio_Backpack"};

--- a/A3-Antistasi/Templates/3CB_Reb_TTF_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_TTF_Arid.sqf
@@ -100,13 +100,13 @@ breachingExplosivesAPC = [["rhs_ec200_mag", 1], ["rhs_ec200_sand_mag", 1], ["rhs
 breachingExplosivesTank = [["rhs_ec400_mag", 1], ["rhs_ec400_sand_mag", 1], ["rhs_ec200_mag", 2], ["rhs_ec200_sand_mag", 2], ["rhsusf_m112x4_mag", 1], ["rhs_charge_M2tet_x2_mag", 1]];
 
 //Starting Unlocks
-initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L107A1","UK3CB_Enfield","UK3CB_Enfield_rail","rhs_weap_rpg75"];
+initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L117A2","UK3CB_Enfield","UK3CB_Enfield_rail","rhs_weap_rpg75"];
 initialRebelEquipment append ["UK3CB_Enfield","UK3CB_Enfield_rail"];
 initialRebelEquipment append ["rhs_weap_rpg75"];
 initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enfield_mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK3CB_TKC_C_B_Sidor_MED","UK3CB_CW_SOV_O_LATE_B_Sidor_RIF","UK3CB_CW_SOV_O_EARLY_B_Sidor_RIF"];
 initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
-initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular"];
+initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular","UK3CB_BAF_Flashlight_L105A1"];
 //TFAR Unlocks
 if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
 if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "UK3CB_B_O_Radio_Backpack"};

--- a/A3-Antistasi/Templates/Vanilla_Reb_FIA_Altis.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_FIA_Altis.sqf
@@ -104,7 +104,7 @@ initialRebelEquipment append ["SMG_01_F","SMG_02_F"];
 initialRebelEquipment append ["6Rnd_45ACP_Cylinder","16Rnd_9x21_Mag","30Rnd_45ACP_Mag_SMG_01","30Rnd_9x21_Mag_SMG_02","MiniGrenade","SmokeShell"];
 initialRebelEquipment append ["B_FieldPack_oli","B_FieldPack_blk","B_FieldPack_ocamo","B_FieldPack_oucamo","B_FieldPack_cbr","B_FieldPack_khk"];
 initialRebelEquipment append ["V_Chestrig_blk","V_Chestrig_rgr","V_Chestrig_khk","V_Chestrig_oli","V_BandollierB_blk","V_BandollierB_cbr","V_BandollierB_rgr","V_BandollierB_khk","V_BandollierB_oli","V_Rangemaster_belt"];
-initialRebelEquipment append ["Binocular","acc_flashlight"];
+initialRebelEquipment append ["Binocular","acc_flashlight","acc_flashlight_smg_01","acc_flashlight_pistol"];
 //TFAR Unlocks
 if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
 if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_anprc155"};

--- a/A3-Antistasi/Templates/Vanilla_Reb_FIA_B_Altis.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_FIA_B_Altis.sqf
@@ -101,7 +101,7 @@ initialRebelEquipment append ["SMG_01_F","hgun_PDW2000_F"];
 initialRebelEquipment append ["6Rnd_45ACP_Cylinder","9Rnd_45ACP_Mag","30Rnd_45ACP_Mag_SMG_01","30Rnd_9x21_Mag","30Rnd_9x21_Mag_SMG_02","MiniGrenade","SmokeShell"];
 initialRebelEquipment append ["B_FieldPack_oli","B_FieldPack_blk","B_FieldPack_ocamo","B_FieldPack_oucamo","B_FieldPack_cbr","B_FieldPack_khk"];
 initialRebelEquipment append ["V_Chestrig_blk","V_Chestrig_rgr","V_Chestrig_khk","V_Chestrig_oli","V_BandollierB_blk","V_BandollierB_cbr","V_BandollierB_rgr","V_BandollierB_khk","V_BandollierB_oli","V_Rangemaster_belt"];
-initialRebelEquipment append ["Binocular","acc_flashlight"];
+initialRebelEquipment append ["Binocular","acc_flashlight","acc_flashlight_smg_01","acc_flashlight_pistol"];
 //TFAR Unlocks
 if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_rf7800str"]};
 if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_rt1523g_big_rhs"};

--- a/A3-Antistasi/Templates/Vanilla_Reb_SDK_Tanoa.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_SDK_Tanoa.sqf
@@ -103,7 +103,7 @@ initialRebelEquipment append ["SMG_05_F","hgun_PDW2000_F"];
 initialRebelEquipment append ["10Rnd_9x21_Mag","16Rnd_9x21_Mag","30Rnd_9x21_Mag_SMG_02","MiniGrenade","SmokeShell"];
 initialRebelEquipment append ["B_FieldPack_blk","B_FieldPack_oucamo","B_FieldPack_cbr","B_FieldPack_oli","B_FieldPack_ghex_F"];
 initialRebelEquipment append ["V_Chestrig_blk","V_Chestrig_rgr","V_Chestrig_khk","V_Chestrig_oli","V_BandollierB_blk","V_BandollierB_ghex","V_BandollierB_rgr","V_BandollierB_oli","V_Rangemaster_belt","V_TacChestrig_cbr_F","V_TacChestrig_oli_F","V_TacChestrig_grn_F"];
-initialRebelEquipment append ["Binocular","acc_flashlight"];
+initialRebelEquipment append ["Binocular","acc_flashlight","acc_flashlight_smg_01","acc_flashlight_pistol"];
 //TFAR unlocks
 if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
 if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_anprc155"};

--- a/A3-Antistasi/functions/Templates/fn_aceModCompat.sqf
+++ b/A3-Antistasi/functions/Templates/fn_aceModCompat.sqf
@@ -46,7 +46,7 @@ aceMedItems = [
 	"ACE_splint",
 	"ACE_bodyBag",
 	"ACE_personalAidKit"
-]
+];
 
 publicVariable "aceItems";
 publicVariable "aceMedItems";

--- a/A3-Antistasi/functions/Templates/fn_aceModCompat.sqf
+++ b/A3-Antistasi/functions/Templates/fn_aceModCompat.sqf
@@ -19,7 +19,9 @@ aceItems = [
 	"ACE_Tripod",
 	"ACE_Spraypaintred",
 	"ACE_UAVBattery",
-	"ACE_SpareBarrel"
+	"ACE_SpareBarrel",
+	"ACE_Flashlight_XL50",
+	"ACE_HandFlare_White"
 ];
 
 aceMedItems = [
@@ -42,10 +44,9 @@ aceMedItems = [
 	"ACE_morphine",
 	"ACE_adenosine",
 	"ACE_splint",
-	"ACE_bodyBag"
+	"ACE_bodyBag",
+	"ACE_personalAidKit"
 ]
-+ ([["ACE_personalAidKit"], ["adv_aceCPR_AED"]] select hasADVCPR)
-+ ([[], ["adv_aceSplint_splint"]] select hasADVSplint);
 
 publicVariable "aceItems";
 publicVariable "aceMedItems";

--- a/A3-Antistasi/functions/Templates/fn_getLoadout.sqf
+++ b/A3-Antistasi/functions/Templates/fn_getLoadout.sqf
@@ -13,7 +13,6 @@ private _basicMedicalSupplies =
 			["ACE_Quikclot",10],
 			["ACE_splint", 2]
 		]
-		+ ([[], [["adv_aceSplint_splint", 2]]] select hasADVSplint);
 	} else {
 		[
 			["FirstAidKit",3]
@@ -52,8 +51,6 @@ private _medicSupplies =
 			["ACE_Tourniquet",3],
 			["ACE_Splint",4]
 		]
-		+ ([[["ACE_PersonalAidKit", 2]], [["adv_aceCPR_AED", 1]]] select hasADVCPR)
-		+ ([[], [["adv_aceSplint_splint", 7]]] select hasADVSplint);
 	} else {
 		[
 			["Medikit", 1]

--- a/A3-Antistasi/functions/init/fn_initVarCommon.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarCommon.sqf
@@ -89,8 +89,6 @@ has3CB = false;
 hasACE = false;
 hasACEHearing = false;
 hasACEMedical = false;
-hasADVCPR = false;
-hasADVSplint = false;
 //Radio Mods
 hasACRE = false;
 hasTFAR = false;
@@ -102,8 +100,6 @@ hasACRE = isClass (configFile >> "cfgPatches" >> "acre_main");
 hasACE = (!isNil "ace_common_fnc_isModLoaded");
 hasACEHearing = isClass (configFile >> "CfgSounds" >> "ACE_EarRinging_Weak");
 hasACEMedical = isClass (configFile >> "CfgSounds" >> "ACE_heartbeat_fast_3");
-hasADVCPR = isClass (configFile >> "CfgPatches" >> "adv_aceCPR");
-hasADVSplint = isClass (configFile >> "CfgPatches" >> "adv_aceSplint");
 //IFA Detection
 //Deactivated for now, as IFA is having some IP problems (08.05.2020 european format)
 if isClass (configFile >> "CfgPatches" >> "LIB_Core") then


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Enhancement

### What have you changed and why?
Information: 
**Added**
Handthrown Flares to Acecompat file ------> Added to Starting Gear.
Added a White Flashlight to Starting Gear Items Aswell (Inventory Flashlight)
Added 2 Flashlights for Vanilla, Pistol Flashlight and SMG Flashlight so they would be availble for the current starting Gear.
Added "UK3CB_BAF_Flashlight_L105A1" to 3CB Reb Templates.
**Changed**
"UK3CB_BAF_L107A1" to "UK3CB_BAF_L117A2" The A2 does Support a Flashlight, the other one didnt.
**Removed**
ADV Detection
ADV Items that would have been given.
### Please specify which Issue this PR Resolves.
closes #1033 
closes #635 
### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:
