### PR TITLE
Road requirement removed from outpost trucks.

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_createAIOutposts.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAIOutposts.sqf
@@ -248,28 +248,23 @@ else
 		};
 	};
 };
-
-//Why does the truck depends on roads?
-if (count _roads != 0) then
+//_pos = _positionX findEmptyPosition [5,_size,"I_Truck_02_covered_F"];//donde pone 5 antes ponía 10
+_spawnParameter = [_markerX, "Vehicle"] call A3A_fnc_findSpawnPosition;
+if (_spawnParameter isEqualType []) then
 {
-	//_pos = _positionX findEmptyPosition [5,_size,"I_Truck_02_covered_F"];//donde pone 5 antes ponía 10
-	_spawnParameter = [_markerX, "Vehicle"] call A3A_fnc_findSpawnPosition;
-	if (_spawnParameter isEqualType []) then
+	_typeVehX = if (_sideX == Occupants) then
 	{
-		_typeVehX = if (_sideX == Occupants) then
-		{
-			if (!_isFIA) then {vehNATOTrucks + vehNATOCargoTrucks} else {[vehFIATruck]};
-		}
-		else
-		{
-			vehCSATTrucks
-		};
-		_veh = createVehicle [selectRandom _typeVehX, (_spawnParameter select 0), [], 0, "NONE"];
-		_veh setDir (_spawnParameter select 1);
-		_vehiclesX pushBack _veh;
-		_nul = [_veh] call A3A_fnc_AIVEHinit;
-		sleep 1;
+		if (!_isFIA) then {vehNATOTrucks + vehNATOCargoTrucks} else {[vehFIATruck]};
+	}
+	else
+	{
+		vehCSATTrucks
 	};
+	_veh = createVehicle [selectRandom _typeVehX, (_spawnParameter select 0), [], 0, "NONE"];
+	_veh setDir (_spawnParameter select 1);
+	_vehiclesX pushBack _veh;
+	_nul = [_veh] call A3A_fnc_AIVEHinit;
+	sleep 1;
 };
 
 _countX = 0;


### PR DESCRIPTION
## What type of PR is this.
- [x] Bug
- Enhancement

### What have you changed and why?
Information:
    Outpost trucks no longer require a road in proximity to permit spawning. Note: Before this change, there was no use of road position.


### Please specify which Issue this PR Resolves.
closes [#1051](https://github.com/official-antistasi-community/A3-Antistasi/issues/1051#issue-623669534)

### Please verify the following and ensure all checks are completed.

- Have you loaded the Mission in Singleplayer?
- [x] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
- [x] No
- Yes (Please provide further detail below.)

********************************************************
Notes:
I have not noticed any side effects as of yet.