### PR TITLE
Remove ACE group join action from all rebel unit types

### DIFF
--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -423,6 +423,15 @@ gameMenu = (findDisplay 46) displayAddEventHandler ["KeyDown",A3A_fnc_keys];
 
 //if ((!isServer) and (isMultiplayer)) then {boxX call jn_fnc_arsenal_init};
 
+if (hasACE) then
+{
+	// Remove group join action from all rebel unit types
+	{
+		[_x, 1,["ACE_SelfActions", "ACE_TeamManagement", "ACE_LeaveGroup"]] call ace_interact_menu_fnc_removeActionFromClass;
+		[_x, 0,["ACE_MainActions", "ACE_JoinGroup"]] call ace_interact_menu_fnc_removeActionFromClass;
+	} forEach ([typePetros, staticCrewTeamPlayer, SDKUnarmed] + SDKSniper + SDKATman + SDKMedic + SDKMG + SDKExp + SDKGL + SDKMil + SDKSL + SDKEng);
+};
+
 boxX allowDamage false;
 boxX addAction ["Transfer Vehicle cargo to Ammobox", {[] spawn A3A_fnc_empty;}, 4];
 boxX addAction ["Move this asset", A3A_fnc_moveHQObject,nil,0,false,true,"","(_this == theBoss)", 4];

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -431,12 +431,14 @@ if (hasACE) then
 	};
 	// Remove group join action from all rebel unit types
 	// Need to compile the menus first, because ACE delays creating menus until a unit of that class is created
+	private _playerUnits = ["I_G_soldier_F", "I_G_Soldier_TL_F", "I_G_Soldier_AR_F", "I_G_medic_F", "I_G_engineer_F", "I_G_Soldier_GL_F" /*greenfor*/,
+		"B_G_soldier_F", "B_G_Soldier_TL_F", "B_G_Soldier_AR_F", "B_G_medic_F", "B_G_engineer_F", "B_G_Soldier_GL_F" /*bluefor*/];
 	{
 		[_x] call ace_interact_menu_fnc_compileMenu;
 		[_x] call ace_interact_menu_fnc_compileMenuSelfAction;
 		[_x, 1,["ACE_SelfActions", "ACE_TeamManagement", "ACE_LeaveGroup"]] call ace_interact_menu_fnc_removeActionFromClass;
 		[_x, 0,["ACE_MainActions", "ACE_JoinGroup"]] call ace_interact_menu_fnc_removeActionFromClass;
-	} forEach ([typePetros, staticCrewTeamPlayer, SDKUnarmed] + SDKSniper + SDKATman + SDKMedic + SDKMG + SDKExp + SDKGL + SDKMil + SDKSL + SDKEng);
+	} forEach (_playerUnits + [typePetros, staticCrewTeamPlayer, SDKUnarmed] + SDKSniper + SDKATman + SDKMedic + SDKMG + SDKExp + SDKGL + SDKMil + SDKSL + SDKEng);
 };
 
 boxX allowDamage false;

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -423,10 +423,17 @@ gameMenu = (findDisplay 46) displayAddEventHandler ["KeyDown",A3A_fnc_keys];
 
 //if ((!isServer) and (isMultiplayer)) then {boxX call jn_fnc_arsenal_init};
 
+
 if (hasACE) then
 {
+	if (isNil "ace_interact_menu_fnc_compileMenu" || isNil "ace_interact_menu_fnc_compileMenuSelfAction") exitWith {
+		[1, "ACE non-public functions have changed, rebel group join/leave actions will not be removed", _filename] call A3A_fnc_log;
+	};
 	// Remove group join action from all rebel unit types
+	// Need to compile the menus first, because ACE delays creating menus until a unit of that class is created
 	{
+		[_x] call ace_interact_menu_fnc_compileMenu;
+		[_x] call ace_interact_menu_fnc_compileMenuSelfAction;
 		[_x, 1,["ACE_SelfActions", "ACE_TeamManagement", "ACE_LeaveGroup"]] call ace_interact_menu_fnc_removeActionFromClass;
 		[_x, 0,["ACE_MainActions", "ACE_JoinGroup"]] call ace_interact_menu_fnc_removeActionFromClass;
 	} forEach ([typePetros, staticCrewTeamPlayer, SDKUnarmed] + SDKSniper + SDKATman + SDKMedic + SDKMG + SDKExp + SDKGL + SDKMil + SDKSL + SDKEng);


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug?
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Version of #1190 that works on clients other than the server host. Removes ACE group join action from all rebel unit types to prevent players joining HC and garrison groups. 

I forgot exactly why we're doing this, although there are several related exploits and breakages that can result from joining HC groups or garrisons. There should be an issue but I can't find one.

I'm assuming that all playable rebel unit types are always present in the rebel templates. If not, some player units may be missed and be able to leave groups using ACE. I don't think this causes any serious problems though.

### Please specify which Issue this PR Resolves.
Where is the issue for this? huh.
Closes #1064 

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in singleplayer?
2. [ ] Have you loaded the mission in LAN host?
3. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
