### PR TITLE
Fix double airbomb spawn

### DIFF
--- a/A3-Antistasi/functions/AI/fn_airbomb.sqf
+++ b/A3-Antistasi/functions/AI/fn_airbomb.sqf
@@ -1,7 +1,7 @@
 if (not isServer and hasInterface) exitWith {};
 private _filename = "fn_airbomb";
-private ["_countX","_pilot","_typeX","_ammo","_cluster","_sleep","_bomb"];
-_pilot = _this select 0;
+private ["_countX","_plane","_typeX","_ammo","_cluster","_sleep","_bomb"];
+_plane = vehicle (_this select 0);
 _typeX = _this select 1;
 _countX = 4;
 _cluster = false;
@@ -9,32 +9,35 @@ _cluster = false;
 switch (_typeX) do {
     case ("HE"): {
         _ammo = "Bo_Mk82";
-				_sleep = 0.25
+		_sleep = 0.25
     };
-		case ("CLUSTER"): {
-			_ammo = "BombCluster_03_Ammo_F";
-			_sleep = 0.5
-		};
-		case ("NAPALM"): {
-			_ammo = "ammo_Bomb_SDB";
-			_sleep = 0.5
-		};
-		default {
-			[1, "Invalid bomb type", _filename] call A3A_fnc_log;
-		};
+	case ("CLUSTER"): {
+		_ammo = "BombCluster_03_Ammo_F";
+		_sleep = 0.5
+	};
+	case ("NAPALM"): {
+		_ammo = "ammo_Bomb_SDB";
+		_sleep = 0.5
+	};
+	default {
+		[1, "Invalid bomb type", _filename] call A3A_fnc_log;
+	};
 };
 
-if (typeOf (vehicle _pilot) == vehSDKPlane) then {_countX = round (_countX / 2)};
+if (typeOf _plane == vehSDKPlane) then {_countX = round (_countX / 2); [3, "Rebel Airstrike", _filename] call A3A_fnc_log;};
 sleep random 5;
 
+[3, format ["Dropping %1 bombs of type %2 at %3 (near %4)", _countX, _typeX, getPos _plane,text nearestLocation [getPos _plane, "NameCity"]], _filename] call A3A_fnc_log;
+private _debugCounter = 0;
 for "_i" from 1 to _countX do
 	{
+	_debugCounter = _debugCounter + 1;
 	sleep _sleep;
-	if (alive _pilot) then
+	if (alive _plane) then
 		{
-		_bomb = _ammo createvehicle ([getPos _pilot select 0,getPos _pilot select 1,(getPos _pilot select 2)- 5]);
+		_bomb = _ammo createvehicle ([getPos _plane select 0,getPos _plane select 1,(getPos _plane select 2)- 5]);
 		waituntil {!isnull _bomb};
-		_bomb setDir (getDir _pilot);
+		_bomb setDir (getDir _plane);
 		_bomb setVelocity [0,0,-50];
 		if (_typeX == "NAPALM") then
 			{
@@ -52,4 +55,5 @@ for "_i" from 1 to _countX do
 			};
 		};
 	};
+[3, format ["Bombs dropped: %1", _debugCounter], _filename] call A3A_fnc_log;	
 //_bomba is used to track when napalm bombs hit the ground in order to call the napalm script on the correct position

--- a/A3-Antistasi/functions/AI/fn_airbomb.sqf
+++ b/A3-Antistasi/functions/AI/fn_airbomb.sqf
@@ -4,7 +4,7 @@ private _filename = "fn_airbomb";
 private ["_countX","_plane","_typeX","_ammo","_cluster","_sleep","_bomb"];
 _plane = vehicle (_this select 0);
 _typeX = _this select 1;
-_countX = 6;
+_countX = 4;
 _cluster = false;
 
 switch (_typeX) do {

--- a/A3-Antistasi/functions/AI/fn_airbomb.sqf
+++ b/A3-Antistasi/functions/AI/fn_airbomb.sqf
@@ -1,9 +1,10 @@
 if (not isServer and hasInterface) exitWith {};
 private _filename = "fn_airbomb";
+[3, format ["Executing on: %1", clientOwner], _filename] call A3A_fnc_log;
 private ["_countX","_plane","_typeX","_ammo","_cluster","_sleep","_bomb"];
 _plane = vehicle (_this select 0);
 _typeX = _this select 1;
-_countX = 4;
+_countX = 6;
 _cluster = false;
 
 switch (_typeX) do {

--- a/A3-Antistasi/functions/AI/fn_airbomb.sqf
+++ b/A3-Antistasi/functions/AI/fn_airbomb.sqf
@@ -2,7 +2,12 @@ if (not isServer and hasInterface) exitWith {};
 private _filename = "fn_airbomb";
 [3, format ["Executing on: %1", clientOwner], _filename] call A3A_fnc_log;
 private ["_countX","_plane","_typeX","_ammo","_cluster","_sleep","_bomb"];
+
 _plane = vehicle (_this select 0);
+if (isNil "_plane") exitWith {[1, "No plane passed, terminating", _filename] call A3A_fnc_log;};
+if (_plane getVariable ["airbomb", false]) exitWith {[1, "Airbomb already executing on this plane", _filename] call A3A_fnc_log;};
+_plane setVariable ["airbomb", true, true];
+
 _typeX = _this select 1;
 _countX = 6;
 _cluster = false;
@@ -57,4 +62,5 @@ for "_i" from 1 to _countX do
 		};
 	};
 [3, format ["Bombs dropped: %1", _debugCounter], _filename] call A3A_fnc_log;	
+_plane setVariable ["airbomb", nil, true];
 //_bomba is used to track when napalm bombs hit the ground in order to call the napalm script on the correct position

--- a/A3-Antistasi/functions/AI/fn_airbomb.sqf
+++ b/A3-Antistasi/functions/AI/fn_airbomb.sqf
@@ -2,12 +2,7 @@ if (not isServer and hasInterface) exitWith {};
 private _filename = "fn_airbomb";
 [3, format ["Executing on: %1", clientOwner], _filename] call A3A_fnc_log;
 private ["_countX","_plane","_typeX","_ammo","_cluster","_sleep","_bomb"];
-
 _plane = vehicle (_this select 0);
-if (isNil "_plane") exitWith {[1, "No plane passed, terminating", _filename] call A3A_fnc_log;};
-if (_plane getVariable ["airbomb", false]) exitWith {[1, "Airbomb already executing on this plane", _filename] call A3A_fnc_log;};
-_plane setVariable ["airbomb", true, true];
-
 _typeX = _this select 1;
 _countX = 6;
 _cluster = false;
@@ -62,5 +57,4 @@ for "_i" from 1 to _countX do
 		};
 	};
 [3, format ["Bombs dropped: %1", _debugCounter], _filename] call A3A_fnc_log;	
-_plane setVariable ["airbomb", nil, true];
 //_bomba is used to track when napalm bombs hit the ground in order to call the napalm script on the correct position

--- a/A3-Antistasi/functions/AI/fn_airstrike.sqf
+++ b/A3-Antistasi/functions/AI/fn_airstrike.sqf
@@ -112,8 +112,7 @@ _wp1 setWaypointBehaviour "CARELESS";
 _plane setCollisionLight true;
 
 if ((_typeX == "NAPALM") and (napalmCurrent)) then {_typeX = "CLUSTER"};
-private _executeOn = if (count hcArray == 0) then {2} else {hcArray select 0};
-_wp1 setWaypointStatements ["true", format ["[this, '%1'] remoteExec ['A3A_fnc_airbomb', %2]", _typeX, _executeOn]];
+_wp1 setWaypointStatements ["local this", format ["[this, '%1'] spawn A3A_fnc_airbomb", _typeX]];
 
 _wp2 = _groupPlane addWaypoint [_pos2, 1];
 _wp2 setWaypointSpeed "LIMITED";

--- a/A3-Antistasi/functions/AI/fn_airstrike.sqf
+++ b/A3-Antistasi/functions/AI/fn_airstrike.sqf
@@ -112,7 +112,7 @@ _wp1 setWaypointBehaviour "CARELESS";
 _plane setCollisionLight true;
 
 if ((_typeX == "NAPALM") and (napalmCurrent)) then {_typeX = "CLUSTER"};
-_wp1 setWaypointStatements ["local this", format ["[this, '%1'] spawn A3A_fnc_airbomb", _typeX]];
+_wp1 setWaypointStatements ["true", format ["if !(local this) exitWith {}; [this, '%1'] spawn A3A_fnc_airbomb", _typeX]];
 
 _wp2 = _groupPlane addWaypoint [_pos2, 1];
 _wp2 setWaypointSpeed "LIMITED";

--- a/A3-Antistasi/functions/AI/fn_airstrike.sqf
+++ b/A3-Antistasi/functions/AI/fn_airstrike.sqf
@@ -110,8 +110,10 @@ _wp1 setWaypointType "MOVE";
 _wp1 setWaypointSpeed "LIMITED";
 _wp1 setWaypointBehaviour "CARELESS";
 _plane setCollisionLight true;
+
 if ((_typeX == "NAPALM") and (napalmCurrent)) then {_typeX = "CLUSTER"};
-if (_typeX == "HE") then {_wp1 setWaypointStatements ["true", "[this,""HE""] spawn A3A_fnc_airbomb"]} else {if (_typeX == "NAPALM") then {_wp1 setWaypointStatements ["true", "[this,""NAPALM""] spawn A3A_fnc_airbomb"]} else {_wp1 setWaypointStatements ["true", "[this,""CLUSTER""] spawn A3A_fnc_airbomb"]}};
+private _executeOn = if (count hcArray == 0) then {2} else {hcArray select 0};
+_wp1 setWaypointStatements ["true", format ["[this, '%1'] remoteExec ['A3A_fnc_airbomb', %2]", _typeX, _executeOn]];
 
 _wp2 = _groupPlane addWaypoint [_pos2, 1];
 _wp2 setWaypointSpeed "LIMITED";

--- a/A3-Antistasi/functions/REINF/fn_NATObomb.sqf
+++ b/A3-Antistasi/functions/REINF/fn_NATObomb.sqf
@@ -72,8 +72,7 @@ _wp1 setWaypointSpeed "LIMITED";
 _wp1 setWaypointBehaviour "CARELESS";
 
 if ((_typeX == "NAPALM") and (!napalmEnabled)) then {_typeX = "HE"};
-private _executeOn = if (count hcArray == 0) then {2} else {hcArray select 0};
-_wp1 setWaypointStatements ["true", format ["[this, '%1'] remoteExec ['A3A_fnc_airbomb', %2]", _typeX, _executeOn]];
+_wp1 setWaypointStatements ["local this", format ["[this, '%1'] spawn A3A_fnc_airbomb", _typeX]];
 
 
 

--- a/A3-Antistasi/functions/REINF/fn_NATObomb.sqf
+++ b/A3-Antistasi/functions/REINF/fn_NATObomb.sqf
@@ -71,9 +71,9 @@ _wp1 setWaypointType "MOVE";
 _wp1 setWaypointSpeed "LIMITED";
 _wp1 setWaypointBehaviour "CARELESS";
 
-if (_typeX == "NAPALM" && napalmEnabled) then {_wp1 setWaypointStatements ["true", "[this,""NAPALM""] spawn A3A_fnc_airbomb"]} else {_typeX = "HE"};
-if (_typeX == "CLUSTER") then {_wp1 setWaypointStatements ["true", "[this,""CLUSTER""] spawn A3A_fnc_airbomb"]};
-if (_typeX == "HE") then {_wp1 setWaypointStatements ["true", "[this,""HE""] spawn A3A_fnc_airbomb"]};
+if ((_typeX == "NAPALM") and (!napalmEnabled)) then {_typeX = "HE"};
+private _executeOn = if (count hcArray == 0) then {2} else {hcArray select 0};
+_wp1 setWaypointStatements ["true", format ["[this, '%1'] remoteExec ['A3A_fnc_airbomb', %2]", _typeX, _executeOn]];
 
 
 

--- a/A3-Antistasi/functions/REINF/fn_NATObomb.sqf
+++ b/A3-Antistasi/functions/REINF/fn_NATObomb.sqf
@@ -72,9 +72,7 @@ _wp1 setWaypointSpeed "LIMITED";
 _wp1 setWaypointBehaviour "CARELESS";
 
 if ((_typeX == "NAPALM") and (!napalmEnabled)) then {_typeX = "HE"};
-_wp1 setWaypointStatements ["local this", format ["[this, '%1'] spawn A3A_fnc_airbomb", _typeX]];
-
-
+_wp1 setWaypointStatements ["true", format ["if !(local this) exitWith {}; [this, '%1'] spawn A3A_fnc_airbomb", _typeX]];
 
 _wp2 = group _plane addWaypoint [_pos2, 1];
 _wp2 setWaypointSpeed "LIMITED";


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    airbomb was executed on hc as well when it spawned duplication the effect, now it will execute on either the firs hc or server

### Please specify which Issue this PR Resolves.
closes #1223
### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in singleplayer?
2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
call in an airstrike and watch, it also logs the airstrike heavely
********************************************************
Notes:
