### PR TITLE
navGrid loading fixes and cleanup

### DIFF
--- a/A3-Antistasi/functions/Pathfinding/fn_loadNavGrid.sqf
+++ b/A3-Antistasi/functions/Pathfinding/fn_loadNavGrid.sqf
@@ -1,71 +1,60 @@
-[] spawn
+private _filename = "fn_loadNavGrid";
+
+[2, "Started loading nav grid", _filename] call A3A_fnc_log;
+
+private _firstLetter = toUpper (worldName select [0,1]);
+private _remaining = toLower (worldName select [1]);
+private _path = format ["Navigation\navGrid%1%2.sqf", _firstLetter, _remaining];
+
+private _abort = false;
+try
 {
-  _deltaTime = time;
-  _abort = false;
-  mainMarker = [];
-
-  _worldName = worldName;
-  _firstLetter = _worldName select [0,1];
-  _remaining = _worldName select [1];
-  _firstLetter = toUpper _firstLetter;
-  _remaining = toLower _remaining;
-  _worldName = format ["%1%2", _firstLetter, _remaining];
-
-  _path = format ["Navigation\navGrid%1.sqf", _worldName];
-
-  try
-  {
-    //Load in the nav grid array
-    [] call compile preprocessFileLineNumbers _path;
-  }
-  catch
-  {
-    //Stop launch of mission, road database is missing
-    diag_log format ["Road database could not be loaded, there is no file called<br/> %1<br/><br/> Aborting mission start!", _path];
-    _abort = true;
-  };
-
-  roadDataDone = true;
-  publicVariable "roadDataDone";
-
-  if(_abort) exitWith {};
-
-  _worldSize = worldSize;
-  _chunkSize = 1000; //1000 meters per marker
-  _offset = _chunkSize / 2;
-
-  _markerNeeded =  floor (_worldSize / _chunkSize) + 1;
-
-  //hint format ["Marker per side %1, all %2", _markerNeeded, (_markerNeeded * _markerNeeded)];
-
-  {
-      _navPointData = _x;
-      _index = _navPointData select 0;
-      _position = _navPointData select 1;
-      _mainMarkers = [_position] call A3A_fnc_getMainMarkers;
-      {
-          [_index, _x] call A3A_fnc_setNavOnMarker;
-      } forEach _mainMarkers;
-
-  } forEach navGrid;
-
-  for "_i" from 0 to (_markerNeeded - 1) do
-  {
-    for "_j" from 0 to (_markerNeeded - 1) do
-    {
-      _markerPos = [_offset + _i * _chunkSize, _offset + _j * _chunkSize];
-      _marker = createMarker [format ["%1/%2", _i, _j], _markerPos];
-      _marker setMarkerShape "ICON";
-      _marker setMarkerType "mil_circle";
-      _marker setMarkerColor "ColorBlack";
-      _points = missionNamespace getVariable [(format ["%1/%2_data", _i, _j]), []];
-      _marker setMarkerText (format ["%1/%2, NavPoints: %3", _i, _j, count _points]);
-      _marker setMarkerAlpha 0;
-
-      mainMarker pushBack "_marker";
-    };
-  };
-
-  _deltaTime = time - _deltaTime;
-  ["Nav Grid", format ["Nav grid load and prepared in %1 seconds", _deltaTime]] call A3A_fnc_customHint;
+	//Load in the nav grid array
+	[] call compile preprocessFileLineNumbers _path;
+}
+catch
+{
+	[1, format ["Road database at %1 could not be loaded", _path], _filename] call A3A_fnc_log;
+	_abort = true;
 };
+if(_abort) exitWith {};
+
+{
+	private _navPointData = _x;
+	private _index = _navPointData select 0;
+	private _position = _navPointData select 1;
+	private _mainMarkers = [_position] call A3A_fnc_getMainMarkers;
+	{
+		[_index, _x] call A3A_fnc_setNavOnMarker;
+	} forEach _mainMarkers;
+} forEach navGrid;
+
+roadDataDone = true;
+
+[2, "Finished loading nav grid", _filename] call A3A_fnc_log;
+
+
+/*
+// Left this code here in case someone needs it for debugging
+mainMarker = [];
+
+private _chunkSize = 1000; //1000 meters per marker
+private _markerNeeded =  floor (worldSize / _chunkSize) + 1;
+
+for "_i" from 0 to (_markerNeeded - 1) do
+{
+	for "_j" from 0 to (_markerNeeded - 1) do
+	{
+		_markerPos = [_offset + _i * _chunkSize, _offset + _j * _chunkSize];
+		_marker = createMarker [format ["%1/%2", _i, _j], _markerPos];
+		_marker setMarkerShape "ICON";
+		_marker setMarkerType "mil_circle";
+		_marker setMarkerColor "ColorBlack";
+		_points = missionNamespace getVariable [(format ["%1/%2_data", _i, _j]), []];
+		_marker setMarkerText (format ["%1/%2, NavPoints: %3", _i, _j, count _points]);
+		_marker setMarkerAlpha 0;
+		
+		mainMarker pushBack "_marker";
+	};
+};
+*/

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -23,6 +23,7 @@ if (!isServer) then {
 	call A3A_fnc_initVar;
 	if (!hasInterface) exitWith {
 		[2,format ["Headless client version: %1",localize "STR_antistasi_credits_generic_version_text"],_fileName] call A3A_fnc_log;
+		call A3A_fnc_loadNavGrid;
 		[clientOwner] remoteExec ["A3A_fnc_addHC",2];
 	};
 	[2,format ["MP client version: %1",localize "STR_antistasi_credits_generic_version_text"],_fileName] call A3A_fnc_log;

--- a/A3-Antistasi/functions/init/fn_initServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initServer.sqf
@@ -122,9 +122,10 @@ _nul = call A3A_fnc_initVar;
 savingServer = true;
 [2,format ["%1 server version: %2", ["SP","MP"] select isMultiplayer, localize "STR_antistasi_credits_generic_version_text"],_fileName] call A3A_fnc_log;
 bookedSlots = floor ((("memberSlots" call BIS_fnc_getParamValue)/100) * (playableSlotsNumber teamPlayer)); publicVariable "bookedSlots";
-_nul = call A3A_fnc_initFuncs;
+call A3A_fnc_initFuncs;
 if (hasACEMedical) then { call A3A_fnc_initACEUnconsciousHandler };
-_nul = call A3A_fnc_initZones;
+call A3A_fnc_loadNavGrid;
+call A3A_fnc_initZones;
 if (gameMode != 1) then {
 	Occupants setFriend [Invaders,1];
 	Invaders setFriend [Occupants,1];

--- a/A3-Antistasi/functions/init/fn_initZones.sqf
+++ b/A3-Antistasi/functions/init/fn_initZones.sqf
@@ -157,10 +157,6 @@ if (debug) then {
 diag_log format ["%1: [Antistasi] | DEBUG | initZones | Roads built in %2.",servertime,worldname];
 };
 
-[2,"Loading nav grid",_fileName] call A3A_fnc_log;
-[] call A3A_fnc_loadNavGrid;
-[2,"Loaded nav grid",_fileName] call A3A_fnc_log;
-
 
 markersX = markersX + citiesX;
 sidesX setVariable ["Synd_HQ", teamPlayer, true];


### PR DESCRIPTION

## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
The navGrid and other generated data used by A3A_fnc_findPath was only loaded on the server, but the convoy missions use findPath and run on HCs. The main use was new reinforcement convoys, which are only executed on the server for some reason.

This PR loads and generates the navGrid data on HCs as well. Also cleaned up the code and disabled the section that was spamming 400 invisible markers to all clients.

One thing I didn't change is that the function expects the navGrid file to have the first letter of the world name uppercased, but some of the navgrid files have all-lowercase world names. This works fine on Windows but may be an issue on Linux servers.

### Please specify which Issue this PR Resolves.
closes #1121

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

