### PR TITLE
added a block for JoinGroup and leavGroup ace interaction menu actions

### DIFF
--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -9,6 +9,7 @@ class A3A
 		//Other initialisation functions (generally called by the above)
 		class cityinfo {};
 		class credits {};
+		class initAceTeamManagement {};
 		class initACEUnconsciousHandler {};
 		class initFuncs {};
 		class initGarrisons {};

--- a/A3-Antistasi/functions/CREATE/fn_FIAinitBASES.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_FIAinitBASES.sqf
@@ -24,6 +24,7 @@ if (count _this > 1) then
 		};
 	};
 [_unit] call A3A_fnc_initRevive;
+_unit call A3A_fnc_initAceTeamManagement;
 
 _unit allowFleeing 0;
 _typeX = typeOf _unit;

--- a/A3-Antistasi/functions/CREATE/fn_createUnit.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createUnit.sqf
@@ -35,5 +35,6 @@ private _unit = _group createUnit  [_type, _position, _markers, _placement, _spe
 if !(_unitLoadout isEqualTo []) then {
 	_unit setUnitLoadout _unitLoadout;
 };
+_unit call A3A_fnc_initAceTeamManagement;
 
 _unit

--- a/A3-Antistasi/functions/REINF/fn_FIAinit.sqf
+++ b/A3-Antistasi/functions/REINF/fn_FIAinit.sqf
@@ -3,6 +3,7 @@ private ["_victim","_killer"];
 private _unit = _this select 0;
 
 [_unit] call A3A_fnc_initRevive;
+_unit call A3A_fnc_initAceTeamManagement;
 _unit setVariable ["spawner",true,true];
 
 _unit allowFleeing 0;

--- a/A3-Antistasi/functions/init/fn_initAceTeamManagement.sqf
+++ b/A3-Antistasi/functions/init/fn_initAceTeamManagement.sqf
@@ -1,0 +1,8 @@
+//needs to be run on units when theyre created to disable joinGroup and leaveGroup
+params ["_unit"];
+if !(hasAce) exitWith {};
+private _fileName = "initAceTeamManagement";
+
+[typeOf _unit, 0,["ACE_MainActions", "ACE_JoinGroup"]] call ace_interact_menu_fnc_removeActionFromClass;
+[typeOf _unit, 1,["ACE_SelfActions", "ACE_TeamManagement", "ACE_LeaveGroup"]] call ace_interact_menu_fnc_removeActionFromClass;
+

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -107,6 +107,7 @@ if (isMultiplayer && {playerMarkersEnabled}) then {
 };
 
 [player] spawn A3A_fnc_initRevive;		// with ACE medical, only used for helmet popping & TK checks
+player call A3A_fnc_initAceTeamManagement;
 
 if (!hasACE) then {
 	[] spawn A3A_fnc_tags;

--- a/A3-Antistasi/onPlayerRespawn.sqf
+++ b/A3-Antistasi/onPlayerRespawn.sqf
@@ -23,6 +23,7 @@ _nul = [_oldUnit] spawn A3A_fnc_postmortem;
 
 _oldUnit setVariable ["incapacitated",false,true];
 _newUnit setVariable ["incapacitated",false,true];
+_newUnit call A3A_fnc_initAceTeamManagement;
 
 if (side group player == teamPlayer) then
 	{


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    added a block for ace interaction menu actions: JoinGroup, LeaveGroup
this is done to prevent exploitation that can occur when using these

### Please specify which Issue this PR Resolves.
closes #1064 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in singleplayer?
2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: spawn in to new save, spawn units, try to leave group with ace interaction menu, leave with dynamic group manager, try to join group with ace interaction menu. you should still be able to step up as leader

********************************************************
Notes:
