### PR TITLE
AddEH Param to avoid unintentional EH's for FIA AI

### DIFF
--- a/A3-Antistasi/functions/Base/fn_initPetros.sqf
+++ b/A3-Antistasi/functions/Base/fn_initPetros.sqf
@@ -9,7 +9,7 @@ petros allowDamage false;
 
 [petros,unlockedRifles] call A3A_fnc_randomRifle;
 petros selectWeapon (primaryWeapon petros);
-[petros] call A3A_fnc_punishment_FF_addEH;
+[petros,true] call A3A_fnc_punishment_FF_addEH;
 petros addEventHandler
 [
     "HandleDamage",


### PR DESCRIPTION
## What type of PR is this.
* [x] Bug
* Change
* Enhancement

### What have you changed and why?
Information:
    Adding an EH to AI now requires explicit permission through the param `_addToAI`

### Please specify which Issue this PR Resolves.
closes [#1219](https://github.com/official-antistasi-community/A3-Antistasi/issues/1219)

### Please verify the following and ensure all checks are completed.

2. [x] Have you loaded the mission in LAN host?
3. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
* [x] No
* Yes (Please provide further detail below.)
Needs testing on a dedicated server.

### How can the changes be tested?
Steps: 
1. `Petros allowDamage true` and shoot him => Get warning.
2. Hire friendly AI and shoot it => No warning.
3. Go to friendly garrison and shoot them => No warning.
4. Find enemy AI and shoot them => No warning.

********************************************************
Notes:
There maybe another cause of the referenced bug.