### PR TITLE
Fix incorrect uses of local-only inventory modification functions

### DIFF
--- a/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal.sqf
@@ -539,7 +539,7 @@ switch _mode do {
 					case 1: {vestContainer player;};
 					case 2: {backpackContainer player;};
 				};
-				clearMagazineCargo _container;
+				clearMagazineCargoGlobal _container;
 				{
 					_item = _x select 0;
 					_amount = _x select 1;
@@ -590,7 +590,7 @@ switch _mode do {
 		{
 			_container = _x;
 			{
-				_container addItemCargo [_x,1];
+				_container addItemCargoGlobal [_x,1];
 			} forEach ((missionNamespace getVariable "jna_containerCargo_init") select _foreachindex);
 		} forEach [uniformContainer player,vestContainer player,backpackContainer player];
 	};
@@ -1792,7 +1792,7 @@ switch _mode do {
 					//remove magazines
 					_oldMagazines = magazinesAmmoFull player;//["30Rnd_65x39_caseless_mag",30,false,-1,"Uniform"]
 					_loadout = getUnitLoadout player;
-					{player removeMagazine _x} forEach magazines player;
+					{player removeMagazineGlobal _x} forEach magazines player;
 
 
 					//remove weapon
@@ -1844,7 +1844,7 @@ switch _mode do {
 						}else{
 							if([_oldCompatableMagazines, _magazine] call _arrayContains)then{
 								if!([_newCompatableMagazines, _magazine] call _arrayContains)then{
-									player removemagazine _magazine;
+									player removeMagazineGlobal _magazine;
 								};
 							};
 						};
@@ -2159,7 +2159,7 @@ switch _mode do {
 					//save mags in list and remove them
 					_mags = magazinesAmmoCargo _container;
 					if (_mags findIf {(_x select 0) isEqualTo _item} == -1) exitWith {};
-					clearMagazineCargo _container;
+					clearMagazineCargoGlobal _container;
 
 					//add back magazines exept the one that needs to be removed
 					_removed = false;

--- a/A3-Antistasi/functions/Ammunition/fn_randomRifle.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_randomRifle.sqf
@@ -16,7 +16,7 @@ private _rifleFinal = selectRandom _pool;
 if !(primaryWeapon _unit isEqualTo "") then {
 	if (_rifleFinal == primaryWeapon _unit) exitWith {};
 	private _magazines = getArray (configFile / "CfgWeapons" / (primaryWeapon _unit) / "magazines");
-	{_unit removeMagazines _x} forEach _magazines;
+	{_unit removeMagazines _x} forEach _magazines;			// Broken, doesn't remove mags globally. Pain to fix.
 	_unit removeWeapon (primaryWeapon _unit);
 };
 

--- a/A3-Antistasi/functions/Base/fn_startBreachVehicle.sqf
+++ b/A3-Antistasi/functions/Base/fn_startBreachVehicle.sqf
@@ -171,7 +171,7 @@ if
 //Remove the correct amount of explosives
 for "_count" from 1 to _explosiveCount do
 {
-    _caller removeMagazine _explosive;
+    _caller removeMagazineGlobal _explosive;
 };
 
 //Added as the vehicle might blow up. Best not to blow up in the player's face.

--- a/A3-Antistasi/functions/CREATE/fn_NATOinit.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_NATOinit.sqf
@@ -87,7 +87,7 @@ if (faction _unit isEqualTo factionGEN) then
         private _rifleFinal = primaryWeapon _unit;
         private _magazines = getArray (configFile / "CfgWeapons" / _rifleFinal / "magazines");
         {
-            _unit removeMagazines _x;
+            _unit removeMagazines _x;			// Broken, doesn't remove mags globally. Pain to fix.
         } forEach _magazines;
         _unit removeWeaponGlobal (_rifleFinal);
         if (tierWar < 5) then


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Some functions (mostly in the arsenal code) were using local-only inventory modification functions, causing a class of exploits where the player's loadout as saved on the server could contain several times as many magazines as expected. This PR fixes most of them.

I marked a couple of minor cases rather than fixing them, as they have very limited effects due to AI-only use, and will be obsoleted by the template overhaul.

### Please specify which Issue this PR Resolves.
closes #1169 

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
