### PR TITLE
WavedCA vehicle selection overhaul

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_WPCreate.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_WPCreate.sqf
@@ -120,7 +120,7 @@ if (worldName == "Tanoa") then {
 	if (_roadsMrk isEqualTo []) exitWith
 	{
 		diag_log "Could not find any road marker in range, assuming direct way!";
-		_finalArray = [_mrkDestination];
+		_finalArray = [];
 	};
 
 	_roadsMrk = [_roadsMrk, [], {getMarkerPos _x distance2d _posOrigin}, "ASCEND"] call BIS_fnc_sortBy;
@@ -143,7 +143,8 @@ if (worldName == "Tanoa") then {
 };
 
 private _waypoints = _finalArray apply {_groupX addWaypoint [getMarkerPos (_x), 0]};
+{_x setWaypointBehaviour "SAFE"} forEach _waypoints;
 
-_groupX setCurrentWaypoint (_waypoints select 0);
+if (count _waypoints > 0) then { _groupX setCurrentWaypoint (_waypoints select 0) };
 
 _waypoints;

--- a/A3-Antistasi/functions/CREATE/fn_createQRF.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createQRF.sqf
@@ -149,8 +149,6 @@ if (_landAttack) then
 				_groupVeh spawn A3A_fnc_attackDrillAI;
 				//_groups pushBack _groupX;
 				[_source,_landPos,_groupVeh] call A3A_fnc_WPCreate;
-				_Vwp0 = (wayPoints _groupVeh) select 0;
-				_Vwp0 setWaypointBehaviour "SAFE";
 				_Vwp0 = _groupVeh addWaypoint [_landPos,count (wayPoints _groupVeh)];
 				_Vwp0 setWaypointType "TR UNLOAD";
 				//_Vwp0 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI"];
@@ -169,8 +167,6 @@ if (_landAttack) then
 				_groupVeh spawn A3A_fnc_attackDrillAI;
 				if (count units _groupVeh > 1) then {_groupVeh selectLeader (units _groupVeh select 1)};
 				[_source,_landPos,_groupVeh] call A3A_fnc_WPCreate;
-				_Vwp0 = (wayPoints _groupVeh) select 0;
-				_Vwp0 setWaypointBehaviour "SAFE";
 				/*
 				_Vwp0 = (wayPoints _groupVeh) select ((count wayPoints _groupVeh) - 1);
 				_Vwp0 setWaypointType "GETOUT";
@@ -205,8 +201,6 @@ if (_landAttack) then
 		{
 			{_x disableAI "MINEDETECTION"} forEach (units _groupVeh);
 			[_source,_posDest,_groupVeh] call A3A_fnc_WPCreate;
-			_Vwp0 = (wayPoints _groupVeh) select 0;
-			_Vwp0 setWaypointBehaviour "SAFE";
 			_Vwp0 = _groupVeh addWaypoint [_posDest, count (waypoints _groupVeh)];
 			[_veh,"Tank"] spawn A3A_fnc_inmuneConvoy;
 			_Vwp0 setWaypointType "SAD";

--- a/A3-Antistasi/functions/CREATE/fn_patrolReinf.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_patrolReinf.sqf
@@ -65,8 +65,6 @@ if (_land) then
 	[_veh,"Inf Truck."] spawn A3A_fnc_inmuneConvoy;
 	_groupX spawn A3A_fnc_attackDrillAI;
 	[_mrkOrigin,_posDestination,_groupX] call A3A_fnc_WPCreate;
-	_Vwp0 = (wayPoints _groupX) select 0;
-	_Vwp0 setWaypointBehaviour "SAFE";
 	_Vwp0 = _groupX addWaypoint [_posDestination, count (wayPoints _groupX)];
 	_Vwp0 setWaypointType "GETOUT";
 	_Vwp0 setWaypointStatements ["true","nul = [(thisList select {alive _x}),side this,(group this) getVariable [""reinfMarker"",""""],0] remoteExec [""A3A_fnc_garrisonUpdate"",2];[group this] spawn A3A_fnc_groupDespawner; reinfPatrols = reinfPatrols - 1; publicVariable ""reinfPatrols"";"];

--- a/A3-Antistasi/functions/CREATE/fn_wavedCA.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_wavedCA.sqf
@@ -458,7 +458,7 @@ while {(_waves > 0)} do
 
 	private _nVehAir = _nVeh;
 	if !(_posOriginLand isEqualTo []) then {
-		sleep ((_posOrigin distance _posDestination)/30);			// give land vehicles a head start
+		sleep ((_posOrigin distance _posDestination)/15);			// give land vehicles a head start
 		_nVehAir = floor (_nVeh / 2);								// fill out with air vehicles
 	};
 	_posGround = [_posOrigin select 0,_posOrigin select 1,0];


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
The primary change is to limit the proportion of air supports used for an attack so that there's always a reasonable quantity of infantry for the termination conditions to work. Ground vehicle selection also takes greater care to maintain a balance of vehicle firepower vs infantry cargo.

Additional changes:

- Fixed a recent bug where land vehicles didn't reduce the number of air vehicles.
- Fixed a bug with WPCreate where an additional 0,0 waypoint was often added.
- Boosted the first wave vehicle count relative to later waves.
- A single available vehicle can no longer be used multiple times per wave.
- Force aircraft to return after termination, as with createQRF/patrolCA.
- Improved unit limit handling, will not longer drop single unit squads.
- Cut UAVs to one at a time, as they don't do much aside from VANTinfo.

### Please specify which Issue this PR Resolves.
closes #1203 

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Things that could do with more testing:
- Invaders.
- High-aggro cases.
- Weird available-vehicle inputs.
- Cases with several fresh ground bases nearby (to see wave 2+ ground vehicles).
- Cases where WPCreate actually does something.

### How can the changes be tested?

`["outpost_41", "airport_4", 3] remoteExec ["A3A_fnc_wavedCA", 2]`
Spawn a 3-wave attack from outpost_41 to airport_4, executed on the server.

```
{
   _mrk = format ["Dum%1", _x];
   _mrk setMarkerTextLocal _x;
} forEach (outposts + seaports + airportsX + resourcesX + factories);
```
Locally rename locations with their actual marker names, for debugging.

```
{
   _vcount = timer getVariable [_x, 0];
   timer setVariable [_x, _vcount+1, true];
} forEach vehNATOAPC;
```
Add one of each occupant APC type to the reserve pool, in case you ran out.
