### PR TITLE
fn_artySupport spelling error

### DIFF
--- a/A3-Antistasi/functions/AI/fn_artySupport.sqf
+++ b/A3-Antistasi/functions/AI/fn_artySupport.sqf
@@ -122,7 +122,7 @@ _mrkFinal setMarkerColorLocal "ColorRed";
 
 if (_typeArty == "BARRAGE") then
 	{
-	_mrkFinal setMarkerTextLocal "Atry Barrage Begin";
+	_mrkFinal setMarkerTextLocal "Artilley Barrage Begin";
 	positionTel = [];
 
 	["Artillery Support", "Select the position to finish the barrage"] call A3A_fnc_customHint;
@@ -187,7 +187,7 @@ if (_typeArty == "BARRAGE") then
 	_mrkFinal2 setMarkerShapeLocal "ICON";
 	_mrkFinal2 setMarkerTypeLocal "hd_destroy";
 	_mrkFinal2 setMarkerColorLocal "ColorRed";
-	_mrkFinal2 setMarkerTextLocal "Arty Barrage End";
+	_mrkFinal2 setMarkerTextLocal "Artilley Barrage End";
 	_ang = [_positionTel,_positionTel2] call BIS_fnc_dirTo;
 	sleep 5;
 	_eta = (_artyArrayDef1 select 0) getArtilleryETA [_positionTel, ((getArtilleryAmmo [(_artyArrayDef1 select 0)]) select 0)];

--- a/A3-Antistasi/functions/AI/fn_artySupport.sqf
+++ b/A3-Antistasi/functions/AI/fn_artySupport.sqf
@@ -122,7 +122,7 @@ _mrkFinal setMarkerColorLocal "ColorRed";
 
 if (_typeArty == "BARRAGE") then
 	{
-	_mrkFinal setMarkerTextLocal "Artilley Barrage Begin";
+	_mrkFinal setMarkerTextLocal "Artillery Barrage Begin";
 	positionTel = [];
 
 	["Artillery Support", "Select the position to finish the barrage"] call A3A_fnc_customHint;
@@ -187,7 +187,7 @@ if (_typeArty == "BARRAGE") then
 	_mrkFinal2 setMarkerShapeLocal "ICON";
 	_mrkFinal2 setMarkerTypeLocal "hd_destroy";
 	_mrkFinal2 setMarkerColorLocal "ColorRed";
-	_mrkFinal2 setMarkerTextLocal "Artilley Barrage End";
+	_mrkFinal2 setMarkerTextLocal "Artillery Barrage End";
 	_ang = [_positionTel,_positionTel2] call BIS_fnc_dirTo;
 	sleep 5;
 	_eta = (_artyArrayDef1 select 0) getArtilleryETA [_positionTel, ((getArtilleryAmmo [(_artyArrayDef1 select 0)]) select 0)];


### PR DESCRIPTION
##What type of PR is this.
1. [x] Bug
2. [x] Enhancement

### What have you changed and why?
Information:
Fixed a spelling error in the artillery support function.
Atry ---> Artillery
Arty ---> Artillery (I know, not a spelling error, but still)

### Please specify which Issue this PR Resolves.
closes #1064 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the Mission in Singleplayer?
2. [x] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:
