### PR TITLE
Make AA vehicles breachable plus fixes

### DIFF
--- a/A3-Antistasi/functions/Base/fn_addActionBreachVehicle.sqf
+++ b/A3-Antistasi/functions/Base/fn_addActionBreachVehicle.sqf
@@ -1,8 +1,7 @@
 params ["_vehicle"];
 
-_isAPC = (typeOf _vehicle) in vehAPCs;
-_isTank = (typeOf _vehicle) in vehTanks;
+private _type = typeOf _vehicle;
 
-if (_isAPC || _isTank) exitWith {
+if (_type in vehAPCs || _type in vehTanks || _type in vehAA) exitWith {
 	[_vehicle, ["Breach Vehicle", A3A_fnc_startBreachVehicle,nil,4,false,true,"","(isPlayer _this) && (_this == vehicle _this)",5]] remoteExec ["addAction", 0, _vehicle];
 };

--- a/A3-Antistasi/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_AIVEHinit.sqf
@@ -35,7 +35,7 @@ if (_side == teamPlayer) then
 };
 
 private _typeX = typeOf _veh;
-if ((_typeX in vehNormal) or (_typeX in vehAttack) or (_typeX in vehBoats)) then
+if ((_typeX in vehNormal) or (_typeX in vehAttack) or (_typeX in vehBoats) or (_typeX in vehAA)) then
 {
 	_veh call A3A_fnc_addActionBreachVehicle;
 
@@ -67,7 +67,7 @@ if ((_typeX in vehNormal) or (_typeX in vehAttack) or (_typeX in vehBoats)) then
 			{
 				_veh addEventHandler ["HandleDamage",{private ["_veh"]; _veh = _this select 0; if (!canFire _veh) then {[_veh] call A3A_fnc_smokeCoverAuto;  _veh removeEventHandler ["HandleDamage",_thisEventHandler]}}];
 			}
-			else
+			else		// never called? vehAttack is APCs+tank
 			{
 				_veh addEventHandler ["HandleDamage",{if (((_this select 1) find "wheel" != -1) and ((_this select 4=="") or (side (_this select 3) != teamPlayer)) and (!isPlayer driver (_this select 0))) then {0} else {(_this select 2)}}];
 			};


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Enhancement

### What have you changed and why?
AA vehicles look a lot like APCs but weren't breachable. This was confusing and probably unintentional. This patch makes them breachable like APCs. Also fixed a couple of issues with the breach results:

- Aggro was being added twice, once for the breach and once for the capture.
- SurrenderAction on crew wasn't being called locally to the targets.

### Please specify which Issue this PR Resolves.
closes #1128 

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
