### PR TITLE
Make airstrikes despawn correctly after reaching their final waypoint

### DIFF
--- a/A3-Antistasi/functions/AI/fn_airstrike.sqf
+++ b/A3-Antistasi/functions/AI/fn_airstrike.sqf
@@ -94,6 +94,8 @@ _plane = _planefn select 0;
 _planeCrew = _planefn select 1;
 _groupPlane = _planefn select 2;
 {_x setVariable ["spawner",true,true]} forEach _planeCrew;
+[_plane, _sideX] call A3A_fnc_AIVEHinit;
+
 _plane setPosATL [getPosATL _plane select 0, getPosATL _plane select 1, 1000];
 _plane setVelocityModelSpace (velocityModelSpace _plane vectorAdd [0, 150, 50]);
 _plane disableAI "TARGET";
@@ -118,17 +120,15 @@ _wp2 setWaypointType "MOVE";
 _wp3 = _groupPlane addWaypoint [_finpos, 2];
 _wp3 setWaypointType "MOVE";
 _wp3 setWaypointSpeed "FULL";
-_wp3 setWaypointStatements ["true", "{deleteVehicle _x} forEach crew this; deleteVehicle this"];
 
-waitUntil {sleep 2; (currentWaypoint _groupPlane == 4) or (!alive _plane)};
+_timeOut = time + 300;
+waitUntil { sleep 2; (currentWaypoint _groupPlane == 4) or (time > _timeOut) };
 
-if (alive _plane) then
-	{
-	deleteVehicle _plane;
-	}
-else
-	{
-	[_plane] spawn A3A_fnc_postMortem;
-	};
-{deleteVehicle _x} forEach _planeCrew;
-deleteGroup _groupPlane;
+if (time >_timeOut) then {
+    [_groupPlane] spawn A3A_fnc_groupDespawner;
+    [_plane] spawn A3A_fnc_vehDespawner;
+} else {
+    { deleteVehicle _x } forEach _planeCrew;
+    deleteGroup _groupPlane;
+    deleteVehicle _plane;
+};


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Enhancement

### What have you changed and why?
Rewritten the airstrike despawn code, because it was completely broken. The waypoint statements were deleting the pilot but not the aircraft, which caused the current waypoint to stick at 3 and so the rest of the termination code was never executed if the plane survived the impact with the ground.

Also added the airstrike aircraft to AIVEHInit, to make it worth shooting them down. Previously it had no effect on the vehicle pool or aggro.

### Please specify which Issue this PR Resolves.
closes #1181

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
