### PR TITLE
Improve diveGear spawning.

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_itemSort.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_itemSort.sqf
@@ -1,8 +1,7 @@
-diveGear append ["V_RebreatherIA","G_Diving"];
 if (side (group petros) == west) then {
-	diveGear pushBack "U_B_Wetsuit"
+	diveGear append ["U_B_Wetsuit","V_RebreatherB","G_Diving"];
 } else {
-	diveGear pushBack "U_I_Wetsuit"
+	diveGear append ["U_I_Wetsuit","V_RebreatherIA","G_Diving"];
 };
 
 if (side (group petros) == west) then {

--- a/A3-Antistasi/functions/CREATE/fn_createAIOutposts.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAIOutposts.sqf
@@ -169,8 +169,8 @@ if ((_markerX in seaports) and !hasIFA) then
 			diag_log format ["createAIOutposts: Could not find seaSpawn marker on %1!", _markerX];
 		};
 	};
+	sleep 1;
 	{
-		  sleep 1;
 		 _ammoBox addItemCargoGlobal [_x, round random [2,6,8]];
 	} forEach diveGear;
 }

--- a/A3-Antistasi/functions/CREATE/fn_createAIOutposts.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAIOutposts.sqf
@@ -169,7 +169,7 @@ if ((_markerX in seaports) and !hasIFA) then
 			diag_log format ["createAIOutposts: Could not find seaSpawn marker on %1!", _markerX];
 		};
 	};
-	sleep 1;
+	sleep 1;    //make sure fillLootCrate finished clearing the crate
 	{
 		 _ammoBox addItemCargoGlobal [_x, round random [2,6,8]];
 	} forEach diveGear;

--- a/A3-Antistasi/functions/CREATE/fn_createAIOutposts.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAIOutposts.sqf
@@ -170,7 +170,8 @@ if ((_markerX in seaports) and !hasIFA) then
 		};
 	};
 	{
-		_ammoBox addItemCargoGlobal [_x,2]
+		  sleep 1;
+		 _ammoBox addItemCargoGlobal [_x, round random [2,6,8]];
 	} forEach diveGear;
 }
 else
@@ -328,13 +329,6 @@ for "_i" from 0 to (count _array - 1) do
 	};
 };//TODO need delete UPSMON link
 
-
-if (_markerX in seaports) then
-	{
-	_ammoBox addItemCargo ["V_RebreatherIA",round random 5];
-	_ammoBox addItemCargo ["G_I_Diving",round random 5];
-	};
-
 waitUntil {sleep 1; (spawner getVariable _markerX == 2)};
 
 [_markerX] call A3A_fnc_freeSpawnPositions;
@@ -352,4 +346,3 @@ deleteMarker _mrk;
 		else { if !(_x isKindOf "StaticWeapon") then { [_x] spawn A3A_fnc_VEHdespawner } };
 	};
 } forEach _vehiclesX;
-

--- a/A3-Antistasi/functions/CREATE/fn_createAISite.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAISite.sqf
@@ -84,11 +84,6 @@ if(_marker in airportsX || {_marker in seaports || {_marker in outposts}}) then
   };
   _box call jn_fnc_logistics_addAction;
 
-  if (_marker in seaports) then
-  {
-  	_box addItemCargo ["V_RebreatherIA", round (random 5)];
-  	_box addItemCargo ["G_I_Diving", round (random 5)];
-  };
 };
 
 [_marker, _patrolMarker, _flag, _box] call A3A_fnc_cycleSpawn;


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [x] Enhancement

### What have you changed and why?
Information:
**Removed**
Rebreathers and Diving Googles from **fn_createAIOutposts.sqf** line 331-337 and from
**fn_createAISite.sqf** line 87-91
**Added**
A Sleep to ensure that diveGear applies, it did improve spawning during my Tests.
**Added**
A bit of Randomisation lowest is 2 Middle is roughly 6 Max is 8.
Seaports are usually more Common than Airbases on some Maps and they tend to be captured multiple times so thats why i set the Amount is a bit lower than flyGear.

### Please specify which Issue this PR Resolves.
closes #1151 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes: If you have any Ideas how to do it better tell me :D