### PR TITLE
Added code to end undercover heli exploit and groundwork for the upcoming support rework

### DIFF
--- a/A3-Antistasi/FSMs/ConvoyTravel.fsm
+++ b/A3-Antistasi/FSMs/ConvoyTravel.fsm
@@ -2,7 +2,7 @@
 /*%FSM<HEAD>*/
 /*
 item0[] = {"Start",0,250,-258.071289,-342.907776,-168.071396,-292.907776,0.000000,"Start"};
-item1[] = {"End_and_Rejoin",1,4346,64.791161,-139.450836,154.791199,-89.450851,0.000000,"End and Rejoin"};
+item1[] = {"End_and_Rejoin",1,250,64.791161,-139.450836,154.791199,-89.450851,0.000000,"End and Rejoin"};
 item2[] = {"HasArrived",4,218,-256.153625,-77.311310,-166.153625,-27.311371,10.000000,"HasArrived"};
 item3[] = {"Abort",4,218,-91.228699,-251.971512,-1.228698,-201.971497,100.000000,"Abort"};
 item4[] = {"Head_to__Next_Po",2,250,-256.894318,-166.599014,-166.894302,-116.599007,0.000000,"Head to " \n "Next Pos"};
@@ -10,7 +10,7 @@ item5[] = {"True",8,218,-257.487732,-253.817780,-167.487717,-203.817780,0.000000
 item6[] = {"At_Next_Pos",4,218,-403.907898,-167.404144,-313.907928,-117.404137,5.000000,"At Next Pos"};
 item7[] = {"Veh_stuck",4,218,-92.573151,-109.810966,-2.573151,-59.810974,0.000000,"Veh stuck"};
 item8[] = {"Veh_or_Crew_Dead",4,218,-91.259125,-177.638184,-1.259125,-127.638184,20.000000,"Veh or Crew" \n "Dead"};
-item9[] = {"End_and_Unload",1,250,-256.463623,15.090240,-166.463593,65.090225,0.000000,"End and Unload"};
+item9[] = {"End_and_Unload",1,4346,-256.463623,15.090240,-166.463593,65.090225,0.000000,"End and Unload"};
 item10[] = {"Hard_Abort",4,218,-92.573059,-344.041931,-2.573059,-294.041931,100.000000,"Hard Abort"};
 item11[] = {"End_and_Abort",1,250,66.121887,-341.269958,156.121918,-291.269989,0.000000,"End and Abort"};
 link0[] = {0,5};
@@ -28,7 +28,7 @@ link11[] = {7,1};
 link12[] = {8,1};
 link13[] = {10,11};
 globals[] = {0.000000,0,0,0,0,640,480,1,52,6316128,1,-539.552429,231.053772,136.200928,-476.403259,1112,884,1};
-window[] = {2,-1,-1,-1,-1,889,130,1570,130,3,1130};
+window[] = {2,-1,-1,-1,-1,863,104,1544,104,3,1130};
 *//*%FSM</HEAD>*/
 class FSM
 {
@@ -109,13 +109,15 @@ class FSM
                          "	(units _cargoGroup) joinSilent _crewGroup;" \n
                          "	deleteGroup _cargoGroup;" \n
                          "};" \n
-                         "[_crewGroup] spawn A3A_fnc_groupDespawner;" \n
                          "" \n
                          "// Send back to base" \n
                          "private _wp3 = _crewGroup addWaypoint [getMarkerPos (_markers # 0), 100];" \n
                          "_wp3 setWaypointType ""MOVE"";" \n
-                         "_wp3 setWaypointBehaviour ""SAFE"";" \n
+                         "_wp3 setWaypointBehaviour ""AWARE"";" \n
                          "_crewGroup setCurrentWaypoint _wp3;" \n
+                         "" \n
+                         "[_crewGroup] spawn A3A_fnc_groupDespawner;" \n
+                         "[_vehicle] spawn A3A_fnc_vehDespawner;" \n
                          "" \n
                          ""/*%FSM</STATEINIT""">*/;
                         precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
@@ -243,18 +245,20 @@ class FSM
                          "" \n
                          "	// synchronize despawning with the target marker" \n
                          "	// remove this once addGarrison takes control of the units" \n
-                         "	[_crewGroup, _cargoGroup, _markers # 1] spawn {" \n
-                         "		params[""_crew"", ""_cargo"", ""_marker""];" \n
+                         "	[_vehicle, _crewGroup, _cargoGroup, _markers # 1] spawn {" \n
+                         "		params[""_vehicle"", ""_crew"", ""_cargo"", ""_marker""];" \n
                          "		waitUntil {sleep 5; (spawner getVariable _marker == 2)};" \n
                          "		{ deleteVehicle _x } forEach units _cargo;" \n
                          "		{ deleteVehicle _x } forEach units _crew;" \n
                          "		deleteGroup _cargo;" \n
                          "		deleteGroup _crew;" \n
+                         "		if !(_vehicle getVariable [""inDespawner"", false]) then { deleteVehicle _vehicle };" \n
                          "	};" \n
                          "} else {" \n
                          "	// otherwise just use the stock despawning" \n
                          "	[_crewGroup] spawn A3A_fnc_groupDespawner;" \n
                          "	[_cargoGroup] spawn A3A_fnc_groupDespawner;" \n
+                         "	[_vehicle] spawn A3A_fnc_vehDespawner;" \n
                          "};"/*%FSM</STATEINIT""">*/;
                         precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
                         class Links

--- a/A3-Antistasi/FSMs/ConvoyTravelAir.fsm
+++ b/A3-Antistasi/FSMs/ConvoyTravelAir.fsm
@@ -39,7 +39,7 @@ link19[] = {12,4};
 link20[] = {13,11};
 link21[] = {14,11};
 globals[] = {0.000000,0,0,0,0,640,480,1,70,6316128,1,-725.928467,294.090576,352.494415,-458.383972,1112,884,1};
-window[] = {2,-1,-1,-32000,-32000,889,130,1570,130,3,1130};
+window[] = {2,-1,-1,-1,-1,863,104,1544,104,3,1130};
 *//*%FSM</HEAD>*/
 class FSM
 {
@@ -128,11 +128,12 @@ class FSM
                          "	deleteGroup _cargoGroup;" \n
                          "};" \n
                          "[_crewGroup] spawn A3A_fnc_groupDespawner;" \n
+                         "[_vehicle] spawn A3A_fnc_vehDespawner;" \n
                          "" \n
                          "// Send back to base" \n
                          "private _wp3 = _crewGroup addWaypoint [_originPos, 100];" \n
                          "_wp3 setWaypointType ""MOVE"";" \n
-                         "_wp3 setWaypointBehaviour ""SAFE"";" \n
+                         "_wp3 setWaypointBehaviour ""AWARE"";" \n
                          "_crewGroup setCurrentWaypoint _wp3;"/*%FSM</STATEINIT""">*/;
                         precondition = /*%FSM<STATEPRECONDITION""">*/""/*%FSM</STATEPRECONDITION""">*/;
                         class Links

--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -234,6 +234,7 @@ class A3A
 		class spawnGroup {};
 		class vehAvailable {};
 		class VEHdespawner {};
+		class vehKilledOrCaptured {};
 		class wavedCA {};
 		class WPCreate {};
 	};

--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -101,6 +101,7 @@ class A3A
 		class sellVehicle {};
 		class setDataOnClient {};
 		class setMarkerAlphaForSide {};
+        class singlePlayerBlackScreenWarning {};
 		class sizeMarker {};
 		class splitVehicleCrewIntoOwnGroups {};
 		class startBreachVehicle {};

--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -36,6 +36,7 @@ class A3A
 		class addTimeForIdle {};
         class aggressionUpdateLoop {};
 		class AILoadInfo {};
+        class airspaceControl {};
 		class rebelAttack {};
 		class blackout {};
 		class buildHQ {};

--- a/A3-Antistasi/functions/AI/fn_artillery.sqf
+++ b/A3-Antistasi/functions/AI/fn_artillery.sqf
@@ -20,7 +20,7 @@ _vehicle=[_pos, random 360,_typeVehX, _attackingSide] call bis_fnc_spawnvehicle;
 _veh = _vehicle select 0;
 _vehCrew = _vehicle select 1;
 {[_x] call A3A_fnc_NATOinit} forEach _vehCrew;
-[_veh] call A3A_fnc_AIVEHinit;
+[_veh, _attackingSide] call A3A_fnc_AIVEHinit;
 _groupVeh = _vehicle select 2;
 _size = [_mrkDestination] call A3A_fnc_sizeMarker;
 
@@ -72,12 +72,5 @@ if (_posDestination inRangeOfArtillery [[_veh], ((getArtilleryAmmo [_veh]) selec
 		};
 	};
 
-if (!([distanceSPWN,1,_veh,teamPlayer] call A3A_fnc_distanceUnits) and (({_x distance _veh <= distanceSPWN} count (allPlayers - (entities "HeadlessClient_F"))) == 0)) then {deleteVehicle _veh};
-
-{
-_veh = _x;
-waitUntil {sleep 1; !([distanceSPWN,1,_veh,teamPlayer] call A3A_fnc_distanceUnits) and (({_x distance _veh <= distanceSPWN} count (allPlayers - (entities "HeadlessClient_F"))) == 0)};
-deleteVehicle _veh;
-} forEach _vehCrew;
-
-deleteGroup _groupVeh;
+[_groupVeh] spawn A3A_fnc_groupDespawner;
+[_veh] spawn A3A_fnc_vehDespawner;

--- a/A3-Antistasi/functions/AI/fn_mineSweep.sqf
+++ b/A3-Antistasi/functions/AI/fn_mineSweep.sqf
@@ -17,7 +17,7 @@ _pos = position _road findEmptyPosition [1,30,"B_G_Van_01_transport_F"];
 
 _truckX = vehSDKRepair createVehicle _pos;
 
-[_truckX] call A3A_fnc_AIVEHinit;
+[_truckX, teamPlayer] call A3A_fnc_AIVEHinit;
 [_unit] spawn A3A_fnc_FIAinit;
 clearMagazineCargo unitBackpack _unit;
 _unit addItemToBackpack "MineDetector";

--- a/A3-Antistasi/functions/AI/fn_mortarDrill.sqf
+++ b/A3-Antistasi/functions/AI/fn_mortarDrill.sqf
@@ -64,7 +64,7 @@ _groupX addVehicle _mortarX;
 _morty assignAsGunner _mortarX;
 [_morty] orderGetIn true;
 [_morty] allowGetIn true;
-_nul = [_mortarX] call A3A_fnc_AIVEHinit;
+[_mortarX, side _groupX] call A3A_fnc_AIVEHinit;
 _movable = _groupX getVariable ["movable",[]];
 _movable pushBack _helperX;
 _groupX setVariable ["movable",_movable];

--- a/A3-Antistasi/functions/AI/fn_mortyAI.sqf
+++ b/A3-Antistasi/functions/AI/fn_mortyAI.sqf
@@ -31,7 +31,7 @@ while {(alive _morty0) and (alive _morty1)} do
 	_morty1 assignAsGunner _mortarX;
 	[_morty1] orderGetIn true;
 	[_morty1] allowGetIn true;
-	_nul = [_mortarX] call A3A_fnc_AIVEHinit;
+	[_mortarX, side _groupX] call A3A_fnc_AIVEHinit;
 
 	waitUntil {sleep 1; ({!(alive _x)} count units _groupX != 0) or !(unitReady _morty0)};
 

--- a/A3-Antistasi/functions/AI/fn_staticMGDrill.sqf
+++ b/A3-Antistasi/functions/AI/fn_staticMGDrill.sqf
@@ -80,7 +80,7 @@ while {(alive _gunner)} do
 						[_gunner] orderGetIn true;
 						[_gunner] allowGetIn true;
 						_gunner moveInGunner _veh;
-						[_veh] call A3A_fnc_AIVEHinit;
+						[_veh, side _groupX] call A3A_fnc_AIVEHinit;
 						_mounted = true;
 						if (_isMortar) then {_groupX setVariable ["mortarsX",_gunner]};
 						sleep 60;

--- a/A3-Antistasi/functions/Base/fn_airspaceControl.sqf
+++ b/A3-Antistasi/functions/Base/fn_airspaceControl.sqf
@@ -70,7 +70,7 @@ while {!(isNull _vehicle) && {alive _vehicle && {count (crew _vehicle) != 0}}} d
             {_markerPos distance2D _vehPos < _airportWarningRange}
         };
 
-        private _newAirports = _inWarningRangeAirport - _airportsInWarningRange;
+        private _newAirports = _airportsInWarningRange - _inWarningRangeAirport;
         _inWarningRangeAirport = _airportsInWarningRange;
 
         private _outpostsInWarningRange = _enemyOutposts select
@@ -81,13 +81,13 @@ while {!(isNull _vehicle) && {alive _vehicle && {count (crew _vehicle) != 0}}} d
             {_markerPos distance2D _vehPos < _outpostWarningRange}
         };
 
-        private _newOutposts = _inWarningRangeOutpost - _outpostsInWarningRange;
+        private _newOutposts = _outpostsInWarningRange - _inWarningRangeOutpost;
         _inWarningRangeOutpost = _outpostsInWarningRange;
 
         {
             //Assuming you only get a single one each second, need to split it otherwise
-            private _warningText = format ["Unidentified helicopter</br>You are closing in on the airspace of %1. Change your course or we will take defensive actions!", [_x] call A3A_fnc_locilizar];
-            [_warningText] remoteExec ["hint", (crew _vehicle)];
+            private _warningText = format ["Unidentified helicopter<br/><br/>You are closing in on the airspace of %1.<br/><br/> Change your course or we will take defensive actions!", [_x] call A3A_fnc_localizar];
+            ["Undercover", _warningText] remoteExec ["A3A_fnc_customHint", (crew _vehicle)];
         } forEach _newAirports + _newOutposts;
 
         {
@@ -96,7 +96,7 @@ while {!(isNull _vehicle) && {alive _vehicle && {count (crew _vehicle) != 0}}} d
             if(_heightDiff < _airportDetectionHeight && {_markerPos distance2D _vehPos < _airportDetectionRange}) exitWith
             {
                 //Too close to airport, break undercover and let the other routine handle it
-                _vehicle getVariable ["NoFlyZoneDetected", _x, true];
+                _vehicle setVariable ["NoFlyZoneDetected", _x, true];
                 _vehicleIsUndercover = false;
             };
         } forEach _inWarningRangeAirport;
@@ -107,7 +107,7 @@ while {!(isNull _vehicle) && {alive _vehicle && {count (crew _vehicle) != 0}}} d
             if(_heightDiff < _outpostDetectionHeight && {_markerPos distance2D _vehPos < _outpostDetectionRange}) exitWith
             {
                 //Too close to airport, break undercover and let the other routine handle it
-                _vehicle getVariable ["NoFlyZoneDetected", _x, true];
+                _vehicle setVariable ["NoFlyZoneDetected", _x, true];
                 _vehicleIsUndercover = false;
             };
         } forEach _inWarningRangeOutpost;
@@ -123,7 +123,7 @@ while {!(isNull _vehicle) && {alive _vehicle && {count (crew _vehicle) != 0}}} d
             {_markerPos distance2D _vehPos < _airportDetectionRange}
         };
 
-        private _newAirports = _inDetectionRangeAirport - _airportsInRange;
+        private _newAirports = _airportsInRange - _inDetectionRangeAirport;
         _inDetectionRangeAirport = _airportsInRange;
 
         if(count _newAirports > 0) then
@@ -145,8 +145,8 @@ while {!(isNull _vehicle) && {alive _vehicle && {count (crew _vehicle) != 0}}} d
                     {_markerPos distance2D _vehPos < _outpostDetectionRange}
                 };
 
-                private _newOutposts = _inDetectionRangeOutpost - _outpostsInRange;
-                _inDetectionRangeOutpost = _outpostsInRange
+                private _newOutposts = _outpostsInRange - _inDetectionRangeOutpost;
+                _inDetectionRangeOutpost = _outpostsInRange;
 
                 if(count _newOutposts > 0) then
                 {

--- a/A3-Antistasi/functions/Base/fn_airspaceControl.sqf
+++ b/A3-Antistasi/functions/Base/fn_airspaceControl.sqf
@@ -1,7 +1,163 @@
+#define CIV_HELI        0
+#define MIL_HELI        1
+#define JET             2
+
+
 params ["_vehicle"];
 
 //If vehicle already has an airspace control script, exit here
-if(_vehicle getVariable ["airspaceControl", -1] != -1) exitWith {};
+if(_vehicle getVariable ["airspaceControl", false]) exitWith {};
 
-private _random = round (random 1000);
-_vehicle setVariable ["airspaceControl", _random, true];
+_vehicle setVariable ["airspaceControl", true, true];
+
+private _airType = -1;
+if(_vehicle isKindOf "Helicopter") then
+{
+    if(typeOf _vehicle == civHeli) then
+    {
+        _airType = CIV_HELI;
+    }
+    else
+    {
+        _airType = MIL_HELI;
+    };
+}
+else
+{
+    _airType = JET;
+};
+
+//Select height and range for outposts, numbers are values for [CIV_HELI, MIL_HELI, JET]
+private _outpostDetectionRange = [300, 500, 750] select _airType;
+private _outpostDetectionHeight = [150, 250, 500] select _airType;
+
+//Select height and range for outposts, numbers are values for [CIV_HELI, MIL_HELI, JET]
+private _airportDetectionRange = [500, 750, 1500] select _airType;
+private _airportDetectionHeight = [500, 500, 2500] select _airType;
+
+//Selecting height and distance warning for outposts
+private _outpostWarningRange = 500;
+private _outpostWarningHeight = 250;
+
+//Selecting height and distance warning for airports
+private _airportWarningRange = 750;
+private _airportWarningHeight = 750;
+
+private _inWarningRangeOutpost = [];
+private _inDetectionRangeOutpost = [];
+private _inWarningRangeAirport = [];
+private _inDetectionRangeAirport = [];
+private _vehicleIsUndercover = false;
+private _supportCallAt = -1;
+private _vehPos = [];
+
+while {!(isNull _vehicle) && {alive _vehicle && {count (crew _vehicle) != 0}}} do
+{
+    _vehicleIsUndercover = captive ((crew _vehicle) select 0);
+    _vehPos = getPos _vehicle;
+
+    private _enemyAirports = airportsX select {sidesX getVariable [_x, sideUnknown] != teamPlayer};
+    private _enemyOutposts = outposts select {sidesX getVariable [_x, sideUnknown] != teamPlayer};
+
+    if(_vehicleIsUndercover && {_vehicle getVariable ["NoFlyZoneDetected", ""] == ""}) then
+    {
+        //Warnings will be issued before undercover is broken
+        private _airportsInWarningRange = _enemyAirports select
+        {
+            private _markerPos = getMarkerPos _x;
+            private _heightDiff = (_vehPos select 2) - (_markerPos select 2);
+            _heightDiff < _airportWarningHeight &&
+            {_markerPos distance2D _vehPos < _airportWarningRange}
+        };
+
+        private _newAirports = _inWarningRangeAirport - _airportsInWarningRange;
+        _inWarningRangeAirport = _airportsInWarningRange;
+
+        private _outpostsInWarningRange = _enemyOutposts select
+        {
+            private _markerPos = getMarkerPos _x;
+            private _heightDiff = (_vehPos select 2) - (_markerPos select 2);
+            _heightDiff < _outpostWarningHeight &&
+            {_markerPos distance2D _vehPos < _outpostWarningRange}
+        };
+
+        private _newOutposts = _inWarningRangeOutpost - _outpostsInWarningRange;
+        _inWarningRangeOutpost = _outpostsInWarningRange;
+
+        {
+            //Assuming you only get a single one each second, need to split it otherwise
+            private _warningText = format ["Unidentified helicopter</br>You are closing in on the airspace of %1. Change your course or we will take defensive actions!", [_x] call A3A_fnc_locilizar];
+            [_warningText] remoteExec ["hint", (crew _vehicle)];
+        } forEach _newAirports + _newOutposts;
+
+        {
+            private _markerPos = getMarkerPos _x;
+            private _heightDiff = (_vehPos select 2) - (_markerPos select 2);
+            if(_heightDiff < _airportDetectionHeight && {_markerPos distance2D _vehPos < _airportDetectionRange}) exitWith
+            {
+                //Too close to airport, break undercover and let the other routine handle it
+                _vehicle getVariable ["NoFlyZoneDetected", _x, true];
+                _vehicleIsUndercover = false;
+            };
+        } forEach _inWarningRangeAirport;
+
+        {
+            private _markerPos = getMarkerPos _x;
+            private _heightDiff = (_vehPos select 2) - (_markerPos select 2);
+            if(_heightDiff < _outpostDetectionHeight && {_markerPos distance2D _vehPos < _outpostDetectionRange}) exitWith
+            {
+                //Too close to airport, break undercover and let the other routine handle it
+                _vehicle getVariable ["NoFlyZoneDetected", _x, true];
+                _vehicleIsUndercover = false;
+            };
+        } forEach _inWarningRangeOutpost;
+    }
+    else
+    {
+        //Vehicles will be attacked instantly once detected
+        private _airportsInRange = _enemyAirports select
+        {
+            private _markerPos = getMarkerPos _x;
+            private _heightDiff = (_vehPos select 2) - (_markerPos select 2);
+            _heightDiff < _airportDetectionHeight &&
+            {_markerPos distance2D _vehPos < _airportDetectionRange}
+        };
+
+        private _newAirports = _inDetectionRangeAirport - _airportsInRange;
+        _inDetectionRangeAirport = _airportsInRange;
+
+        if(count _newAirports > 0) then
+        {
+            //Vehicle detected by another airport
+            //Call support here, not in this branch currently
+            _supportCallAt = time + 300;
+        }
+        else
+        {
+            //No airport near, to save performance we only check outpost if they would be able to send support
+            if(time > _supportCallAt) then
+            {
+                private _outpostsInRange = _enemyOutposts select
+                {
+                    private _markerPos = getMarkerPos _x;
+                    private _heightDiff = (_vehPos select 2) - (_markerPos select 2);
+                    _heightDiff < _outpostDetectionHeight &&
+                    {_markerPos distance2D _vehPos < _outpostDetectionRange}
+                };
+
+                private _newOutposts = _inDetectionRangeOutpost - _outpostsInRange;
+                _inDetectionRangeOutpost = _outpostsInRange
+
+                if(count _newOutposts > 0) then
+                {
+                    //Vehicle detected by another outpost, call support if possible
+                    //Call support here, not in this branch currently
+                    _supportCallAt = time + 300;
+                };
+            };
+        };
+    };
+    sleep 1;
+};
+
+_vehicle setVariable ["airspaceControl", nil, true];

--- a/A3-Antistasi/functions/Base/fn_airspaceControl.sqf
+++ b/A3-Antistasi/functions/Base/fn_airspaceControl.sqf
@@ -1,0 +1,7 @@
+params ["_vehicle"];
+
+//If vehicle already has an airspace control script, exit here
+if(_vehicle getVariable ["airspaceControl", -1] != -1) exitWith {};
+
+private _random = round (random 1000);
+_vehicle setVariable ["airspaceControl", _random, true];

--- a/A3-Antistasi/functions/Base/fn_singlePlayerBlackScreenWarning.sqf
+++ b/A3-Antistasi/functions/Base/fn_singlePlayerBlackScreenWarning.sqf
@@ -1,0 +1,10 @@
+/*  The temporary warning for SP
+*/
+
+cutText ["Single player modus detected!\n\nFor the best experience please play as a local hosted game. SP support will end in the near future.\n\nYou can still play as SP modus for now, this screen will vanish in a few seconds!","BLACK",1];
+
+sleep 1;
+cutText ["Single player modus detected!\n\nFor the best experience please play as a local hosted game. SP support will end in the near future.\n\nYou can still play as SP modus for now, this screen will vanish in a few seconds!","BLACK FADED", 10];
+
+sleep 10;
+cutText ["Single player modus detected!\n\nFor the best experience please play as a local hosted game. SP support will end in the near future.\n\nYou can still play as SP modus for now, this screen will vanish in a few seconds!","BLACK IN",1];

--- a/A3-Antistasi/functions/CREATE/fn_AAFroadPatrol.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_AAFroadPatrol.sqf
@@ -114,7 +114,7 @@ if (_typePatrol != "AIR") then
 
 _vehicle=[_posBase, 0,_typeCar, _sideX] call bis_fnc_spawnvehicle;
 _veh = _vehicle select 0;
-[_veh] call A3A_fnc_AIVEHinit;
+[_veh, _sideX] call A3A_fnc_AIVEHinit;
 [_veh,"Patrol"] spawn A3A_fnc_inmuneConvoy;
 _vehCrew = _vehicle select 1;
 {[_x] call A3A_fnc_NATOinit} forEach _vehCrew;
@@ -178,12 +178,13 @@ while {alive _veh} do
 		};
 	};
 
-_enemiesX = if (_sideX == Occupants) then {Invaders} else {Occupants};
+{ 
+	private _wp = _x addWaypoint [getMarkerPos _base, 50];
+	_wp setWaypointType "MOVE";
+	_x setCurrentWaypoint _wp;
+	[_x] spawn A3A_fnc_groupDespawner;		// this one did care about enemies. Not sure why.
+} forEach _groups;
 
-{_unit = _x;
-waitUntil {sleep 1;!([distanceSPWN,1,_unit,teamPlayer] call A3A_fnc_distanceUnits) and !([distanceSPWN,1,_unit,_enemiesX] call A3A_fnc_distanceUnits)};deleteVehicle _unit} forEach _soldiers;
+{ [_x] spawn A3A_fnc_vehDespawner } forEach _vehiclesX;
 
-{_veh = _x;
-if (!([distanceSPWN,1,_veh,teamPlayer] call A3A_fnc_distanceUnits) and !([distanceSPWN,1,_veh,_enemiesX] call A3A_fnc_distanceUnits)) then {deleteVehicle _veh}} forEach _vehiclesX;
-{deleteGroup _x} forEach _groups;
 AAFpatrols = AAFpatrols - 1;

--- a/A3-Antistasi/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_AIVEHinit.sqf
@@ -1,162 +1,95 @@
-private ["_veh","_typeX"];
+/*
+	Installs various damage/smoke/kill/capture logic for vehicles
+	Will set and modify the "originalSide" and "ownerSide" variables on the vehicle indicating side ownership
+	If a rebel enters a vehicle, it will be switched to rebel side and added to vehDespawner
+	
+	Params:
+	1. Object: Vehicle object
+	2. Side: Side ownership for vehicle
+*/
 
-_veh = _this select 0;
+private _filename = "fn_AIVEHinit";
+params ["_veh", "_side"];
 if (isNil "_veh") exitWith {};
+
+if !(isNil { _veh getVariable "ownerSide" }) exitWith
+{
+	// vehicle already initialized, just swap side and exit
+	[_veh, _side] call A3A_fnc_vehKilledOrCaptured;
+	_veh setVariable ["ownerSide", _side, true];
+};
+
+_veh setVariable ["originalSide", _side, true];
+_veh setVariable ["ownerSide", _side, true];
+
+// probably just shouldn't be called for these
 if ((_veh isKindOf "FlagCarrier") or (_veh isKindOf "Building") or (_veh isKindOf "ReammoBox_F")) exitWith {};
 //if (_veh isKindOf "ReammoBox_F") exitWith {[_veh] call A3A_fnc_NATOcrate};
 
-_typeX = typeOf _veh;
+// this might need moving into a different function later
+if (_side == teamPlayer) then
+{
+	clearMagazineCargoGlobal _veh;			// might need an exception on this for vehicle weapon mags?
+	clearWeaponCargoGlobal _veh;
+	clearItemCargoGlobal _veh;
+	clearBackpackCargoGlobal _veh;
+};
 
+private _typeX = typeOf _veh;
 if ((_typeX in vehNormal) or (_typeX in vehAttack) or (_typeX in vehBoats)) then
 {
 	_veh call A3A_fnc_addActionBreachVehicle;
 
-	_veh addEventHandler ["Killed",
-		{
-		private _veh = _this select 0;
-		(typeOf _veh) call A3A_fnc_removeVehFromPool;
-		_veh removeAllEventHandlers "HandleDamage";
-		}];
 	if !(_typeX in vehAttack) then
 	{
 		if (_veh isKindOf "Car") then
-			{
+		{
 			_veh addEventHandler ["HandleDamage",{if (((_this select 1) find "wheel" != -1) and ((_this select 4=="") or (side (_this select 3) != teamPlayer)) and (!isPlayer driver (_this select 0))) then {0} else {(_this select 2)}}];
 			if ({"SmokeLauncher" in (_veh weaponsTurret _x)} count (allTurrets _veh) > 0) then
-				{
+			{
 				_veh setVariable ["within",true];
 				_veh addEventHandler ["GetOut", {private ["_veh"]; _veh = _this select 0; if (side (_this select 2) != teamPlayer) then {if (_veh getVariable "within") then {_veh setVariable ["within",false]; [_veh] call A3A_fnc_smokeCoverAuto}}}];
 				_veh addEventHandler ["GetIn", {private ["_veh"]; _veh = _this select 0; if (side (_this select 2) != teamPlayer) then {_veh setVariable ["within",true]}}];
-				};
 			};
-        if(_typeX in vehTrucks) then
-        {
-            _veh addEventHandler ["killed",
-            {
-                private ["_veh","_typeX"];
-                _veh = _this select 0;
-                _typeX = typeOf _veh;
-                if (side (_this select 1) == teamPlayer) then
-                {
-                    if (_typeX in vehNATOTrucks) then
-                    {
-                        [[2, 45], [0, 0]] remoteExec ["A3A_fnc_prestige",2];
-                    }
-                    else
-                    {
-                        [[0, 0], [2, 45]] remoteExec ["A3A_fnc_prestige",2];
-                    };
-                };
-            }];
-        }
-        else
-        {
-            _veh addEventHandler ["killed",
-            {
-                private ["_veh","_typeX"];
-                _veh = _this select 0;
-                _typeX = typeOf _veh;
-                if (side (_this select 1) == teamPlayer) then
-                {
-                    if (_typeX in vehNATOLight) then
-                    {
-                        [[5, 45], [0, 0]] remoteExec ["A3A_fnc_prestige",2];
-                    }
-                    else
-                    {
-                        [[0, 0], [5, 45]] remoteExec ["A3A_fnc_prestige",2];
-                    };
-                };
-            }];
-        };
+		};
 	}
 	else
-		{
+	{
 		if (_typeX in vehAPCs) then
-			{
-			_veh addEventHandler ["killed",
-				{
-				private ["_veh","_typeX"];
-				_veh = _this select 0;
-				_typeX = typeOf _veh;
-				if (side (_this select 1) == teamPlayer) then
-				{
-					if (_typeX in vehNATOAPC) then
-                    {
-                        [-2,2,position (_veh)] remoteExec ["A3A_fnc_citySupportChange",2];
-                        [[10, 45], [0, 0]] remoteExec ["A3A_fnc_prestige",2];
-                    }
-                    else
-                    {
-                        [[0, 0], [10, 45]] remoteExec ["A3A_fnc_prestige",2];
-                    };
-				};
-				}];
+		{
 			_veh addEventHandler ["HandleDamage",{private ["_veh"]; _veh = _this select 0; if (!canFire _veh) then {[_veh] call A3A_fnc_smokeCoverAuto; _veh removeEventHandler ["HandleDamage",_thisEventHandler]};if (((_this select 1) find "wheel" != -1) and (_this select 4=="") and (!isPlayer driver (_veh))) then {0;} else {(_this select 2);}}];
 			_veh setVariable ["within",true];
 			_veh addEventHandler ["GetOut", {private ["_veh"];  _veh = _this select 0; if (side (_this select 2) != teamPlayer) then {if (_veh getVariable "within") then {_veh setVariable ["within",false];[_veh] call A3A_fnc_smokeCoverAuto}}}];
 			_veh addEventHandler ["GetIn", {private ["_veh"];_veh = _this select 0; if (side (_this select 2) != teamPlayer) then {_veh setVariable ["within",true]}}];
-			}
+		}
 		else
-			{
+		{
 			if (_typeX in vehTanks) then
-				{
-				_veh addEventHandler ["killed",
-					{
-					private ["_veh","_typeX"];
-					_veh = _this select 0;
-					_typeX = typeOf _veh;
-					if (side (_this select 1) == teamPlayer) then
-						{
-                            [
-                                3,
-                                "Rebels killed a tank",
-                                "aggroEvent",
-                                true
-                            ] call A3A_fnc_log;
-						if (_typeX == vehNATOTank) then
-                        {
-                            [-5,5,position (_veh)] remoteExec ["A3A_fnc_citySupportChange",2];
-                            [[20, 45], [0, 0]] remoteExec ["A3A_fnc_prestige",2];
-                        }
-                        else
-                        {
-                            [[0, 0], [20, 45]] remoteExec ["A3A_fnc_prestige",2];
-                        };
-						};
-					}];
+			{
 				_veh addEventHandler ["HandleDamage",{private ["_veh"]; _veh = _this select 0; if (!canFire _veh) then {[_veh] call A3A_fnc_smokeCoverAuto;  _veh removeEventHandler ["HandleDamage",_thisEventHandler]}}];
-				}
+			}
 			else
-				{
+			{
 				_veh addEventHandler ["HandleDamage",{if (((_this select 1) find "wheel" != -1) and ((_this select 4=="") or (side (_this select 3) != teamPlayer)) and (!isPlayer driver (_this select 0))) then {0} else {(_this select 2)}}];
-				};
 			};
 		};
-	}
+	};
+}
 else
-	{
+{
 	if (_typeX in vehPlanes) then
-		{
-		_veh addEventHandler ["killed",
-			{
-			private ["_veh","_typeX"];
-			_veh = _this select 0;
-			(typeOf _veh) call A3A_fnc_removeVehFromPool;
-			}];
+	{
 		_veh addEventHandler ["GetIn",
+		{
+			if (_this select 1 != "driver") exitWith {};
+			_unit = _this select 2;
+			if ((!isPlayer _unit) and (_unit getVariable ["spawner",false]) and (side group _unit == teamPlayer)) then
 			{
-			_positionX = _this select 1;
-			if (_positionX == "driver") then
-				{
-				_unit = _this select 2;
-				if ((!isPlayer _unit) and (_unit getVariable ["spawner",false]) and (side group _unit == teamPlayer)) then
-					{
-					moveOut _unit;
-					["General", "Only Humans can pilot an air vehicle"] call A3A_fnc_customHint;
-					};
-				};
-			}];
+				moveOut _unit;
+				["General", "Only Humans can pilot an air vehicle"] call A3A_fnc_customHint;
+			};
+		}];
+
 		if (_veh isKindOf "Helicopter") then
 		{
 			if (_typeX in vehTransportAir) then
@@ -164,198 +97,189 @@ else
 				_veh setVariable ["within",true];
 				_veh addEventHandler ["GetOut", {private ["_veh"];_veh = _this select 0; if ((isTouchingGround _veh) and (isEngineOn _veh)) then {if (side (_this select 2) != teamPlayer) then {if (_veh getVariable "within") then {_veh setVariable ["within",false]; [_veh] call A3A_fnc_smokeCoverAuto}}}}];
 				_veh addEventHandler ["GetIn", {private ["_veh"];_veh = _this select 0; if (side (_this select 2) != teamPlayer) then {_veh setVariable ["within",true]}}];
-                _veh addEventHandler ["killed",
-				{
-					private ["_veh","_typeX"];
-					_veh = _this select 0;
-					_typeX = typeOf _veh;
-					if (side (_this select 1) == teamPlayer) then
-					{
-						if (_typeX in vehNATOTransportHelis) then
-                        {
-                            [[5, 45], [0, 0]] remoteExec ["A3A_fnc_prestige",2];
-                        }
-                        else
-                        {
-                            [[0, 0], [5, 45]] remoteExec ["A3A_fnc_prestige",2];
-                        };
-					};
-				}];
-			}
-			else
-			{
-				_veh addEventHandler ["killed",
-				{
-					private ["_veh","_typeX"];
-					_veh = _this select 0;
-					_typeX = typeOf _veh;
-					if (side (_this select 1) == teamPlayer) then
-					{
-						if (_typeX in vehNATOAttackHelis) then
-                        {
-                            [-5,5,position (_veh)] remoteExec ["A3A_fnc_citySupportChange",2];
-                            [[15, 45], [0, 0]] remoteExec ["A3A_fnc_prestige",2];
-                        }
-                        else
-                        {
-                            [[0, 0], [15, 45]] remoteExec ["A3A_fnc_prestige",2];
-                        };
-					};
-				}];
 			};
-		};
-		if (_veh isKindOf "Plane") then
-		{
-			_veh addEventHandler ["killed",
-			{
-				private ["_veh","_typeX"];
-				_veh = _this select 0;
-				_typeX = typeOf _veh;
-				if (side (_this select 1) == teamPlayer) then
-				{
-					if ((_typeX == vehNATOPlane) or (_typeX == vehNATOPlaneAA)) then
-                    {
-                        [-8,8,position (_veh)] remoteExec ["A3A_fnc_citySupportChange",2];
-                        [[10, 45], [0, 0]] remoteExec ["A3A_fnc_prestige",2];
-                    }
-                    else
-                    {
-                        [[0, 0], [10, 45]] remoteExec ["A3A_fnc_prestige",2];
-                    };
-				};
-			}];
 		};
 	}
 	else
-		{
+	{
 		if (_veh isKindOf "StaticWeapon") then
-			{
+		{
 			_veh setCenterOfMass [(getCenterOfMass _veh) vectorAdd [0, 0, -1], 0];
 			if ((not (_veh in staticsToSave)) and (side gunner _veh != teamPlayer)) then
-				{
+			{
 				if (activeGREF and ((_typeX == staticATteamPlayer) or (_typeX == staticAAteamPlayer))) then {[_veh,"moveS"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_veh]} else {[_veh,"steal"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_veh]};
-				};
+			};
 			if (_typeX == SDKMortar) then
-				{
+			{
 				if (!isNull gunner _veh) then
-					{
+				{
 					[_veh,"steal"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_veh];
-					};
+				};
 				_veh addEventHandler ["Fired",
-					{
+				{
 					_mortarX = _this select 0;
 					_dataX = _mortarX getVariable ["detection",[position _mortarX,0]];
 					_positionX = position _mortarX;
 					_chance = _dataX select 1;
 					if ((_positionX distance (_dataX select 0)) < 300) then
-						{
+					{
 						_chance = _chance + 2;
-						}
+					}
 					else
-						{
+					{
 						_chance = 0;
-						};
+					};
 					if (random 100 < _chance) then
-						{
+					{
 						{if ((side _x == Occupants) or (side _x == Invaders)) then {_x reveal [_mortarX,4]}} forEach allUnits;
 						if (_mortarX distance posHQ < 300) then
-							{
+						{
 							if (!(["DEF_HQ"] call BIS_fnc_taskExists)) then
-								{
+							{
 								_LeaderX = leader (gunner _mortarX);
 								if (!isPlayer _LeaderX) then
-									{
+								{
 									[[],"A3A_fnc_attackHQ"] remoteExec ["A3A_fnc_scheduler",2];
-									}
+								}
 								else
-									{
+								{
 									if ([_LeaderX] call A3A_fnc_isMember) then {[[],"A3A_fnc_attackHQ"] remoteExec ["A3A_fnc_scheduler",2]};
-									};
 								};
-							}
+							};
+						}
 						else
-							{
+						{
 							_bases = airportsX select {(getMarkerPos _x distance _mortarX < distanceForAirAttack) and ([_x,true] call A3A_fnc_airportCanAttack) and (sidesX getVariable [_x,sideUnknown] != teamPlayer)};
 							if (count _bases > 0) then
-								{
+							{
 								_base = [_bases,_positionX] call BIS_fnc_nearestPosition;
 								_sideX = sidesX getVariable [_base,sideUnknown];
 								[[getPosASL _mortarX,_sideX,"Normal",false],"A3A_fnc_patrolCA"] remoteExec ["A3A_fnc_scheduler",2];
-								};
 							};
 						};
-					_mortarX setVariable ["detection",[_positionX,_chance]];
-					}];
-				}
-			else
-			{
-				_veh addEventHandler ["killed",
-				{
-					private ["_veh","_typeX"];
-					_veh = _this select 0;
-                    _typeX = typeOf _veh;
-					_typeX call A3A_fnc_removeVehFromPool;
-				}];
-			};
-		}
-		else
-			{
-			if ((_typeX in vehAA) or (_typeX in vehMRLS)) then
-				{
-				_veh addEventHandler ["killed",
-					{
-					private ["_veh","_typeX"];
-					_veh = _this select 0;
-					_typeX = typeOf _veh;
-					if (side (_this select 1) == teamPlayer) then
-					{
-                        [
-                            3,
-                            "Rebels killed a special vehicle",
-                            "aggroEvent",
-                            true
-                        ] call A3A_fnc_log;
-						if (_typeX == vehNATOAA || _typeX == vehNATOMRLS) then
-                        {
-                            [-5,5,position (_veh)] remoteExec ["A3A_fnc_citySupportChange",2];
-                            [[20, 45], [0, 0]] remoteExec ["A3A_fnc_prestige",2];
-                        }
-                        else
-                        {
-                            [[0, 0], [20, 45]] remoteExec ["A3A_fnc_prestige",2];
-                        };
 					};
-					_typeX call A3A_fnc_removeVehFromPool;
-					}];
-				};
+					_mortarX setVariable ["detection",[_positionX,_chance]];
+				}];
 			};
 		};
 	};
+};
 
+if (_side == civilian) then
+{
+	_veh addEventHandler ["HandleDamage",{if (((_this select 1) find "wheel" != -1) and (_this select 4=="") and (!isPlayer driver (_this select 0))) then {0;} else {(_this select 2);};}];
+	_veh addEventHandler ["HandleDamage", {
+		_veh = _this select 0;
+		if (side(_this select 3) == teamPlayer) then
+		{
+			_driverX = driver _veh;
+			if (side group _driverX == civilian) then {_driverX leaveVehicle _veh};
+			_veh removeEventHandler ["HandleDamage", _thisEventHandler];
+		};
+	}];
+};
+
+// EH behaviour:
+// GetIn/GetOut/Dammaged: Runs where installed, regardless of locality 
+// Local: Runs where installed if target was local before or after the transition
+// HandleDamage/Killed: Runs where installed, only if target is local
+// MPKilled: Runs everywhere, regardless of target locality or install location
+
+if (_side != teamPlayer) then {
+
+	// Vehicle stealing handler
+	// When a rebel first enters a vehicle, flip side, fire capture function and start vehDespawner (unless static)
+	_veh addEventHandler ["GetIn", {
+
+		params ["_veh", "_role", "_unit"];
+		if (side group _unit != teamPlayer) exitWith {};		// only rebels can flip vehicles atm
+		private _oldside = _veh getVariable ["ownerSide", teamPlayer];
+		if (_oldside != teamPlayer) then
+		{
+			[3, format ["%1 switching side from %2 to rebels", typeof _veh, _oldside], "fn_AIVEHinit"] call A3A_fnc_log;
+			[_veh, teamPlayer, true] call A3A_fnc_vehKilledOrCaptured;
+			_veh setVariable ["ownerSide", teamPlayer, true];
+			if !(_veh isKindOf "StaticWeapon") then { [_veh] spawn A3A_fnc_VEHdespawner };
+		};
+		_veh removeEventHandler ["GetIn", _thisEventHandler];
+	}];
+};
+
+// Handler to prevent vehDespawner deleting vehicles for an hour after rebels exit them
+
+_veh addEventHandler ["GetOut", {
+	params ["_veh", "_role", "_unit"];
+	if !(_unit isEqualType objNull) exitWith {
+		[1, format ["GetOut handler weird input: %1, %2, %3", _veh, _role, _unit], "fn_AIVEHinit"] call A3A_fnc_log;
+	};
+	if (side group _unit == teamPlayer) then {
+		_veh setVariable ["despawnBlockTime", time + 3600];			// despawner always launched locally
+	};
+}];
+
+// Because Killed and MPKilled are both retarded, we use Dammaged
+
+_veh addEventHandler ["Dammaged", {
+	params ["_veh", "_selection", "_damage"];
+	if (_damage >= 1 && _selection == "") then {
+		private _killerSide = side group (_this select 5);
+		[3, format ["%1 destroyed by %2", typeof _veh, _killerSide], "fn_AIVEHinit"] call A3A_fnc_log;
+		[_veh, _killerSide, false] call A3A_fnc_vehKilledOrCaptured;
+		[_veh] spawn A3A_fnc_postmortem;
+		_veh removeEventHandler ["Dammaged", _thisEventHandler];
+	};
+}];
+
+
+// deletes vehicle if it exploded on spawn...
 [_veh] spawn A3A_fnc_cleanserVeh;
 
-_veh addEventHandler ["Killed",{[_this select 0] spawn A3A_fnc_postmortem}];
 
+
+/*
+if (isNil "A3A_vehicleEH_addHandlers") then 
+{	
+	A3A_vehicleEH_Killed = {
+		params ["_veh", "_killer", "_instigator"];
+		[_veh, side group _instigator, false] call A3A_fnc_vehKilledOrCaptured;
+		[_veh] spawn A3A_fnc_postmortem;
+	};
+	
+	A3A_vehicleEH_Local = {
+		params ["_veh", "_isLocal"];
+		[_veh] remoteExec ["A3A_vehicleEH_addHandlers", _veh];
+		_veh removeEventHandler ["Killed", _veh getVariable "killedEHindex"];
+		_veh removeEventHandler ["Local", _thisEventHandler];
+	};
+
+	A3A_vehicleEH_addHandlers = {
+		params ["_veh"];
+		_veh addEventHandler ["Local", A3A_vehicleEH_Local];
+		_idx = _veh addEventHandler ["Killed", A3A_vehicleEH_Killed];
+		_veh setVariable ["killedEHIndex", _idx];
+	};
+};
+_veh call A3A_vehicleEH_addHandlers;
+*/
+
+
+/*
+_veh addMPEventHandler ["MPKilled", {
+	
+	if (!isServer) exitWith {};			// MPKilled runs everywhere for some reason
+	params ["_veh", "_killer", "_instigator"];
+	[_veh, side group _instigator, false] call A3A_fnc_vehKilledOrCaptured;
+	[_veh] spawn A3A_fnc_postmortem;
+}];
+*/
+/*
 if (not(_veh in staticsToSave)) then
 	{
 	if (((count crew _veh) > 0) and (not (_typeX in vehAA)) and (not (_typeX in vehMRLS) and !(_veh isKindOf "StaticWeapon"))) then
 		{
 		[_veh] spawn A3A_fnc_VEHdespawner
-		}
-	else
-		{
-		_veh addEventHandler ["GetIn",
-			{
-			_unit = _this select 2;
-			if ((side _unit == teamPlayer) or (isPlayer _unit)) then {[_this select 0] spawn A3A_fnc_VEHdespawner};
-			}
-			];
-		};
-	if (_veh distance getMarkerPos respawnTeamPlayer <= 50) then
-		{
-		clearMagazineCargoGlobal _veh;
-		clearWeaponCargoGlobal _veh;
-		clearItemCargoGlobal _veh;
-		clearBackpackCargoGlobal _veh;
 		};
 	};
+*/
+
+

--- a/A3-Antistasi/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_AIVEHinit.sqf
@@ -207,7 +207,7 @@ if (_side != teamPlayer) then {
 
 if(_veh isKindOf "Air") then
 {
-    //Start airspace control script if rebel unit enters
+    //Start airspace control script if rebel player enters
     _veh addEventHandler
     [
         "GetIn",

--- a/A3-Antistasi/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_AIVEHinit.sqf
@@ -2,7 +2,7 @@
 	Installs various damage/smoke/kill/capture logic for vehicles
 	Will set and modify the "originalSide" and "ownerSide" variables on the vehicle indicating side ownership
 	If a rebel enters a vehicle, it will be switched to rebel side and added to vehDespawner
-	
+
 	Params:
 	1. Object: Vehicle object
 	2. Side: Side ownership for vehicle
@@ -180,7 +180,7 @@ if (_side == civilian) then
 };
 
 // EH behaviour:
-// GetIn/GetOut/Dammaged: Runs where installed, regardless of locality 
+// GetIn/GetOut/Dammaged: Runs where installed, regardless of locality
 // Local: Runs where installed if target was local before or after the transition
 // HandleDamage/Killed: Runs where installed, only if target is local
 // MPKilled: Runs everywhere, regardless of target locality or install location
@@ -203,6 +203,22 @@ if (_side != teamPlayer) then {
 		};
 		_veh removeEventHandler ["GetIn", _thisEventHandler];
 	}];
+};
+
+if(_veh isKindOf "Air") then
+{
+    //Start airspace control script if rebel unit enters
+    _veh addEventHandler
+    [
+        "GetIn",
+        {
+            params ["_veh", "_role", "_unit"];
+            if(side group _unit == teamPlayer) then
+            {
+                [_veh] spawn A3A_fnc_airspaceControl;
+            };
+        }
+    ];
 };
 
 // Handler to prevent vehDespawner deleting vehicles for an hour after rebels exit them
@@ -237,14 +253,14 @@ _veh addEventHandler ["Dammaged", {
 
 
 /*
-if (isNil "A3A_vehicleEH_addHandlers") then 
-{	
+if (isNil "A3A_vehicleEH_addHandlers") then
+{
 	A3A_vehicleEH_Killed = {
 		params ["_veh", "_killer", "_instigator"];
 		[_veh, side group _instigator, false] call A3A_fnc_vehKilledOrCaptured;
 		[_veh] spawn A3A_fnc_postmortem;
 	};
-	
+
 	A3A_vehicleEH_Local = {
 		params ["_veh", "_isLocal"];
 		[_veh] remoteExec ["A3A_vehicleEH_addHandlers", _veh];
@@ -265,7 +281,7 @@ _veh call A3A_vehicleEH_addHandlers;
 
 /*
 _veh addMPEventHandler ["MPKilled", {
-	
+
 	if (!isServer) exitWith {};			// MPKilled runs everywhere for some reason
 	params ["_veh", "_killer", "_instigator"];
 	[_veh, side group _instigator, false] call A3A_fnc_vehKilledOrCaptured;
@@ -281,5 +297,3 @@ if (not(_veh in staticsToSave)) then
 		};
 	};
 */
-
-

--- a/A3-Antistasi/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_AIVEHinit.sqf
@@ -213,7 +213,7 @@ if(_veh isKindOf "Air") then
         "GetIn",
         {
             params ["_veh", "_role", "_unit"];
-            if(side group _unit == teamPlayer) then
+            if((side (group _unit) == teamPlayer) && {isPlayer _unit}) then
             {
                 [_veh] spawn A3A_fnc_airspaceControl;
             };

--- a/A3-Antistasi/functions/CREATE/fn_VEHdespawner.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_VEHdespawner.sqf
@@ -1,38 +1,30 @@
-private _veh = _this select 0;
+_filename = "fn_VEHdespawner";
+params ["_veh", ["_checkNonRebel", false]];
 
-_inside = _veh getVariable "inDespawner";
-if (!isNil "_inside") exitWith {};
+if (!isNil {_veh getVariable "inDespawner"}) exitWith {};
+_veh setVariable ["inDespawner", true, true];
 
-_veh setVariable ["inDespawner",true,true];
-
-if ((typeOf _veh in arrayCivVeh) and ({(_x getVariable ["spawner",false]) and (side group _x == teamPlayer)} count crew _veh > 0) and (_veh distance getMarkerPos respawnTeamPlayer > 50)) then
-	{
-	_pos = position _veh;
-	[0,-1,_pos] remoteExec ["A3A_fnc_citySupportChange",2];
-	_city = [citiesX, _pos] call BIS_fnc_nearestPosition;
-	_dataX = server getVariable _city;
-	_prestigeOPFOR = _dataX select 2;
-	sleep 5;
-	if (random 100 < _prestigeOPFOR) then
-		{
-		{_friendX = _x;
-		if ((captive _friendX) and (isPlayer _friendX)) then
-			{
-			[_friendX,false] remoteExec ["setCaptive",0,_friendX];
-			_friendX setCaptive false;
-			};
-		{
-		if ((side _x == Occupants) and (_x distance _pos < distanceSPWN)) then {_x reveal [_friendX,4]};
-		} forEach allUnits;
-		} forEach crew _veh;
-		};
-	};
+// despawnBlockTime should be increased when a rebel exits a vehicle
+private _blockTime = _veh getVariable ["despawnBlockTime", 0];
 while {alive _veh} do
-	{
-	if ((not([distanceSPWN,1,_veh,teamPlayer] call A3A_fnc_distanceUnits)) and (not([distanceSPWN,1,_veh,Invaders] call A3A_fnc_distanceUnits)) and (not([distanceSPWN,1,_veh,Occupants] call A3A_fnc_distanceUnits)) and (not(_veh in staticsToSave)) and (_veh distance getMarkerPos respawnTeamPlayer > 100)) then
-		{
-		if (_veh in reportedVehs) then {reportedVehs = reportedVehs - [_veh]; publicVariable "reportedVehs"};
-		deleteVehicle _veh
-		};
-	sleep 60;
+{
+	sleep (60 max (_blockTime - time));
+	if !(alive _veh) exitWith {};
+	_blockTime = _veh getVariable ["despawnBlockTime", 0];
+
+	private _despawn = call {
+		if (count crew _veh > 0) exitWith {false};			// includes dead crew. This is fine.
+		if (_blockTime > time) exitWith {false};
+		if (_veh distance getMarkerPos respawnTeamPlayer < 100) exitWith {false};
+		if ([distanceSPWN,1,_veh,teamPlayer] call A3A_fnc_distanceUnits) exitWith {false};
+		if !(_checkNonRebel) exitWith {true};
+		if ([distanceSPWN,1,_veh,Occupants] call A3A_fnc_distanceUnits) exitWith {false};
+		if ([distanceSPWN,1,_veh,Invaders] call A3A_fnc_distanceUnits) exitWith {false};
+		true;
 	};
+
+	if (_despawn) exitWith {
+		if (_veh in reportedVehs) then {reportedVehs = reportedVehs - [_veh]; publicVariable "reportedVehs"};
+		deleteVehicle _veh;
+	};
+};

--- a/A3-Antistasi/functions/CREATE/fn_cleanserVeh.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_cleanserVeh.sqf
@@ -1,13 +1,15 @@
-private ["_veh"];
-
-_veh = _this select 0;
+private _filename = "fn_cleanserVeh";
+params ["_veh"];
 
 sleep 5;
 
-if (isNull _veh) exitWith {};
+if (isNull _veh) exitWith {
+	[3, format ["%1 is null on spawn", typeof _veh], _filename] call A3A_fnc_log;
+};
 
 if (!alive _veh) then
-	{
+{
+	[3, format ["%1 destroyed on spawn", typeof _veh], _filename] call A3A_fnc_log;
 	_veh hideObjectGlobal true;
 	deleteVehicle _veh;
-	};
+};

--- a/A3-Antistasi/functions/CREATE/fn_createAIAirplane.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAIAirplane.sqf
@@ -45,7 +45,7 @@ for "_i" from 1 to _max do
 		_veh = _vehicle select 0;
 		_vehCrew = _vehicle select 1;
 		{[_x,_markerX] call A3A_fnc_NATOinit} forEach _vehCrew;
-		[_veh] call A3A_fnc_AIVEHinit;
+		[_veh, _sideX] call A3A_fnc_AIVEHinit;
 		_groupVeh = _vehicle select 2;
 		_soldiers = _soldiers + _vehCrew;
 		_groups pushBack _groupVeh;
@@ -85,7 +85,7 @@ if (_frontierX) then
 		_typeUnit = if (_sideX==Occupants) then {staticCrewOccupants} else {staticCrewInvaders};
 		_unit = [_groupX, _typeUnit, _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
 		[_unit,_markerX] call A3A_fnc_NATOinit;
-		[_veh] call A3A_fnc_AIVEHinit;
+		[_veh, _sideX] call A3A_fnc_AIVEHinit;
 		_unit moveInGunner _veh;
 		_soldiers pushBack _unit;
 	};
@@ -158,7 +158,7 @@ while {_spawnParameter isEqualType []} do
 	_unit moveInGunner _veh;
 	_soldiers pushBack _unit;
 	_vehiclesX pushBack _veh;
-	_nul = [_veh] call A3A_fnc_AIVEHinit;
+	[_veh, _sideX] call A3A_fnc_AIVEHinit;
 	_spawnParameter = [_markerX, "Mortar"] call A3A_fnc_findSpawnPosition;
 	sleep 1;
 };
@@ -183,7 +183,7 @@ if (spawner getVariable _markerX != 2) then
 		_unit moveInGunner _veh;
 		_soldiers pushBack _unit;
 		_vehiclesX pushBack _veh;
-		_nul = [_veh] call A3A_fnc_AIVEHinit;
+		[_veh, _sideX] call A3A_fnc_AIVEHinit;
 		sleep 1;
 		};
 	};
@@ -209,7 +209,7 @@ if (spawner getVariable _markerX != 2) then
 		_unit moveInGunner _veh;
 		_soldiers pushBack _unit;
 		_vehiclesX pushBack _veh;
-		_nul = [_veh] call A3A_fnc_AIVEHinit;
+		[_veh, _sideX] call A3A_fnc_AIVEHinit;
 		sleep 1;
 		};
 	};
@@ -235,7 +235,7 @@ if (spawner getVariable _markerX != 2) then
 		_unit moveInGunner _veh;
 		_soldiers pushBack _unit;
 		_vehiclesX pushBack _veh;
-		_nul = [_veh] call A3A_fnc_AIVEHinit;
+		[_veh, _sideX] call A3A_fnc_AIVEHinit;
 		sleep 1;
 		};
 	};
@@ -243,7 +243,7 @@ if (spawner getVariable _markerX != 2) then
 
 _ret = [_markerX,_size,_sideX,_frontierX] call A3A_fnc_milBuildings;
 
-{[_x] call A3A_fnc_AIVEHinit} forEach (_ret select 1);
+{[_x, _sideX] call A3A_fnc_AIVEHinit} forEach (_ret select 1);
 {[_x,_markerX] call A3A_fnc_NATOinit} forEach (_ret select 2);
 
 _groups pushBack (_ret select 0);
@@ -290,7 +290,7 @@ if (!_busy) then
 				_veh setDir (_spawnParameter select 1);
 				_veh setPos (_spawnParameter select 0);
 				_vehiclesX pushBack _veh;
-				_nul = [_veh] call A3A_fnc_AIVEHinit;
+				[_veh, _sideX] call A3A_fnc_AIVEHinit;
 			};
 			_spawnParameter = [_markerX, "Plane"] call A3A_fnc_findSpawnPosition;
 		}
@@ -303,7 +303,7 @@ if (!_busy) then
 				_veh setDir (_ang);
 				_pos = [_pos, 50,_ang] call BIS_fnc_relPos;
 				_vehiclesX pushBack _veh;
-				_nul = [_veh] call A3A_fnc_AIVEHinit;
+				[_veh, _sideX] call A3A_fnc_AIVEHinit;
 			}
 			else
 			{
@@ -320,20 +320,12 @@ _flagX = createVehicle [_typeVehX, _positionX, [],0, "NONE"];
 _flagX allowDamage false;
 [_flagX,"take"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_flagX];
 _vehiclesX pushBack _flagX;
-if (_sideX == Occupants) then
-{
-	_veh = NATOAmmoBox createVehicle _positionX;
-	[_veh] spawn A3A_fnc_fillLootCrate;
-	_vehiclesX pushBack _veh;
-	_veh call jn_fnc_logistics_addAction;
-}
-else
-{
-	_veh = CSATAmmoBox createVehicle _positionX;
-	[_veh] spawn A3A_fnc_fillLootCrate;
-	_vehiclesX pushBack _veh;
-	_veh call jn_fnc_logistics_addAction;
-};
+
+// keep this out of _vehiclesX as it has different despawn rules
+private _ammoBoxType = if (_sideX == Occupants) then {NATOAmmoBox} else {CSATAmmoBox};
+private _ammoBox = _ammoBoxType createVehicle _positionX;
+[_ammoBox] spawn A3A_fnc_fillLootCrate;
+_ammoBox call jn_fnc_logistics_addAction;
 
 if (!_busy) then
 {
@@ -346,7 +338,7 @@ if (!_busy) then
 			_veh = createVehicle [selectRandom _arrayVehAAF, (_spawnParameter select 0), [], 0, "CAN_COLLIDE"];
 			_veh setDir (_spawnParameter select 1);
 			_vehiclesX pushBack _veh;
-			_nul = [_veh] call A3A_fnc_AIVEHinit;
+			[_veh, _sideX] call A3A_fnc_AIVEHinit;
 			_nVeh = _nVeh -1;
 			sleep 1;
 		};
@@ -365,7 +357,7 @@ while {_countX < _nVeh && {_countX < 3}} do
 		_veh = createVehicle [_typeVehX, (_spawnParameter select 0), [], 0, "NONE"];
 		_veh setDir (_spawnParameter select 1);
 		_vehiclesX pushBack _veh;
-		_nul = [_veh] call A3A_fnc_AIVEHinit;
+		[_veh, _sideX] call A3A_fnc_AIVEHinit;
 		sleep 1;
 		_countX = _countX + 1;
 	}
@@ -398,16 +390,13 @@ waitUntil {sleep 1; (spawner getVariable _markerX == 2)};
 [_markerX] call A3A_fnc_freeSpawnPositions;
 
 deleteMarker _mrk;
-{if (alive _x) then
-	{
-	deleteVehicle _x
-	};
-} forEach _soldiers;
-//if (!isNull _periodista) then {deleteVehicle _periodista};
-{deleteGroup _x} forEach _groups;
+{ if (alive _x) then { deleteVehicle _x } } forEach _soldiers;
+{ deleteGroup _x } forEach _groups;
+
 {
-if (!(_x in staticsToSave)) then
-	{
-	if ((!([distanceSPWN-_size,1,_x,teamPlayer] call A3A_fnc_distanceUnits))) then {deleteVehicle _x}
-	};
+	// delete all vehicles that haven't been captured
+	if !(_x getVariable ["inDespawner", false]) then { deleteVehicle _x };
 } forEach _vehiclesX;
+
+// Delete ammobox if it's within 200m. Magic number bad.
+if (_ammoBox distance2d _positionX < 200) then { deleteVehicle _ammoBox };

--- a/A3-Antistasi/functions/CREATE/fn_createAIResources.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAIResources.sqf
@@ -62,7 +62,7 @@ if (_frontierX) then
 		_typeUnit = if (_sideX==Occupants) then {staticCrewOccupants} else {staticCrewInvaders};
 		_unit = [_groupX, _typeUnit, _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
 		[_unit,_markerX] call A3A_fnc_NATOinit;
-		[_veh] call A3A_fnc_AIVEHinit;
+		[_veh, _sideX] call A3A_fnc_AIVEHinit;
 		_unit moveInGunner _veh;
 		_soldiers pushBack _unit;
 
@@ -194,7 +194,7 @@ if (_spawnParameter isEqualType []) then
 	_veh = createVehicle [selectRandom _typeVehX, (_spawnParameter select 0), [], 0, "NONE"];
 	_veh setDir (_spawnParameter select 1);
 	_vehiclesX pushBack _veh;
-	_nul = [_veh] call A3A_fnc_AIVEHinit;
+	[_veh, _sideX] call A3A_fnc_AIVEHinit;
 	sleep 1;
 };
 
@@ -239,25 +239,12 @@ waitUntil {sleep 1; (spawner getVariable _markerX == 2)};
 [_markerX] call A3A_fnc_freeSpawnPositions;
 
 deleteMarker _mrk;
-{
-	if (alive _x) then
-	{
-		deleteVehicle _x
-	};
-} forEach _soldiers;
-//if (!isNull _periodista) then {deleteVehicle _periodista};
-//Deleting civs before deleting groups
-{
-	deleteVehicle _x
-} forEach _civs;
-{
-	deleteGroup _x
-} forEach _groups;
+
+{ if (alive _x) then { deleteVehicle _x } } forEach _soldiers;
+{ deleteVehicle _x } forEach _civs;
+{ deleteGroup _x } forEach _groups;
 
 {
-	//distanceSPWN - _size? Shouldn't it be distanceSPWN + _size
-	if (!([distanceSPWN-_size,1,_x,teamPlayer] call A3A_fnc_distanceUnits)) then
-	{
-		deleteVehicle _x;
-	}
+	// delete all vehicles that haven't been captured
+	if !(_x getVariable ["inDespawner", false]) then { deleteVehicle _x };
 } forEach _vehiclesX;

--- a/A3-Antistasi/functions/CREATE/fn_createAIcontrols.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAIcontrols.sqf
@@ -96,7 +96,7 @@ if (_isControl) then
 			_unit moveInGunner _veh;
 			_soldiers pushBack _unit;
 			sleep 1;
-			{_nul = [_x] call A3A_fnc_AIVEHinit} forEach _vehiclesX;
+			{ [_x, _sideX] call A3A_fnc_AIVEHinit } forEach _vehiclesX;
 			};
 		_typeGroup = if (_sideX == Occupants) then {selectRandom groupsNATOmid} else {selectRandom groupsCSATmid};
 		_groupX = [_positionX,_sideX, _typeGroup, true] call A3A_fnc_spawnGroup;
@@ -121,7 +121,7 @@ if (_isControl) then
 		_typeVehX = if !(hasIFA) then {vehFIAArmedCar} else {vehFIACar};
 		_veh = _typeVehX createVehicle getPos (_roads select 0);
 		_veh setDir _dirveh + 90;
-		_nul = [_veh] call A3A_fnc_AIVEHinit;
+		[_veh, _sideX] call A3A_fnc_AIVEHinit;
 		_vehiclesX pushBack _veh;
 		sleep 1;
 		_typeGroup = selectRandom groupsFIAMid;
@@ -222,7 +222,7 @@ if (spawner getVariable _markerX != 2) then
 	_closest = [_allUnits,_positionX] call BIS_fnc_nearestPosition;
 	_winner = side _closest;
 	_loser = Occupants;
-	diag_log format ["%1: [Antistasi]: Server | Control %1 captured by %2. Is Roadblock: %3",servertime, _markerX, _winner, _isControl];
+	diag_log format ["%1: [Antistasi]: Server | Control %2 captured by %3. Is Roadblock: %4",servertime, _markerX, _winner, _isControl];
 	if (_isControl) then
 		{
 		["TaskSucceeded", ["", "Roadblock Destroyed"]] remoteExec ["BIS_fnc_showNotification",_winner];
@@ -259,20 +259,15 @@ if (spawner getVariable _markerX != 2) then
 
 waitUntil {sleep 1;(spawner getVariable _markerX == 2)};
 
-{_veh = _x;
-if (not(_veh in staticsToSave)) then
-	{
-	if ((!([distanceSPWN,1,_x,teamPlayer] call A3A_fnc_distanceUnits))) then {deleteVehicle _x}
-	};
-} forEach _vehiclesX;
-{
-if (alive _x) then
-	{
-	if (_x != vehicle _x) then {deleteVehicle (vehicle _x)};
-	deleteVehicle _x
-	}
-} forEach (_soldiers + _pilots);
+
+{ if (alive _x) then { deleteVehicle _x } } forEach (_soldiers + _pilots);
 deleteGroup _groupX;
+
+{
+	// delete all vehicles that haven't been captured
+	if !(_x getVariable ["inDespawner", false]) then { deleteVehicle _x };
+} forEach _vehiclesX;
+
 
 if (_conquered) then
 	{

--- a/A3-Antistasi/functions/CREATE/fn_createCIV.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createCIV.sqf
@@ -73,7 +73,7 @@ while {(spawner getVariable _markerX != 2) and (_countParked < _numParked)} do
 			_veh = _typeVehX createVehicle _pos;
 			_veh setDir _dirveh;
 			_vehiclesX pushBack _veh;
-			_nul = [_veh] spawn A3A_fnc_civVEHinit;
+			[_veh, civilian] spawn A3A_fnc_AIVEHinit;
 			};
 		};
 	sleep 0.5;
@@ -92,7 +92,7 @@ if (count _mrkMar > 0) then
 			_veh = _typeVehX createVehicle _pos;
 			_veh setDir (random 360);
 			_vehiclesX pushBack _veh;
-			[_veh] spawn A3A_fnc_civVEHinit;
+			[_veh, civilian] spawn A3A_fnc_AIVEHinit;
 			sleep 0.5;
 			};
 		};
@@ -139,17 +139,7 @@ if ([_markerX,false] call A3A_fnc_fogCheck > 0.2) then
 					_typeVehX = selectRandomWeighted civVehiclesWeighted;
 					_veh = _typeVehX createVehicle _p1;
 					_veh setDir _dirveh;
-					_veh addEventHandler ["HandleDamage",{if (((_this select 1) find "wheel" != -1) and (_this select 4=="") and (!isPlayer driver (_this select 0))) then {0;} else {(_this select 2);};}];
-					_veh addEventHandler ["HandleDamage",
-						{
-						_veh = _this select 0;
-						if (side(_this select 3) == teamPlayer) then
-							{
-							_driverX = driver _veh;
-							if (side _driverX == civilian) then {_driverX leaveVehicle _veh};
-							};
-						}
-						];
+
 					//_veh forceFollowRoad true;
 					_vehPatrol = _vehPatrol + [_veh];
 					_typeCiv = selectRandom arrayCivs;
@@ -157,6 +147,8 @@ if ([_markerX,false] call A3A_fnc_fogCheck > 0.2) then
 					_nul = [_civ] spawn A3A_fnc_CIVinit;
 					_civsPatrol = _civsPatrol + [_civ];
 					_civ moveInDriver _veh;
+					[_veh, civilian] call A3A_fnc_AIVEHInit;
+
 					_groupP addVehicle _veh;
 					_groupP setBehaviour "CARELESS";
 					_veh limitSpeed 50;
@@ -183,25 +175,13 @@ waitUntil {sleep 1;(spawner getVariable _markerX == 2)};
 
 {deleteVehicle _x} forEach _civs;
 {deleteGroup _x} forEach _groups;
+
 {
-if (!([distanceSPWN-_size,1,_x,teamPlayer] call A3A_fnc_distanceUnits)) then
-	{
-	if (_x in reportedVehs) then {reportedVehs = reportedVehs - [_x]; publicVariable "reportedVehs"};
-	deleteVehicle _x;
-	}
+	// delete all parked vehicles that haven't been stolen
+	if !(_x getVariable ["inDespawner", false]) then { deleteVehicle _x };
 } forEach _vehiclesX;
-{
-waitUntil {sleep 1; !([distanceSPWN,1,_x,teamPlayer] call A3A_fnc_distanceUnits)};
-deleteVehicle _x} forEach _civsPatrol;
-{
-if (!([distanceSPWN,1,_x,teamPlayer] call A3A_fnc_distanceUnits)) then
-	{
-	if (_x in reportedVehs) then {reportedVehs = reportedVehs - [_x]; publicVariable "reportedVehs"};
-	deleteVehicle _x
-	}
-else
-	{
-	[_x] spawn A3A_fnc_civVEHinit
-	};
-} forEach _vehPatrol;
-{deleteGroup _x} forEach _groupsPatrol;
+
+// Chuck all the civ vehicle patrols into the despawners
+{ [_x] spawn A3A_fnc_groupDespawner } forEach _groupsPatrol;
+{ [_x] spawn A3A_fnc_VEHdespawner } forEach _vehPatrol;
+

--- a/A3-Antistasi/functions/CREATE/fn_createFIAOutposts2.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createFIAOutposts2.sqf
@@ -35,7 +35,7 @@ if (_isRoad) then
 		_veh = vehSDKLightArmed createVehicle getPos (_road select 0);
 		_veh setDir _dirveh + 90;
 		_veh lock 3;
-		_nul = [_veh] call A3A_fnc_AIVEHinit;
+		[_veh, teamPlayer] call A3A_fnc_AIVEHinit;
 		sleep 1;
 		};
 	_groupX = [_positionX, teamPlayer, _garrison,true,false] call A3A_fnc_spawnGroup;
@@ -77,6 +77,7 @@ if ({alive _x} count units _groupX == 0) then
 
 waitUntil {sleep 1; (spawner getVariable _markerX == 2) or (not(_markerX in outpostsFIA))};
 
-if (_isRoad) then {if (!isNull _veh) then {deleteVehicle _veh}};
-{deleteVehicle _x} forEach units _groupX;
+// Case where players drive off with the vehicle is not really handled...
+if (_isRoad) then { if (!isNull _veh) then { deleteVehicle _veh } };
+{ deleteVehicle _x } forEach units _groupX;
 deleteGroup _groupX;

--- a/A3-Antistasi/functions/CREATE/fn_createSDKgarrisons.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createSDKgarrisons.sqf
@@ -84,7 +84,7 @@ if (staticCrewTeamPlayer in _garrison) then
 		_nul=[_veh] execVM "scripts\UPSMON\MON_artillery_add.sqf";//TODO need delete UPSMON link
 		_unit assignAsGunner _veh;
 		_unit moveInGunner _veh;
-		[_veh] call A3A_fnc_AIVEHinit;
+		[_veh, teamPlayer] call A3A_fnc_AIVEHinit;
 		_soldiers pushBack _unit;
 	} forEach (_garrison select {_x == staticCrewTeamPlayer});
 	_garrison = _garrison - [staticCrewTeamPlayer];

--- a/A3-Antistasi/functions/CREATE/fn_createSDKgarrisonsTemp.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createSDKgarrisonsTemp.sqf
@@ -21,7 +21,7 @@ if (_typeX isEqualType "") then
 		_nul=[_veh] execVM "scripts\UPSMON\MON_artillery_add.sqf";//TODO need delete UPSMON link
 		_unit assignAsGunner _veh;
 		_unit moveInGunner _veh;
-		[_veh] call A3A_fnc_AIVEHinit;
+		[_veh, teamPlayer] call A3A_fnc_AIVEHinit;
 		};
 	if (_groups isEqualTo []) then
 		{

--- a/A3-Antistasi/functions/CREATE/fn_groupDespawner.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_groupDespawner.sqf
@@ -1,22 +1,46 @@
-private ["_groupX","_sideX","_eny1","_eny2"];
-_groupX = _this select 0;
-_sideX = side _groupX;
-_eny1 = Occupants;
-_eny2 = Invaders;
-if (_sideX == Occupants) then {_eny1 = teamPlayer} else {if (_sideX == Invaders) then {_eny2 = teamPlayer}};
+_filename = "fn_groupDespawner";
+params ["_group", ["_checkNonRebel", false]];
 
+if (count units _group == 0) exitWith { deleteGroup _group };
+
+private _eny1 = Occupants;
+private _eny2 = Invaders;
+private _side = side _group;
+if (_side == Occupants) then {_eny1 = teamPlayer} else {if (_side == Invaders) then {_eny2 = teamPlayer}};
+
+private _fnc_distCheckEnemy = {
+	params ["_unit"];
+	if !([distanceSPWN,1,_unit,_eny1] call A3A_fnc_distanceUnits) exitWith { true };
+	if !([distanceSPWN,1,_unit,_eny2] call A3A_fnc_distanceUnits) exitWith { true };
+	false;
+};
+
+private _fnc_distCheckRebel = {
+	params ["_unit"];
+	if !([distanceSPWN,1,_unit,teamPlayer] call A3A_fnc_distanceUnits) exitWith { true };
+	false;
+};
+
+_fnc_distCheck = if (_checkNonRebel) then {_fnc_distCheckEnemy} else {_fnc_distCheckRebel};
+
+while {count units _group > 0} do
 {
-  _unit = _x;
-  if (!([distanceSPWN,1,_unit,_eny1] call A3A_fnc_distanceUnits) and !([distanceSPWN,1,_unit,_eny2] call A3A_fnc_distanceUnits)) then
-  {
-    deleteVehicle _unit;
-  }
-} forEach units _groupX;
+	private _leader = objNull;
+	waitUntil {
+		sleep 10;
+		_leader = leader _group;
+		isNull _leader || {[_leader] call _fnc_distCheck};
+	};
+	if !(isNull _leader) then
+	{
+		private _pos = position _leader;
+		{
+			if (_x distance2d _pos < 100) then {
+				if (vehicle _x != _x) then { deleteVehicle (vehicle _x) };
+				deleteVehicle _x;
+			};
+		} forEach units _group;
+	};
+};
 
-{
-  _unit = _x;
-  waitUntil {sleep 1;!([distanceSPWN,1,_unit,_eny1] call A3A_fnc_distanceUnits) and !([distanceSPWN,1,_unit,_eny2] call A3A_fnc_distanceUnits)};
-  deleteVehicle _unit;
-} forEach units _groupX;
-
-deleteGroup _groupX;
+deleteGroup _group;

--- a/A3-Antistasi/functions/CREATE/fn_patrolReinf.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_patrolReinf.sqf
@@ -61,7 +61,7 @@ if (_land) then
 			[_x] call A3A_fnc_NATOinit;
 		};
 	} forEach units _groupX;
-	[_veh] call A3A_fnc_AIVEHinit;
+	[_veh, _sideX] call A3A_fnc_AIVEHinit;
 	[_veh,"Inf Truck."] spawn A3A_fnc_inmuneConvoy;
 	_groupX spawn A3A_fnc_attackDrillAI;
 	[_mrkOrigin,_posDestination,_groupX] call A3A_fnc_WPCreate;
@@ -94,7 +94,7 @@ else
 		[_x] call A3A_fnc_NATOinit;
 		_x addEventHandler ["Killed",{deleteVehicle (group (_this select 0) getVariable ["myPad",objNull])}];
 	} forEach units _groupVeh;
-	[_veh] call A3A_fnc_AIVEHinit;
+	[_veh, _sideX] call A3A_fnc_AIVEHinit;
 
 	_groupX = [_posOrigin,_sideX,_typeGroup] call A3A_fnc_spawnGroup;
 	{

--- a/A3-Antistasi/functions/CREATE/fn_vehKilledOrCaptured.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_vehKilledOrCaptured.sqf
@@ -1,0 +1,67 @@
+/*
+	Updates enemy vehicle reserve pool, city support and aggro for vehicle destruction or capture
+
+	Params:
+	1. Object: Vehicle object
+	2. Side: Side of unit that captured or destroyed the vehicle
+	2. Bool (default false): True if captured, else destroyed
+*/
+
+private _filename = "fn_vehKilledOrCaptured";
+params ["_veh", "_sideEnemy", ["_captured", false]];
+
+private _type = typeof _veh;
+private _side = _veh getVariable ["ownerSide", teamPlayer];
+
+private _act = if (_captured) then {"captured"} else {"destroyed"};
+[3, format ["%1 of %2 %3 by %4", _type, _side, _act, _sideEnemy], _filename] call A3A_fnc_log;
+
+if (_side == Occupants or _side == Invaders) then
+{
+	_type call A3A_fnc_removeVehFromPool;
+	if (_sideEnemy != teamPlayer) exitWith {};
+
+	private _value = call {
+		if (_type in vehAPCs) exitWith {8};
+		if (_type in vehTanks) exitWith {15};
+		if (_type in vehAA or _type in vehMRLS) exitWith {15};
+		if (_type in vehAttackHelis) exitWith {15};
+		if (_type in vehTransportAir) exitWith {6};
+		if (_type in vehFixedWing) exitWith {15};		// transportAir must be before this
+		if (_type in vehBoats) exitWith {3};
+		if (_type isKindOf "StaticWeapon") exitWith {1};
+		2;		// trucks, light attack, boats, UAV etc
+	};
+	
+	if (_side == Occupants) then {
+		[-_value/3, _value/3, position _veh] remoteExec ["A3A_fnc_citySupportChange", 2];
+		[[_value, 45], [0, 0]] remoteExec ["A3A_fnc_prestige", 2];
+	}
+	else {
+		[[0, 0], [_value, 45]] remoteExec ["A3A_fnc_prestige", 2];
+	};
+};
+
+if (_side == civilian) then
+{
+	if (_sideEnemy != teamPlayer) exitWith {};
+
+	// Punish players slightly for stealing cars. Code used to be in vehDespawner.
+	private _pos = position _veh;
+	[0, -1, _pos] remoteExec ["A3A_fnc_citySupportChange", 2];
+
+	private _city = [citiesX, _pos] call BIS_fnc_nearestPosition;
+	private _dataX = server getVariable _city;
+	private _prestigeOPFOR = _dataX select 2;		// government support?
+	if (random 100 > _prestigeOPFOR) exitWith {};
+
+	{
+		private _thief = _x;
+		if ((captive _thief) and (isPlayer _thief)) then {
+			[_thief, false] remoteExec ["setCaptive", _thief];
+		};
+		{
+			if ((side _x == Occupants) and (_x distance _pos < distanceSPWN2)) then {_x reveal _thief};
+		} forEach allUnits;
+	} forEach crew _veh;
+};

--- a/A3-Antistasi/functions/Convoy/fn_spawnConvoy.sqf
+++ b/A3-Antistasi/functions/Convoy/fn_spawnConvoy.sqf
@@ -89,15 +89,13 @@ while {true} do
 
 		private _units = _createdUnits select _i;
 		private _veh = _units select 0;
-		private _result = _veh getVariable["fsmresult", 0];
-		// should also check whether vehicle still exists, to handle forced despawns?
+		private _result = if (isNull _veh) then {-10} else {_veh getVariable["fsmresult", 0]};
 
 		// could test for success vs failure here but we don't care yet
 		if (_result != 0) then {		// completed or abandoned mission, don't track here anymore
 			_createdUnits deleteAt _i;
 			_airVehicles deleteAt (_airVehicles find _veh);
 			_landVehicles deleteAt (_landVehicles find _veh);
-			[_veh] spawn A3A_fnc_VEHdespawner;		// FSM handles the groups, vehicle remains for tracking
 			[3, format["Vehicle FSM result %1, rem units %2", _result, count _createdUnits], "fn_spawnConvoy"] call A3A_fnc_log;
 		}
 		else {

--- a/A3-Antistasi/functions/Convoy/fn_spawnConvoyLine.sqf
+++ b/A3-Antistasi/functions/Convoy/fn_spawnConvoyLine.sqf
@@ -34,7 +34,7 @@ if(_vehicleType != "") then
   _vehicleGroup addVehicle _vehicleObj;
 
   //Init vehicle
-  [_vehicleObj] call A3A_fnc_AIVEHinit;
+  [_vehicleObj, _side] call A3A_fnc_AIVEHinit;
 };
 
 //Sleep to decrease spawn lag

--- a/A3-Antistasi/functions/Garage/fn_vehPlacementCallbacks.sqf
+++ b/A3-Antistasi/functions/Garage/fn_vehPlacementCallbacks.sqf
@@ -55,7 +55,8 @@ switch (_callbackTarget) do {
 		
 			case CALLBACK_VEH_PLACED_SUCCESSFULLY: {
 				private _garageVeh = _callbackParams param [0];
-				[_garageVeh] call A3A_fnc_AIVEHinit;
+				[_garageVeh, teamPlayer] call A3A_fnc_AIVEHinit;
+				if !(_garageVeh isKindOf "StaticWeapon") then { [_garageVeh] spawn A3A_fnc_vehDespawner };
 
 				if (_garageVeh isKindOf "Car") then {_garageVeh setPlateNumber format ["%1",name player]};
 				
@@ -130,7 +131,9 @@ switch (_callbackTarget) do {
 				private _purchasedVeh = _callbackParams param [0];
 				private _typeVehX = typeOf _purchasedVeh;
 				
-				[_purchasedVeh] call A3A_fnc_AIVEHinit;
+				[_purchasedVeh, teamPlayer] call A3A_fnc_AIVEHinit;
+				if !(_purchasedVeh isKindOf "StaticWeapon") then { [_purchasedVeh] spawn A3A_fnc_vehDespawner };
+
 				if (_purchasedVeh isKindOf "Car") then {_purchasedVeh setPlateNumber format ["%1",name player]};
 				
 				//Handle Money

--- a/A3-Antistasi/functions/Missions/fn_AS_Traitor.sqf
+++ b/A3-Antistasi/functions/Missions/fn_AS_Traitor.sqf
@@ -90,7 +90,7 @@ _veh setDir _dirVeh;
 sleep 15;
 _veh allowDamage true;
 _traitor allowDamage true;
-_nul = [_veh] call A3A_fnc_AIVEHinit;
+[_veh, Occupants] call A3A_fnc_AIVEHinit;
 {_x disableAI "MOVE"; _x setUnitPos "UP"} forEach units _groupTraitor;
 
 _mrk = createMarkerLocal [format ["%1patrolarea", floor random 100], getPos _houseX];
@@ -207,17 +207,8 @@ else
 traitorIntel = false; publicVariable "traitorIntel";
 _nul = [1200,"AS"] spawn A3A_fnc_deleteTask;
 _nul = [10,"AS1"] spawn A3A_fnc_deleteTask;
-if (!([distanceSPWN,1,_veh,teamPlayer] call A3A_fnc_distanceUnits)) then {deleteVehicle _veh};
 
-// Surrender routine will (eventually) despawn the traitor, if separated
-{
-waitUntil {sleep 1; !([distanceSPWN,1,_x,teamPlayer] call A3A_fnc_distanceUnits)};
-deleteVehicle _x
-} forEach units _groupTraitor;
-deleteGroup _groupTraitor;
+[_groupX] spawn A3A_fnc_groupDespawner;
+[_groupTraitor] spawn A3A_fnc_groupDespawner;
+[_veh] spawn A3A_fnc_vehDespawner;
 
-{
-waitUntil {sleep 1; !([distanceSPWN,1,_x,teamPlayer] call A3A_fnc_distanceUnits)};
-deleteVehicle _x
-} forEach units _groupX;
-deleteGroup _groupX;

--- a/A3-Antistasi/functions/Missions/fn_DES_Vehicle.sqf
+++ b/A3-Antistasi/functions/Missions/fn_DES_Vehicle.sqf
@@ -38,7 +38,7 @@ if (spawner getVariable _markerX == 0) then
 	_veh = createVehicle [_typeVehX, _pos, [], 0, "NONE"];
 	_veh allowdamage false;
 	_veh setDir random 360;
-	[_veh] call A3A_fnc_AIVEHinit;
+	[_veh, _sideX] call A3A_fnc_AIVEHinit;
 
 	_groupX = createGroup _sideX;
 
@@ -102,8 +102,7 @@ _nul = [1200,"DES"] spawn A3A_fnc_deleteTask;
 waitUntil {sleep 1; (spawner getVariable _markerX == 2)};
 
 if (_truckCreated) then
-	{
-	{deleteVehicle _x} forEach units _groupX;
-	deleteGroup _groupX;
-	if (!([distanceSPWN,1,_veh,teamPlayer] call A3A_fnc_distanceUnits)) then {deleteVehicle _veh};
-	};
+{
+	[_groupX] spawn A3A_fnc_groupDespawner;
+	[_veh] spawn A3A_fnc_vehDespawner;
+};

--- a/A3-Antistasi/functions/Missions/fn_LOG_Ammo.sqf
+++ b/A3-Antistasi/functions/Missions/fn_LOG_Ammo.sqf
@@ -42,6 +42,7 @@ if ((spawner getVariable _markerX != 2) and !(sidesX getVariable [_markerX,sideU
 	_truckX setDir (getDir _road);
 	_truckCreated = true;
 	[_truckX] spawn A3A_fnc_fillLootCrate;
+	[_truckX, _sideX] call A3A_fnc_AIVEHinit;
 
 	_mrk = createMarkerLocal [format ["%1patrolarea", floor random 100], _pos];
 	_mrk setMarkerShapeLocal "RECTANGLE";
@@ -75,11 +76,10 @@ if ((spawner getVariable _markerX != 2) and !(sidesX getVariable [_markerX,sideU
 	};
 
 	_truckX setVariable ["ammoTruckLocation", _nameDest];
-	_truckX setVariable ["sideOwner", _sideX];
 	_truckX addEventHandler ["GetIn", {
 		params ["_vehicle", "_role", "_unit", "_turret"];
 
-		private _owningSide = (_vehicle getVariable "sideOwner");
+		private _owningSide = (_vehicle getVariable "originalSide");		// set by AIVEHinit
 
 		if (_unit getVariable ["spawner",false]) then {
 			["TaskFailed", ["", format ["Ammotruck Stolen in an %1",(_vehicle getVariable ["ammoTruckLocation", ""])]]] remoteExec ["BIS_fnc_showNotification",_owningSide];
@@ -117,12 +117,10 @@ else
 
 _nul = [1200,"LOG"] spawn A3A_fnc_deleteTask;
 if (_truckCreated) then
-	{
-	{deleteVehicle _x} forEach units _groupX;
-	deleteGroup _groupX;
-	{deleteVehicle _x} forEach units _groupX1;
-	deleteGroup _groupX1;
-	deleteMarker _mrk;
-	waitUntil {sleep 1; !([300,1,_truckX,teamPlayer] call A3A_fnc_distanceUnits)};
-	deleteVehicle _truckX;
-	};
+{
+	// TODO: Head off to nearby base
+	[_groupX] spawn A3A_fnc_groupDespawner;
+	[_groupX1] spawn A3A_fnc_groupDespawner;
+	[_truckX] spawn A3A_fnc_vehDespawner;
+	// delete truck contents maybe?
+};

--- a/A3-Antistasi/functions/Missions/fn_LOG_Bank.sqf
+++ b/A3-Antistasi/functions/Missions/fn_LOG_Bank.sqf
@@ -33,7 +33,7 @@ _pos = (getMarkerPos respawnTeamPlayer) findEmptyPosition [1,50,"C_Van_01_box_F"
 
 _truckX = "C_Van_01_box_F" createVehicle _pos;
 {_x reveal _truckX} forEach (allPlayers - (entities "HeadlessClient_F"));
-[_truckX] call A3A_fnc_AIVEHinit;
+[_truckX, teamPlayer] call A3A_fnc_AIVEHinit;
 _truckX setVariable ["destinationX",_nameDest,true];
 _truckX addEventHandler ["GetIn",
 	{
@@ -152,12 +152,7 @@ deleteVehicle _truckX;
 
 _nul = [1200,"LOG"] spawn A3A_fnc_deleteTask;
 
-waitUntil {sleep 1; !([distanceSPWN,1,_positionX,teamPlayer] call A3A_fnc_distanceUnits)};
-
-{_groupX = _x;
-{deleteVehicle _x} forEach units _groupX;
-deleteGroup _x;
-} forEach _groups;
+{ [_x] spawn A3A_fnc_groupDespawner } forEach _groups;
 
 //sleep (600 + random 1200);
 //_nul = [_tsk,true] call BIS_fnc_deleteTask;

--- a/A3-Antistasi/functions/Missions/fn_LOG_Salvage.sqf
+++ b/A3-Antistasi/functions/Missions/fn_LOG_Salvage.sqf
@@ -81,7 +81,7 @@ private _typeGroup = if (_difficultX) then {if (_sideX == Occupants) then {NATOS
 private _boatSpawnLocation = selectRandom [_mrk1Pos, _mrk2Pos, _mrk3Pos];
 
 private _veh = createVehicle [_typeVeh, _boatSpawnLocation, [], 0, "NONE"];
-[_veh] call A3A_fnc_AIVEHinit;
+[_veh, _sideX] call A3A_fnc_AIVEHinit;
 private _vehCrewGroup = [_positionX,_sideX, _typeGroup] call A3A_fnc_spawnGroup;
 private _vehCrew = units _vehCrewGroup;
 {_x moveInAny _veh} forEach (_vehCrew);
@@ -139,9 +139,6 @@ deleteMarker _mrk2;
 deleteMarker _mrk3;
 deleteVehicle _ship;
 
-[_veh, _vehCrew] spawn {
-	params ["_veh", "_crew"];
-	waitUntil { sleep 5; allPlayers inAreaArray [getPos _veh, distanceSPWN, distanceSPWN] isEqualTo [] || isNull _veh };
-	deleteVehicle _veh;
-	{ deleteVehicle _x } forEach _crew;
-};
+[_vehCrewGroup] spawn A3A_fnc_groupDespawner;
+[_veh] spawn A3A_fnc_vehDespawner;
+

--- a/A3-Antistasi/functions/Missions/fn_LOG_Supplies.sqf
+++ b/A3-Antistasi/functions/Missions/fn_LOG_Supplies.sqf
@@ -42,7 +42,7 @@ _truckX addAction ["Delivery infos",
 	"",
 	"(isPlayer _this) and (_this == _this getVariable ['owner',objNull])"
 ];
-[_truckX] call A3A_fnc_AIVEHinit;
+[_truckX, teamPlayer] call A3A_fnc_AIVEHinit;
 //{_x reveal _truckX} forEach (allPlayers - (entities "HeadlessClient_F"));
 _truckX setVariable ["destinationX",_nameDest,true];
 
@@ -119,11 +119,10 @@ else
 _ecpos = getpos _truckX;
 deleteVehicle _truckX;
 _emptybox = "Land_PaperBox_01_open_empty_F" createVehicle _ecpos;
+[_emptybox] spawn A3A_fnc_postmortem;
 
 //sleep (600 + random 1200);
 
 //_nul = [_tsk,true] call BIS_fnc_deleteTask;
 _nul = [1200,"LOG"] spawn A3A_fnc_deleteTask;
-waitUntil {sleep 1; (not([distanceSPWN,1,_truckX,teamPlayer] call A3A_fnc_distanceUnits)) or (_truckX distance (getMarkerPos respawnTeamPlayer) < 60)};
 
-deleteVehicle _emptybox;

--- a/A3-Antistasi/functions/Missions/fn_REP_Antenna.sqf
+++ b/A3-Antistasi/functions/Missions/fn_REP_Antenna.sqf
@@ -40,7 +40,7 @@ if (spawner getVariable _markerX != 2) then
 	_veh = createVehicle [vehNATORepairTruck, _pos, [], 0, "NONE"];
 	_veh allowdamage false;
 	_veh setDir (getDir _road);
-	_nul = [_veh] call A3A_fnc_AIVEHinit;
+	_nul = [_veh, Occupants] call A3A_fnc_AIVEHinit;
 	_groupX = createGroup Occupants;
 
 	sleep 5;
@@ -112,9 +112,6 @@ _nul = [30,"REP"] spawn A3A_fnc_deleteTask;
 
 waitUntil {sleep 1; (spawner getVariable _markerX == 2)};
 
-if (_truckCreated) then
-	{
-	{deleteVehicle _x} forEach units _groupX;
-	deleteGroup _groupX;
-	if (!([distanceSPWN,1,_veh,teamPlayer] call A3A_fnc_distanceUnits)) then {deleteVehicle _veh};
-	};
+// could make these guys return home, too much work atm
+[_groupX] spawn A3A_fnc_groupDespawner;
+[_veh] spawn A3A_fnc_vehDespawner;

--- a/A3-Antistasi/functions/Missions/fn_RES_Refugees.sqf
+++ b/A3-Antistasi/functions/Missions/fn_RES_Refugees.sqf
@@ -118,7 +118,7 @@ else
 	_veh setDir _dirVeh;
 	sleep 15;
 	_veh allowDamage true;
-	_nul = [_veh] call A3A_fnc_AIVEHinit;
+	_nul = [_veh, Occupants] call A3A_fnc_AIVEHinit;
 	_mrk = createMarkerLocal [format ["%1patrolarea", floor random 100], getPos _houseX];
 	_mrk setMarkerShapeLocal "RECTANGLE";
 	_mrk setMarkerSizeLocal [50,50];
@@ -211,23 +211,13 @@ deleteGroup _groupPOW;
 {boxX addItemCargoGlobal [_x,1]} forEach _items;
 
 if (_sideX == Occupants) then
-	{
+{
 	deleteMarkerLocal _mrk;
-	if (!isNull _veh) then {if (!([distanceSPWN,1,_veh,teamPlayer] call A3A_fnc_distanceUnits)) then {deleteVehicle _veh}};
-	{
-	waitUntil {sleep 1; !([distanceSPWN,1,_x,teamPlayer] call A3A_fnc_distanceUnits)};
-	deleteVehicle _x;
-	} forEach units _groupX;
-	deleteGroup _groupX;
-	if (!isNull _groupX1) then
-		{
-		{
-		waitUntil {sleep 1; !([distanceSPWN,1,_x,teamPlayer] call A3A_fnc_distanceUnits)};
-		deleteVehicle _x;
-		} forEach units _groupX1;
-		deleteGroup _groupX1;
-		};
-	};
+	if (!isNull _veh) then { [_veh] spawn A3A_fnc_vehDespawner };
+	if (!isNull _groupX1) then { [_groupX1] spawn A3A_fnc_groupDespawner };
+	[_groupX] spawn A3A_fnc_groupDespawner; 
+};
+
 //sleep (540 + random 1200);
 
 //_nul = [_tsk,true] call BIS_fnc_deleteTask;

--- a/A3-Antistasi/functions/Missions/fn_attackHQ.sqf
+++ b/A3-Antistasi/functions/Missions/fn_attackHQ.sqf
@@ -33,7 +33,7 @@ if (count _typesVeh > 0) then
 	_groups pushBack _groupHeli;
 	_vehiclesX pushBack _heli;
 	{[_x] call A3A_fnc_NATOinit} forEach _heliCrew;
-	[_heli] call A3A_fnc_AIVEHinit;
+	[_heli, _sideX] call A3A_fnc_AIVEHinit;
 	_wp1 = _groupHeli addWaypoint [_positionX, 0];
 	_wp1 setWaypointType "SAD";
 	//[_heli,"Air Attack"] spawn A3A_fnc_inmuneConvoy;
@@ -106,34 +106,13 @@ _nul = [1200,"DEF_HQ"] spawn A3A_fnc_deleteTask;
 sleep 60;
 _nul = [0,"DEF_HQ1"] spawn A3A_fnc_deleteTask;
 
-{
-_veh = _x;
-if (!([distanceSPWN,1,_veh,teamPlayer] call A3A_fnc_distanceUnits) and (({_x distance _veh <= distanceSPWN} count (allPlayers - (entities "HeadlessClient_F"))) == 0)) then {deleteVehicle _x};
-} forEach _vehiclesX;
-{
-_veh = _x;
-if (!([distanceSPWN,1,_veh,teamPlayer] call A3A_fnc_distanceUnits) and (({_x distance _veh <= distanceSPWN} count (allPlayers - (entities "HeadlessClient_F"))) == 0)) then {deleteVehicle _x; _soldiers = _soldiers - [_x]};
-} forEach _soldiers;
-{
-_veh = _x;
-if (!([distanceSPWN,1,_veh,teamPlayer] call A3A_fnc_distanceUnits) and (({_x distance _veh <= distanceSPWN} count (allPlayers - (entities "HeadlessClient_F"))) == 0)) then {deleteVehicle _x; _pilots = _pilots - [_x]};
-} forEach _pilots;
 
-if (count _soldiers > 0) then
-	{
-	{
-	_veh = _x;
-	waitUntil {sleep 1; !([distanceSPWN,1,_veh,teamPlayer] call A3A_fnc_distanceUnits) and (({_x distance _veh <= distanceSPWN} count (allPlayers - (entities "HeadlessClient_F"))) == 0)};
-	deleteVehicle _veh;
-	} forEach _soldiers;
-	};
+{
+	// return to base
+	private _wp = _x addWaypoint [_posOrigin, 50];
+	_wp setWaypointType "MOVE";
+	_x setCurrentWaypoint _wp;
+	[_x] spawn A3A_fnc_groupDespawner;
+} forEach _groups;
 
-if (count _pilots > 0) then
-	{
-	{
-	_veh = _x;
-	waitUntil {sleep 1; !([distanceSPWN,1,_x,teamPlayer] call A3A_fnc_distanceUnits) and (({_x distance _veh <= distanceSPWN} count (allPlayers - (entities "HeadlessClient_F"))) == 0)};
-	deleteVehicle _veh;
-	} forEach _pilots;
-	};
-{deleteGroup _x} forEach _groups;
+{ [_x] spawn A3A_fnc_VEHdespawner } forEach _vehiclesX;

--- a/A3-Antistasi/functions/Missions/fn_convoy.sqf
+++ b/A3-Antistasi/functions/Missions/fn_convoy.sqf
@@ -170,7 +170,7 @@ _vehCrew = _vehicle select 1;
 {[_x] call A3A_fnc_NATOinit;_x allowDamage false} forEach _vehCrew;
 _soldiers append _vehCrew;
 _vehiclesX pushBack _vehLead;
-[_vehLead] call A3A_fnc_AIVEHinit;
+[_vehLead, _sideX] call A3A_fnc_AIVEHinit;
 _vehLead limitSpeed _speedLimit;
 
 _countX = 1;
@@ -199,7 +199,7 @@ for "_i" from 1 to _countX do
 	{[_x] call A3A_fnc_NATOinit;_x allowDamage false} forEach _vehCrew;
 	_soldiers = _soldiers + _vehCrew;
 	_vehiclesX pushBack _veh;
-	[_veh] call A3A_fnc_AIVEHinit;
+	[_veh, _sideX] call A3A_fnc_AIVEHinit;
 	if (_i == 1) then {_veh setConvoySeparation 60} else {_veh setConvoySeparation 20};
 	if (!_isFIA) then
 	{
@@ -250,7 +250,7 @@ _vehCrew = _vehicle select 1;
 {[_x] call A3A_fnc_NATOinit; _x allowDamage false} forEach _vehCrew;
 _soldiers = _soldiers + _vehCrew;
 _vehiclesX pushBack _vehObj;
-[_vehObj] call A3A_fnc_AIVEHinit;
+[_vehObj, _sideX] call A3A_fnc_AIVEHinit;
 
 if (_typeConvoyX == "Armor") then {_vehObj lock 3};// else {_vehObj forceFollowRoad true};
 if (_typeConvoyX == "Prisoners") then
@@ -313,7 +313,7 @@ _veh allowDamage false;
 [_veh,"Convoy Escort"] spawn A3A_fnc_inmuneConvoy;
 _vehCrew = _vehicle select 1;
 {[_x] call A3A_fnc_NATOinit; _x allowDamage false} forEach _vehCrew;
-[_veh] call A3A_fnc_AIVEHinit;
+[_veh, _sideX] call A3A_fnc_AIVEHinit;
 _soldiers = _soldiers + _vehCrew;
 _vehiclesX pushBack _veh;
 
@@ -784,18 +784,7 @@ if (_typeConvoyX == "Prisoners") then
 
 _nul = [600,"CONVOY"] spawn A3A_fnc_deleteTask;
 _nul = [0,"CONVOY1"] spawn A3A_fnc_deleteTask;
-{
-if (!([distanceSPWN,1,_x,teamPlayer] call A3A_fnc_distanceUnits)) then {deleteVehicle _x}
-} forEach _vehiclesX;
-{
-if (!([distanceSPWN,1,_x,teamPlayer] call A3A_fnc_distanceUnits)) then {deleteVehicle _x; _soldiers = _soldiers - [_x]}
-} forEach _soldiers;
 
-if (count _soldiers > 0) then
-	{
-	{
-	waitUntil {sleep 1; (!([distanceSPWN,1,_x,teamPlayer] call A3A_fnc_distanceUnits))};
-	deleteVehicle _x;
-	} forEach _soldiers;
-	};
-{deleteGroup _x} forEach _groups;
+{ [_x] spawn A3A_fnc_groupDespawner } forEach _groups;
+{ [_x] spawn A3A_fnc_VEHdespawner } forEach _vehiclesX;
+

--- a/A3-Antistasi/functions/REINF/fn_NATOQuadbike.sqf
+++ b/A3-Antistasi/functions/REINF/fn_NATOQuadbike.sqf
@@ -24,4 +24,4 @@ while {_pos isEqualTo []} do
 	};
 lastVehicleSpawned = createVehicle [_typeBike,_pos, [], 10, "NONE"];
 
-[lastVehicleSpawned] call A3A_fnc_AIVEHinit;
+[lastVehicleSpawned, _sideX] call A3A_fnc_AIVEHinit;

--- a/A3-Antistasi/functions/REINF/fn_addFIAsquadHC.sqf
+++ b/A3-Antistasi/functions/REINF/fn_addFIAsquadHC.sqf
@@ -156,7 +156,8 @@ if (_esinf) then {
 	if (_typeGroup == staticAAteamPlayer) then {_groupX setGroupIdGlobal [format ["M.AA-%1",{side (leader _x) == teamPlayer} count allGroups]]};
 
 	driver _truckX action ["engineOn", _truckX];
-	[_truckX] call A3A_fnc_AIVEHinit;
+	[_truckX, teamPlayer] call A3A_fnc_AIVEHinit;
+	[_truckX] spawn A3A_fnc_vehDespawner;
 	_bypassAI = true;
 };
 
@@ -202,7 +203,8 @@ vehQuery = nil;
 _pos = position _road findEmptyPosition [1,30,"B_G_Van_01_transport_F"];
 private _purchasedVehicle = _typeVehX createVehicle _pos;
 _purchasedVehicle setDir _roadDirection;
-[_purchasedVehicle] call A3A_fnc_AIVEHinit;
+[_purchasedVehicle, teamPlayer] call A3A_fnc_AIVEHinit;
+[_purchasedVehicle] spawn A3A_fnc_vehDespawner;
 _groupX addVehicle _purchasedVehicle;
 _purchasedVehicle setVariable ["owner",_groupX,true];
 [0, - _costs] remoteExec ["A3A_fnc_resourcesFIA",2];

--- a/A3-Antistasi/functions/REINF/fn_buildMinefield.sqf
+++ b/A3-Antistasi/functions/REINF/fn_buildMinefield.sqf
@@ -78,7 +78,8 @@ _truckX = vehSDKTruck createVehicle _pos;
 
 _groupX addVehicle _truckX;
 {[_x] spawn A3A_fnc_FIAinit; [_x] orderGetIn true} forEach units _groupX;
-_nul = [_truckX] call A3A_fnc_AIVEHinit;
+[_truckX, teamPlayer] call A3A_fnc_AIVEHinit;
+[_truckX] spawn A3A_fnc_vehDespawner;
 leader _groupX setBehaviour "SAFE";
 theBoss hcSetGroup [_groupX];
 _truckX allowCrewInImmobile true;

--- a/A3-Antistasi/functions/REINF/fn_stealStatic.sqf
+++ b/A3-Antistasi/functions/REINF/fn_stealStatic.sqf
@@ -30,9 +30,6 @@ for "_i" from 0 to ((count _staticComponents) - 1) do
 		_groundWeaponHolder addBackpackCargoGlobal [(_staticComponents select _i), 1];
 	};
 
-[_groundWeaponHolder] call A3A_fnc_AIVEHinit;
-
-/* [_bag1] call A3A_fnc_AIVEHinit;
-[_bag2] call A3A_fnc_AIVEHinit; */
+[_groundWeaponHolder] call A3A_fnc_postmortem;
 
 ["Steal Static", "Weapon Stolen. It won't despawn when you assemble it again"] call A3A_fnc_customHint;

--- a/A3-Antistasi/functions/Save/fn_loadStat.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadStat.sqf
@@ -274,10 +274,13 @@ if (_varName in specialVarLoads) then {
 				_veh setPosATL _posVeh;
 				_veh setVectorDirAndUp [_xVectorDir,_xVectorUp];
 			};
+			[_veh, teamPlayer] call A3A_fnc_AIVEHinit;
 			if ((_veh isKindOf "StaticWeapon") or (_veh isKindOf "Building")) then {
 				staticsToSave pushBack _veh;
+			}
+			else {
+				[_veh] spawn A3A_fnc_vehDespawner;
 			};
-			[_veh] call A3A_fnc_AIVEHinit;
 		};
 		publicVariable "staticsToSave";
 	};

--- a/A3-Antistasi/functions/Undercover/fn_goUndercover.sqf
+++ b/A3-Antistasi/functions/Undercover/fn_goUndercover.sqf
@@ -193,12 +193,13 @@ do {
 				};
 			}
 			else {
-				if (_typeX == civHeli) then {
-					_base = [_airportsX1, _player] call BIS_fnc_nearestPosition;
-					_size = [_base] call A3A_fnc_sizeMarker;
-					if ((_player distance2d getMarkerPos _base < _size * 3) and((sidesX getVariable[_base, sideUnknown] == Occupants) or(sidesX getVariable[_base, sideUnknown] == Invaders))) then {
-						_changeX = "NoFly";
-					};
+				if (_typeX == civHeli) then
+                {
+                    if(_veh getVariable ["NoFlyZoneDetected", ""] != "") then
+                    {
+                        _changeX = "NoFly";
+                    };
+
 				};
 			};
 		};
@@ -282,10 +283,13 @@ switch _changeX do {
 			};
 		};
 	case "NoFly":{
-			["Undercover", "You have gotten too close to an enemy Airbase no-fly zone"] call A3A_fnc_customHint;
+            private _veh = vehicle _player;
+            private _detectedBy = _veh getVariable "NoFlyZoneDetected";
+			["Undercover", format ["You have violated the airspace of %1", [_detectedBy] call A3A_fnc_locilizar]] call A3A_fnc_customHint;
 			//_compromised = _player getVariable "compromised";
-			reportedVehs pushBackUnique(vehicle _player);
+			reportedVehs pushBackUnique _veh;
 			publicVariable "reportedVehs";
+            _veh setVariable ["NoFlyZoneDetected", nil, true];
 		};
 	case "Control":{
 			["Undercover", "The Installation Garrison has recognised you"] call A3A_fnc_customHint;

--- a/A3-Antistasi/functions/Undercover/fn_goUndercover.sqf
+++ b/A3-Antistasi/functions/Undercover/fn_goUndercover.sqf
@@ -205,7 +205,7 @@ do {
 		};
 	};
 };
-diag_log format["[Antistasi] Player detected in %1 (undercover.sqf)", _onDetectionMarker];
+//diag_log format["[Antistasi] Player detected in %1 (undercover.sqf)", _onDetectionMarker];
 
 if (captive _player) then {
 	[_player, false] remoteExec["setCaptive"];
@@ -285,7 +285,7 @@ switch _changeX do {
 	case "NoFly":{
             private _veh = vehicle _player;
             private _detectedBy = _veh getVariable "NoFlyZoneDetected";
-			["Undercover", format ["You have violated the airspace of %1", [_detectedBy] call A3A_fnc_locilizar]] call A3A_fnc_customHint;
+			["Undercover", format ["You have violated the airspace of %1", [_detectedBy] call A3A_fnc_localizar]] call A3A_fnc_customHint;
 			//_compromised = _player getVariable "compromised";
 			reportedVehs pushBackUnique _veh;
 			publicVariable "reportedVehs";

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -515,3 +515,8 @@ player setPos (getMarkerPos respawnTeamPlayer);
 enableEnvironment [false, true];
 
 [2,"initClient completed",_fileName] call A3A_fnc_log;
+
+if(!isMultiplayer) then
+{
+    [] spawn A3A_fnc_singlePlayerBlackScreenWarning;
+};

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -276,30 +276,33 @@ player addEventHandler ["HandleHeal", {
 		};
 	};
 }];
+
+// notes:
+// Static weapon objects are persistent through assembly/disassembly
+// The bags are not persistent, object IDs change each time
+// Static weapon position seems to follow bag1, but it's not an attached object
+// Can use objectParent to identify backpack of static weapon
+
 player addEventHandler ["WeaponAssembled", {
-	private ["_veh"];
-	_veh = _this select 1;
+	private _veh = _this select 1;
+	[_veh, teamPlayer] call A3A_fnc_AIVEHinit;		// will flip/capture if already initialized
 	if (_veh isKindOf "StaticWeapon") then {
 		if (not(_veh in staticsToSave)) then {
 			staticsToSave pushBack _veh;
 			publicVariable "staticsToSave";
-			[_veh] call A3A_fnc_AIVEHinit;
 		};
-	_markersX = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
-	_pos = position _veh;
-	if (_markersX findIf {_pos inArea _x} != -1) then {["Static Deployed", "Static weapon has been deployed for use in a nearby zone, and will be used by garrison militia if you leave it here the next time the zone spawns"] call A3A_fnc_customHint;};
-	}
-	else {
-		_veh addEventHandler ["Killed",{[_this select 0] remoteExec ["A3A_fnc_postmortem",2]}];
+		_markersX = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
+		_pos = position _veh;
+		if (_markersX findIf {_pos inArea _x} != -1) then {["Static Deployed", "Static weapon has been deployed for use in a nearby zone, and will be used by garrison militia if you leave it here the next time the zone spawns"] call A3A_fnc_customHint;};
 	};
 }];
 player addEventHandler ["WeaponDisassembled", {
-	_bag1 = _this select 1;
-	_bag2 = _this select 2;
+	private _bag1 = _this select 1;
+	private _bag2 = _this select 2;
 	//_bag1 = objectParent (_this select 1);
 	//_bag2 = objectParent (_this select 2);
-	[_bag1] call A3A_fnc_AIVEHinit;
-	[_bag2] call A3A_fnc_AIVEHinit;
+	[_bag1] remoteExec ["A3A_fnc_postmortem", 2];
+	[_bag2] remoteExec ["A3A_fnc_postmortem", 2];
 }];
 
 player addEventHandler ["GetInMan", {

--- a/A3-Antistasi/onPlayerRespawn.sqf
+++ b/A3-Antistasi/onPlayerRespawn.sqf
@@ -231,20 +231,16 @@ if (side group player == teamPlayer) then
 		];
 	player addEventHandler ["WeaponAssembled",
 		{
-		private ["_veh"];
-		_veh = _this select 1;
-		if (_veh isKindOf "StaticWeapon") then
-			{
-			if (not(_veh in staticsToSave)) then
-				{
-				staticsToSave pushBack _veh;
-				publicVariable "staticsToSave";
-				[_veh] call A3A_fnc_AIVEHinit;
+			private _veh = _this select 1;
+			[_veh, teamPlayer] call A3A_fnc_AIVEHinit;		// will flip/capture if already initialized
+			if (_veh isKindOf "StaticWeapon") then {
+				if (not(_veh in staticsToSave)) then {
+					staticsToSave pushBack _veh;
+					publicVariable "staticsToSave";
 				};
-			}
-		else
-			{
-			_veh addEventHandler ["Killed",{[_this select 0] remoteExec ["A3A_fnc_postmortem",2]}];
+				_markersX = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
+				_pos = position _veh;
+				if (_markersX findIf {_pos inArea _x} != -1) then {["Static Deployed", "Static weapon has been deployed for use in a nearby zone, and will be used by garrison militia if you leave it here the next time the zone spawns"] call A3A_fnc_customHint;};
 			};
 		}];
 	player addEventHandler ["WeaponDisassembled",
@@ -253,8 +249,8 @@ if (side group player == teamPlayer) then
 			_bag2 = _this select 2;
 			//_bag1 = objectParent (_this select 1);
 			//_bag2 = objectParent (_this select 2);
-			[_bag1] call A3A_fnc_AIVEHinit;
-			[_bag2] call A3A_fnc_AIVEHinit;
+			[_bag1] remoteExec ["A3A_fnc_postmortem", 2];
+			[_bag2] remoteExec ["A3A_fnc_postmortem", 2];
 			}
 		];
 	[true] spawn A3A_fnc_reinitY;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Enhancement

### What have you changed and why?
Information:
!!!Johns AIVEHinit reworks needs to be merged first to get rid of alot of changes!!!

Added a new case to AIVEHinit when a rebel player enters any kind of aircraft. From there fn_airspaceControl.sqf is spawned which selects the type of aircraft and the corresponding ranges to airports and outposts.

The script then loops over these conditions every seconds to find out when a no fly zone is violated until the vehicle is garaged, destroyed or has no crew left. For undercover vehicle there will be warning before breaking undercover, with the info which location will break the undercover if you get to close to it. The undercover break message is also packing the location which broke it.

The no flight zones are defined by range (calculated as distance2D) and height, so passing over outposts is possible if you are high enough. Warning zones are higher than detection zones, so that lowering the altitude over an outpost will still result in a warning first.

As the minimal height currently is 100 meter, exploiting undercover helicopters is no longer possible, as you cannot sling load the crate from this height.

For anyone reviewing, I fucked up the commit messages, sorry for that.

### Please specify which Issue this PR Resolves.
closes #331

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

********************************************************
Notes: The values are currently guessed, so they most likely need to be adapted.
