### PR TITLE
Various fixes for building-placed static weapons

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_createAIAirplane.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAIAirplane.sqf
@@ -242,13 +242,10 @@ if (spawner getVariable _markerX != 2) then
 } forEach _posAT;
 
 _ret = [_markerX,_size,_sideX,_frontierX] call A3A_fnc_milBuildings;
-
-{[_x, _sideX] call A3A_fnc_AIVEHinit} forEach (_ret select 1);
-{[_x,_markerX] call A3A_fnc_NATOinit} forEach (_ret select 2);
-
 _groups pushBack (_ret select 0);
 _vehiclesX append (_ret select 1);
 _soldiers append (_ret select 2);
+{[_x, _sideX] call A3A_fnc_AIVEHinit} forEach (_ret select 1);
 
 if(random 100 < (50 + tierWar * 3)) then
 {

--- a/A3-Antistasi/functions/CREATE/fn_milBuildings.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_milBuildings.sqf
@@ -30,145 +30,62 @@ while {_spawnParameter isEqualType [] && {_count > 0}} do
 	_count = _count - 1;
 };
 
-for "_i" from 0 to (count _buildings) - 1 do
-	{
-	if (spawner getVariable _markerX == 2) exitWith {};
-	_building = _buildings select _i;
-	/*
-	if !(_building getVariable ["conEH",false]) then
-		{
-		_building setVariable ["conEH",true,true];
-		_building addEventHandler ["Killed",{
-			_building = _this select 0;
-			destroyedBuildings pushBackUnique (getPos _building);
-			publicVariable "destroyedBuildings";
-			}
-			];
-		};*/
-	_typeB = typeOf _building;
-	//Helipads spawn in different types of helicopter. By default, patrol helis.
-	//In the editor, drop this code in 'init' on the helipad to change that.
-	//this setVariable ["spawnableHelicopterTypes", ["patrol", "transport", "attack"]];
-	//Disabled by Wurzel, newer system in place
 
-	/*
-	if ((_typeB == "Land_HelipadSquare_F") and (!_frontierX)) then
-	{
-		private _helicopterCategories = _building getVariable ["spawnableHelicopterTypes", ["patrol"]];
-		private _helicopterTypes = [];
-		{
-			switch _x do
-			{
-				case "patrol":
-				{
-					_helicopterTypes pushBack (if (_sideX == Occupants) then {vehNATOPatrolHeli} else {vehCSATPatrolHeli});
-				};
-				case "transport":
-				{
-					_helicopterTypes append (if (_sideX == Occupants) then {vehNATOTransportHelis} else {vehCSATTransportHelis});
-				};
-				case "attack":
-				{
-					_helicopterTypes append (if (_sideX == Occupants) then {vehNATOAttackHelis} else {vehCSATAttackHelis});
-				};
-			};
-		} forEach _helicopterCategories;
-		diag_log format ["Types of All Heli: %1", _helicopterTypes];
-		_helicopterTypes = _helicopterTypes select {[_x] call A3A_fnc_vehAvailable};
-		diag_log format ["Types of Heli: %1", _helicopterTypes];
-		_typeVehX = selectRandom _helicopterTypes;
-		_veh = createVehicle [_typeVehX, position _building, [],0, "CAN_COLLIDE"];
-		_veh setDir (getDir _building);
-		_vehiclesX pushBack _veh;
-	}
-	else
-	{
-		*/
-	if 	((_typeB == "Land_Cargo_HQ_V1_F") or (_typeB == "Land_Cargo_HQ_V2_F") or (_typeB == "Land_Cargo_HQ_V3_F")) then
-	{
-		_typeVehX = if (_sideX == Occupants) then {staticAAOccupants} else {staticAAInvaders};
-		_veh = createVehicle [_typeVehX, (_building buildingPos 8), [],0, "CAN_COLLIDE"];
-		_veh setDir (getDir _building);
-		_veh setPosATL [(getPos _building select 0),(getPos _building select 1),(getPosATL _veh select 2)];
-		_unit = [_groupX, _typeUnit, _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
-		[_unit,_markerX] call A3A_fnc_NATOinit;
-		_unit moveInGunner _veh;
-		_soldiers pushBack _unit;
-		_vehiclesX pushBack _veh;
-	}
-else
+private _fnc_spawnStatic = {
+	params ["_type", "_pos", "_dir"];
+	private _veh = createVehicle [_type, _pos, [], 0, "CAN_COLLIDE"];
+	if (!isNil "_dir") then { _veh setDir _dir };
+	private _unit = [_groupX, _typeUnit, _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
+	[_unit,_markerX] call A3A_fnc_NATOinit;
+	_unit moveInGunner _veh;
+	_soldiers pushBack _unit;
+	_vehiclesX pushBack _veh;
+};
+
+for "_i" from 0 to (count _buildings) - 1 do
 {
-	if 	((_typeB == "Land_Cargo_Patrol_V1_F") or (_typeB == "Land_Cargo_Patrol_V2_F") or (_typeB == "Land_Cargo_Patrol_V3_F")) then
-	{
-		_typeVehX = if (_sideX == Occupants) then {NATOMG} else {CSATMG};
-		_veh = createVehicle [_typeVehX, (_building buildingPos 1), [], 0, "CAN_COLLIDE"];
-		_ang = (getDir _building) - 180;
-		_pos = [getPosATL _veh, 2.5, _ang] call BIS_Fnc_relPos;
-		_veh setPosATL _pos;
-		_veh setDir (getDir _building) - 180;
-		_unit = [_groupX, _typeUnit, _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
-		[_unit,_markerX] call A3A_fnc_NATOinit;
-		_unit moveInGunner _veh;
-		_soldiers pushBack _unit;
-		_vehiclesX pushBack _veh;
-	}
-	else
-	{
-		if 	((_typeB == "Land_fortified_nest_small_EP1") or (_typeB == "Land_BagBunker_Small_F") or (_typeB == "Land_BagBunker_01_small_green_F") or (_typeB == "Land_fortified_nest_small") or (_typeB == "Fort_Nest")) then
+	if (spawner getVariable _markerX == 2) exitWith {};
+	private _building = _buildings select _i;
+	private _typeB = typeOf _building;
+
+	call {
+		if (isObjectHidden _building) exitWith {};			// don't put statics on destroyed buildings
+		if 	((_typeB == "Land_Cargo_Patrol_V1_F") or (_typeB == "Land_Cargo_Patrol_V2_F") or (_typeB == "Land_Cargo_Patrol_V3_F")) exitWith
 		{
-			_typeVehX = if (_sideX == Occupants) then {NATOMG} else {CSATMG};
-			_veh = createVehicle [_typeVehX, (_building buildingPos 1), [], 0, "CAN_COLLIDE"];
-			_ang = (getDir _building) - 180;
-			_pos = [getPosATL _veh, -1, _ang] call BIS_Fnc_relPos;
-			_veh setPosATL _pos;
-			_veh setDir (getDir _building) - 180;
-			_unit = [_groupX, _typeUnit, _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
-			[_unit,_markerX] call A3A_fnc_NATOinit;
-			_unit moveInGunner _veh;
-			_soldiers pushBack _unit;
-			_vehiclesX pushBack _veh;
-		}
-		else
+			private _type = if (_sideX == Occupants) then {NATOMG} else {CSATMG};
+			private _dir = (getDir _building) - 180;
+			private _zpos = ATLtoASL (_building buildingPos 1);
+			private _pos = _zpos getPos [2.5, _dir];			// zeroes Z value because BIS
+			_pos = ASLtoATL [_pos select 0, _pos select 1, _zpos select 2];
+			[_type, _pos, _dir] call _fnc_spawnStatic;
+		};
+		if 	((_typeB == "Land_fortified_nest_small_EP1") or (_typeB == "Land_BagBunker_Small_F") or (_typeB == "Land_BagBunker_01_small_green_F")
+			or (_typeB == "Land_fortified_nest_small") or (_typeB == "Fort_Nest") or (_typeB == "Land_Hlaska")) exitWith
 		{
-			if 	((_typeB == "Land_Hlaska")) then
-			{
-				_typeVehX = if (_sideX == Occupants) then {NATOMG} else {CSATMG};
-				_veh = createVehicle [_typeVehX, (_building buildingPos 1), [], 0, "CAN_COLLIDE"];
-				_ang = (getDir _building) - 180;
-				_pos = [getPosATL _veh, -1, _ang] call BIS_Fnc_relPos;
-				_veh setPosATL _pos;
-				_veh setDir (getDir _building) - 180;
-							 
-			  
-																					   
-				_unit = [_groupX, _typeUnit, _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
-				[_unit,_markerX] call A3A_fnc_NATOinit;
-				_unit moveInGunner _veh;
-				_soldiers pushBack _unit;
-				_vehiclesX pushBack _veh;
-			}
-			else
-			{
-				if 	(_typeB in listbld) then
-				{
-					_typeVehX = if (_sideX == Occupants) then {NATOMG} else {CSATMG};
-					_veh = createVehicle [_typeVehX, (_building buildingPos 11), [], 0, "CAN_COLLIDE"];
-					_unit = [_groupX, _typeUnit, _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
-					[_unit,_markerX] call A3A_fnc_NATOinit;
-					_unit moveInGunner _veh;
-					_soldiers pushBack _unit;
-					_vehiclesX pushBack _veh;
-					sleep 0.5;
-					_veh = createVehicle [_typeVehX, (_building buildingPos 13), [], 0, "CAN_COLLIDE"];
-					_unit = [_groupX, _typeUnit, _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
-					[_unit,_markerX] call A3A_fnc_NATOinit;
-					_unit moveInGunner _veh;
-					_soldiers pushBack _unit;
-					_vehiclesX pushBack _veh;
-				};
-			};
+			private _type = if (_sideX == Occupants) then {NATOMG} else {CSATMG};
+			private _dir = (getDir _building) - 180;
+			private _zpos = ATLtoASL (_building buildingPos 1);
+			private _pos = _zpos getPos [-1, _dir];
+			_pos = ASLtoATL [_pos select 0, _pos select 1, _zpos select 2];
+			[_type, _pos, _dir] call _fnc_spawnStatic;
+		};
+		if 	(_typeB in listbld) exitWith			// just the big towers?
+		{
+			private _type = if (_sideX == Occupants) then {NATOMG} else {CSATMG};
+			[_type, _building buildingpos 11] call _fnc_spawnStatic;
+			sleep 0.5;			// why only here?
+			[_type, _building buildingpos 13] call _fnc_spawnStatic;
+		};
+		if 	((_typeB == "Land_Cargo_HQ_V1_F") or (_typeB == "Land_Cargo_HQ_V2_F") or (_typeB == "Land_Cargo_HQ_V3_F")) exitWith
+		{
+			private _type = if (_sideX == Occupants) then {staticAAOccupants} else {staticAAInvaders};
+			private _dir = getDir _building;
+			private _zpos = ATLtoASL (_building buildingPos 8);
+			private _pos = getPosASL _building;
+			_pos = ASLtoATL [_pos select 0, _pos select 1, _zpos select 2];
+			[_type, _pos, _dir] call _fnc_spawnStatic;
 		};
 	};
 };
-};
+
 [_groupX,_vehiclesX,_soldiers]


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
- Fixed statics being placed in destroyed buildings.
- Fixed misplaced statics where building is placed on rough terrain.
- Refactored milBuildings to reduce code duplication.
- Fixed case where NATOinit was called twice on airport static crew.

### Please specify which Issue this PR Resolves.
closes #1123

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

Positions 11 and 13 in the large towers are pretty shaky though, as the flat floor area isn't large enough for the statics and they often end up hanging at an angle. Tempted to switch them to other positions.