### PR TITLE
Remove more junk in the garbage cleaner

### DIFF
--- a/A3-Antistasi/functions/Base/fn_garbageCleaner.sqf
+++ b/A3-Antistasi/functions/Base/fn_garbageCleaner.sqf
@@ -1,16 +1,45 @@
-private ["_toDelete"];
-
+private _filename = "fn_garbageCleaner.sqf";
 [petros,"hint","Deleting Garbage. Please wait", "Garbage Cleaner"] remoteExec ["A3A_fnc_commsMP", 0];
+[2, "Cleaning garbage...", _filename] call A3A_fnc_log;
 
-/*
-_toDelete = nearestObjects [markerPos "base_4", ["WeaponHolderSimulated", "GroundWeaponHolder", "WeaponHolder"], 16000];
-//_toDelete = _toDelete + ((markerPos "base_4") nearObjects ["Default", 16000]); // fix for bug with detecting satchels
-for "_i" from 0 to ((count _toDelete) - 1) do
-{
-	deleteVehicle (_toDelete select _i);
-};*/
-{deleteVehicle _x} forEach allDead;
-{deleteVehicle _x} forEach (allMissionObjects "WeaponHolder");
-{deleteVehicle _x} forEach (allMissionObjects "WeaponHolderSimulated");
+private _rebelSpawners = allUnits select { side group _x == teamPlayer && {_x getVariable ["spawner",false]} };
+
+private _fnc_distCheck = {
+	params["_object", "_dist"];
+	private _inRange = { if (_x distance _object <= _dist) exitWith {1}; false } count _rebelSpawners;
+	if (_inRange == 0) then { deleteVehicle _object };
+};
+
+
+{ deleteVehicle _x } forEach allDead;
+{ deleteVehicle _x } forEach (allMissionObjects "WeaponHolder");
+{ deleteVehicle _x } forEach (allMissionObjects "WeaponHolderSimulated");
+{ deleteVehicle _x } forEach (allMissionObjects "Box_IND_Wps_F");				// Surrender boxes
+{ deleteVehicle _x } forEach (allMissionObjects "Leaflet_05_F");				// Drone drop leaflets
+{ deleteVehicle _x } forEach (allMissionObjects "Ejection_Seat_Base_F");		// All vanilla ejection seats
+
+if (hasACE) then {
+	{ deleteVehicle _x } forEach (allMissionObjects "ACE_bodyBagObject");
+	{ deleteVehicle _x } forEach (allMissionObjects "UserTexture1m_F");						// ACE spraycan tags
+	{ [_x, 200] call _fnc_distCheck } forEach (allMissionObjects "ACE_envelope_big");		// ACE trench objects
+	{ [_x, 200] call _fnc_distCheck } forEach (allMissionObjects "ACE_envelope_small");
+};
+
+// Base type for trenches is Base_Bag_F, so we can't use that
+if (isClass (configFile >> "CfgVehicles" >> "GRAD_envelope_short")) then {
+	{ [_x, 200] call _fnc_distCheck } forEach (allMissionObjects "GRAD_envelope_short");	// GRAD trench objects
+	{ [_x, 200] call _fnc_distCheck } forEach (allMissionObjects "GRAD_envelope_giant");
+	{ [_x, 200] call _fnc_distCheck } forEach (allMissionObjects "GRAD_envelope_vehicle");
+	{ [_x, 200] call _fnc_distCheck } forEach (allMissionObjects "GRAD_envelope_long");
+};
+
+if (hasRHS) then {
+	{ deleteVehicle _x } forEach (allMissionObjects "rhs_a10_acesII_seat");		// Ejection seat for A-10 and F-22
+	{ deleteVehicle _x } forEach (allMissionObjects "rhs_a10_canopy");			// other canopies delete on ground contact
+	{ deleteVehicle _x } forEach (allMissionObjects "rhs_k36d5_seat");			// AFRF ejection seat
+};
 
 [petros,"hint","Garbage deleted", "Garbage Cleaner"] remoteExec ["A3A_fnc_commsMP", 0];
+[2, "Garbage clean completed", _filename] call A3A_fnc_log;
+
+


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Enhancement

### What have you changed and why?
Garbage cleaner left a lot of junk untouched. This should remove most of it. Stuff now removed:

- Surrender boxes
- Drone drop leaflets
- Ejection seats (vanilla and RHS at least)
- ACE bodybags and spraycan tags
- ACE and GRAD trenches, if no rebel spawners are within 200m

### Please specify which Issue this PR Resolves.
closes #850 

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
