### PR TITLE
Fix arsenal item removal exploit

### DIFF
--- a/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal.sqf
@@ -2158,6 +2158,7 @@ switch _mode do {
 
 					//save mags in list and remove them
 					_mags = magazinesAmmoCargo _container;
+					if (_mags findIf {(_x select 0) isEqualTo _item} == -1) exitWith {};
 					clearMagazineCargo _container;
 
 					//add back magazines exept the one that needs to be removed


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
JNA assumes that removing and then adding identical magazines will cause loadBackpack to return the same value as before. Depending on the exact items in the backpack, this is not always true.

This causes an exploit where a player can indefinitely increase the number of magazines in the arsenal.
    
### Please specify which Issue this PR Resolves.
closes #1142

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
