### PR TITLE
Enable cargo-to-arsenal transfer for planes and helis

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_ammunitionTransfer.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_ammunitionTransfer.sqf
@@ -156,7 +156,7 @@ else
 
 if (_destinationX == boxX) then
 	{
-	{if (_x distance boxX < 10) then {[petros,"hint","Ammobox Loaded", "Cargo"] remoteExec ["A3A_fnc_commsMP",_x]}} forEach (call A3A_fnc_playableUnits);
+//	{if (_x distance boxX < 10) then {[petros,"hint","Ammobox Loaded", "Cargo"] remoteExec ["A3A_fnc_commsMP",_x]}} forEach (call A3A_fnc_playableUnits);
 	if ((_originX isKindOf "ReammoBox_F") and (_originX != vehicleBox)) then {deleteVehicle _originX};
 	_updated = [] call A3A_fnc_arsenalManage;
 	if (_updated != "") then

--- a/A3-Antistasi/functions/Ammunition/fn_empty.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_empty.sqf
@@ -26,10 +26,21 @@ _backpcks = backpackCargo _truckX;
 
 _todo = _weaponsX + _ammunition + _items + _backpcks;
 
+private _vehName = getText (configFile >> "CfgVehicles" >> (typeof _truckX) >> "displayName");
+
 if (count _todo < 1) exitWith
 	{
-	if (count _this == 0) then {["Cargo", "Closest vehicle cargo is empty"] call A3A_fnc_customHint;};
+	if (count _this == 0) then {["Cargo", format ["Closest vehicle (%1) is empty", _vehName]] call A3A_fnc_customHint;};
 	if (count _this == 2) then {deleteVehicle _truckX};
 	};
 
-if (count _this == 2) then {[_truckX,boxX,true] remoteExec ["A3A_fnc_ammunitionTransfer",2]} else {[_truckX,boxX] remoteExec ["A3A_fnc_ammunitionTransfer",2]}
+if (count _this == 0) then {
+	["Cargo", format ["Transferred cargo from %1 to arsenal", _vehName]] call A3A_fnc_customHint;
+};
+
+if (count _this == 2) then {
+	[_truckX,boxX,true] remoteExec ["A3A_fnc_ammunitionTransfer",2];
+}
+else {
+	[_truckX,boxX] remoteExec ["A3A_fnc_ammunitionTransfer",2];
+};

--- a/A3-Antistasi/functions/Ammunition/fn_empty.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_empty.sqf
@@ -11,6 +11,8 @@ else
 	{
 	_trucksX = nearestObjects [boxX, ["Helicopter","Plane","LandVehicle","ReammoBox_F"], 20];
 	_trucksX = _trucksX select {not (_x isKindOf "StaticWeapon")};
+	// Prevent trolling by hiding small UAVs near the arsenal
+	_trucksX = _trucksX select {getNumber (configFile >> "CfgVehicles" >> (typeof _x) >> "isUAV") == 0};
 	_trucksX = _trucksX - [boxX,vehicleBox];
 	if (count _trucksX < 1) then {_truckX = vehicleBox} else {_truckX = _trucksX select 0};
 	};

--- a/A3-Antistasi/functions/Ammunition/fn_empty.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_empty.sqf
@@ -9,7 +9,7 @@ if (count _this > 0) then
 	}
 else
 	{
-	_trucksX = nearestObjects [boxX, ["LandVehicle","ReammoBox_F"], 20];
+	_trucksX = nearestObjects [boxX, ["Helicopter","Plane","LandVehicle","ReammoBox_F"], 20];
 	_trucksX = _trucksX select {not (_x isKindOf "StaticWeapon")};
 	_trucksX = _trucksX - [boxX,vehicleBox];
 	if (count _trucksX < 1) then {_truckX = vehicleBox} else {_truckX = _trucksX select 0};


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Enhancement

### What have you changed and why?
The cargo-to-arsenal transfer action only works on ammoboxes and land vehicles. This PR extends the check to planes and helicopters.

I removed UAVs from the check, to prevent trolling by hiding small UAVs near the arsenal and blocking arsenal transfers.

Also added some feedback about which vehicle has been selected for the transfer.

### Please specify which Issue this PR Resolves.
closes #1063

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

