### PR TITLE
RHS-USAF-Template Update Full Camo.

### DIFF
--- a/A3-Antistasi/Templates/RHS_Occ_USAF_Arid.sqf
+++ b/A3-Antistasi/Templates/RHS_Occ_USAF_Arid.sqf
@@ -126,8 +126,8 @@ groupsNATOGen = [policeOfficer,policeGrunt];
 //Military Vehicles
 //Lite
 vehNATOBike = "B_Quadbike_01_F";
-vehNATOLightArmed = ["rhsusf_m1025_d_s_m2","rhsusf_CGRCAT1A2_M2_usmc_d","rhsusf_CGRCAT1A2_Mk19_usmc_d","rhsusf_M1117_W","rhsusf_M1220_M2_usarmy_d","rhsusf_M1237_M2_usarmy_d","rhsusf_M1238A1_M2_socom_d","rhsusf_m1045_d_s","rhsusf_m1240a1_usmc_d"];
-vehNATOLightUnarmed = ["rhsusf_m1025_d_s","rhsusf_m998_d_s_2dr","rhsusf_m998_d_s_2dr_fulltop","rhsusf_m998_d_s_4dr","rhsusf_CGRCAT1A2_usmc_d","rhsusf_M1232_usarmy_d","rhsusf_m1240a1_mk19_usmc_d","rhsusf_m1240a1_m240_usmc_d","rhsusf_m1240a1_m2_usmc_d"];
+vehNATOLightArmed = ["rhsusf_m1025_d_s_m2","rhsusf_CGRCAT1A2_M2_usmc_d","rhsusf_CGRCAT1A2_Mk19_usmc_d","rhsusf_M1117_W","rhsusf_M1220_M2_usarmy_d","rhsusf_M1237_M2_usarmy_d","rhsusf_M1238A1_M2_socom_d","rhsusf_m1045_d_s","rhsusf_m1240a1_mk19_usmc_d","rhsusf_m1240a1_m240_usmc_d","rhsusf_m1240a1_m2_usmc_d"];
+vehNATOLightUnarmed = ["rhsusf_m1025_d_s","rhsusf_m998_d_s_2dr","rhsusf_m998_d_s_2dr_fulltop","rhsusf_m998_d_s_4dr","rhsusf_CGRCAT1A2_usmc_d","rhsusf_M1232_usarmy_d","rhsusf_m1240a1_usmc_d"];
 vehNATOTrucks = ["rhsusf_M1078A1P2_D_open_fmtv_usarmy","rhsusf_M1078A1P2_B_D_fmtv_usarmy","rhsusf_M1078A1P2_B_D_open_fmtv_usarmy","rhsusf_M1083A1P2_D_fmtv_usarmy","rhsusf_M1083A1P2_B_M2_D_fmtv_usarmy"];
 vehNATOCargoTrucks = [];
 vehNATOAmmoTruck = "rhsusf_M977A4_AMMO_BKIT_usarmy_d";

--- a/A3-Antistasi/Templates/RHS_Occ_USAF_Arid.sqf
+++ b/A3-Antistasi/Templates/RHS_Occ_USAF_Arid.sqf
@@ -134,7 +134,7 @@ vehNATOAmmoTruck = "rhsusf_M977A4_AMMO_BKIT_usarmy_d";
 vehNATORepairTruck = "rhsusf_M977A4_REPAIR_BKIT_usarmy_d";
 vehNATOLight = vehNATOLightArmed + vehNATOLightUnarmed;
 //Armored
-vehNATOAPC = ["rhsusf_stryker_m1126_m2_d","rhsusf_stryker_m1126_mk19_d","rhsusf_stryker_m1127_m2_d","rhsusf_stryker_m1132_m2_d","rhsusf_stryker_m1134_d","RHS_M2A3_BUSKIII","RHS_M2A3_BUSKI","rhsusf_M1237_MK19_usarmy_d","RHS_M2A2_BUSKI","rhsusf_m113d_usarmy","rhsusf_m113d_usarmy_M240","rhsusf_m113d_usarmy_MK19"];
+vehNATOAPC = ["rhsusf_stryker_m1126_m2_d","rhsusf_stryker_m1126_mk19_d","rhsusf_stryker_m1127_m2_d","rhsusf_stryker_m1132_m2_d","RHS_M2A3_BUSKIII","RHS_M2A3_BUSKI","rhsusf_M1237_MK19_usarmy_d","RHS_M2A2_BUSKI","rhsusf_m113d_usarmy","rhsusf_m113d_usarmy_M240","rhsusf_m113d_usarmy_MK19"];
 vehNATOTank = "rhsusf_m1a1fep_d";
 vehNATOAA = "RHS_M6";
 vehNATOAttack = vehNATOAPC + [vehNATOTank];

--- a/A3-Antistasi/Templates/RHS_Occ_USAF_Arid.sqf
+++ b/A3-Antistasi/Templates/RHS_Occ_USAF_Arid.sqf
@@ -1,3 +1,9 @@
+//Woodland Call, Yes i know there are better ways.
+if (worldName == "Tanoa") exitWith {call compile preProcessFileLineNumbers "Templates\RHS_Occ_USAF_Wdl.sqf"};
+if (worldName == "chernarus_summer") exitWith {call compile preProcessFileLineNumbers "Templates\RHS_Occ_USAF_Wdl.sqf"};
+if (worldName == "Enoch") exitWith {call compile preProcessFileLineNumbers "Templates\RHS_Occ_USAF_Wdl.sqf"};
+if (worldName == "Tembelan") exitWith {call compile preProcessFileLineNumbers "Templates\RHS_Occ_USAF_Wdl.sqf"};
+if (worldName == "vt7") exitWith {call compile preProcessFileLineNumbers "Templates\RHS_Occ_USAF_Wdl.sqf"};
 ////////////////////////////////////
 //       NAMES AND FLAGS         ///
 ////////////////////////////////////
@@ -40,20 +46,20 @@ NATOPlayerLoadouts = [
 ];
 
 //PVP Player Vehicles
-vehNATOPVP = ["rhsusf_m1025_w_s","rhsusf_m998_w_s_2dr","rhsusf_m998_w_s_2dr_fulltop","rhsusf_m998_w_s_4dr","rhsusf_m1025_w_s_m2","rhsusf_mrzr4_d"];
+vehNATOPVP = ["rhsusf_m1025_d_s","rhsusf_m998_d_s_2dr","rhsusf_m998_d_s_2dr_fulltop","rhsusf_m998_d_s_4dr","rhsusf_m1025_d_s_m2","rhsusf_mrzr4_d_mud","rhsusf_m1240a1_m240_usmc_d"];
 
 ////////////////////////////////////
 //             UNITS             ///
 ////////////////////////////////////
 //Military Units
-NATOGrunt = "rhsusf_usmc_marpat_wd_rifleman_light";
-NATOOfficer = "rhsusf_usmc_marpat_wd_officer";
+NATOGrunt = "rhsusf_usmc_marpat_d_rifleman_light";
+NATOOfficer = "rhsusf_usmc_marpat_d_officer";
 NATOOfficer2 = "rhsusf_army_ucp_rifleman_101st";
 NATOBodyG = "rhsusf_army_ucp_rifleman_1stcav";
-NATOCrew = "rhsusf_usmc_marpat_wd_crewman";
+NATOCrew = "rhsusf_usmc_marpat_d_crewman";
 NATOUnarmed = "B_G_Survivor_F";
-NATOMarksman = "rhsusf_usmc_marpat_wd_marksman";
-staticCrewOccupants = "rhsusf_usmc_marpat_wd_rifleman";
+NATOMarksman = "rhsusf_usmc_marpat_d_marksman";
+staticCrewOccupants = "rhsusf_usmc_marpat_d_rifleman";
 NATOPilot = "rhsusf_airforce_jetpilot";
 
 //Militia Units
@@ -64,30 +70,30 @@ if ((gameMode != 4) and (!hasFFAA)) then
 	};
 
 //Police Units
-policeOfficer = "rhsusf_army_ucp_rifleman_m590";
-policeGrunt = "rhsusf_army_ucp_rifleman_82nd";
+policeOfficer = "rhsusf_army_ocp_rifleman_m590";
+policeGrunt = "rhsusf_army_ocp_rifleman_82nd";
 
 ////////////////////////////////////
 //            GROUPS             ///
 ////////////////////////////////////
 //Military Groups
 //Teams
-groupsNATOSentry = ["rhsusf_usmc_marpat_wd_grenadier",NATOGrunt];
+groupsNATOSentry = ["rhsusf_usmc_marpat_d_grenadier",NATOGrunt];
 groupsNATOSniper = ["rhsusf_socom_marsoc_sniper","rhsusf_socom_marsoc_spotter"];
 groupsNATOsmall = [groupsNATOSentry,groupsNATOSniper];
 //Fireteams
-groupsNATOAA = ["rhsusf_usmc_marpat_wd_teamleader","rhsusf_usmc_marpat_wd_autorifleman","rhsusf_usmc_marpat_wd_rifleman_m4","rhsusf_usmc_marpat_wd_stinger"];
-groupsNATOAT = ["rhsusf_usmc_marpat_wd_teamleader","rhsusf_usmc_marpat_wd_autorifleman","rhsusf_usmc_marpat_wd_rifleman_m4","rhsusf_usmc_marpat_wd_javelin"];
-groupsNATOmid = [["rhsusf_usmc_marpat_wd_teamleader","rhsusf_usmc_marpat_wd_autorifleman_m249","rhsusf_usmc_marpat_wd_rifleman_m4","rhsusf_usmc_marpat_wd_riflemanat"],groupsNATOAA,groupsNATOAT];
+groupsNATOAA = ["rhsusf_usmc_marpat_d_teamleader","rhsusf_usmc_marpat_d_autorifleman","rhsusf_usmc_marpat_d_rifleman_m4","rhsusf_usmc_marpat_d_stinger"];
+groupsNATOAT = ["rhsusf_usmc_marpat_d_teamleader","rhsusf_usmc_marpat_d_autorifleman","rhsusf_usmc_marpat_d_rifleman_m4","rhsusf_usmc_marpat_d_javelin"];
+groupsNATOmid = [["rhsusf_usmc_marpat_d_teamleader","rhsusf_usmc_marpat_d_autorifleman_m249","rhsusf_usmc_marpat_d_rifleman_m4","rhsusf_usmc_marpat_d_riflemanat"],groupsNATOAA,groupsNATOAT];
 //Squads
-NATOSquad = ["rhsusf_usmc_marpat_wd_squadleader","rhsusf_usmc_marpat_wd_teamleader","rhsusf_usmc_marpat_wd_autorifleman_m249","rhsusf_usmc_marpat_wd_rifleman_m4","rhsusf_usmc_marpat_wd_autorifleman_m249","rhsusf_usmc_marpat_wd_rifleman_m4","rhsusf_usmc_marpat_wd_marksman","rhsusf_navy_marpat_wd_medic"];
+NATOSquad = ["rhsusf_usmc_marpat_d_squadleader","rhsusf_usmc_marpat_d_teamleader","rhsusf_usmc_marpat_d_autorifleman_m249","rhsusf_usmc_marpat_d_rifleman_m4","rhsusf_usmc_marpat_d_autorifleman_m249","rhsusf_usmc_marpat_d_rifleman_m4","rhsusf_usmc_marpat_d_marksman","rhsusf_navy_marpat_d_medic"];
 NATOSpecOp = ["rhsusf_socom_marsoc_teamleader","rhsusf_socom_marsoc_teamchief","rhsusf_socom_marsoc_cso_mk17","rhsusf_socom_marsoc_marksman","rhsusf_socom_marsoc_cso_breacher","rhsusf_socom_marsoc_cso_eod","rhsusf_socom_marsoc_cso_grenadier","rhsusf_socom_marsoc_sarc"];
 groupsNATOSquad =
 	[
 	NATOSquad,
-	["rhsusf_usmc_marpat_d_squadleader","rhsusf_usmc_marpat_d_machinegunner","rhsusf_usmc_marpat_d_riflemanat","rhsusf_usmc_marpat_d_riflemanat","rhsusf_usmc_marpat_d_grenadier","rhsusf_usmc_marpat_d_javelin","rhsusf_usmc_marpat_d_javelin_assistant","rhsusf_navy_sarc_d"],
-	["rhsusf_usmc_marpat_d_squadleader","rhsusf_usmc_marpat_d_machinegunner","rhsusf_usmc_marpat_d_riflemanat","rhsusf_usmc_marpat_d_grenadier","rhsusf_usmc_marpat_d_grenadier","rhsusf_usmc_marpat_d_stinger","rhsusf_usmc_marpat_d_rifleman_light","rhsusf_navy_sarc_d"],
-	["rhsusf_usmc_marpat_wd_squadleader","rhsusf_usmc_marpat_wd_teamleader","rhsusf_usmc_marpat_wd_autorifleman_m249","rhsusf_usmc_marpat_wd_rifleman_m4","rhsusf_usmc_marpat_wd_autorifleman_m249","rhsusf_usmc_marpat_wd_rifleman_m4","rhsusf_usmc_marpat_d_explosives","rhsusf_navy_marpat_wd_medic"]
+	["rhsusf_usmc_marpat_d_squadleader","rhsusf_usmc_marpat_d_machinegunner","rhsusf_usmc_marpat_d_riflemanat","rhsusf_usmc_marpat_d_riflemanat","rhsusf_usmc_marpat_d_grenadier","rhsusf_usmc_marpat_d_javelin","rhsusf_usmc_marpat_d_javelin_assistant","rhsusf_navy_marpat_d_medic"],
+	["rhsusf_usmc_marpat_d_squadleader","rhsusf_usmc_marpat_d_machinegunner","rhsusf_usmc_marpat_d_riflemanat","rhsusf_usmc_marpat_d_grenadier","rhsusf_usmc_marpat_d_grenadier","rhsusf_usmc_marpat_d_stinger","rhsusf_usmc_marpat_d_rifleman_light","rhsusf_navy_marpat_d_medic"],
+	["rhsusf_usmc_marpat_d_squadleader","rhsusf_usmc_marpat_d_teamleader","rhsusf_usmc_marpat_d_autorifleman_m249","rhsusf_usmc_marpat_d_rifleman_m4","rhsusf_usmc_marpat_d_autorifleman_m249","rhsusf_usmc_marpat_d_rifleman_m4","rhsusf_usmc_marpat_d_explosives","rhsusf_navy_marpat_d_medic"]
 	];
 
 //Militia Groups
@@ -119,60 +125,60 @@ groupsNATOGen = [policeOfficer,policeGrunt];
 ////////////////////////////////////
 //Military Vehicles
 //Lite
