### PR TITLE
Fixed edge case when vehicle array is empty

### DIFF
--- a/A3-Antistasi/functions/Base/fn_getVehiclePoolForAttacks.sqf
+++ b/A3-Antistasi/functions/Base/fn_getVehiclePoolForAttacks.sqf
@@ -14,7 +14,10 @@
 
 params ["_side", ["_filter", []]];
 
+private _fileName = "getVehiclePoolForAttacks";
 private _vehicleSelection = [];
+
+[3, format ["Now searching for attack vehicle pool for %1 with filter %2", _side, _filter], _fileName] call A3A_fnc_log;
 //In general is Invaders always a bit less chill than the occupants, they will use heavier vehicles more often and earlier
 switch (tierWar) do
 {
@@ -316,7 +319,7 @@ _fn_checkElementAgainstFilter =
             [
                 3,
                 format ["%1 didnt passed filter %2", _element, _x],
-                "getVehiclePoolForAttacks"
+                _fileName
             ] call A3A_fnc_log;
         };
     } forEach _filter;
@@ -329,7 +332,16 @@ private _vehiclePool = [];
 {
     if((_x select 0) isEqualType []) then
     {
-        private _points = (_x select 1)/(count (_x select 0));
+        private _points = 0;
+        private _vehicleCount = count (_x select 0);
+        if(_vehicleCount != 0) then
+        {
+            _points = (_x select 1)/(count (_x select 0));
+        }
+        else
+        {
+            [1, "Found vehicle array with no defined vehicles!", _fileName] call A3A_fnc_log;
+        };
         {
             if(([_x, _filter] call _fn_checkElementAgainstFilter) && {[_x] call A3A_fnc_vehAvailable}) then
             {
@@ -351,7 +363,7 @@ private _vehiclePool = [];
 [
     3,
     format ["For %1 and war level %2 selected units are %3, filter was %4", _side, tierWar, _vehiclePool, _filter],
-    "getVehiclePoolForAttacks"
+    _fileName
 ] call A3A_fnc_log;
 
 _vehiclePool;

--- a/A3-Antistasi/functions/Base/fn_getVehiclePoolForAttacks.sqf
+++ b/A3-Antistasi/functions/Base/fn_getVehiclePoolForAttacks.sqf
@@ -336,7 +336,7 @@ private _vehiclePool = [];
         private _vehicleCount = count (_x select 0);
         if(_vehicleCount != 0) then
         {
-            _points = (_x select 1)/(count (_x select 0));
+            _points = (_x select 1)/_vehicleCount;
         }
         else
         {

--- a/A3-Antistasi/functions/Base/fn_getVehiclePoolForQRFs.sqf
+++ b/A3-Antistasi/functions/Base/fn_getVehiclePoolForQRFs.sqf
@@ -14,7 +14,7 @@
 
 params ["_side", ["_filter", []]];
 
-private _fileName = "getVehiclePoolForQRFs"
+private _fileName = "getVehiclePoolForQRFs";
 private _vehicleSelection = [];
 
 [3, format ["Now searching for QRF vehicle pool for %1 with filter %2", _side, _filter], _fileName] call A3A_fnc_log;

--- a/A3-Antistasi/functions/Base/fn_getVehiclePoolForQRFs.sqf
+++ b/A3-Antistasi/functions/Base/fn_getVehiclePoolForQRFs.sqf
@@ -14,7 +14,10 @@
 
 params ["_side", ["_filter", []]];
 
+private _fileName = "getVehiclePoolForQRFs"
 private _vehicleSelection = [];
+
+[3, format ["Now searching for QRF vehicle pool for %1 with filter %2", _side, _filter], _fileName] call A3A_fnc_log;
 //In general is Invaders always a bit less chill than the occupants, they will use heavier vehicles more often and earlier
 switch (tierWar) do
 {
@@ -301,7 +304,7 @@ _fn_checkElementAgainstFilter =
             [
                 3,
                 format ["%1 didnt passed filter %2", _element, _x],
-                "getVehiclePoolForQRFs"
+                _fileName
             ] call A3A_fnc_log;
         };
     } forEach _filter;
@@ -314,7 +317,16 @@ private _vehiclePool = [];
 {
     if((_x select 0) isEqualType []) then
     {
-        private _points = (_x select 1)/(count (_x select 0));
+        private _points = 0;
+        private _vehicleCount = count (_x select 0);
+        if(_vehicleCount != 0) then
+        {
+            _points = (_x select 1)/(count (_x select 0));
+        }
+        else
+        {
+            [1, "Found vehicle array with no defined vehicles!", _fileName] call A3A_fnc_log;
+        };
         {
             if(([_x, _filter] call _fn_checkElementAgainstFilter) && {[_x] call A3A_fnc_vehAvailable}) then
             {
@@ -336,7 +348,7 @@ private _vehiclePool = [];
 [
     3,
     format ["For %1 and war level %2 selected units are %3, filter was %4", _side, tierWar, _vehiclePool, _filter],
-    "getVehiclePoolForQRFs"
+    _fileName
 ] call A3A_fnc_log;
 
 _vehiclePool;

--- a/A3-Antistasi/functions/Base/fn_getVehiclePoolForQRFs.sqf
+++ b/A3-Antistasi/functions/Base/fn_getVehiclePoolForQRFs.sqf
@@ -321,7 +321,7 @@ private _vehiclePool = [];
         private _vehicleCount = count (_x select 0);
         if(_vehicleCount != 0) then
         {
-            _points = (_x select 1)/(count (_x select 0));
+            _points = (_x select 1)/_vehicleCount;
         }
         else
         {


### PR DESCRIPTION
If thats not the case, something strange is happening and more information are needed to solve that

## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Information:
Fixed an edge case when a vehicle array is defined but empty for a modset, resulting in the vehicle pool selection code crashing. 

I added a check if the amount of vehicles is equal zero and if so, the code will log it. Added further logs to find out the array in question.

If that is not the reason for the issue, the new logs should improve debugging abilities.

### Please specify which Issue this PR Resolves.
closes #1126 (hopefully)

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes: 
