### PR TITLE
DestroyedBuildings non-JIP fix

### DIFF
--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -14,7 +14,11 @@ if (!isServer) then {
 	"destroyedBuildings" addPublicVariableEventHandler {
 		{ hideObject _x } forEach (_this select 1);
 	};
-	[clientOwner, "destroyedBuildings"] remoteExecCall ["publicVariableClient", 2];
+	// need to wait until server has loaded the save
+	[] spawn {
+		waitUntil {(!isNil "serverInitDone")};
+		[clientOwner, "destroyedBuildings"] remoteExecCall ["publicVariableClient", 2];
+	};
 };
 
 if (hasInterface) then {


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The code in initClient to acquire the destroyedBuildings array on startup doesn't wait for serverInitDone, so it's likely to acquire an empty (incorrect) array for early-connecting clients (including HCs) because the server won't have loaded the saved game yet. This PR fixes it.

### Please specify which Issue this PR Resolves.
closes #1214 

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in singleplayer?
2. [ ] Have you loaded the mission in LAN host?
3. [X] Have you loaded the mission on a dedicated server?
4. [X] Have you loaded the mission on a dedicated server with HCs?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
