### PR TITLE
Prevent loss of vehicle magazines when transferring to arsenal

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_ammunitionTransfer.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_ammunitionTransfer.sqf
@@ -79,21 +79,31 @@ if (count _weaponsFinal > 0) then
 
 _ammunitionFinal = [];
 _ammunitionFinalCount = [];
+_vehicleAmmo = [];
 if (isNil "_ammunition") then
-	{
+{
 	diag_log format ["Error en transmisión de munición. Tenía esto: %1 y estos containers: %2, el originX era un %3 y el objectX está definido como: %4", magazineCargo _originX, everyContainer _originX,typeOf _originX,_originX];
-	}
+}
 else
+{
 	{
-	{
-	_weaponX = _x;
-	if ((not(_weaponX in _ammunitionFinal)) and (not(_weaponX in unlockedMagazines))) then
+		_weaponX = _x;
+		if !(_weaponX in _ammunitionFinal) then
 		{
-		_ammunitionFinal pushBack _weaponX;
-		_ammunitionFinalCount pushBack ({_x == _weaponX} count _ammunition);
+			_magcount = {_x == _weaponX} count _ammunition;
+			if (getNumber (configFile >> "CfgMagazines" >> _weaponX >> "type") == 0) then
+			{
+				// save vehicle ammo for re-adding after clearance
+				_vehicleAmmo pushBack [_weaponX, _magcount];
+			};
+			if !(_weaponX in unlockedMagazines) then
+			{
+				_ammunitionFinal pushBack _weaponX;
+				_ammunitionFinalCount pushBack _magcount;
+			};
 		};
-	} forEach  _ammunition;
-	};
+	} forEach _ammunition;
+};
 
 
 if (count _ammunitionFinal > 0) then
@@ -143,16 +153,19 @@ if (count _backpcksFinal > 0) then
 	};
 
 if (count _this == 3) then
-	{
+{
 	deleteVehicle _originX;
-	}
+}
 else
-	{
+{
 	clearMagazineCargoGlobal _originX;
 	clearWeaponCargoGlobal _originX;
 	clearItemCargoGlobal _originX;
 	clearBackpackCargoGlobal _originX;
-	};
+
+	// restore original vehicle ammo
+	{ _originX addMagazineCargoGlobal _x } forEach _vehicleAmmo;
+};
 
 if (_destinationX == boxX) then
 	{


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
3CB vehicles expose their ammunition to the inventory system, which means that the arsenal ammunition transfer action will strip it all, throwing away the vehicle-specific ammo because it doesn't have a proper magazine type.

This PR detects vehicle-specific ammo and preserves it in the vehicle. Ammo that does have a known magazine type (eg 200rnd 7.62 belts) will still be moved to the arsenal, which is not ideal but determining the vehicle's full magazine list is too complicated for a 2.2.2 quick fix.

An alternative "fix" would be to add all magazines to the arsenal by default regardless of type, but this feels like it'd be more annoying, even if it's more consistent.

### Please specify which Issue this PR Resolves.
closes #959

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
