### PR TITLE
punishment_notPlayer does EH-lvl obj checks.

### DIFF
--- a/A3-Antistasi/REINF/controlHCsquad.sqf
+++ b/A3-Antistasi/REINF/controlHCsquad.sqf
@@ -36,6 +36,7 @@ _eh1 = player addEventHandler ["HandleDamage",
 	(units group player) joinsilent group player;
 	group player selectLeader player;
 	["Control Squad", "Returned to original Unit as it received damage"] call A3A_fnc_customHint;
+	nil;
 	}];
 _eh2 = _unit addEventHandler ["HandleDamage",
 	{
@@ -46,6 +47,7 @@ _eh2 = _unit addEventHandler ["HandleDamage",
 	(units group player) joinsilent group player;
 	group player selectLeader player;
 	["Control Squad", "Returned to original Unit as controlled AI received damage"] call A3A_fnc_customHint;
+	nil;
 	}];
 selectPlayer _unit;
 

--- a/A3-Antistasi/REINF/controlunit.sqf
+++ b/A3-Antistasi/REINF/controlunit.sqf
@@ -34,6 +34,7 @@ _eh1 = player addEventHandler ["HandleDamage",
 	(units group player) joinsilent group player;
 	group player selectLeader player;
 	["Control Unit", "Returned to original Unit as it received damage"] call A3A_fnc_customHint;
+	nil;
 	}];
 _eh2 = _unit addEventHandler ["HandleDamage",
 	{
@@ -44,6 +45,7 @@ _eh2 = _unit addEventHandler ["HandleDamage",
 	(units group player) joinsilent group player;
 	group player selectLeader player;
 	["Control Unit", "Returned to original Unit as controlled AI received damage"] call A3A_fnc_customHint;
+	nil;
 	}];
 selectPlayer _unit;
 

--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -431,6 +431,7 @@ class A3A
 		class punishment_removeActionForgive {};
 		class punishment_sentence_client {};
 		class punishment_sentence_server {};
+		class punishment_notPlayer {};
 	};
 
 	class pvp

