### PR TITLE
Side Petros check removal #282

### DIFF
--- a/A3-Antistasi/Templates/3CB_Reb_TTF_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_TTF_Arid.sqf
@@ -1,5 +1,5 @@
 //3CB Blufor ALtis Template Call
-if (side petros == west) exitWith {call compile preProcessFileLineNumbers "Templates\3CB_Reb_TPGM_Arid.sqf"};
+if (teamPlayer == west) exitWith {call compile preProcessFileLineNumbers "Templates\3CB_Reb_TPGM_Arid.sqf"};
 //Tanoa Template Call
 if (worldName == "Tanoa") exitWith {call compile preProcessFileLineNumbers "Templates\3CB_Reb_CNM_Trop.sqf"};
 ////////////////////////////////////

--- a/A3-Antistasi/Templates/BAF_Occ_BAF_Arid.sqf
+++ b/A3-Antistasi/Templates/BAF_Occ_BAF_Arid.sqf
@@ -1,4 +1,4 @@
-if (side petros == west) exitWith {call compile preProcessFileLineNumbers "Templates\3CB_Occ_TKA_Arid.sqf"};
+if (teamPlayer == west) exitWith {call compile preProcessFileLineNumbers "Templates\3CB_Occ_TKA_Arid.sqf"};
 if (worldName == "Tanoa") exitWith {call compile preProcessFileLineNumbers "Templates\BAF_Occ_BAF_Trop.sqf"};
 ////////////////////////////////////
 //       NAMES AND FLAGS         ///

--- a/A3-Antistasi/Templates/Vanilla_Occ_NATO_Altis.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Occ_NATO_Altis.sqf
@@ -1,5 +1,5 @@
 //Call to Blufor Alits Template
-if (side petros == west) exitWith {call compile preProcessFileLineNumbers "Templates\Vanilla_Occ_AAF_Altis.sqf"};
+if (teamPlayer == west) exitWith {call compile preProcessFileLineNumbers "Templates\Vanilla_Occ_AAF_Altis.sqf"};
 //Call For Tanoa
 if (worldName == "Tanoa") exitWith {call compile preProcessFileLineNumbers "Templates\Vanilla_Occ_NATO_Tanoa.sqf"};
 //Call for Woodland --------> I know there are better ways but that the Current one, dont reee at me.

--- a/A3-Antistasi/Templates/Vanilla_Occ_NATO_WDL.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Occ_NATO_WDL.sqf
@@ -1,4 +1,4 @@
-if (side petros == west) exitWith {call compile preProcessFileLineNumbers "Templates\Vanilla_Occ_AAF_Altis.sqf"};
+if (teamPlayer == west) exitWith {call compile preProcessFileLineNumbers "Templates\Vanilla_Occ_AAF_Altis.sqf"};
 ////////////////////////////////////
 //       NAMES AND FLAGS         ///
 ////////////////////////////////////
@@ -49,7 +49,7 @@ vehNATOPVP = ["B_MRAP_01_F","B_MRAP_01_hmg_F","B_Quadbike_01_F"];
 //Military Units
 NATOGrunt = "B_W_Soldier_F";
 NATOOfficer = "B_W_Officer_F";
-NATOOfficer2 = "B_Competitor_F"; 
+NATOOfficer2 = "B_Competitor_F";
 NATOBodyG = "B_W_Soldier_TL_F";
 NATOCrew = "B_W_Crew_F";
 NATOUnarmed = "B_W_Survivor_F";

--- a/A3-Antistasi/Templates/Vanilla_Reb_FIA_Altis.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_FIA_Altis.sqf
@@ -1,5 +1,5 @@
 //Blufor Altis Template Call
-if (side petros == west) exitWith {call compile preProcessFileLineNumbers "Templates\Vanilla_Reb_FIA_B_Altis.sqf"};
+if (teamPlayer == west) exitWith {call compile preProcessFileLineNumbers "Templates\Vanilla_Reb_FIA_B_Altis.sqf"};
 if (worldName == "Tanoa") exitWith {call compile preProcessFileLineNumbers "Templates\Vanilla_Reb_SDK_Tanoa.sqf"};
 ////////////////////////////////////
 //       NAMES AND FLAGS         ///

--- a/A3-Antistasi/Templates/Vanilla_Reb_FIA_Enoch.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_FIA_Enoch.sqf
@@ -1,5 +1,5 @@
 //Blufor Altis Template Call
-if (side petros == west) exitWith {call compile preProcessFileLineNumbers "Templates\Vanilla_Reb_FIA_B_Altis.sqf"};
+if (teamPlayer == west) exitWith {call compile preProcessFileLineNumbers "Templates\Vanilla_Reb_FIA_B_Altis.sqf"};
 ////////////////////////////////////
 //       NAMES AND FLAGS         ///
 ////////////////////////////////////

--- a/A3-Antistasi/functions/Ammunition/fn_itemSort.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_itemSort.sqf
@@ -1,5 +1,5 @@
 diveGear append ["V_RebreatherIA","G_Diving"];
-if (side (group petros) == west) then {
+if (teamPlayer == west) then {
 	diveGear pushBack "U_B_Wetsuit"
 } else {
 	diveGear pushBack "U_I_Wetsuit"

--- a/A3-Antistasi/functions/Save/fn_varNameToSaveName.sqf
+++ b/A3-Antistasi/functions/Save/fn_varNameToSaveName.sqf
@@ -4,9 +4,9 @@ params ["_varName", ""];
 if (worldName == "Tanoa") then {
 	format["%1%2%3%4",_varName,serverID,campaignID,"WotP"];
 } else {
-	if (side group petros == independent) then {
+	if (teamPlayer == independent) then {
 		format["%1%2%3%4%5",_varName,serverID,campaignID,"Antistasi",worldName];
 	} else {
-		format["%1%2%3%4%5",_varName,serverID,campaignID,"AntistasiB",worldName]; 
+		format["%1%2%3%4%5",_varName,serverID,campaignID,"AntistasiB",worldName];
 	};
 };

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -88,7 +88,7 @@ else {
 private ["_colourTeamPlayer", "_colorInvaders"];
 _colourTeamPlayer = teamPlayer call BIS_fnc_sideColor;
 _colorInvaders = Invaders call BIS_fnc_sideColor;
-_positionX = if (side player == side (group petros)) then {position petros} else {getMarkerPos "respawn_west"};
+_positionX = if (side player == teamPlayer) then {position petros} else {getMarkerPos "respawn_west"};
 
 {
 	_x set [3, 0.33]
@@ -341,7 +341,7 @@ if (isMultiplayer) then {
 				_isMember = true;
 				["General Info", "You are not in the member's list, but as you are Server Admin, you have been added. Welcome!"] call A3A_fnc_customHint;
 			};
-			
+
 			if (_isMember) then {
 				membersX pushBack (getPlayerUID player);
 				publicVariable "membersX";
@@ -349,7 +349,7 @@ if (isMultiplayer) then {
 				_nonMembers = {(side group _x == teamPlayer) and !([_x] call A3A_fnc_isMember)} count (call A3A_fnc_playableUnits);
 				if (_nonMembers >= (playableSlotsNumber teamPlayer) - bookedSlots) then {["memberSlots",false,1,false,false] call BIS_fnc_endMission};
 				if (memberDistance != 16000) then {[] execVM "orgPlayers\nonMemberDistance.sqf"};
-				
+
 				["General Info", "Welcome Guest<br/><br/>You have joined this server as guest"] call A3A_fnc_customHint;
 			};
 		};
@@ -380,7 +380,7 @@ if (_isJip) then {
 		} forEach missionsX;
 	};
 }
-else 
+else
 {
 	[2,"Not Joining in Progress (JIP)",_filename] call A3A_fnc_log;
 };
@@ -489,7 +489,7 @@ if (isNil "placementDone") then {
 if (isMultiplayer) then {
 	[] spawn A3A_fnc_createDialog_shouldLoadPersonalSave;
 }
-else 
+else
 {
 	if (loadLastSave) then {
 		[] spawn A3A_fnc_loadPlayer;


### PR DESCRIPTION
All references to petros as a check for players sides has been changed to teamPlayer

## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    Attempted to change `side petros` and `side (group petros)` in all checks for player side. Bug was caused by dead petros on check.

### Please specify which Issue this PR Resolves.
closes #282 

### Please verify the following and ensure all checks are completed.

2. [ ] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: have not tested

********************************************************
Notes:
