### PR TITLE
added block if units are already in a garrison

### DIFF
--- a/A3-Antistasi/REINF/addToGarrison.sqf
+++ b/A3-Antistasi/REINF/addToGarrison.sqf
@@ -39,6 +39,13 @@ else
 
 _leave = false;
 
+private _alreadyInGarrison = false;
+{
+	private _garrisondIn = _x getVariable "markerX";
+	if !(isNil "_garrisondIn") then {_alreadyInGarrison = true};
+} forEach _unitsX;
+if _alreadyInGarrison exitWith {["Garrison", "The units selected already are in a garrison"] call A3A_fnc_customHint};
+
 {
 if ((typeOf _x == staticCrewTeamPlayer) or (typeOf _x == SDKUnarmed) or (typeOf _x in arrayCivs) or (!alive _x)) exitWith {_leave = true}
 } forEach _unitsX;


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Enhancement

### What have you changed and why?
Information:
    added a block to prevent re adding units that are already assigned to a garrison

### Please specify which Issue this PR Resolves.
closes #1177

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the Mission in Singleplayer?
2. [ ] Have you loaded the Mission in a Dedicated Server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

********************************************************
Notes:
