### PR TITLE
Fix double player save and DS refund bugs

### DIFF
--- a/A3-Antistasi/dialogs.hpp
+++ b/A3-Antistasi/dialogs.hpp
@@ -981,7 +981,7 @@ class game_options 		{
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			tooltip = "Use this option to save your current game. It does save the most important data in a ""Grand Theft Auto"" way. This opnion allows good MP save and independent saves of any version update. Vanilla saves are disabled because of lack of several features";
-			action = "closeDialog 0;if (player == theBoss) then {[] remoteExecCall [""A3A_fnc_saveLoop"", 0, false];} else {[] remoteExecCall [""A3A_fnc_saveLoop"", player, false]; hintC ""Personal Stats Saved""};";
+			action = "closeDialog 0;if (player == theBoss) then {[] remoteExecCall [""A3A_fnc_saveLoop"", 2, false];} else {[] remoteExecCall [""A3A_fnc_saveLoop"", player, false]; hintC ""Personal Stats Saved""};";
 		};
 	};
 };										//slots 6+1

--- a/A3-Antistasi/functions/REINF/fn_FIAinit.sqf
+++ b/A3-Antistasi/functions/REINF/fn_FIAinit.sqf
@@ -33,7 +33,7 @@ private _victim = objNull;
 private _killer = objNull;
 
 if (player == leader _unit) then {
-	_unit setVariable ["owner",player];
+	_unit setVariable ["owner", player, true];
 	_unit addEventHandler ["killed", {
 		_victim = _this select 0;
 		[_victim] spawn A3A_fnc_postmortem;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Some old code that I missed was preventing #1015 from working correctly on a dedicated server:

- Players were already being saved by the server->client->server route, now removed.
- FIAinit wasn't setting the unit ownership globally for player squad recruits.    

### Please specify which Issue this PR Resolves.
closes #1055 

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the Mission in Singleplayer?
2. [X] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
