### PR TITLE
Change JNA to accept all magazine types

### DIFF
--- a/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_itemType.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_itemType.sqf
@@ -163,21 +163,25 @@ private _itemCategory = switch true do {
 		// Check what the magazine actually is
 		switch true do {
 			// Rifle, handgun, secondary weapons mags
-			case (
-			       (getNumber (configFile >> "CfgMagazines" >> _item >> "type") in [TYPE_MAGAZINE_PRIMARY_AND_THROW,TYPE_MAGAZINE_SECONDARY_AND_PUT,1536,TYPE_MAGAZINE_HANDGUN_AND_GL]) &&
-			       {!(_item in _grenadeList)} &&
-			       {!(_item in _putList)}
-			     ): {
-						"Magazine";
-				};
-				// Grenades
-				case (_item in _grenadeList): {
-						"Throwable";
-				};
-				// Put
-				case (_item in _putList): {
-						"Placeable";
-				};
+//			case (
+//			       (getNumber (configFile >> "CfgMagazines" >> _item >> "type") in [TYPE_MAGAZINE_PRIMARY_AND_THROW,TYPE_MAGAZINE_SECONDARY_AND_PUT,1536,TYPE_MAGAZINE_HANDGUN_AND_GL]) &&
+//			       {!(_item in _grenadeList)} &&
+//			       {!(_item in _putList)}
+//			     ): {
+//						"Magazine";
+//				};
+			// Grenades
+			case (_item in _grenadeList): {
+				"Throwable";
+			};
+			// Put
+			case (_item in _putList): {
+				"Placeable";
+			};
+			// Everything else
+			default {
+				"Magazine";
+			};
 		};
 	};
 


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Enhancement
3. [X] 3CB misfeature workaround

### What have you changed and why?
3CB vehicles expose their ammunition to the inventory system, which means that the arsenal ammunition transfer action will strip it all, throwing away the vehicle-specific ammo because it doesn't have a proper magazine type.

Tried to fix this in #1059 by not moving the vehicle ammo, but because all inventory is cleared from vehicle when they're pulled from the garage, and the vehicle box rearm doesn't work on inventory ammunition, the problem vehicles would be impossible to rearm once garaged.

This PR instead changes JNA to accept all magazine types, not just a fixed list, so that you can at least use the vehicle arsenal to rearm 3CB vehicles. I can't think of any negative side effects.

### Please specify which Issue this PR Resolves.
closes #959

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