-vehNATOBike = "B_T_Quadbike_01_F";
-vehNATOLightArmed = ["rhsusf_m1025_w_s_m2","rhsusf_CGRCAT1A2_M2_usmc_wd","rhsusf_CGRCAT1A2_Mk19_usmc_wd","rhsusf_M1117_W","rhsusf_M1220_M2_usarmy_wd","rhsusf_M1237_M2_usarmy_wd","rhsusf_M1238A1_M2_socom_d","rhsusf_m1045_w_s"];
-vehNATOLightUnarmed = ["rhsusf_m1025_w_s","rhsusf_m998_w_s_2dr","rhsusf_m998_w_s_2dr_fulltop","rhsusf_m998_w_s_4dr","rhsusf_CGRCAT1A2_usmc_wd","rhsusf_M1232_usarmy_wd"];
-vehNATOTrucks = ["rhsusf_M1078A1P2_wd_open_fmtv_usarmy","rhsusf_M1078A1P2_B_wd_fmtv_usarmy","rhsusf_M1078A1P2_B_wd_open_fmtv_usarmy","rhsusf_M1083A1P2_wd_fmtv_usarmy","rhsusf_M1083A1P2_B_M2_wd_fmtv_usarmy"];
+vehNATOBike = "B_Quadbike_01_F";
+vehNATOLightArmed = ["rhsusf_m1025_d_s_m2","rhsusf_CGRCAT1A2_M2_usmc_d","rhsusf_CGRCAT1A2_Mk19_usmc_d","rhsusf_M1117_W","rhsusf_M1220_M2_usarmy_d","rhsusf_M1237_M2_usarmy_d","rhsusf_M1238A1_M2_socom_d","rhsusf_m1045_d_s","rhsusf_m1240a1_usmc_d"];
+vehNATOLightUnarmed = ["rhsusf_m1025_d_s","rhsusf_m998_d_s_2dr","rhsusf_m998_d_s_2dr_fulltop","rhsusf_m998_d_s_4dr","rhsusf_CGRCAT1A2_usmc_d","rhsusf_M1232_usarmy_d","rhsusf_m1240a1_mk19_usmc_d","rhsusf_m1240a1_m240_usmc_d","rhsusf_m1240a1_m2_usmc_d"];
+vehNATOTrucks = ["rhsusf_M1078A1P2_D_open_fmtv_usarmy","rhsusf_M1078A1P2_B_D_fmtv_usarmy","rhsusf_M1078A1P2_B_D_open_fmtv_usarmy","rhsusf_M1083A1P2_D_fmtv_usarmy","rhsusf_M1083A1P2_B_M2_D_fmtv_usarmy"];
 vehNATOCargoTrucks = [];
-vehNATOAmmoTruck = "rhsusf_M977A4_AMMO_BKIT_usarmy_wd";
-vehNATORepairTruck = "rhsusf_M977A4_REPAIR_BKIT_usarmy_wd";
+vehNATOAmmoTruck = "rhsusf_M977A4_AMMO_BKIT_usarmy_d";
+vehNATORepairTruck = "rhsusf_M977A4_REPAIR_BKIT_usarmy_d";
 vehNATOLight = vehNATOLightArmed + vehNATOLightUnarmed;
 //Armored
-vehNATOAPC = ["rhsusf_stryker_m1126_m2_wd","RHS_M2A3_BUSKIII_wd","RHS_M2A3_BUSKI_wd","rhsusf_M1237_MK19_usarmy_wd","RHS_M2A2_BUSKI_WD","rhsusf_m113_usarmy","rhsusf_m113_usarmy_MK19","rhsusf_m113_usarmy"];
-vehNATOTank = "rhsusf_m1a1fep_wd";
+vehNATOAPC = ["rhsusf_stryker_m1126_m2_d","rhsusf_stryker_m1126_mk19_d","rhsusf_stryker_m1127_m2_d","rhsusf_stryker_m1132_m2_d","rhsusf_stryker_m1134_d","RHS_M2A3_BUSKIII","RHS_M2A3_BUSKI","rhsusf_M1237_MK19_usarmy_d","RHS_M2A2_BUSKI","rhsusf_m113d_usarmy","rhsusf_m113d_usarmy_M240","rhsusf_m113d_usarmy_MK19"];
+vehNATOTank = "rhsusf_m1a1fep_d";
 vehNATOAA = "RHS_M6";
 vehNATOAttack = vehNATOAPC + [vehNATOTank];
 //Boats
 vehNATOBoat = "rhsusf_mkvsoc";
-vehNATORBoat = "B_T_Boat_Transport_01_F";
-vehNATOBoats = [vehNATOBoat,vehNATORBoat,"rhsusf_m113_usarmy_MK19","rhsusf_m113_usarmy"];
+vehNATORBoat = "rhsgref_hidf_rhib";
+vehNATOBoats = [vehNATOBoat,vehNATORBoat,"rhsusf_m113d_usarmy","rhsusf_m113d_usarmy_M240","rhsusf_m113d_usarmy_MK19"];
 //Planes
 vehNATOPlane = "RHS_A10_AT";
 vehNATOPlaneAA = "rhsusf_f22";
 vehNATOTransportPlanes = ["RHS_C130J"];
 //Heli
 vehNATOPatrolHeli = "RHS_MELB_MH6M";
-vehNATOTransportHelis = ["RHS_UH60M_d","RHS_CH_47F","rhsusf_CH53E_USMC_GAU21",vehNATOPatrolHeli];
-vehNATOAttackHelis = ["RHS_MELB_AH6M_L","RHS_AH64D_wd","RHS_UH1Y","RHS_AH1Z_wd"];
+vehNATOTransportHelis = ["RHS_UH60M_d","RHS_CH_47F_light","rhsusf_CH53E_USMC_GAU21_D",vehNATOPatrolHeli];
+vehNATOAttackHelis = ["RHS_MELB_AH6M_L","RHS_AH64D","RHS_UH1Y_d","RHS_AH1Z"];
 //UAV
 vehNATOUAV = "B_UAV_02_F";
 vehNATOUAVSmall = "B_UAV_01_F";
 //Artillery
-vehNATOMRLS = "rhsusf_m109_usarmy";
+vehNATOMRLS = "rhsusf_m109d_usarmy";
 vehNATOMRLSMags = "rhs_mag_155mm_m795_28";
 //Combined Arrays
-vehNATONormal = vehNATOLight + vehNATOTrucks + [vehNATOAmmoTruck, "rhsusf_M978A4_BKIT_usarmy_wd","rhsusf_m113_usarmy_medical", vehNATORepairTruck];
+vehNATONormal = vehNATOLight + vehNATOTrucks + [vehNATOAmmoTruck, "rhsusf_M978A4_BKIT_usarmy_d","rhsusf_m113d_usarmy_medical", vehNATORepairTruck];
 vehNATOAir = vehNATOTransportHelis + vehNATOAttackHelis + [vehNATOPlane,vehNATOPlaneAA] + vehNATOTransportPlanes;
 
 //Militia Vehicles
 if ((gameMode != 4) and (!hasFFAA)) then
 	{
 	vehFIAArmedCar = "rhsgref_hidf_m1025_m2";
-	vehFIATruck = "rhsgref_cdf_b_ural_open";
+	vehFIATruck = "rhsusf_M1078A1P2_D_fmtv_usarmy";
 	vehFIACar = "rhsgref_hidf_m998_4dr";
 	};
 
 //Police Vehicles
-vehPoliceCar = "rhsusf_mrzr4_d";
+vehPoliceCar = "rhsusf_mrzr4_d_mud";
 
 ////////////////////////////////////
 //        STATIC WEAPONS         ///
 ////////////////////////////////////
 //Assembled Statics
-NATOMG = "RHS_M2StaticMG_USMC_WD";
-staticATOccupants = "RHS_TOW_TriPod_USMC_WD";
+NATOMG = "RHS_M2StaticMG_USMC_D";
+staticATOccupants = "RHS_TOW_TriPod_USMC_D";
 staticAAOccupants = "RHS_Stinger_AA_pod_D";
-NATOMortar = "RHS_M252_USMC_WD";
+NATOMortar = "RHS_M252_USMC_D";
 
 //Static Weapon Bags
 MGStaticNATOB = "RHS_M2_Gun_Bag";

--- a/A3-Antistasi/Templates/RHS_Occ_USAF_Wdl.sqf
+++ b/A3-Antistasi/Templates/RHS_Occ_USAF_Wdl.sqf
@@ -120,8 +120,8 @@ groupsNATOGen = [policeOfficer,policeGrunt];
 //Military Vehicles
 //Lite
 vehNATOBike = "B_Quadbike_01_F";
-vehNATOLightArmed = ["rhsusf_m1025_w_s_m2","rhsusf_CGRCAT1A2_M2_usmc_wd","rhsusf_CGRCAT1A2_Mk19_usmc_wd","rhsusf_M1117_W","rhsusf_M1220_M2_usarmy_wd","rhsusf_M1237_M2_usarmy_wd","rhsusf_m1045_w_s","rhsusf_m1240a1_usmc_wd"];
-vehNATOLightUnarmed = ["rhsusf_m1025_w_s","rhsusf_m998_w_s_2dr","rhsusf_m998_w_s_2dr_fulltop","rhsusf_m998_w_s_4dr","rhsusf_CGRCAT1A2_usmc_wd","rhsusf_M1232_usarmy_wd","rhsusf_m1240a1_m2_usmc_wd","rhsusf_m1240a1_mk19_usmc_wd","rhsusf_m1240a1_m240_usmc_wd"];
+vehNATOLightArmed = ["rhsusf_m1025_w_s_m2","rhsusf_CGRCAT1A2_M2_usmc_wd","rhsusf_CGRCAT1A2_Mk19_usmc_wd","rhsusf_M1117_W","rhsusf_M1220_M2_usarmy_wd","rhsusf_M1237_M2_usarmy_wd","rhsusf_M1238A1_M2_socom_wd","rhsusf_m1045_w_s","rhsusf_m1240a1_m2_usmc_wd","rhsusf_m1240a1_mk19_usmc_wd","rhsusf_m1240a1_m240_usmc_wd"];
+vehNATOLightUnarmed = ["rhsusf_m1025_w_s","rhsusf_m998_w_s_2dr","rhsusf_m998_w_s_2dr_fulltop","rhsusf_m998_w_s_4dr","rhsusf_CGRCAT1A2_usmc_wd","rhsusf_M1232_usarmy_wd","rhsusf_m1240a1_usmc_wd"];
 vehNATOTrucks = ["rhsusf_M1078A1P2_WD_open_fmtv_usarmy","rhsusf_M1078A1P2_B_WD_fmtv_usarmy","rhsusf_M1078A1P2_B_WD_open_fmtv_usarmy","rhsusf_M1083A1P2_WD_fmtv_usarmy","rhsusf_M1083A1P2_B_M2_WD_fmtv_usarmy"];
 vehNATOCargoTrucks = [];
 vehNATOAmmoTruck = "rhsusf_M977A4_AMMO_BKIT_usarmy_wd";

--- a/A3-Antistasi/Templates/RHS_Occ_USAF_Wdl.sqf
+++ b/A3-Antistasi/Templates/RHS_Occ_USAF_Wdl.sqf
@@ -128,7 +128,7 @@ vehNATOAmmoTruck = "rhsusf_M977A4_AMMO_BKIT_usarmy_wd";
 vehNATORepairTruck = "rhsusf_M977A4_REPAIR_BKIT_usarmy_wd";
 vehNATOLight = vehNATOLightArmed + vehNATOLightUnarmed;
 //Armored
-vehNATOAPC = ["rhsusf_stryker_m1126_m2_wd","rhsusf_stryker_m1126_mk19_wd","rhsusf_stryker_m1127_m2_wd","rhsusf_stryker_m1132_m2_wd","rhsusf_stryker_m1134_wd","RHS_M2A3_BUSKIII_wd","RHS_M2A3_BUSKI_wd","rhsusf_M1237_MK19_usarmy_wd","RHS_M2A2_BUSKI_WD","rhsusf_m113_usarmy","rhsusf_m113_usarmy_M240","rhsusf_m113_usarmy_MK19"];
+vehNATOAPC = ["rhsusf_stryker_m1126_m2_wd","rhsusf_stryker_m1126_mk19_wd","rhsusf_stryker_m1127_m2_wd","rhsusf_stryker_m1132_m2_wd","RHS_M2A3_BUSKIII_wd","RHS_M2A3_BUSKI_wd","rhsusf_M1237_MK19_usarmy_wd","RHS_M2A2_BUSKI_WD","rhsusf_m113_usarmy","rhsusf_m113_usarmy_M240","rhsusf_m113_usarmy_MK19"];
 vehNATOTank = "rhsusf_m1a1fep_wd";
 vehNATOAA = "RHS_M6_wd";
 vehNATOAttack = vehNATOAPC + [vehNATOTank];

--- a/A3-Antistasi/Templates/RHS_Occ_USAF_Wdl.sqf
+++ b/A3-Antistasi/Templates/RHS_Occ_USAF_Wdl.sqf
@@ -40,7 +40,7 @@ NATOPlayerLoadouts = [
 ];
 
 //PVP Player Vehicles
-vehNATOPVP = ["rhsusf_m1025_w_s","rhsusf_m998_w_s_2dr","rhsusf_m998_w_s_2dr_fulltop","rhsusf_m998_w_s_4dr","rhsusf_m1025_w_s_m2","rhsusf_mrzr4_d"];
+vehNATOPVP = ["rhsusf_m1025_w_s","rhsusf_m998_w_s_2dr","rhsusf_m998_w_s_2dr_fulltop","rhsusf_m998_w_s_4dr","rhsusf_m1025_w_s_m2","rhsusf_mrzr4_w_mud","rhsusf_m1240a1_m240_usmc_wd"];
 
 ////////////////////////////////////
 //             UNITS             ///
@@ -85,9 +85,9 @@ NATOSpecOp = ["rhsusf_socom_marsoc_teamleader","rhsusf_socom_marsoc_teamchief","
 groupsNATOSquad =
 	[
 	NATOSquad,
-	["rhsusf_usmc_marpat_d_squadleader","rhsusf_usmc_marpat_d_machinegunner","rhsusf_usmc_marpat_d_riflemanat","rhsusf_usmc_marpat_d_riflemanat","rhsusf_usmc_marpat_d_grenadier","rhsusf_usmc_marpat_d_javelin","rhsusf_usmc_marpat_d_javelin_assistant","rhsusf_navy_sarc_d"],
-	["rhsusf_usmc_marpat_d_squadleader","rhsusf_usmc_marpat_d_machinegunner","rhsusf_usmc_marpat_d_riflemanat","rhsusf_usmc_marpat_d_grenadier","rhsusf_usmc_marpat_d_grenadier","rhsusf_usmc_marpat_d_stinger","rhsusf_usmc_marpat_d_rifleman_light","rhsusf_navy_sarc_d"],
-	["rhsusf_usmc_marpat_wd_squadleader","rhsusf_usmc_marpat_wd_teamleader","rhsusf_usmc_marpat_wd_autorifleman_m249","rhsusf_usmc_marpat_wd_rifleman_m4","rhsusf_usmc_marpat_wd_autorifleman_m249","rhsusf_usmc_marpat_wd_rifleman_m4","rhsusf_usmc_marpat_d_explosives","rhsusf_navy_marpat_wd_medic"]
+	["rhsusf_usmc_marpat_wd_squadleader","rhsusf_usmc_marpat_wd_machinegunner","rhsusf_usmc_marpat_wd_riflemanat","rhsusf_usmc_marpat_wd_riflemanat","rhsusf_usmc_marpat_wd_grenadier","rhsusf_usmc_marpat_wd_javelin","rhsusf_usmc_marpat_wd_javelin_assistant","rhsusf_navy_marpat_wd_medic"],
+	["rhsusf_usmc_marpat_wd_squadleader","rhsusf_usmc_marpat_wd_machinegunner","rhsusf_usmc_marpat_wd_riflemanat","rhsusf_usmc_marpat_wd_grenadier","rhsusf_usmc_marpat_wd_grenadier","rhsusf_usmc_marpat_wd_stinger","rhsusf_usmc_marpat_wd_rifleman_light","rhsusf_navy_marpat_wd_medic"],
+	["rhsusf_usmc_marpat_wd_squadleader","rhsusf_usmc_marpat_wd_teamleader","rhsusf_usmc_marpat_wd_autorifleman_m249","rhsusf_usmc_marpat_wd_rifleman_m4","rhsusf_usmc_marpat_wd_autorifleman_m249","rhsusf_usmc_marpat_wd_rifleman_m4","rhsusf_usmc_marpat_wd_explosives","rhsusf_navy_marpat_wd_medic"]
 	];
 
 //Militia Groups
@@ -119,30 +119,30 @@ groupsNATOGen = [policeOfficer,policeGrunt];
 ////////////////////////////////////
 //Military Vehicles
 //Lite
-vehNATOBike = "B_T_Quadbike_01_F";
-vehNATOLightArmed = ["rhsusf_m1025_w_s_m2","rhsusf_CGRCAT1A2_M2_usmc_wd","rhsusf_CGRCAT1A2_Mk19_usmc_wd","rhsusf_M1117_W","rhsusf_M1220_M2_usarmy_wd","rhsusf_M1237_M2_usarmy_wd","rhsusf_M1238A1_M2_socom_d","rhsusf_m1045_w_s"];
-vehNATOLightUnarmed = ["rhsusf_m1025_w_s","rhsusf_m998_w_s_2dr","rhsusf_m998_w_s_2dr_fulltop","rhsusf_m998_w_s_4dr","rhsusf_CGRCAT1A2_usmc_wd","rhsusf_M1232_usarmy_wd"];
-vehNATOTrucks = ["rhsusf_M1078A1P2_wd_open_fmtv_usarmy","rhsusf_M1078A1P2_B_wd_fmtv_usarmy","rhsusf_M1078A1P2_B_wd_open_fmtv_usarmy","rhsusf_M1083A1P2_wd_fmtv_usarmy","rhsusf_M1083A1P2_B_M2_wd_fmtv_usarmy"];
+vehNATOBike = "B_Quadbike_01_F";
+vehNATOLightArmed = ["rhsusf_m1025_w_s_m2","rhsusf_CGRCAT1A2_M2_usmc_wd","rhsusf_CGRCAT1A2_Mk19_usmc_wd","rhsusf_M1117_W","rhsusf_M1220_M2_usarmy_wd","rhsusf_M1237_M2_usarmy_wd","rhsusf_m1045_w_s","rhsusf_m1240a1_usmc_wd"];
+vehNATOLightUnarmed = ["rhsusf_m1025_w_s","rhsusf_m998_w_s_2dr","rhsusf_m998_w_s_2dr_fulltop","rhsusf_m998_w_s_4dr","rhsusf_CGRCAT1A2_usmc_wd","rhsusf_M1232_usarmy_wd","rhsusf_m1240a1_m2_usmc_wd","rhsusf_m1240a1_mk19_usmc_wd","rhsusf_m1240a1_m240_usmc_wd"];
+vehNATOTrucks = ["rhsusf_M1078A1P2_WD_open_fmtv_usarmy","rhsusf_M1078A1P2_B_WD_fmtv_usarmy","rhsusf_M1078A1P2_B_WD_open_fmtv_usarmy","rhsusf_M1083A1P2_WD_fmtv_usarmy","rhsusf_M1083A1P2_B_M2_WD_fmtv_usarmy"];
 vehNATOCargoTrucks = [];
 vehNATOAmmoTruck = "rhsusf_M977A4_AMMO_BKIT_usarmy_wd";
 vehNATORepairTruck = "rhsusf_M977A4_REPAIR_BKIT_usarmy_wd";
 vehNATOLight = vehNATOLightArmed + vehNATOLightUnarmed;
 //Armored
-vehNATOAPC = ["rhsusf_stryker_m1126_m2_wd","RHS_M2A3_BUSKIII_wd","RHS_M2A3_BUSKI_wd","rhsusf_M1237_MK19_usarmy_wd","RHS_M2A2_BUSKI_WD","rhsusf_m113_usarmy","rhsusf_m113_usarmy_MK19","rhsusf_m113_usarmy"];
+vehNATOAPC = ["rhsusf_stryker_m1126_m2_wd","rhsusf_stryker_m1126_mk19_wd","rhsusf_stryker_m1127_m2_wd","rhsusf_stryker_m1132_m2_wd","rhsusf_stryker_m1134_wd","RHS_M2A3_BUSKIII_wd","RHS_M2A3_BUSKI_wd","rhsusf_M1237_MK19_usarmy_wd","RHS_M2A2_BUSKI_WD","rhsusf_m113_usarmy","rhsusf_m113_usarmy_M240","rhsusf_m113_usarmy_MK19"];
 vehNATOTank = "rhsusf_m1a1fep_wd";
-vehNATOAA = "RHS_M6";
+vehNATOAA = "RHS_M6_wd";
 vehNATOAttack = vehNATOAPC + [vehNATOTank];
 //Boats
 vehNATOBoat = "rhsusf_mkvsoc";
-vehNATORBoat = "B_T_Boat_Transport_01_F";
-vehNATOBoats = [vehNATOBoat,vehNATORBoat,"rhsusf_m113_usarmy_MK19","rhsusf_m113_usarmy"];
+vehNATORBoat = "rhsgref_hidf_rhib";
+vehNATOBoats = [vehNATOBoat,vehNATORBoat,"rhsusf_m113_usarmy","rhsusf_m113_usarmy_M240","rhsusf_m113_usarmy_MK19"];
 //Planes
 vehNATOPlane = "RHS_A10_AT";
 vehNATOPlaneAA = "rhsusf_f22";
 vehNATOTransportPlanes = ["RHS_C130J"];
 //Heli
 vehNATOPatrolHeli = "RHS_MELB_MH6M";
-vehNATOTransportHelis = ["RHS_UH60M_d","RHS_CH_47F","rhsusf_CH53E_USMC_GAU21",vehNATOPatrolHeli];
+vehNATOTransportHelis = ["RHS_UH60M","RHS_CH_47F","rhsusf_CH53E_USMC_GAU21",vehNATOPatrolHeli];
 vehNATOAttackHelis = ["RHS_MELB_AH6M_L","RHS_AH64D_wd","RHS_UH1Y","RHS_AH1Z_wd"];
 //UAV
 vehNATOUAV = "B_UAV_02_F";
@@ -158,12 +158,12 @@ vehNATOAir = vehNATOTransportHelis + vehNATOAttackHelis + [vehNATOPlane,vehNATOP
 if ((gameMode != 4) and (!hasFFAA)) then
 	{
 	vehFIAArmedCar = "rhsgref_hidf_m1025_m2";
-	vehFIATruck = "rhsgref_cdf_b_ural_open";
+	vehFIATruck = "rhsusf_M1078A1P2_WD_fmtv_usarmy";
 	vehFIACar = "rhsgref_hidf_m998_4dr";
 	};
 
 //Police Vehicles
-vehPoliceCar = "rhsusf_mrzr4_d";
+vehPoliceCar = "rhsusf_mrzr4_w_mud";
 
 ////////////////////////////////////
 //        STATIC WEAPONS         ///
@@ -171,7 +171,7 @@ vehPoliceCar = "rhsusf_mrzr4_d";
 //Assembled Statics
 NATOMG = "RHS_M2StaticMG_USMC_WD";
 staticATOccupants = "RHS_TOW_TriPod_USMC_WD";
-staticAAOccupants = "RHS_Stinger_AA_pod_D";
+staticAAOccupants = "RHS_Stinger_AA_pod_WD";
 NATOMortar = "RHS_M252_USMC_WD";
 
 //Static Weapon Bags


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [x] Enhancement

### What have you changed and why?
Information:
Since we had this mixed Mess of Template for Multiple versions and 2.2.2 being pretty close to be Done we could Finally have Full Camo Templates, thats why this PR exists.
**Arid Template:**
Call for Woodland Maps.
**PVP Vehicles**
Changed the MRZR4 to the Mud Variant
Added M124A1 with M240 (M-ATV/Hunter) ------> Less fire Power more Armor, similar to 3CB BAF Husky.
**Both Templates**
Changed Vehicles to be Tan/Woodland for their Specific Template.
**Infantry Units**
Changed SARC Medical to a Normal one since that Array is not part of any kind of Special Forces.
**vehNATOLightArmed**
Added M1240 as M240, Mk19 and M2 Variant.
**vehNATOLightUnarmed**
Added M1240 Unarmed Variant.
**vehNATOTrucks**
Matched Cases for all Classnames.
**vehNATOAPC**
Added Multiple new Stryker Variants: Recon, EOD and Mk19, TOW Launcher can't be in the APC array due to having 0 Passenger Seats.
Added M113 M240 Variant
**vehNATORBoat**
Changed the Vanilla Tropical Boat to a HIDF Rhib to get rid of a Vanilla unit that spawns.
**vehNATOBoats**
Added M113 M240 to the Array of Amphibious vehicles.
**vehFIATruck**
Changed the Ural to a US Truck since HIDF doesent use any Soviet Gear
### Please specify which Issue this PR Resolves.
closes #1136 
closes #1134  

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the Mission in Singleplayer?
2. [x] Have you loaded the Mission in a Dedicated Server? -------> Test server

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes: 99.99999999999% sure Helicopter Classnames match Cases too.
