### PR TITLE
Split patrolCA into decision & execution functions

### DIFF
--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -207,6 +207,7 @@ class A3A
 		class createAISite {};
 		class createCIV {};
 		class createFIAOutposts2 {};
+		class createQRF {};
 		class createSDKGarrisons {};
 		class createSDKgarrisonsTemp {};
 		class createUnit {};
@@ -230,6 +231,7 @@ class A3A
 		class removeVehFromPool {};
 		class safeVehicleSpawn {};
 		class spawnGroup {};
+		class updateCAMark {};
 		class vehAvailable {};
 		class VEHdespawner {};
 		class vehKilledOrCaptured {};

--- a/A3-Antistasi/functions/AI/fn_AIreactOnKill.sqf
+++ b/A3-Antistasi/functions/AI/fn_AIreactOnKill.sqf
@@ -26,11 +26,14 @@ if (fleeing _x) then
 						};
 					if (vehicle _killer == _killer) then
 						{
-						[[getPosASL _enemy,side _x,"Normal",_super],"A3A_fnc_patrolCA"] remoteExec ["A3A_fnc_scheduler",2]
+						[getPosASL _enemy,side _x,"Normal",_super] remoteExec ["A3A_fnc_patrolCA", 2];
 						}
 					else
 						{
-						if (vehicle _killer isKindOf "Air") then {[[getPosASL _enemy,side _x,"Air",_super],"A3A_fnc_patrolCA"] remoteExec ["A3A_fnc_scheduler",2]} else {if (vehicle _killer isKindOf "Tank") then {[[getPosASL _enemy,side _x,"Tank",_super],"A3A_fnc_patrolCA"] remoteExec ["A3A_fnc_scheduler",2]} else {[[getPosASL _enemy,side _x,"Normal",_super],"A3A_fnc_patrolCA"] remoteExec ["A3A_fnc_scheduler",2]}};
+						private _attackType = "Normal";
+						if (vehicle _killer isKindOf "Air") then {_attackType = "Air"};
+						if (vehicle _killer isKindof "Tank") then {_attackType = "Tank"};
+						[getPosASL _enemy,side _x,_attackType,_super] remoteExec ["A3A_fnc_patrolCA", 2];
 						};
 					};
 				if (([primaryWeapon _x] call BIS_fnc_baseWeapon) in allMachineGuns) then {[_x,_enemy] call A3A_fnc_suppressingFire} else {[_x,_x,_enemy] spawn A3A_fnc_chargeWithSmoke};

--- a/A3-Antistasi/functions/AI/fn_attackDrillAI.sqf
+++ b/A3-Antistasi/functions/AI/fn_attackDrillAI.sqf
@@ -140,7 +140,7 @@ while {true} do
 				{
 				if (_allNearFriends findIf {(_x call A3A_fnc_typeOfSoldier == "AAMan") or (_x call A3A_fnc_typeOfSoldier == "StaticGunner")} == -1) then
 					{
-					if (_sideX != teamPlayer) then {[[getPosASL _LeaderX,_sideX,"Air",false],"A3A_fnc_patrolCA"] remoteExec ["A3A_fnc_scheduler",2]};
+					if (_sideX != teamPlayer) then {[getPosASL _LeaderX,_sideX,"Air",false] remoteExec ["A3A_fnc_patrolCA",2]};
 					};
 				//_nuevataskX = ["Hide",_soldiers - (_soldiers select {(_x call A3A_fnc_typeOfSoldier == "AAMan") or (_x getVariable ["typeOfSoldier",""] == "StaticGunner")})];
 				_groupX setVariable ["taskX","Hide"];
@@ -157,7 +157,7 @@ while {true} do
 						}
 					else
 						{
-						if (_sideX != teamPlayer) then {[[getPosASL _LeaderX,_sideX,"Tank",false],"A3A_fnc_patrolCA"] remoteExec ["A3A_fnc_scheduler",2]};
+						if (_sideX != teamPlayer) then {[getPosASL _LeaderX,_sideX,"Tank",false] remoteExec ["A3A_fnc_patrolCA",2]};
 						};
 					};
 				//_nuevataskX = ["Hide",_soldiers - (_soldiers select {(_x getVariable ["typeOfSoldier",""] == "ATMan")})];
@@ -168,7 +168,7 @@ while {true} do
 				{
 				if !(isNull _nearX) then
 					{
-					if (_sideX != teamPlayer) then {[[getPosASL _LeaderX,_sideX,"Normal",false],"A3A_fnc_patrolCA"] remoteExec ["A3A_fnc_scheduler",2]};
+					if (_sideX != teamPlayer) then {[getPosASL _LeaderX,_sideX,"Normal",false] remoteExec ["A3A_fnc_patrolCA",2]};
 					_mortarX = _groupX getVariable ["mortarsX",objNull];
 					if (!(isNull _mortarX) and ([_mortarX] call A3A_fnc_canFight)) then
 						{

--- a/A3-Antistasi/functions/Base/fn_markerChange.sqf
+++ b/A3-Antistasi/functions/Base/fn_markerChange.sqf
@@ -64,9 +64,10 @@ garrison setVariable [format ["%1_requested", _markerX], [], true];
 if (_winner == teamPlayer) then
 {
 	_super = if (_markerX in airportsX) then {true} else {false};
-	[[_markerX,_looser,"",_super],"A3A_fnc_patrolCA"] call A3A_fnc_scheduler;
+	[_markerX,_looser,"",_super] spawn A3A_fnc_patrolCA;
 	//sleep 15;
-	[[_markerX],"A3A_fnc_autoGarrison"] call A3A_fnc_scheduler;
+	// Removed for the moment, old broken stuff
+//	[[_markerX],"A3A_fnc_autoGarrison"] call A3A_fnc_scheduler;
 }
 else
 {

--- a/A3-Antistasi/functions/CREATE/fn_cargoSeats.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_cargoSeats.sqf
@@ -33,7 +33,7 @@ else
 			case Occupants:
 				{
 				_return = selectRandom groupsNATOSquad;
-				if (_cargoSeats > 8) then
+/*				if (_cargoSeats > 8) then
 					{
 					_countX = _cargoSeats - (count _return);
 					for "_i" from 1 to _countX do
@@ -41,11 +41,11 @@ else
 						if (random 10 < (tierWar + difficultyCoef)) then {_return pushBack NATOGrunt};
 						};
 					};
-				};
+*/				};
 			case Invaders:
 				{
 				_return = selectRandom groupsCSATSquad;
-				if (_cargoSeats > 8) then
+/*				if (_cargoSeats > 8) then
 					{
 					_countX = _cargoSeats - (count _return);
 					for "_i" from 1 to _countX do
@@ -53,7 +53,7 @@ else
 						if (random 10 < (tierWar + difficultyCoef)) then {_return pushBack CSATGrunt};
 						};
 					};
-				};
+*/				};
 			};
 		};
 	};

--- a/A3-Antistasi/functions/CREATE/fn_createQRF.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createQRF.sqf
@@ -1,0 +1,467 @@
+private _filename = "fn_createQRF";
+//if (!isServer and hasInterface) exitWith {};
+
+// target can be either position or marker. Source is always outpost or airport marker
+params ["_target", "_source", "_sideX", "_vehicleCount", "_landAttack", "_typeOfAttack"];
+
+[2, format ["Spawning CA. Target:%1, Source:%2, Side:%3, Count:%4, Land:%5, Type:%6", _target, _source, _sideX, _vehicleCount, _landAttack, _typeOfAttack], _filename] call A3A_fnc_log;
+
+private _fnc_remUnitCount = {
+	private _unitCount = {(local _x) and (alive _x)} count allUnits;
+	private _remUnitCount = maxUnits - _unitCount;
+	if (gameMode <3) then
+	{
+		private _sideCount = {(local _x) and (alive _x) and (side group _x == _sideX)} count allUnits;
+		_remUnitCount = _remUnitCount min (maxUnits * 0.7 - _sideCount);
+	};
+	_remUnitCount;
+};
+
+private _isMarker = false;
+private _posOrigin = getMarkerPos _source;
+private _posDest = _target;
+private _isRebelMarker = false;
+
+if (_target isEqualType "") then
+{
+	_isMarker = true;
+	_posDest = getMarkerPos _target;
+	if (sidesX getVariable [_target,sideUnknown] == teamPlayer) then { _isRebelMarker = true };
+};
+
+
+private _soldiers = [];
+private _vehiclesX = [];
+private _groups = [];
+private _roads = [];
+
+if (_landAttack) then
+{
+	private _pos = [];
+	private _dir = 0;
+	if (_source in airportsX) then
+	{
+		[_source,30] call A3A_fnc_addTimeForIdle;
+		private _spawnPoint = server getVariable (format ["spawn_%1", _source]);
+		_pos = getMarkerPos _spawnPoint;
+		_dir = markerDir _spawnPoint;
+	}
+	else
+	{
+		[_source,60] call A3A_fnc_addTimeForIdle;
+		private _spawnPoint = [_posOrigin] call A3A_fnc_findNearestGoodRoad;
+		_pos = position _spawnPoint;
+		_dir = getDir _spawnPoint;
+	};
+
+	private _vehPool = [_sideX, ["Air"]] call A3A_fnc_getVehiclePoolForQRFs;
+    if(count _vehPool == 0) then
+    {
+        if(_sideX == Occupants) then
+        {
+            {
+                _vehPool pushBack _x;
+                _vehPool pushBack 5;
+            } forEach (vehNATOTrucks + vehNATOLightArmed);
+        }
+        else
+        {
+            {
+                _vehPool pushBack _x;
+                _vehPool pushBack 5;
+            } forEach (vehCSATTrucks + vehCSATLightArmed);
+        };
+    };
+	if (_typeOfAttack == "Air") then {
+		private _aaType = if (_sideX == Occupants) then {vehNATOAA} else {vehCSATAA};
+		if ([_aaType] call A3A_fnc_vehAvailable) then { _vehPool append [_aaType, 30] };
+	};
+	if (_typeOfAttack == "Tank") then {
+		private _tankType = if (_sideX == Occupants) then {vehNATOTank} else {vehCSATTank};
+		if ([_tankType] call A3A_fnc_vehAvailable) then { _vehPool append [_tankType, 30] };
+	};
+
+	_road = [_posDest] call A3A_fnc_findNearestGoodRoad;
+	_landPosBlacklist = [];
+
+	for "_i" from 1 to _vehicleCount do
+	{
+		_typeVehX = selectRandomWeighted _vehPool;
+		_timeOut = 0;
+		_pos = _pos findEmptyPosition [0,100,_typeVehX];
+		while {_timeOut < 60} do
+		{
+			if (count _pos > 0) exitWith {};
+			_timeOut = _timeOut + 1;
+			_pos = _pos findEmptyPosition [0,100,_typeVehX];
+			sleep 1;
+		};
+		if (count _pos == 0) then {_pos = if (_indexX == -1) then {getMarkerPos _spawnPoint} else {position _spawnPoint}};
+		_vehicle=[_pos, _dir,_typeVehX, _sideX] call bis_fnc_spawnvehicle;
+
+		_veh = _vehicle select 0;
+		_vehCrew = _vehicle select 1;
+		{[_x] call A3A_fnc_NATOinit} forEach _vehCrew;
+		[_veh, _sideX] call A3A_fnc_AIVEHinit;
+		_groupVeh = _vehicle select 2;
+		_soldiers = _soldiers + _vehCrew;
+		_groups pushBack _groupVeh;
+		_vehiclesX pushBack _veh;
+		_landPos = [_posDest,_pos,false,_landPosBlacklist] call A3A_fnc_findSafeRoadToUnload;
+		if ((not(_typeVehX in vehTanks)) and (not(_typeVehX in vehAA))) then
+		{
+			_landPosBlacklist pushBack _landPos;
+			_typeGroup = if (_typeOfAttack == "Normal") then
+			{
+				[_typeVehX,_sideX] call A3A_fnc_cargoSeats;
+			}
+			else
+			{
+				if (_typeOfAttack == "Air") then
+				{
+					if (_sideX == Occupants) then {groupsNATOAA} else {groupsCSATAA}
+				}
+				else
+				{
+					if (_sideX == Occupants) then {groupsNATOAT} else {groupsCSATAT}
+				};
+			};
+			_groupX = [_posOrigin,_sideX,_typeGroup] call A3A_fnc_spawnGroup;
+			{
+                _x assignAsCargo _veh;
+                _x moveInCargo _veh;
+                if (vehicle _x == _veh) then
+                {
+                    _soldiers pushBack _x;
+                    [_x] call A3A_fnc_NATOinit;
+                    _x setVariable ["originX",_source];
+                }
+                else
+                {
+                    deleteVehicle _x;
+                };
+            } forEach units _groupX;
+			if (not(_typeVehX in vehTrucks)) then
+			{
+				{_x disableAI "MINEDETECTION"} forEach (units _groupVeh);
+				(units _groupX) joinSilent _groupVeh;
+				deleteGroup _groupX;
+				_groupVeh spawn A3A_fnc_attackDrillAI;
+				//_groups pushBack _groupX;
+				[_source,_landPos,_groupVeh] call A3A_fnc_WPCreate;
+				_Vwp0 = (wayPoints _groupVeh) select 0;
+				_Vwp0 setWaypointBehaviour "SAFE";
+				_Vwp0 = _groupVeh addWaypoint [_landPos,count (wayPoints _groupVeh)];
+				_Vwp0 setWaypointType "TR UNLOAD";
+				//_Vwp0 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI"];
+				//_Vwp0 setWaypointStatements ["true", "[vehicle this] call A3A_fnc_smokeCoverAuto"];
+				_Vwp1 = _groupVeh addWaypoint [_posDest, count (wayPoints _groupVeh)];
+				_Vwp1 setWaypointType "SAD";
+				_Vwp1 setWaypointStatements ["true","{if (side _x != side this) then {this reveal [_x,4]}} forEach allUnits"];
+				_Vwp1 setWaypointBehaviour "COMBAT";
+				[_veh,"APC"] spawn A3A_fnc_inmuneConvoy;
+				_veh allowCrewInImmobile true;
+			}
+			else
+			{
+				(units _groupX) joinSilent _groupVeh;
+				deleteGroup _groupX;
+				_groupVeh spawn A3A_fnc_attackDrillAI;
+				if (count units _groupVeh > 1) then {_groupVeh selectLeader (units _groupVeh select 1)};
+				[_source,_landPos,_groupVeh] call A3A_fnc_WPCreate;
+				_Vwp0 = (wayPoints _groupVeh) select 0;
+				_Vwp0 setWaypointBehaviour "SAFE";
+				/*
+				_Vwp0 = (wayPoints _groupVeh) select ((count wayPoints _groupVeh) - 1);
+				_Vwp0 setWaypointType "GETOUT";
+				*/
+				_Vwp0 = _groupVeh addWaypoint [_landPos, count (wayPoints _groupVeh)];
+				_Vwp0 setWaypointType "GETOUT";
+				//_Vwp0 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI"];
+				_Vwp1 = _groupVeh addWaypoint [_posDest, count (wayPoints _groupVeh)];
+				_Vwp1 setWaypointStatements ["true","{if (side _x != side this) then {this reveal [_x,4]}} forEach allUnits"];
+				if (_isMarker) then
+				{
+					if ((count (garrison getVariable [_target, []])) < 4) then
+					{
+						_Vwp1 setWaypointType "MOVE";
+						_Vwp1 setWaypointBehaviour "AWARE";
+					}
+					else
+					{
+						_Vwp1 setWaypointType "SAD";
+						_Vwp1 setWaypointBehaviour "COMBAT";
+					};
+				}
+				else
+				{
+					_Vwp1 setWaypointType "SAD";
+					_Vwp1 setWaypointBehaviour "COMBAT";
+				};
+				[_veh,"Inf Truck."] spawn A3A_fnc_inmuneConvoy;
+			};
+		}
+		else
+		{
+			{_x disableAI "MINEDETECTION"} forEach (units _groupVeh);
+			[_source,_posDest,_groupVeh] call A3A_fnc_WPCreate;
+			_Vwp0 = (wayPoints _groupVeh) select 0;
+			_Vwp0 setWaypointBehaviour "SAFE";
+			_Vwp0 = _groupVeh addWaypoint [_posDest, count (waypoints _groupVeh)];
+			[_veh,"Tank"] spawn A3A_fnc_inmuneConvoy;
+			_Vwp0 setWaypointType "SAD";
+			_Vwp0 setWaypointBehaviour "AWARE";
+			_Vwp0 setWaypointStatements ["true","{if (side _x != side this) then {this reveal [_x,4]}} forEach allUnits"];
+			_veh allowCrewInImmobile true;
+		};
+		[3, format ["QRF vehicle %1 sent with %2 soldiers", typeof _veh, count crew _veh], _filename] call A3A_fnc_log;
+
+		if (call _fnc_remUnitCount < 5) exitWith {
+			[3, "QRF reached maximum unit limit", _filename] call A3A_fnc_log;
+		};
+	};
+	[2, format ["Land QRF performed on %1, type %2, veh count %3, troop count %4", _target,_typeOfAttack,count _vehiclesX,count _soldiers], _filename] call A3A_fnc_log;
+}
+else
+{
+	[_source,20] call A3A_fnc_addTimeForIdle;
+	private _vehPool = [_sideX, ["LandVehicle"]] call A3A_fnc_getVehiclePoolForQRFs;
+    if(count _vehPool == 0) then
+    {
+        if(_sideX == Occupants) then
+        {
+            {
+                _vehPool pushBack _x;
+                _vehPool pushBack 10;
+            } forEach vehNATOTransportHelis + [vehNATOPatrolHeli];
+        }
+        else
+        {
+            {
+                _vehPool pushBack _x;
+                _vehPool pushBack 10;
+            } forEach vehCSATTransportHelis + [vehCSATPatrolHeli];
+        };
+    };
+	if (_typeOfAttack == "Air") then {
+		private _vehType = if (_sideX == Occupants) then {vehNATOPlaneAA} else {vehCSATPlaneAA};
+		if ([_vehType] call A3A_fnc_vehAvailable) then { _vehPool append [_vehType, 30] };
+	};
+	if (_typeOfAttack == "Tank") then {
+		private _vehType = if (_sideX == Occupants) then {vehNATOPlane} else {vehCSATPlane};
+		if ([_vehType] call A3A_fnc_vehAvailable) then { _vehPool append [_vehType, 30] };
+	};
+
+	for "_i" from 1 to _vehicleCount do
+	{
+		private _typeVehX = selectRandomWeighted _vehPool;
+		_pos = _posOrigin;
+		_ang = 0;
+		_size = [_source] call A3A_fnc_sizeMarker;
+		_buildings = nearestObjects [_posOrigin, ["Land_LandMark_F","Land_runway_edgelight"], _size / 2];
+		if (count _buildings > 1) then
+		{
+			_pos1 = getPos (_buildings select 0);
+			_pos2 = getPos (_buildings select 1);
+			_ang = [_pos1, _pos2] call BIS_fnc_DirTo;
+			_pos = [_pos1, 5,_ang] call BIS_fnc_relPos;
+		};
+		if (count _pos == 0) then {_pos = _posOrigin};
+		_vehicle=[_pos, _ang + 90,_typeVehX, _sideX] call bis_fnc_spawnvehicle;
+		_veh = _vehicle select 0;
+		if (hasIFA) then {_veh setVelocityModelSpace [((velocityModelSpace _veh) select 0) + 0,((velocityModelSpace _veh) select 1) + 150,((velocityModelSpace _veh) select 2) + 50]};
+		_vehCrew = _vehicle select 1;
+		_groupVeh = _vehicle select 2;
+		_soldiers append _vehCrew;
+		_groups pushBack _groupVeh;
+		_vehiclesX pushBack _veh;
+		{[_x] call A3A_fnc_NATOinit} forEach units _groupVeh;
+		[_veh, _sideX] call A3A_fnc_AIVEHinit;
+		if (not (_typeVehX in vehTransportAir)) then
+		{
+			_Hwp0 = _groupVeh addWaypoint [_posDest, 0];
+			_Hwp0 setWaypointBehaviour "AWARE";
+			_Hwp0 setWaypointType "SAD";
+			//[_veh,"Air Attack"] spawn A3A_fnc_inmuneConvoy;
+		}
+		else
+		{
+			_typeGroup = if (_typeOfAttack == "Normal") then
+			{
+				[_typeVehX,_sideX] call A3A_fnc_cargoSeats;
+			}
+			else
+			{
+				if (_typeOfAttack == "Air") then
+				{
+					if (_sideX == Occupants) then {groupsNATOAA} else {groupsCSATAA}
+				}
+				else
+				{
+					if (_sideX == Occupants) then {groupsNATOAT} else {groupsCSATAT}
+				};
+			};
+			_groupX = [_posOrigin,_sideX,_typeGroup] call A3A_fnc_spawnGroup;
+			//{_x assignAsCargo _veh;_x moveInCargo _veh; [_x] call A3A_fnc_NATOinit;_soldiers pushBack _x;_x setVariable ["originX",_source]} forEach units _groupX;
+			{
+                _x assignAsCargo _veh;
+                _x moveInCargo _veh;
+                if (vehicle _x == _veh) then
+                {
+                    _soldiers pushBack _x;
+                    [_x] call A3A_fnc_NATOinit;
+                    _x setVariable ["originX",_source];
+                }
+                else
+                {
+                    deleteVehicle _x;
+                };
+			} forEach units _groupX;
+			_groups pushBack _groupX;
+			_landpos = [];
+			_proceed = true;
+			if (_isMarker) then
+			{
+				if ((_target in airportsX) or !(_veh isKindOf "Helicopter")) then
+				{
+					_proceed = false;
+					[_veh,_groupX,_target,_source] spawn A3A_fnc_airdrop;
+				}
+				else
+				{
+					if (_isRebelMarker) then
+					{
+						if (((count(garrison getVariable [_target,[]])) < 10) and (_typeVehX in vehFastRope)) then
+						{
+							_proceed = false;
+                            //_groupX setVariable ["mrkAttack",_target];
+							[_veh,_groupX,_posDest,_posOrigin,_groupVeh] spawn A3A_fnc_fastrope;
+						};
+					};
+				};
+			}
+			else
+			{
+				if !(_veh isKindOf "Helicopter") then
+				{
+					_proceed = false;
+					[_veh,_groupX,_posDest,_source] spawn A3A_fnc_airdrop;
+				};
+			};
+			if (_proceed) then
+			{
+				_landPos = [_posDest, 300, 550, 10, 0, 0.20, 0,[],[[0,0,0],[0,0,0]]] call BIS_fnc_findSafePos;
+				if !(_landPos isEqualTo [0,0,0]) then
+				{
+					_landPos set [2, 0];
+					_pad = createVehicle ["Land_HelipadEmpty_F", _landpos, [], 0, "NONE"];
+					_vehiclesX pushBack _pad;
+					_wp0 = _groupVeh addWaypoint [_landpos, 0];
+					_wp0 setWaypointType "TR UNLOAD";
+					_wp0 setWaypointStatements ["true", "(vehicle this) land 'GET OUT';[vehicle this] call A3A_fnc_smokeCoverAuto"];
+					_wp0 setWaypointBehaviour "CARELESS";
+					_wp3 = _groupX addWaypoint [_landpos, 0];
+					_wp3 setWaypointType "GETOUT";
+					_wp3 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI"];
+					_wp0 synchronizeWaypoint [_wp3];
+					_wp4 = _groupX addWaypoint [_posDest, 1];
+					_wp4 setWaypointType "MOVE";
+					_wp4 setWaypointStatements ["true","{if (side _x != side this) then {this reveal [_x,4]}} forEach allUnits"];
+					_wp2 = _groupVeh addWaypoint [_posOrigin, 1];
+					_wp2 setWaypointType "MOVE";
+					_wp2 setWaypointStatements ["true", "deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
+					[_groupVeh,1] setWaypointBehaviour "AWARE";
+				}
+				else
+				{
+					if (_typeVehX in vehFastRope) then
+					{
+						[_veh,_groupX,_posDest,_posOrigin,_groupVeh] spawn A3A_fnc_fastrope;
+					}
+					else
+					{
+						[_veh,_groupX,_target,_source] spawn A3A_fnc_airdrop;
+					};
+				};
+			};
+		};
+		sleep 30;
+		[3, format ["QRF vehicle %1 sent with %2 soldiers", typeof _veh, count crew _veh], _filename] call A3A_fnc_log;
+
+		if (call _fnc_remUnitCount < 5) exitWith {
+			[3, "QRF reached maximum unit limit", _filename] call A3A_fnc_log;
+		};
+	};
+	[2, format ["Air QRF performed on %1, type %2, veh count %3, troop count %4", _target,_typeOfAttack,count _vehiclesX,count _soldiers], _filename] call A3A_fnc_log;
+};
+
+private _fnc_lowStrength = {
+	({[_x] call A3A_fnc_canFight} count _soldiers) <= 0.25 * (count _soldiers);
+};
+
+if (_isMarker) then
+{
+	_timeX = time + 3600;
+	_size = [_target] call A3A_fnc_sizeMarker;
+
+	waitUntil {sleep 5; (call _fnc_lowStrength) or (time > _timeX) or (sidesX getVariable [_target,sideUnknown] == _sideX) or (({[_x,_target] call A3A_fnc_canConquer} count _soldiers) > 3*({(side _x != _sideX) and (side _x != civilian) and ([_x,_target] call A3A_fnc_canConquer)} count allUnits))};
+	if  ((({[_x,_target] call A3A_fnc_canConquer} count _soldiers) > 3*({(side _x != _sideX) and (side _x != civilian) and ([_x,_target] call A3A_fnc_canConquer)} count allUnits)) and (not(sidesX getVariable [_target,sideUnknown] == _sideX))) then
+	{
+		[_sideX,_target] remoteExec ["A3A_fnc_markerChange",2];
+		[3, format ["QRF from %1 to retake %2 has outnumbered the enemy, changing marker!", _source, _target], _filename] call A3A_fnc_log;
+	};
+	sleep 10;
+	if (!(sidesX getVariable [_target,sideUnknown] == _sideX)) then
+	{
+		{_x doMove _posOrigin} forEach _soldiers;
+		if (sidesX getVariable [_source,sideUnknown] == _sideX) then
+		{
+			_killZones = killZones getVariable [_source,[]];
+			_killZones = _killZones + [_target,_target];
+			killZones setVariable [_source,_killZones,true];
+		};
+		[3, format ["QRF from %1 to retake %2 has failed as the marker is not changed!", _source, _target], _filename] call A3A_fnc_log;
+	};
+}
+else
+{
+	_timeX = time + 1800;
+	_sideEnemy = if (_sideX == Occupants) then {Invaders} else {Occupants};
+
+	if (_typeOfAttack != "Air") then {waitUntil {sleep 5; (_timeX < time) or (call _fnc_lowStrength) or (!([distanceSPWN1,1,_posDest,teamPlayer] call A3A_fnc_distanceUnits) and !([distanceSPWN1,1,_posDest,_sideEnemy] call A3A_fnc_distanceUnits))}}
+	else {waitUntil {sleep 5; (_timeX < time) or (call _fnc_lowStrength)}};
+	if (call _fnc_lowStrength) then
+	{
+		_markersX = resourcesX + factories + airportsX + outposts + seaports select {getMarkerPos _x distance _posDest < distanceSPWN};
+		_killZones = killZones getVariable [_source,[]];
+		_killZones append _markersX;
+		killZones setVariable [_source,_killZones,true];
+		[3, format ["QRF from %1 on position %2 defeated", _source, _target], _filename] call A3A_fnc_log;
+	}
+	else {
+		[3, format ["QRF from %1 on position %2 despawned", _source, _target], _filename] call A3A_fnc_log;
+	};
+};
+[2, format ["QRF on %1 finished", _target], _filename] call A3A_fnc_log;
+
+//if (_target in forcedSpawn) then {forcedSpawn = forcedSpawn - [_target]; publicVariable "forcedSpawn"};
+
+
+// Hand remaining aggressor units to the group despawner.
+{
+	private _isPilot = vehicle leader _x isKindOf "Air";
+	if (_isPilot || !_isMarker || {_target in citiesX || sidesX getVariable [_target,sideUnknown] != _sideX}) then {
+		private _wp = _x addWaypoint [_posOrigin, 50];
+		_wp setWaypointType "MOVE";
+		_x setCurrentWaypoint _wp;
+	};
+	[_x] spawn A3A_fnc_groupDespawner;
+} forEach _groups;
+
+{ [_x] spawn A3A_fnc_VEHdespawner } forEach _vehiclesX;
+
+
+// After a delay, remove the fencing mark
+sleep (60 * (20 - (tierWar + difficultyCoef))) max 0;		// 10-20 min delay. Maybe uisleep?
+[_target, "remove"] remoteExecCall ["A3A_fnc_updateCAMark", 2];
+

--- a/A3-Antistasi/functions/CREATE/fn_patrolCA.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_patrolCA.sqf
@@ -191,7 +191,7 @@ else
     + ([0, 3] select _super)
 };
 
-_vehicleCount = _vehicleCount * skillMult / 2;			// skillMult range 1-3
+_vehicleCount = _vehicleCount + ((skillMult - 2) / 2);			// skillMult range 1-3
 if !(_isMarker) then { _vehicleCount = _vehicleCount / 2 };
 _vehicleCount = (round (_vehicleCount)) max 1;
 

--- a/A3-Antistasi/functions/CREATE/fn_patrolCA.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_patrolCA.sqf
@@ -77,7 +77,7 @@ if ((!_isMarker) and (_typeOfAttack != "Air") and (!_super) and ({sidesX getVari
 	if !([_plane] call A3A_fnc_vehAvailable) exitWith {};
 
 	// Government have much broader definition of "friendlies" than invaders do
-	private _friendlies = if (_sideX == Occupants) then {allUnits select {(_x distance _posDest < 200) and (alive _x) and ((side (group _x) == _sideX) or (side (group _x) == civilian))}} else {allUnits select {(_x distance _posDestination < 100) and ([_x] call A3A_fnc_canFight) and (side (group _x) == _sideX)}};
+	private _friendlies = if (_sideX == Occupants) then {allUnits select {(_x distance _posDest < 200) and (alive _x) and ((side (group _x) == _sideX) or (side (group _x) == civilian))}} else {allUnits select {(_x distance _posDest < 100) and ([_x] call A3A_fnc_canFight) and (side (group _x) == _sideX)}};
 	if (count _friendlies == 0) then
 	{
 		// select ordnance to use

--- a/A3-Antistasi/functions/CREATE/fn_patrolCA.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_patrolCA.sqf
@@ -1,203 +1,185 @@
-if (!isServer and hasInterface) exitWith {};
-_filename = "fn_patrolCA";
+private _filename = "fn_patrolCA";
+if (!isServer) exitWith {
+	_this remoteExec ["A3A_fnc_patrolCA", 2];			// fudge until the other calls are fixed up
+//	[1, "Server-only function miscalled", _filename] call A3A_fnc_log;
+};
 
-private ["_markerX","_isMarker","_exit","_radio","_base","_airportX","_posDestination","_soldiers","_vehiclesX","_groups","_roads","_posOrigin","_radiusX","_typeVehX","_vehicle","_veh","_vehCrew","_groupVeh","_landPos","_typeGroup","_groupX","_soldierX","_threatEval","_pos","_timeOut","_sideX","_vehicleCount","_isMarker","_inWaves","_typeOfAttack","_nearX","_airportsX","_siteX","_enemiesX","_plane","_friendlies","_typeX","_isSDK","_weapons","_nameDest","_vehPool","_super","_spawnPoint","_pos1","_pos2"];
+waitUntil {sleep 1; isNil "requestQRFactive"};
+requestQRFactive = true;
 
-_markerX = _this select 0;//[position player,Occupants,"Normal",false] spawn A3A_Fnc_patrolCA
-_airportX = _this select 1;
-_typeOfAttack = _this select 2;
-_super = if (!isMultiplayer) then {false} else {_this select 3};
-_inWaves = false;
-_sideX = Occupants;
-_posOrigin = [];
-_posDestination = [];
+// call methods:
+// first param (target) can be either position or marker name
+// second param (origin) can be either an (airport?) marker or a side
+// second param as airport is only used for rebelAttack and the refugee mission (probably broken)
+// forces the attack to progress regardless of other patrolCAs?
 
-[2, format ["Spawning PatrolCA. Target:%1, Origin:%2, Type:%3, IsSuper:%4",_markerX,_airportX,_typeOfAttack,_super], _filename] call A3A_fnc_log;
+params ["_target", "_source", "_typeOfAttack"];
+private _super = if (!isMultiplayer) then {false} else {_this select 3};
+private _forced = false;
+private _sideX = Occupants;
+private _posOrigin = [];
+private _posDest = [];
 
-if ([_markerX,false] call A3A_fnc_fogCheck < 0.3) exitWith {[2, format ["PatrolCA on %1 cancelled due to heavy fog",_markerX], _filename] call A3A_fnc_log};
-if (_airportX isEqualType "") then
-	{
-	_inWaves = true;
-	if (sidesX getVariable [_airportX,sideUnknown] == Invaders) then {_sideX = Invaders};
-	_posOrigin = getMarkerPos _airportX;
-	}
+[2, format ["QRF requested. Target:%1, Source:%2, Type:%3, IsSuper:%4",_target,_source,_typeOfAttack,_super], _filename] call A3A_fnc_log;
+
+if ([_target, false] call A3A_fnc_fogCheck < 0.3) exitWith {
+	[2, format ["PatrolCA on %1 cancelled due to heavy fog",_target], _filename] call A3A_fnc_log;
+	requestQRFactive = nil;
+};
+
+if (_source isEqualType "") then
+{
+	_forced = true;
+	if (sidesX getVariable [_source,sideUnknown] == Invaders) then {_sideX = Invaders};
+	_posOrigin = getMarkerPos _source;
+}
 else
-	{
-	_sideX = _airportX;
-	};
+{
+	_sideX = _source;
+};
 
-//if ((!_inWaves) and (diag_fps < minimoFPS)) exitWith {diag_log format ["Antistasi PatrolCA: CA cancelled because of FPS %1",""]};
-
-_isMarker = false;
-_exit = false;
-if (_markerX isEqualType "") then
-	{
+// Check whether there's already a patrolCA active in the vicinity
+private _isMarker = false;
+private _exit = false;
+if (_target isEqualType "") then
+{
+	// If the target is a marker, only consider other marker attacks
 	_isMarker = true;
-	_posDestination = getMarkerPos _markerX;
-	if (!_inWaves) then {if (_markerX in smallCAmrk) then {_exit = true}};
-	}
+	_posDest = getMarkerPos _target;
+	if (!_forced) then {if (_target in smallCAmrk) then {_exit = true}};
+}
 else
+{
+	// If the target is a position, consider both position and marker attacks
+	_posDest = _target;
+	private _nearX = [smallCApos,_target] call BIS_fnc_nearestPosition;
+	if (_nearX distance _target < 500) exitWith {_exit = true};
+
+	if (count smallCAmrk > 0) then
 	{
-	_posDestination = _markerX;
-	_nearX = [smallCApos,_markerX] call BIS_fnc_nearestPosition;
-	if (_nearX distance _markerX < (distanceSPWN2)) then
-		{
-		_exit = true;
-		}
-	else
-		{
-		if (count smallCAmrk > 0) then
-			{
-			_nearX = [smallCAmrk,_markerX] call BIS_fnc_nearestPosition;
-			if (getMarkerPos _nearX distance _markerX < (distanceSPWN2)) then {_exit = true};
-			};
-		};
+		_nearX = [smallCAmrk,_target] call BIS_fnc_nearestPosition;
+		if (getMarkerPos _nearX distance _target < 500) then {_exit = true};
 	};
+};
 
-if (_exit) exitWith {[2, format ["PatrolCA on %1 cancelled due to other CA in vicinity",_markerX], _filename] call A3A_fnc_log};
+if (_exit) exitWith {
+	[2, format ["PatrolCA on %1 cancelled due to other CA in vicinity",_target], _filename] call A3A_fnc_log;
+	requestQRFactive = nil;
+};
 
-_enemiesX = allUnits select {_x distance _posDestination < distanceSPWN2 and (side (group _x) != _sideX) and (side (group _x) != civilian) and (alive _x)};
 
+private _enemiesX = allUnits select {_x distance _posDest < distanceSPWN2 and (side (group _x) != _sideX) and (side (group _x) != civilian) and (alive _x)};
+
+// Use an airstrike if suitable 
 if ((!_isMarker) and (_typeOfAttack != "Air") and (!_super) and ({sidesX getVariable [_x,sideUnknown] == _sideX} count airportsX > 0)) then
+{
+	private _plane = if (_sideX == Occupants) then {vehNATOPlane} else {vehCSATPlane};
+	if !([_plane] call A3A_fnc_vehAvailable) exitWith {};
+
+	// Government have much broader definition of "friendlies" than invaders do
+	private _friendlies = if (_sideX == Occupants) then {allUnits select {(_x distance _posDest < 200) and (alive _x) and ((side (group _x) == _sideX) or (side (group _x) == civilian))}} else {allUnits select {(_x distance _posDestination < 100) and ([_x] call A3A_fnc_canFight) and (side (group _x) == _sideX)}};
+	if (count _friendlies == 0) then
 	{
-	_plane = if (_sideX == Occupants) then {vehNATOPlane} else {vehCSATPlane};
-	if ([_plane] call A3A_fnc_vehAvailable) then
+		// select ordnance to use
+		private _bombType = if (napalmEnabled) then {"NAPALM"} else {"HE"};		// anti-infantry default. why?
 		{
-		_friendlies = if (_sideX == Occupants) then {allUnits select {(_x distance _posDestination < 200) and (alive _x) and ((side (group _x) == _sideX) or (side (group _x) == civilian))}} else {allUnits select {(_x distance _posDestination < 100) and ([_x] call A3A_fnc_canFight) and (side (group _x) == _sideX)}};
-		if (count _friendlies == 0) then
-			{
-			_typeX = if (napalmEnabled) then {"NAPALM"} else {"HE"};
-			{
-			if (vehicle _x isKindOf "Tank") then
-				{
-				_typeX = "HE"
-				}
-			else
-				{
-				if (vehicle _x != _x) then
-					{
-					if !(vehicle _x isKindOf "StaticWeapon") then {_typeX = "CLUSTER"};
-					};
-				};
-			if (_typeX == "HE") exitWith {};
-			} forEach _enemiesX;
-			_exit = true;
-			if (!_isMarker) then {smallCApos pushBack _posDestination};
-			[_posDestination,_sideX,_typeX] spawn A3A_fnc_airstrike;
-			[2, format ["PatrolCA airstrike of type %1 sent to %2",_typeX,_markerX], _filename] call A3A_fnc_log;
-			if (!_isMarker) then
-				{
-				sleep 120;
-				smallCApos = smallCApos - [_posDestination];
-				};
-			};
-		};
-	};
-if (_exit) exitWith {};
-_threatEvalLand = 0;
-if (!_inWaves) then
-	{
-	_threatEvalLand = [_posDestination,_sideX] call A3A_fnc_landThreatEval;
-	_airportsX = airportsX select {(sidesX getVariable [_x,sideUnknown] == _sideX) and ([_x,true] call A3A_fnc_airportCanAttack) and (getMarkerPos _x distance2D _posDestination < distanceForAirAttack)};
-	if (hasIFA and (_threatEvalLand <= 15)) then {_airportsX = _airportsX select {(getMarkerPos _x distance2D _posDestination < distanceForLandAttack)}};
-	_outposts = if (_threatEvalLand <= 15) then {outposts select {(sidesX getVariable [_x,sideUnknown] == _sideX) and ([_posDestination,getMarkerPos _x] call A3A_fnc_isTheSameIsland) and (getMarkerPos _x distance _posDestination < distanceForLandAttack)  and ([_x,true] call A3A_fnc_airportCanAttack)}} else {[]};
-	_airportsX = _airportsX + _outposts;
-	if (_isMarker) then
-		{
-		if (_markerX in blackListDest) then
-			{
-			_airportsX = _airportsX - outposts;
-			};
-		_airportsX = _airportsX - [_markerX];
-		_airportsX = _airportsX select {({_x == _markerX} count (killZones getVariable [_x,[]])) < 3};
-		}
-	else
-		{
-		if (!_super) then
-			{
-			_siteX = [(resourcesX + factories + airportsX + outposts + seaports),_posDestination] call BIS_fnc_nearestPosition;
-			_airportsX = _airportsX select {({_x == _siteX} count (killZones getVariable [_x,[]])) < 3};
-			};
-		};
-	if (_airportsX isEqualTo []) then
-		{
+			private _veh = vehicle _x;
+			if (_veh isKindOf "Tank") exitWith {_bombType = "HE"};
+			if (_veh != _x && !(_veh isKindOf "StaticWeapon")) then {_bombType = "CLUSTER"};
+		} forEach _enemiesX;
+
 		_exit = true;
-		}
+		[_posDest, "add"] call A3A_fnc_updateCAMark;
+		[_posDest, _sideX, _bombType] spawn A3A_fnc_airstrike;			// should be scheduled
+		[2, format ["PatrolCA airstrike of type %1 sent to %2", _bombType, _posDest], _filename] call A3A_fnc_log;
+		requestQRFactive = nil;
+
+		sleep 120;
+		[_posDest, "remove"] call A3A_fnc_updateCAMark;
+	};
+};
+if (_exit) exitWith {};
+
+
+// maxUnits needs to be multiplied by the HC count here, as we're counting all units not just local
+private _maxUnits = (1 max (count hcArray)) * maxUnits;
+private _remUnitCount = _maxUnits - ({!(isPlayer _x) && (alive _x)} count allUnits);
+if (gameMode <3) then
+{
+	private _sideCount = {!(isPlayer _x) and (alive _x) and (side group _x == _sideX)} count allUnits;
+	_remUnitCount = _remUnitCount min (_maxUnits * 0.7 - _sideCount);
+};
+
+if (_remUnitCount < 5) exitWith {
+	[2, format ["PatrolCA on %1 cancelled because maximum unit count reached", _target], _filename] call A3A_fnc_log;
+	requestQRFactive = nil;
+};
+
+
+// Determine origin base, if not specified
+private _threatEvalLand = [_posDest,_sideX] call A3A_fnc_landThreatEval;
+if (!_forced) then
+{
+	private _airportsX = airportsX select {(sidesX getVariable [_x,sideUnknown] == _sideX) and ([_x,true] call A3A_fnc_airportCanAttack) and (getMarkerPos _x distance2D _posDest < distanceForAirAttack)};
+	if (hasIFA and (_threatEvalLand <= 15)) then {_airportsX = _airportsX select {(getMarkerPos _x distance2D _posDest < distanceForLandAttack)}};
+	private _outposts = if (_threatEvalLand <= 15) then {outposts select {(sidesX getVariable [_x,sideUnknown] == _sideX) and ([_posDest,getMarkerPos _x] call A3A_fnc_isTheSameIsland) and (getMarkerPos _x distance _posDest < distanceForLandAttack)  and ([_x,true] call A3A_fnc_airportCanAttack)}} else {[]};
+	private _bases = _airportsX + _outposts;
+	if (_isMarker) then
+	{
+		if (_target in blackListDest) then { _bases = _bases - outposts };
+		_bases = _bases - [_target];
+		_bases = _bases select {({_x == _target} count (killZones getVariable [_x,[]])) < 3};
+	}
 	else
+	{
+		if (!_super) then
 		{
-		_airportX = [_airportsX,_posDestination] call BIS_fnc_nearestPosition;
-		_posOrigin = getMarkerPos _airportX;
+			private _siteX = [(resourcesX + factories + airportsX + outposts + seaports),_posDest] call BIS_fnc_nearestPosition;
+			_bases = _bases select {({_x == _siteX} count (killZones getVariable [_x,[]])) < 3};
 		};
 	};
+	if (_bases isEqualTo []) exitWith {_exit = true};
 
-if (_exit) exitWith {[2, format ["PatrolCA on %1 cancelled because no usable bases in vicinity",_markerX], _filename] call A3A_fnc_log};
+	_source = [_bases, _posDest] call BIS_fnc_nearestPosition;
+	_posOrigin = getMarkerPos _source;
+};
+
+if (_exit) exitWith {
+	[2, format ["PatrolCA on %1 cancelled because no usable bases in vicinity", _target], _filename] call A3A_fnc_log;
+	requestQRFactive = nil;
+};
 
 
-_allUnits = {(local _x) and (alive _x)} count allUnits;
-_allUnitsSide = 0;
-_maxUnitsSide = maxUnits;
+private _landAttack = if ((_posOrigin distance _posDest < distanceForLandAttack) and ([_posDest,_posOrigin] call A3A_fnc_isTheSameIsland) and (_threatEvalLand <= 15)) then {true} else {false};
 
-if (gameMode <3) then
-	{
-	_allUnitsSide = {(local _x) and (alive _x) and (side group _x == _sideX)} count allUnits;
-	_maxUnitsSide = round (maxUnits * 0.7);
-	};
-if ((_allUnits + 4 > maxUnits) or (_allUnitsSide + 4 > _maxUnitsSide)) then {_exit = true};
-
-if (_exit) exitWith {[2, format ["PatrolCA on %1 cancelled because maximum unit count reached",_markerX], _filename] call A3A_fnc_log};
-
-_base = if ((_posOrigin distance _posDestination < distanceForLandAttack) and ([_posDestination,_posOrigin] call A3A_fnc_isTheSameIsland) and (_threatEvalLand <= 15)) then {_airportX} else {""};
-
+// Automatically determine attack type from enemy vehicles, if it was left blank
 if (_typeOfAttack == "") then
-	{
+{
 	_typeOfAttack = "Normal";
 	{
-	_exit = false;
-	if (vehicle _x != _x) then
+		if (vehicle _x != _x) then
 		{
-		_veh = vehicle _x;
-		if (_veh isKindOf "Plane") exitWith {_exit = true; _typeOfAttack = "Air"};
-		if (_veh isKindOf "Helicopter") then
+			private _veh = vehicle _x;
+			if (_veh isKindOf "Plane") exitWith {_typeOfAttack = "Air"};
+			if (_veh isKindOf "Helicopter") then
 			{
-			_weapons = getArray (configfile >> "CfgVehicles" >> (typeOf _veh) >> "weapons");
-			if (_weapons isEqualType []) then
+				_weapons = getArray (configfile >> "CfgVehicles" >> (typeOf _veh) >> "weapons");
+				if (_weapons isEqualType []) then
 				{
-				if (count _weapons > 1) then {_exit = true; _typeOfAttack = "Air"};
+					if (count _weapons > 1) then {_typeOfAttack = "Air"};
 				};
 			}
-		else
+			else
 			{
-			if (_veh isKindOf "Tank") then {_typeOfAttack = "Tank"};
+				if (_veh isKindOf "Tank") then {_typeOfAttack = "Tank"};
 			};
 		};
-	if (_exit) exitWith {};
+		if (_typeOfAttack == "Air") exitWith {};
 	} forEach _enemiesX;
-	};
+};
 
-_isSDK = false;
-if (_isMarker) then
-	{
-	smallCAmrk pushBackUnique _markerX; publicVariable "smallCAmrk";
-	if (sidesX getVariable [_markerX,sideUnknown] == teamPlayer) then
-		{
-		_isSDK = true;
-		_nameDest = [_markerX] call A3A_fnc_localizar;
-		if (!_inWaves) then {["IntelAdded", ["", format ["QRF sent to %1",_nameDest]]] remoteExec ["BIS_fnc_showNotification",_sideX]};
-		};
-	}
-else
-	{
-	smallCApos pushBack _posDestination;
-	};
 
-//if (debug) then {hint format ["Nos contraatacan desde %1 o desde el airportX %2 hacia %3", _base, _airportX,_markerX]; sleep 5};
-//diag_log format ["Antistasi PatrolCA: CA performed from %1 to %2.Is waved:%3.Is super:%4",_airportX,_markerX,_inWaves,_super];
-//_config = if (_sideX == Occupants) then {cfgNATOInf} else {cfgCSATInf};
-
-_soldiers = [];
-_vehiclesX = [];
-_groups = [];
-_roads = [];
+// Determine vehicle count from aggression & attack type
 private _vehicleCount = if(_sideX == Occupants) then
 {
     (aggressionOccupants/16)
@@ -209,440 +191,24 @@ else
     + ([0, 3] select _super)
 };
 
-if(skillMult == 1) then
-{
-    _vehicleCount = _vehicleCount - 0.5;
-};
-if(skillMult == 3) then
-{
-    _vehicleCount = _vehicleCount + 0.5;
-};
+_vehicleCount = _vehicleCount * skillMult / 2;			// skillMult range 1-3
+if !(_isMarker) then { _vehicleCount = _vehicleCount / 2 };
 _vehicleCount = (round (_vehicleCount)) max 1;
 
-[
-    3,
-    format ["Due to %1 aggression, sending %2 vehicles", (if(_sideX == Occupants) then {aggressionOccupants} else {aggressionInvaders}), _vehicleCount],
-    _fileName
-] call A3A_fnc_log;
+private _aggro = if(_sideX == Occupants) then {aggressionOccupants} else {aggressionInvaders};
+[3, format ["Due to %1 aggression, sending %2 vehicles", _aggro, _vehicleCount], _fileName] call A3A_fnc_log;
 
-if (_base != "") then
-{
-	_airportX = "";
-	if (_base in outposts) then {[_base,60] call A3A_fnc_addTimeForIdle} else {[_base,30] call A3A_fnc_addTimeForIdle};
-	_indexX = airportsX find _base;
-	_spawnPoint = objNull;
-	_pos = [];
-	_dir = 0;
-	if (_indexX > -1) then
-	{
-		_spawnPoint = server getVariable (format ["spawn_%1", _base]);
-		_pos = getMarkerPos _spawnPoint;
-		_dir = markerDir _spawnPoint;
-	}
-	else
-	{
-		_spawnPoint = [_posOrigin] call A3A_fnc_findNearestGoodRoad;
-		_pos = position _spawnPoint;
-		_dir = getDir _spawnPoint;
-	};
 
-	_vehPool = [_sideX, ["Air"]] call A3A_fnc_getVehiclePoolForQRFs;
-    if(count _vehPool == 0) then
-    {
-        if(_sideX == Occupants) then
-        {
-            {
-                _vehPool pushBack _x;
-                _vehPool pushBack 1;
-            } forEach (vehNATOTrucks + vehNATOLightArmed);
-        }
-        else
-        {
-            {
-                _vehPool pushBack _x;
-                _vehPool pushBack 1;
-            } forEach (vehCSATTrucks + vehCSATLightArmed);
-        };
-    };
-	_road = [_posDestination] call A3A_fnc_findNearestGoodRoad;
-	_landPosBlacklist = [];
-	for "_i" from 1 to _vehicleCount do
-	{
-		_typeVehX = selectRandomWeighted _vehPool;
-		_timeOut = 0;
-		_pos = _pos findEmptyPosition [0,100,_typeVehX];
-		while {_timeOut < 60} do
-		{
-			if (count _pos > 0) exitWith {};
-			_timeOut = _timeOut + 1;
-			_pos = _pos findEmptyPosition [0,100,_typeVehX];
-			sleep 1;
-		};
-		if (count _pos == 0) then {_pos = if (_indexX == -1) then {getMarkerPos _spawnPoint} else {position _spawnPoint}};
-		_vehicle=[_pos, _dir,_typeVehX, _sideX] call bis_fnc_spawnvehicle;
+// Going ahead with the attack. Add it to the appropriate fencing array
+[_target, "add"] call A3A_fnc_updateCAMark;
 
-		_veh = _vehicle select 0;
-		_vehCrew = _vehicle select 1;
-		{[_x] call A3A_fnc_NATOinit} forEach _vehCrew;
-		[_veh, _sideX] call A3A_fnc_AIVEHinit;
-		_groupVeh = _vehicle select 2;
-		_soldiers = _soldiers + _vehCrew;
-		_groups pushBack _groupVeh;
-		_vehiclesX pushBack _veh;
-		_landPos = [_posDestination,_pos,false,_landPosBlacklist] call A3A_fnc_findSafeRoadToUnload;
-		if ((not(_typeVehX in vehTanks)) and (not(_typeVehX in vehAA))) then
-		{
-			_landPosBlacklist pushBack _landPos;
-			_typeGroup = if (_typeOfAttack == "Normal") then
-			{
-				[_typeVehX,_sideX] call A3A_fnc_cargoSeats;
-			}
-			else
-			{
-				if (_typeOfAttack == "Air") then
-				{
-					if (_sideX == Occupants) then {groupsNATOAA} else {groupsCSATAA}
-				}
-				else
-				{
-					if (_sideX == Occupants) then {groupsNATOAT} else {groupsCSATAT}
-				};
-			};
-			_groupX = [_posOrigin,_sideX,_typeGroup] call A3A_fnc_spawnGroup;
-			{
-                _x assignAsCargo _veh;
-                _x moveInCargo _veh;
-                if (vehicle _x == _veh) then
-                {
-                    _soldiers pushBack _x;
-                    [_x] call A3A_fnc_NATOinit;
-                    _x setVariable ["originX",_base];
-                }
-                else
-                {
-                    deleteVehicle _x;
-                };
-            } forEach units _groupX;
-			if (not(_typeVehX in vehTrucks)) then
-			{
-				{_x disableAI "MINEDETECTION"} forEach (units _groupVeh);
-				(units _groupX) joinSilent _groupVeh;
-				deleteGroup _groupX;
-				_groupVeh spawn A3A_fnc_attackDrillAI;
-				//_groups pushBack _groupX;
-				[_base,_landPos,_groupVeh] call A3A_fnc_WPCreate;
-				_Vwp0 = (wayPoints _groupVeh) select 0;
-				_Vwp0 setWaypointBehaviour "SAFE";
-				_Vwp0 = _groupVeh addWaypoint [_landPos,count (wayPoints _groupVeh)];
-				_Vwp0 setWaypointType "TR UNLOAD";
-				//_Vwp0 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI"];
-				//_Vwp0 setWaypointStatements ["true", "[vehicle this] call A3A_fnc_smokeCoverAuto"];
-				_Vwp1 = _groupVeh addWaypoint [_posDestination, count (wayPoints _groupVeh)];
-				_Vwp1 setWaypointType "SAD";
-				_Vwp1 setWaypointStatements ["true","{if (side _x != side this) then {this reveal [_x,4]}} forEach allUnits"];
-				_Vwp1 setWaypointBehaviour "COMBAT";
-				[_veh,"APC"] spawn A3A_fnc_inmuneConvoy;
-				_veh allowCrewInImmobile true;
-			}
-			else
-			{
-				(units _groupX) joinSilent _groupVeh;
-				deleteGroup _groupX;
-				_groupVeh spawn A3A_fnc_attackDrillAI;
-				if (count units _groupVeh > 1) then {_groupVeh selectLeader (units _groupVeh select 1)};
-				[_base,_landPos,_groupVeh] call A3A_fnc_WPCreate;
-				_Vwp0 = (wayPoints _groupVeh) select 0;
-				_Vwp0 setWaypointBehaviour "SAFE";
-				/*
-				_Vwp0 = (wayPoints _groupVeh) select ((count wayPoints _groupVeh) - 1);
-				_Vwp0 setWaypointType "GETOUT";
-				*/
-				_Vwp0 = _groupVeh addWaypoint [_landPos, count (wayPoints _groupVeh)];
-				_Vwp0 setWaypointType "GETOUT";
-				//_Vwp0 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI"];
-				_Vwp1 = _groupVeh addWaypoint [_posDestination, count (wayPoints _groupVeh)];
-				_Vwp1 setWaypointStatements ["true","{if (side _x != side this) then {this reveal [_x,4]}} forEach allUnits"];
-				if (_isMarker) then
-				{
-					if ((count (garrison getVariable [_markerX, []])) < 4) then
-					{
-						_Vwp1 setWaypointType "MOVE";
-						_Vwp1 setWaypointBehaviour "AWARE";
-					}
-					else
-					{
-						_Vwp1 setWaypointType "SAD";
-						_Vwp1 setWaypointBehaviour "COMBAT";
-					};
-				}
-				else
-				{
-					_Vwp1 setWaypointType "SAD";
-					_Vwp1 setWaypointBehaviour "COMBAT";
-				};
-				[_veh,"Inf Truck."] spawn A3A_fnc_inmuneConvoy;
-			};
-		}
-		else
-		{
-			{_x disableAI "MINEDETECTION"} forEach (units _groupVeh);
-			[_base,_posDestination,_groupVeh] call A3A_fnc_WPCreate;
-			_Vwp0 = (wayPoints _groupVeh) select 0;
-			_Vwp0 setWaypointBehaviour "SAFE";
-			_Vwp0 = _groupVeh addWaypoint [_posDestination, count (waypoints _groupVeh)];
-			[_veh,"Tank"] spawn A3A_fnc_inmuneConvoy;
-			_Vwp0 setWaypointType "SAD";
-			_Vwp0 setWaypointBehaviour "AWARE";
-			_Vwp0 setWaypointStatements ["true","{if (side _x != side this) then {this reveal [_x,4]}} forEach allUnits"];
-			_veh allowCrewInImmobile true;
-		};
-		[3, format ["PatrolCA vehicle %1 sent with %2 soldiers", typeof _veh, count crew _veh], _filename] call A3A_fnc_log;
-	};
-	[2, format ["Land patrolCA performed on %1, type %2, veh count %3, troop count %4", _markerX,_typeOfAttack,count _vehiclesX,count _soldiers], _filename] call A3A_fnc_log;
-}
-else
-{
-	[_airportX,20] call A3A_fnc_addTimeForIdle;
-	_vehPool = [];
-	_typeVehX = "";
-	_vehPool = [_sideX, ["LandVehicle"]] call A3A_fnc_getVehiclePoolForQRFs;
-    if(count _vehPool == 0) then
-    {
-        if(_sideX == Occupants) then
-        {
-            {
-                _vehPool pushBack _x;
-                _vehPool pushBack 1;
-            } forEach vehNATOTransportHelis + [vehNATOPatrolHeli];
-        }
-        else
-        {
-            {
-                _vehPool pushBack _x;
-                _vehPool pushBack 1;
-            } forEach vehCSATTransportHelis + [vehCSATPatrolHeli];
-        };
-    };
-	for "_i" from 1 to _vehicleCount do
-	{
-		_typeVehX = selectRandomWeighted _vehPool;
-		_pos = _posOrigin;
-		_ang = 0;
-		_size = [_airportX] call A3A_fnc_sizeMarker;
-		_buildings = nearestObjects [_posOrigin, ["Land_LandMark_F","Land_runway_edgelight"], _size / 2];
-		if (count _buildings > 1) then
-		{
-			_pos1 = getPos (_buildings select 0);
-			_pos2 = getPos (_buildings select 1);
-			_ang = [_pos1, _pos2] call BIS_fnc_DirTo;
-			_pos = [_pos1, 5,_ang] call BIS_fnc_relPos;
-		};
-		if (count _pos == 0) then {_pos = _posOrigin};
-		_vehicle=[_pos, _ang + 90,_typeVehX, _sideX] call bis_fnc_spawnvehicle;
-		_veh = _vehicle select 0;
-		if (hasIFA) then {_veh setVelocityModelSpace [((velocityModelSpace _veh) select 0) + 0,((velocityModelSpace _veh) select 1) + 150,((velocityModelSpace _veh) select 2) + 50]};
-		_vehCrew = _vehicle select 1;
-		_groupVeh = _vehicle select 2;
-		_soldiers append _vehCrew;
-		_groups pushBack _groupVeh;
-		_vehiclesX pushBack _veh;
-		{[_x] call A3A_fnc_NATOinit} forEach units _groupVeh;
-		[_veh, _sideX] call A3A_fnc_AIVEHinit;
-		if (not (_typeVehX in vehTransportAir)) then
-		{
-			_Hwp0 = _groupVeh addWaypoint [_posDestination, 0];
-			_Hwp0 setWaypointBehaviour "AWARE";
-			_Hwp0 setWaypointType "SAD";
-			//[_veh,"Air Attack"] spawn A3A_fnc_inmuneConvoy;
-		}
-		else
-		{
-			_typeGroup = if (_typeOfAttack == "Normal") then
-			{
-				[_typeVehX,_sideX] call A3A_fnc_cargoSeats;
-			}
-			else
-			{
-				if (_typeOfAttack == "Air") then
-				{
-					if (_sideX == Occupants) then {groupsNATOAA} else {groupsCSATAA}
-				}
-				else
-				{
-					if (_sideX == Occupants) then {groupsNATOAT} else {groupsCSATAT}
-				};
-			};
-			_groupX = [_posOrigin,_sideX,_typeGroup] call A3A_fnc_spawnGroup;
-			//{_x assignAsCargo _veh;_x moveInCargo _veh; [_x] call A3A_fnc_NATOinit;_soldiers pushBack _x;_x setVariable ["originX",_airportX]} forEach units _groupX;
-			{
-                _x assignAsCargo _veh;
-                _x moveInCargo _veh;
-                if (vehicle _x == _veh) then
-                {
-                    _soldiers pushBack _x;
-                    [_x] call A3A_fnc_NATOinit;
-                    _x setVariable ["originX",_airportX];
-                }
-                else
-                {
-                    deleteVehicle _x;
-                };
-			} forEach units _groupX;
-			_groups pushBack _groupX;
-			_landpos = [];
-			_proceed = true;
-			if (_isMarker) then
-			{
-				if ((_markerX in airportsX)  or !(_veh isKindOf "Helicopter")) then
-				{
-					_proceed = false;
-					[_veh,_groupX,_markerX,_airportX] spawn A3A_fnc_airdrop;
-				}
-				else
-				{
-					if (_isSDK) then
-					{
-						if (((count(garrison getVariable [_markerX,[]])) < 10) and (_typeVehX in vehFastRope)) then
-						{
-							_proceed = false;
-                            //_groupX setVariable ["mrkAttack",_markerX];
-							[_veh,_groupX,_posDestination,_posOrigin,_groupVeh] spawn A3A_fnc_fastrope;
-						};
-					};
-				};
-			}
-			else
-			{
-				if !(_veh isKindOf "Helicopter") then
-				{
-					_proceed = false;
-					[_veh,_groupX,_posDestination,_airportX] spawn A3A_fnc_airdrop;
-				};
-			};
-			if (_proceed) then
-			{
-				_landPos = [_posDestination, 300, 550, 10, 0, 0.20, 0,[],[[0,0,0],[0,0,0]]] call BIS_fnc_findSafePos;
-				if !(_landPos isEqualTo [0,0,0]) then
-				{
-					_landPos set [2, 0];
-					_pad = createVehicle ["Land_HelipadEmpty_F", _landpos, [], 0, "NONE"];
-					_vehiclesX pushBack _pad;
-					_wp0 = _groupVeh addWaypoint [_landpos, 0];
-					_wp0 setWaypointType "TR UNLOAD";
-					_wp0 setWaypointStatements ["true", "(vehicle this) land 'GET OUT';[vehicle this] call A3A_fnc_smokeCoverAuto"];
-					_wp0 setWaypointBehaviour "CARELESS";
-					_wp3 = _groupX addWaypoint [_landpos, 0];
-					_wp3 setWaypointType "GETOUT";
-					_wp3 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI"];
-					_wp0 synchronizeWaypoint [_wp3];
-					_wp4 = _groupX addWaypoint [_posDestination, 1];
-					_wp4 setWaypointType "MOVE";
-					_wp4 setWaypointStatements ["true","{if (side _x != side this) then {this reveal [_x,4]}} forEach allUnits"];
-					_wp2 = _groupVeh addWaypoint [_posOrigin, 1];
-					_wp2 setWaypointType "MOVE";
-					_wp2 setWaypointStatements ["true", "deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
-					[_groupVeh,1] setWaypointBehaviour "AWARE";
-				}
-				else
-				{
-					if (_typeVehX in vehFastRope) then
-					{
-						[_veh,_groupX,_posDestination,_posOrigin,_groupVeh] spawn A3A_fnc_fastrope;
-					}
-					else
-					{
-						[_veh,_groupX,_markerX,_airportX] spawn A3A_fnc_airdrop;
-					};
-				};
-			};
-		};
-		sleep 30;
-		[3, format ["PatrolCA vehicle %1 sent with %2 soldiers", typeof _veh, count crew _veh], _filename] call A3A_fnc_log;
-	};
-	[2, format ["Air patrolCA performed on %1, type %2, veh count %3, troop count %4", _markerX,_typeOfAttack,count _vehiclesX,count _soldiers], _filename] call A3A_fnc_log;
+
+if (_isMarker && !_forced) then {
+	// send notification to PvPs for marker counterattacks
+	private _nameDest = [_target] call A3A_fnc_localizar;
+	["IntelAdded", ["", format ["QRF sent to %1",_nameDest]]] remoteExec ["BIS_fnc_showNotification",_sideX];
 };
 
-if (_isMarker) then
-	{
-	_timeX = time + 3600;
-	_size = [_markerX] call A3A_fnc_sizeMarker;
-	if (_sideX == Occupants) then
-		{
-		waitUntil {sleep 5; (({!([_x] call A3A_fnc_canFight)} count _soldiers) >= 3*({([_x] call A3A_fnc_canFight)} count _soldiers)) or (time > _timeX) or (sidesX getVariable [_markerX,sideUnknown] == Occupants) or (({[_x,_markerX] call A3A_fnc_canConquer} count _soldiers) > 3*({(side _x != _sideX) and (side _x != civilian) and ([_x,_markerX] call A3A_fnc_canConquer)} count allUnits))};
-		if  ((({[_x,_markerX] call A3A_fnc_canConquer} count _soldiers) > 3*({(side _x != _sideX) and (side _x != civilian) and ([_x,_markerX] call A3A_fnc_canConquer)} count allUnits)) and (not(sidesX getVariable [_markerX,sideUnknown] == Occupants))) then
-			{
-			[Occupants,_markerX] remoteExec ["A3A_fnc_markerChange",2];
-			[3, format ["PatrolCA from %1 or %2 to retake %3 has outnumbered the enemy, changing marker!", _airportX,_base,_markerX], _filename] call A3A_fnc_log;
-			};
-		sleep 10;
-		if (!(sidesX getVariable [_markerX,sideUnknown] == Occupants)) then
-			{
-			{_x doMove _posOrigin} forEach _soldiers;
-			if (sidesX getVariable [_airportX,sideUnknown] == Occupants) then
-				{
-				_killZones = killZones getVariable [_airportX,[]];
-				_killZones = _killZones + [_markerX,_markerX];
-				killZones setVariable [_airportX,_killZones,true];
-				};
-			[3, format ["PatrolCA from %1 or %2 to retake %3 has failed as the marker is not changed!", _airportX,_base,_markerX], _filename] call A3A_fnc_log;
-			}
-		}
-	else
-		{
-		waitUntil {sleep 5; (({!([_x] call A3A_fnc_canFight)} count _soldiers) >= 3*({([_x] call A3A_fnc_canFight)} count _soldiers))or (time > _timeX) or (sidesX getVariable [_markerX,sideUnknown] == Invaders) or (({[_x,_markerX] call A3A_fnc_canConquer} count _soldiers) > 3*({(side _x != _sideX) and (side _x != civilian) and ([_x,_markerX] call A3A_fnc_canConquer)} count allUnits))};
-		if  ((({[_x,_markerX] call A3A_fnc_canConquer} count _soldiers) > 3*({(side _x != _sideX) and (side _x != civilian) and ([_x,_markerX] call A3A_fnc_canConquer)} count allUnits)) and (not(sidesX getVariable [_markerX,sideUnknown] == Invaders))) then
-			{
-			[Invaders,_markerX] remoteExec ["A3A_fnc_markerChange",2];
-			[3, format ["PatrolCA from %1 or %2 to retake %3 has outnumbered the enemy, changing marker!", _airportX,_base,_markerX], _filename] call A3A_fnc_log;
-			};
-		sleep 10;
-		if (!(sidesX getVariable [_markerX,sideUnknown] == Invaders)) then
-			{
-			{_x doMove _posOrigin} forEach _soldiers;
-			if (sidesX getVariable [_airportX,sideUnknown] == Invaders) then
-				{
-				_killZones = killZones getVariable [_airportX,[]];
-				_killZones = _killZones + [_markerX,_markerX];
-				killZones setVariable [_airportX,_killZones,true];
-				};
-			[3, format ["PatrolCA from %1 or %2 to retake %3 has failed as the marker is not changed!", _airportX,_base,_markerX], _filename] call A3A_fnc_log;
-			}
-		};
-	}
-else
-	{
-	_sideEnemy = if (_sideX == Occupants) then {Invaders} else {Occupants};
-	if (_typeOfAttack != "Air") then {waitUntil {sleep 1; (!([distanceSPWN1,1,_posDestination,teamPlayer] call A3A_fnc_distanceUnits) and !([distanceSPWN1,1,_posDestination,_sideEnemy] call A3A_fnc_distanceUnits)) or (({!([_x] call A3A_fnc_canFight)} count _soldiers) >= 3*({([_x] call A3A_fnc_canFight)} count _soldiers))}} else {waitUntil {sleep 1; (({!([_x] call A3A_fnc_canFight)} count _soldiers) >= 3*({([_x] call A3A_fnc_canFight)} count _soldiers))}};
-	if (({!([_x] call A3A_fnc_canFight)} count _soldiers) >= 3*({([_x] call A3A_fnc_canFight)} count _soldiers)) then
-		{
-		_markersX = resourcesX + factories + airportsX + outposts + seaports select {getMarkerPos _x distance _posDestination < distanceSPWN};
-		_siteX = if (_base != "") then {_base} else {_airportX};
-		_killZones = killZones getVariable [_siteX,[]];
-		_killZones append _markersX;
-		killZones setVariable [_siteX,_killZones,true];
-		[3, format ["PatrolCA from %1 or %2 on position %3 defeated", _airportX,_base,_markerX], _filename] call A3A_fnc_log;
-		}
-	else {
-		[3, format ["PatrolCA from %1 or %2 on position %3 despawned", _airportX,_base,_markerX], _filename] call A3A_fnc_log;
-		};
-	};
-[2, format ["PatrolCA on %1 finished",_markerX], _filename] call A3A_fnc_log;
+[[_target, _source, _sideX, _vehicleCount, _landAttack, _typeOfAttack], "A3A_fnc_createQRF"] call A3A_fnc_scheduler;
+requestQRFactive = nil;				// could set this a bit earlier...
 
-//if (_markerX in forcedSpawn) then {forcedSpawn = forcedSpawn - [_markerX]; publicVariable "forcedSpawn"};
-
-
-// Hand remaining aggressor units to the group despawner.
-{
-	if (!_isMarker || {_markerX in citiesX || sidesX getVariable [_markerX,sideUnknown] != _sideX}) then {
-		private _wp = _x addWaypoint [_posOrigin, 50];
-		_wp setWaypointType "MOVE";
-		_x setCurrentWaypoint _wp;
-	};
-	[_x] spawn A3A_fnc_groupDespawner;
-} forEach _groups;
-
-{ [_x] spawn A3A_fnc_VEHdespawner } forEach _vehiclesX;
-
-
-sleep ((300 - ((tierWar + difficultyCoef) * 5)) max 0);
-if (_isMarker) then {smallCAmrk = smallCAmrk - [_markerX]; publicVariable "smallCAmrk"} else {smallCApos = smallCApos - [_posDestination]};

--- a/A3-Antistasi/functions/CREATE/fn_updateCAMark.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_updateCAMark.sqf
@@ -14,6 +14,6 @@ if (_target isEqualType "") then {
 	[3, format ["%1 CA mark for position %2", _operation, _target], _filename] call A3A_fnc_log;
 
 	if (_operation == "add") then { smallCApos pushBack _target }
-	else { smallCApos = smallCApos select { _x distance2d _target < 100 } };
+	else { smallCApos = smallCApos select { _x distance2d _target > 100 } };
 };
 

--- a/A3-Antistasi/functions/CREATE/fn_updateCAMark.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_updateCAMark.sqf
@@ -1,0 +1,19 @@
+private _filename = "fn_updateCAMark";
+if (!isServer) exitWith {
+	[1, "Server-only function miscalled", _filename] call A3A_fnc_log;
+};
+
+params ["_target", "_operation"];
+
+if (_target isEqualType "") then {
+	[3, format ["%1 CA mark for marker %2", _operation, _target], _filename] call A3A_fnc_log;
+
+	if (_operation == "add") then { smallCAmrk pushBackUnique _target }
+	else { smallCAmrk = smallCAmrk - [_target] };
+} else { 
+	[3, format ["%1 CA mark for position %2", _operation, _target], _filename] call A3A_fnc_log;
+
+	if (_operation == "add") then { smallCApos pushBack _target }
+	else { smallCApos = smallCApos select { _x distance2d _target < 100 } };
+};
+

--- a/A3-Antistasi/functions/Save/fn_loadStat.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadStat.sqf
@@ -49,7 +49,7 @@ if (_varName in specialVarLoads) then {
 	if (_varName == 'bombRuns') then {bombRuns = _varValue; publicVariable "bombRuns"};
 	if (_varName == 'nextTick') then {nextTick = time + _varValue};
 	if (_varName == 'membersX') then {membersX = +_varValue; publicVariable "membersX"};
-	if (_varName == 'smallCAmrk') then {smallCAmrk = +_varValue};
+	if (_varName == 'smallCAmrk') then {};		// Ignore. These are not persistent.
 	if (_varName == 'mrkNATO') then {{sidesX setVariable [_x,Occupants,true]} forEach _varValue;};
 	if (_varName == 'mrkCSAT') then {{sidesX setVariable [_x,Invaders,true]} forEach _varValue;};
 	if (_varName == 'mrkSDK') then {{sidesX setVariable [_x,teamPlayer,true]} forEach _varValue;};


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Change
3. [X] Enhancement

### What have you changed and why?
A synchronization bug in patrolCA was causing multiple patrolCAs to be sent to the same location. It's an old bug but was far more obvious with six vehicles per patrolCA.

This was resolved by splitting patrolCA into decision and execution functions. The decision part (still called patrolCA) is server-only and strictly fenced, so it won't start examining a second patrolCA request until the previous one has been decided. This function calls createQRF to handle the actual spawning and management of the QRFs, or launches airstrikes itself.

The underlying logic is mostly unchanged, except for some bugs discovered although the way and some mostly-uncontroversial balance changes:

- Halved the vehicle count of position-target patrolCAs (they're now 1-3 vehicles. Used to be 1-6).
- Stop sending vehicles once maxUnits is reached.
- Increase post-termination delay before the next patrolCA on the same target.
- Add some minor vehicle adjustment for air/tank targets.
- Removed ability for cargoSeats to send more than one squad per vehicle.
- Fixed an issue where air-target-type patrolCAs would never terminate.
- Force air vehicles to return to base on termination.
- Removed some old code that was creating rebel squads after a capture.
- Fixed a bug where smallCAmrk was incorrectly preserved on save/load.

I'll miss having 50+ paratroopers dropped on my head by a couple of transport planes, but generally the existence of those was a balance and performance disaster.

I would consider this a temporary patch to get things into a workable state for 2.3. The whole QRF/support system needs to be ripped out and replaced after that.

### Please specify which Issue this PR Resolves.
closes #1194 
closes #1197 
fixes #1163 for patrolCA but it'll still happen with wavedCA.

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Vehicle spam levels seemed reasonable to me, but we'll see what the test server thinks about it.

### How can the changes be tested?
You can fire off patrolCAs in the usual way:

`["outpost_25", Occupants, "", false] remoteExec ["A3A_fnc_patrolCA", 2]`
Standard marker-target patrolCA, source determined automatically from side, unit balance determined from enemies.

`[position player, Occupants, "Tank", false] remoteExec ["A3A_fnc_patrolCA", 2]`
Position-target patrolCA, biased towards anti-tank, source determined automatically from side.

`["outpost_25", "airport_4", "Air", true] remoteExec ["A3A_fnc_patrolCA", 2]`
Forced marker-target patrolCA, as used by rebelAttack. Biased towards anti-air and super-sized.

You can also launch createQRF directly to dodge the fencing and sanity checks:

`["outpost_25", "airport_4", Occupants, 4, true, "Normal"], "A3A_fnc_createQRF"] remoteExec ["A3A_fnc_scheduler", 2]`
Send four land vehicles from airport to recapture or defend marker target, standard unit selection.

`[position player, "airport_4", Occupants, 2, true, "Tank"], "A3A_fnc_createQRF"] remoteExec ["A3A_fnc_scheduler", 2]`
Send two air vehicles from airport to search & destroy at position target, anti-tank selection.