--- a/A3-Antistasi/functions/Punishment/fn_punishment_FF.sqf
+++ b/A3-Antistasi/functions/Punishment/fn_punishment_FF.sqf
@@ -71,7 +71,7 @@ private _logPvPKill = {
 private _isCollision = false;
 
 ///////////////Checks if is Collision//////////////
-if (typeName _instigator == "ARRAY") then {
+if (_instigator isEqualType []) then {
     if (isPlayer (_instigator#0)) then {
         _instigator = _instigator#0;
     } else {

--- a/A3-Antistasi/functions/Punishment/fn_punishment_FF_AddEH.sqf
+++ b/A3-Antistasi/functions/Punishment/fn_punishment_FF_AddEH.sqf
@@ -52,10 +52,6 @@ _unit addEventHandler ["Hit", {
 if (!isPlayer _unit || !hasInterface) exitWith {true}; // Because it added killed handlers for Ai.
 if !(_unit isEqualTo player) exitWith {false}; // Needs to be local for ace, self punishment, and checkStatus.
 
-private _verifyPlayer = {
-
-};
-
 if (hasACE) then {
 	["ace_firedPlayer", {
 		params ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile"];

--- a/A3-Antistasi/functions/Punishment/fn_punishment_FF_AddEH.sqf
+++ b/A3-Antistasi/functions/Punishment/fn_punishment_FF_AddEH.sqf
@@ -26,7 +26,7 @@ Examples:
 	[cursorObject] remoteExec ["A3A_fnc_punishment_FF_addEH",cursorObject,false];
 
 Author: Caleb Serafin
-Date Updated: 12 June 2020
+Date Updated: July 2020
 License: MIT License, Copyright (c) 2019 Barbolani & The Official AntiStasi Community
 */
 params [["_unit",objNull,[objNull]]];
@@ -40,33 +40,37 @@ if (!(_unit isKindOf "Man")) exitWith {
 
 _unit addEventHandler ["Killed", {
 	params ["_unit", "_killer", "_instigator", "_useEffects"];
-	if (!isPlayer _instigator && {!isPlayer _killer}) exitWith {}; // A certain company that develops a specific game called ArmaIII hasn't mastered the EH yet. So it's full objNull if a hippo crosses a stream when the day is divisible by the second fortnight of the month during a full moon on a warm summers day while the mosquitoes bit down on Richard Parker as he struggles during the October revolution.
+	if ([_instigator] call A3A_fnc_punishment_notPlayer && {[_killer] call A3A_fnc_punishment_notPlayer}) exitWith {}; // A certain company that develops a specific game called ArmaIII hasn't mastered the EH yet. So it's full objNull if a hippo crosses a stream when the day is divisible by the second fortnight of the month during a full moon on a warm summers day while the mosquitoes bit down on Richard Parker as he struggles during the October revolution.
 	[[_instigator,_killer], 60, 0.4, _unit] remoteExec ["A3A_fnc_punishment_FF",[_killer,_instigator] select (isPlayer _instigator),false];
 }];
 _unit addEventHandler ["Hit", {
 	params ["_unit", "_source", "_damage", "_instigator"];
-	if (!isPlayer _instigator && {!isPlayer _source}) exitWith {};
+	if ([_instigator] call A3A_fnc_punishment_notPlayer && {[_source] call A3A_fnc_punishment_notPlayer}) exitWith {};
 	[[_instigator,_source], 60, 0.4, _unit] remoteExec ["A3A_fnc_punishment_FF",[_source,_instigator] select (isPlayer _instigator),false];
 }];
 
 if (!isPlayer _unit || !hasInterface) exitWith {true}; // Because it added killed handlers for Ai.
 if !(_unit isEqualTo player) exitWith {false}; // Needs to be local for ace, self punishment, and checkStatus.
 
+private _verifyPlayer = {
+
+};
+
 if (hasACE) then {
 	["ace_firedPlayer", {
 		params ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile"];
-		if (!isPlayer _unit || {!(_unit isEqualTo player)}) exitWith {};
+		if ([_unit] call A3A_fnc_punishment_notPlayer || {!(_unit isEqualTo player)}) exitWith {};
 		[_unit,_weapon,_projectile] call A3A_fnc_punishment_FF_checkNearHQ;
 	}] call CBA_fnc_addEventHandler;
 	["ace_explosives_place", {
 		params ["_explosive","_dir","_pitch","_unit"];
-		if (!isPlayer _unit || {!(_unit isEqualTo player)}) exitWith {};
+		if ([_unit] call A3A_fnc_punishment_notPlayer || {!(_unit isEqualTo player)}) exitWith {};
 		[_unit,"Put",_explosive] call A3A_fnc_punishment_FF_checkNearHQ;
 	}] call CBA_fnc_addEventHandler;
 } else {
 	_unit addEventHandler ["FiredMan", {
 		params ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile", "_vehicle"];
-		if (!isPlayer _unit || {!(_unit isEqualTo player)}) exitWith {};
+		if ([_unit] call A3A_fnc_punishment_notPlayer || {!(_unit isEqualTo player)}) exitWith {};
 		[_unit,_weapon,_projectile] call A3A_fnc_punishment_FF_checkNearHQ;
 	}];
 };

--- a/A3-Antistasi/functions/Punishment/fn_punishment_notPlayer.sqf
+++ b/A3-Antistasi/functions/Punishment/fn_punishment_notPlayer.sqf
@@ -32,6 +32,6 @@ License: MIT License, Copyright (c) 2019 Barbolani & The Official AntiStasi Comm
 params["_unknown"];
 private _fileName = "fn_notPlayer.sqf";
 
-if !(typeName _unknown isEqualTo "OBJECT") exitWith {true};
+if !(_unknown isEqualType objNull) exitWith {true};
 if !(isPlayer _unknown) exitWith {true};
 false;

--- a/A3-Antistasi/functions/Punishment/fn_punishment_notPlayer.sqf
+++ b/A3-Antistasi/functions/Punishment/fn_punishment_notPlayer.sqf
@@ -1,0 +1,37 @@
+/*
+Function:
+    A3A_fnc_punishment_notPlayer
+
+Description:
+    Checks if the variable passed is not a player object.
+    Pass anything you want.
+
+Scope:
+    <ANY>
+
+Environment:
+    <ANY>
+
+Parameters 1:
+    <ANY> The variable to verify if not  player.
+
+Parameters 2:
+    <ANY> List of variables, returns true if one is player.
+
+Returns:
+    <BOOLEAN> true if it is not a player; false if it is a player object; nil if it has crashed.
+
+Examples:
+    private _instigator = 1; 	// Really, any object will do just fine according to what BI thinks EHs should return.
+    if ( [_instigator] call A3A_fnc_punishment_notPlayer ) exitWith {};
+
+Author: Caleb Serafin
+Date Updated: July 2020
+License: MIT License, Copyright (c) 2019 Barbolani & The Official AntiStasi Community
+*/
+params["_unknown"];
+private _fileName = "fn_notPlayer.sqf";
+
+if !(typeName _unknown isEqualTo "OBJECT") exitWith {true};
+if !(isPlayer _unknown) exitWith {true};
+false;

--- a/A3-Antistasi/functions/REINF/fn_build.sqf
+++ b/A3-Antistasi/functions/REINF/fn_build.sqf
@@ -27,8 +27,8 @@ private _abortMessage = "";
 
 private _engineerIsBusy = {
 	private _engineer = param [0, objNull];
-	((_engineer getVariable ["helping",false]) 
-	or (_engineer getVariable ["rearming",false]) 
+	((_engineer getVariable ["helping",false])
+	or (_engineer getVariable ["rearming",false])
 	or (_engineer getVariable ["constructing",false]));
 };
 
@@ -53,21 +53,21 @@ if (isNull build_engineerSelected) then {
 	if (count _aiEngineers > 0 && player != leader player) exitWith {
 		_abortMessage =	_abortMessage + "Only squad leaders can order AI to build";
 	};
-	
+
 	{
 		if ([_x] call A3A_fnc_canFight && !([_x] call _engineerIsBusy)) exitWith {
 			build_engineerSelected = _x;
 			_abortMessage = _abortMessage + format ["Ordering %1 to build", _x];
 		};
 	} forEach _aiEngineers;
-	
+
 	if (isNull build_engineerSelected) exitWith {
 		_abortMessage =	_abortMessage + "You have no available engineers in your squad. They may be unconscious or busy.";
 	};
 };
 
 if (isNull build_engineerSelected ||
-   ((player != build_engineerSelected) and (isPlayer build_engineerSelected))) exitWith 
+   ((player != build_engineerSelected) and (isPlayer build_engineerSelected))) exitWith
 {
 	["Build Info", _abortMessage] call A3A_fnc_customHint;
 };
@@ -169,7 +169,7 @@ if ((build_type == "SB") or (build_type == "CB")) then
 
 if (_leave) exitWith {["Build Info", format ["%1",_textX]] call A3A_fnc_customHint;};
 
-build_handleDamageHandler = player addEventHandler ["HandleDamage",{[] call A3A_fnc_vehPlacementCancel;}];
+build_handleDamageHandler = player addEventHandler ["HandleDamage",{[] call A3A_fnc_vehPlacementCancel;nil;}];
 
 //START PLACEMENT HERE
 [_classX, "BUILDSTRUCTURE", ""] call A3A_fnc_vehPlacementBegin;


### PR DESCRIPTION
## What type of PR is this.
* [x] Bug
* Change
* Enhancement

### What have you changed and why?
Information:
> some moments EH's return objNull
> and other moments return random numbers
> it all depends on the moon and the stars
> for the universe does not define TRACE

fn_punishment_addEH:<br/>
Player checks at EH level now check `typeName` before `isPlayer` to ensure that no unexpected errors will be thrown.
added fn_punishment_notPlauyr;

### Please specify which Issue this PR Resolves.
closes [#1201](https://github.com/official-antistasi-community/A3-Antistasi/issues/1201)
closes [#1204](https://github.com/official-antistasi-community/A3-Antistasi/issues/1204)

### Please verify the following and ensure all checks are completed.

* [x] Have you loaded the mission in LAN host?
* [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
* [x] No
* Yes (Please provide further detail below.)
Needs dedicated server test.

### How can the changes be tested?
Steps: 
1. Run game
2. Shoot friendly x3
3. Should be in the ocean.
4. Admin should be notified
5. Should be released automatically.
6. Repeat above for a bit and see if the above RPT appears.

********************************************************
Notes: This is a rare bug.
You might have a bigger chance of getting struck by lightning.
A certain company that develops a specific game called ArmaIII hasn't mastered the EH yet. So it's full objNull if a hippo crosses a stream when the day is divisible by the second fortnight of the month during a full moon on a warm summers day while the mosquitoes bit down on Richard Parker as he struggles during the October revolution.
