### PR TITLE
Improved the text for reinforcements convoys, so they are less confusing

### DIFF
--- a/A3-Antistasi/functions/Convoy/fn_createConvoy.sqf
+++ b/A3-Antistasi/functions/Convoy/fn_createConvoy.sqf
@@ -75,7 +75,7 @@ if(_type == "Mixed") then {_markerType = "_armor"};
 _convoyMarker = createMarker [format ["convoy%1", _convoyID], _origin];
 _convoyMarker setMarkerShapeLocal "ICON";
 _convoyMarker setMarkerType format ["%1%2", _markerPrefix, _markerType];
-_convoyMarker setMarkerText (format ["%1 %2 Convoy [%3]: Simulated", _type, _convoyType, _convoyID]);
+_convoyMarker setMarkerText (format ["[GPS-%3] %1 %2 Convoy", _convoySide, _convoyType, _convoyID]);
 _convoyMarker setMarkerAlpha 0;
 
 if(_convoySide == Occupants) then

--- a/A3-Antistasi/functions/Convoy/fn_createConvoy.sqf
+++ b/A3-Antistasi/functions/Convoy/fn_createConvoy.sqf
@@ -75,7 +75,7 @@ if(_type == "Mixed") then {_markerType = "_armor"};
 _convoyMarker = createMarker [format ["convoy%1", _convoyID], _origin];
 _convoyMarker setMarkerShapeLocal "ICON";
 _convoyMarker setMarkerType format ["%1%2", _markerPrefix, _markerType];
-_convoyMarker setMarkerText (format ["[GPS-%3] %1 %2 Convoy", _convoySide, _convoyType, _convoyID]);
+
 _convoyMarker setMarkerAlpha 0;
 
 if(_convoySide == Occupants) then
@@ -83,12 +83,14 @@ if(_convoySide == Occupants) then
     private _markerArray = server getVariable ["convoyMarker_Occupants", []];
     _markerArray pushBack _convoyMarker;
     server setVariable ["convoyMarker_Occupants", _markerArray, true];
+    _convoyMarker setMarkerText (format ["[GPS-%3] %1 %2 Convoy", nameOccupants, _convoyType, _convoyID]);
 }
 else
 {
     private _markerArray = server getVariable ["convoyMarker_Invaders", []];
     _markerArray pushBack _convoyMarker;
     server setVariable ["convoyMarker_Invaders", _markerArray, true];
+    _convoyMarker setMarkerText (format ["[GPS-%3] %1 %2 Convoy", nameInvaders, _convoyType, _convoyID]);
 };
 
 

--- a/A3-Antistasi/functions/Convoy/fn_spawnConvoy.sqf
+++ b/A3-Antistasi/functions/Convoy/fn_spawnConvoy.sqf
@@ -6,7 +6,6 @@ private ["_targetPos", "_dir", "_convoyMarker"];
 _targetPos = _route select (count _route - 1);
 
 _convoyMarker = format ["convoy%1", _convoyID];
-_convoyMarker setMarkerText (format ["%1 Convoy [%2]: Spawned", _convoyType, _convoyID]);
 
 if (!_isAir) then {
 	private _road = roadAt _pos;
@@ -41,14 +40,14 @@ private _landVehicles = [];
 for "_i" from 0 to ((count _units) - 1) do
 {
 	private _lineData = [_units select _i, _convoySide, _pos, _dir] call A3A_fnc_spawnConvoyLine;
-	
+
 	//Pushback the spawned objects
 	private _unitObjects = _lineData select 0;
 	_createdUnits pushBack _unitObjects;
-	
+
 	private _vehicle = _unitObjects select 0;
 	if (_vehicle != objNull) then {
-	
+
 		if(_vehicle isKindOf "Air") then
 		{
 			_airVehicles pushBack _vehicle;
@@ -66,7 +65,7 @@ for "_i" from 0 to ((count _units) - 1) do
 			private _fsm = [_vehicle, _route, _markers, _convoyType] execFSM "FSMs\ConvoyTravel.fsm";
 			_vehicle setVariable ["fsm", _fsm];
 		};
-				
+
 		// lastSpawn time check will try anyway if a vehicle gets stuck
 		private _lastSpawn = time;
 		waituntil {sleep 1; ((_vehicle distance2d _pos) > 15) or ((time - _lastSpawn) > 20)};
@@ -82,7 +81,7 @@ while {true} do
 {
 	sleep 2;
 	private _despawn = true;
-	
+
 	// Check whether each vehicle in the convoy (controlled by FSM) has completed its mission
 	// check last-to-first so that array deletion works correctly
 	for "_i" from ((count _createdUnits) - 1) to 0 step -1 do {
@@ -129,4 +128,3 @@ while {true} do
 		[_convoyID, _createdUnits, _convoyPos, _targetPos, _markerArray, _convoyType, _convoySide] call A3A_fnc_despawnConvoy;
 	};
 };
-


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Enhancement

### What have you changed and why?
Information: Changed the text shown for the reinforcements convoys once the GPS data is found as intel reward. It now shows like

[GPS-645] NATO reinforcement convoy

The number is the same as the one used in the logs and only for debug purposes (looks cool tho), the remaining information are for the players to know what they are fighting

### Please specify which Issue this PR Resolves.
closes #1064 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

********************************************************
Notes: Needs to be started once, working from my laptop
