### PR TITLE
Add Flight Suit to Airport Crates

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_itemSort.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_itemSort.sqf
@@ -5,6 +5,11 @@ if (side (group petros) == west) then {
 	diveGear pushBack "U_I_Wetsuit"
 };
 
+if (side (group petros) == west) then {
+	flyGear pushBack "U_B_PilotCoveralls"
+} else {
+	flyGear pushBack "U_I_pilotCoveralls"
+};
 //Lights Vs Laser ID
 {
 if (isClass(configfile >> "CfgWeapons" >> _x >> "ItemInfo" >> "FlashLight" >> "Attenuation")) then

--- a/A3-Antistasi/functions/CREATE/fn_createAIAirplane.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAIAirplane.sqf
@@ -335,6 +335,14 @@ else
 	_veh call jn_fnc_logistics_addAction;
 };
 
+[_veh] spawn {
+  sleep 1;
+  _veh = _this select 0;
+  {
+    _veh addItemCargoGlobal [_x, round random [5,15,15]];
+  }forEach flyGear;
+};
+
 if (!_busy) then
 {
 	for "_i" from 1 to (round (random 2)) do

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -169,7 +169,8 @@ private _otherEquipmentArrayNames = [
 	"occupantBackpackDevice",
 	"rebelBackpackDevice",
 	"civilianBackpackDevice",
-	"diveGear"
+	"diveGear",
+	"flyGear"
 ];
 
 DECLARE_SERVER_VAR(otherEquipmentArrayNames, _otherEquipmentArrayNames);


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Enhancement

### What have you changed and why?
Information:
This will add Flight Suits (Pilot Coveralls [AAF]/Pilot Coveralls [NATO]) to Airport crates.
They are useful to withstand higher G-Forces with Ace.
With the Help of Hakon i added "flyGear" to InitVarserver, fn_itemSort and to fn_createAIAirplane.
Added the same Check as diveGear has for Side.
Made the Amount of Uniforms random, minimum is 5, Maximum is 15.


### Please specify which Issue this PR Resolves.
closes #1027 

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)
---------> Tweaking of the Amount of Pilot suits.
********************************************************
Notes:
