### PR TITLE
Overhaul save consistency, especially player saves

### DIFF
--- a/A3-Antistasi/dialogs.hpp
+++ b/A3-Antistasi/dialogs.hpp
@@ -79,7 +79,7 @@ class should_load_personal_save {
 			y = 0.317959 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
-			action = "closeDialog 0; nul = [] spawn A3A_fnc_loadPreviousSession;";
+			action = "closeDialog 0; [true] spawn A3A_fnc_loadPreviousSession;";
 		};
 		class HQ_button_Gstatic: RscButton
 		{
@@ -90,7 +90,7 @@ class should_load_personal_save {
 			y = 0.317959 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
-			action = "closeDialog 0;";
+			action = "closeDialog 0; [false] spawn A3A_fnc_loadPreviousSession;";
 		};
 	};
 };
@@ -981,7 +981,7 @@ class game_options 		{
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			tooltip = "Use this option to save your current game. It does save the most important data in a ""Grand Theft Auto"" way. This opnion allows good MP save and independent saves of any version update. Vanilla saves are disabled because of lack of several features";
-			action = "closeDialog 0;if (player == theBoss) then {[] remoteExecCall [""A3A_fnc_saveLoop"", 2, false];} else {[] remoteExecCall [""A3A_fnc_saveLoop"", player, false]; hintC ""Personal Stats Saved""};";
+			action = "closeDialog 0; [] spawn A3A_fnc_persistentSave;";
 		};
 	};
 };										//slots 6+1

--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -248,7 +248,6 @@ class A3A
 
 	class Dialogs
 	{
-
 		class buyVehicle {};
 		class buyVehicleCiv {};
 		class clearForest {};
@@ -256,8 +255,10 @@ class A3A
 		class createDialog_shouldLoadPersonalSave {};
 		class dialogHQ {};
 		class fastTravelRadio {};
+		class loadPreviousSession {};
 		class mineDialog {};
 		class moveHQObject {};
+		class persistentSave {};
 		class skiptime {};
 		class squadOptions {};
 		class squadRecruit {};
@@ -498,12 +499,12 @@ class A3A
 	{
 		class deleteSave {};
 		class loadPlayer {};
-		class loadPreviousSession {};
 		class loadServer {};
 		class playerHasSave {};
 		class savePlayer {};
 		class getStatVariable {};
 		class loadStat {};
+		class resetPlayer {};
 		class retrievePlayerStat {};
 		class returnSavedStat {};
 		class savePlayerStat {};

--- a/A3-Antistasi/functions/Base/fn_onPlayerDisconnect.sqf
+++ b/A3-Antistasi/functions/Base/fn_onPlayerDisconnect.sqf
@@ -1,10 +1,6 @@
 private _filename = "fn_onPlayerDisconnect";
-private ["_unit","_resourcesX","_hr","_weaponsX","_ammunition","_items","_pos"];
 
-_unit = _this select 0;
-_uid = _this select 2;
-_resourcesX = 0;
-_hr = 0;
+params ["_unit", "_id", "_uid"];
 
 [2, format ["Player disconnected with id %1 and unit %2 on side %3", _uid, _unit, (side _unit)], _filename] call A3A_fnc_log;
 
@@ -16,11 +12,11 @@ if (side _unit == sideLogic || {_uid == ""}) exitWith {
 // find original player unit in case of remote control
 private _realUnit = _unit getVariable ["owner", _unit];
 
-[2, format ["Player unit %1, player unit owner %2, boss %3", _unit, _realUnit, theBoss], _filename] call A3A_fnc_log;
+[3, format ["Player unit %1, original unit %2, boss %3", _unit, _realUnit, theBoss], _filename] call A3A_fnc_log;
 
 if (_realUnit == theBoss) then
 {
-	if (group petros == group _realUnit) then { [] spawn A3A_fnc_buildHQ}; 
+	if (group petros == group _realUnit) then { [] spawn A3A_fnc_buildHQ }; 
 
 	// Remove our real unit from boss
 	_realUnit setVariable ["eligible", false, true];
@@ -36,13 +32,9 @@ if (side group _unit == teamPlayer || side group _unit == sideUnknown) then
 	};
 };
 
-[_uid, _realUnit] call A3A_fnc_savePlayer;
+[_uid, _realUnit, false] call A3A_fnc_savePlayer;
 
 // Preventing duping due to weapon loadout saves
 if (alive _realUnit && {!(_realUnit getVariable ["incapacitated", false])} ) then { deleteVehicle _realUnit }
 else { _realUnit setDamage 1 };			// finish off, if incapped
-
-//if (_realUnit != _unit) then { deleteVehicle _unit };
-
-//diag_log format ["dataX de handledisconnect: %1",_this];
 

--- a/A3-Antistasi/functions/Dialogs/fn_createDialog_shouldLoadPersonalSave.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_createDialog_shouldLoadPersonalSave.sqf
@@ -5,5 +5,3 @@ waitUntil {dialog};
 waitUntil {!dialog};
 
 [] spawn A3A_fnc_credits;
-diag_log "[Antistasi] Saving is now possible.";
-player setVariable ['canSave', true, true];

--- a/A3-Antistasi/functions/Dialogs/fn_loadPreviousSession.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_loadPreviousSession.sqf
@@ -1,0 +1,8 @@
+params ["_load"];
+
+if (_load) then {
+	[getPlayerUID player, player] remoteExecCall ["A3A_fnc_loadPlayer", 2];
+} else {
+	[getPlayerUID player, player] remoteExecCall ["A3A_fnc_resetPlayer", 2];
+};
+

--- a/A3-Antistasi/functions/Dialogs/fn_persistentSave.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_persistentSave.sqf
@@ -1,0 +1,8 @@
+// worker function for persistent save button
+
+if (player == theBoss) then {
+	[] remoteExecCall ["A3A_fnc_saveLoop", 2];
+} else {
+	[getPlayerUID player, player] remoteExecCall ["A3A_fnc_savePlayer", 2];
+	hintC "Personal Stats Saved";
+};

--- a/A3-Antistasi/functions/Save/fn_loadPlayer.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadPlayer.sqf
@@ -29,7 +29,7 @@ if ([_unit] call A3A_fnc_isMember) then
 };
 
 private _money = [_playerId, "moneyX"] call A3A_fnc_retrievePlayerStat;
-if (isNil "_money" || {!(_money isEqualType 0)}) then {_money = 100};
+if (isNil "_money" || {!(_money isEqualType 0)}) then {_money = playerStartingMoney};
 
 private _garage = [_playerId, "personalGarage"] call A3A_fnc_retrievePlayerStat;
 if (isNil "_garage" || {!(_garage isEqualType [])}) then {_garage = []};

--- a/A3-Antistasi/functions/Save/fn_loadPlayer.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadPlayer.sqf
@@ -1,53 +1,47 @@
-params [["_playerId", ""], ["_unit", objNull]];
-
-if (hasInterface) then {
-	if (count _playerId == 0 || isNull _unit) then {
-		_playerId = getPlayerUID player;
-		_unit = player;
-		[format ["[Antistasi] Telling server to load player %1 into %2", _playerId, _unit]] remoteExec ["diag_log", 2];
-	};
+private _filename = "fn_loadPlayer";
+if (!isServer) exitWith {
+	[1, "Miscalled server-only function", _filename] call A3A_fnc_log;
 };
+waitUntil {(!isNil "initVar")};		// hmm...
 
-if (isMultiplayer && !isServer) exitwith {
-	[_playerId, _unit] remoteExec ["A3A_fnc_loadPlayer", 2];
-};
-
-waitUntil {(!isNil "initVar")};
+params ["_playerId", "_unit"];
 
 if !([_playerId] call A3A_fnc_playerHasSave) exitWith {
-	diag_log format ["[Antistasi] No save found for player %1 into unit %2", _playerId, _unit];
+	[2, format ["No save found for player ID %1", _playerId], _filename] call A3A_fnc_log;
+	[_playerId, _unit] call A3A_fnc_resetPlayer;
 };
 
-diag_log format ["[Antistasi] Server loading player %1 into unit %2", _playerId, _unit];
+[2, format ["Loading player data for ID %1 into unit %2", _playerId, _unit], _filename] call A3A_fnc_log;
 
-private _loadoutInfo =	[_playerId, "loadoutPlayer"] call A3A_fnc_retrievePlayerStat;
-	
-if (!isNil "_loadoutInfo") then {
-	_unit setUnitLoadout _loadoutInfo;
-};
+private _loadout = [_playerId, "loadoutPlayer"] call A3A_fnc_retrievePlayerStat;
+if (!isNil "_loadout") then { _unit setUnitLoadout _loadout };
 
-if (isMultiplayer && side _unit == teamPlayer) then
+private _score = 0;
+private _rank = "PRIVATE";
+
+if ([_unit] call A3A_fnc_isMember) then
 {
-	//player setPos getMarkerPos respawnTeamPlayer;
-	if ([_unit] call A3A_fnc_isMember) then
-	{
-		private _score = ([_playerId, "scorePlayer"] call A3A_fnc_retrievePlayerStat);
-		_score = if (isNil "_score") then {0} else {_score};
-		_unit setVariable ["score",_score,true];
-		
-		private _rank = [_playerId, "rankPlayer"] call A3A_fnc_retrievePlayerStat;
-		_rank = if (isNil "_rank" || {count _rank == 0}) then {"PRIVATE"} else {_rank};
-		[_unit, _rank] remoteExec ["A3A_fnc_ranksMP"]; 
-		_unit setVariable ["rankX",_rank,true];
-	};
+	private _saveScore = [_playerId, "scorePlayer"] call A3A_fnc_retrievePlayerStat;
+	if (!isNil "_saveScore" && { _saveScore isEqualType 0 }) then {_score = _saveScore};
 	
-	private _money = ([_playerId, "moneyX"] call A3A_fnc_retrievePlayerStat);
-	_money = if (isNil "_money" || {typeName _money != typeName 0}) then {100} else {_money};
-	_unit setVariable ["moneyX",_money,true];
-	
-	//Personal garage has a nil check built in
-	[_unit, [_playerId, "personalGarage"] call A3A_fnc_retrievePlayerStat] call A3A_fnc_setPersonalGarage;
+	private _saveRank = [_playerId, "rankPlayer"] call A3A_fnc_retrievePlayerStat;
+	if (!isNil "_saveRank" && { _saveRank isEqualType "" }) then {_rank = _saveRank};
 };
-diag_log format ["%1: [Antistasi] | INFO | Personal player stats loaded.",servertime];
+
+private _money = [_playerId, "moneyX"] call A3A_fnc_retrievePlayerStat;
+if (isNil "_money" || {!(_money isEqualType 0)}) then {_money = 100};
+
+private _garage = [_playerId, "personalGarage"] call A3A_fnc_retrievePlayerStat;
+if (isNil "_garage" || {!(_garage isEqualType [])}) then {_garage = []};
+
+_unit setVariable ["score", _score, true];
+_unit setUnitRank _rank;
+_unit setVariable ["rankX", _rank, true];
+_unit setVariable ["moneyX", _money, true];
+[_unit, _garage] call A3A_fnc_setPersonalGarage;
 
 [] remoteExec ["A3A_fnc_statistics", _unit];
+_unit setVariable ["canSave", true, true];
+
+[2, format ["Player %1: Score %2, rank %3, money %4, garage count %5", _playerId, _score, _rank, _money, count _garage], _filename] call A3A_fnc_log;
+

--- a/A3-Antistasi/functions/Save/fn_loadPreviousSession.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadPreviousSession.sqf
@@ -1,4 +1,0 @@
-[] call A3A_fnc_loadPlayer;
-
-
-

--- a/A3-Antistasi/functions/Save/fn_resetPlayer.sqf
+++ b/A3-Antistasi/functions/Save/fn_resetPlayer.sqf
@@ -1,0 +1,25 @@
+private _filename = "fn_resetPlayer";
+if (!isServer) exitWith {
+	[1, "Miscalled server-only function", _filename] call A3A_fnc_log;
+};
+waitUntil {(!isNil "initVar")};		// hmm...
+
+params ["_playerId", "_unit"];
+
+[2, format ["Resetting player data for ID %1, unit %2", _playerId, _unit], _filename] call A3A_fnc_log;
+
+// Don't restore more money than this player had previously
+private _money = 100;
+if ([_playerId] call A3A_fnc_playerHasSave) then {
+	_money = _money min ([_playerId, "moneyX"] call A3A_fnc_retrievePlayerStat);
+};
+
+_unit setVariable ["moneyX", _money, true];
+_unit setVariable ["score", 0, true];
+_unit setVariable ["rankX", "PRIVATE", true];
+_unit setUnitRank "PRIVATE";
+[_unit, []] call A3A_fnc_setPersonalGarage;
+
+[] remoteExec ["A3A_fnc_statistics", _unit];
+_unit setVariable ["canSave", true, true];
+

--- a/A3-Antistasi/functions/Save/fn_resetPlayer.sqf
+++ b/A3-Antistasi/functions/Save/fn_resetPlayer.sqf
@@ -9,7 +9,7 @@ params ["_playerId", "_unit"];
 [2, format ["Resetting player data for ID %1, unit %2", _playerId, _unit], _filename] call A3A_fnc_log;
 
 // Don't restore more money than this player had previously
-private _money = 100;
+private _money = playerStartingMoney;
 if ([_playerId] call A3A_fnc_playerHasSave) then {
 	_money = _money min ([_playerId, "moneyX"] call A3A_fnc_retrievePlayerStat);
 };

--- a/A3-Antistasi/functions/Save/fn_saveLoop.sqf
+++ b/A3-Antistasi/functions/Save/fn_saveLoop.sqf
@@ -1,18 +1,16 @@
-if (hasInterface) then {
-	if (!isNil "savingClient" && {savingClient}) exitWith {["Save", "Your personal stats are being saved"] call A3A_fnc_customHint;};
-	[getPlayerUID player, player] call A3A_fnc_savePlayer;
+private _filename = "fn_saveLoop";
+if (!isServer) exitWith {
+	[1, "Miscalled server-only function", _filename] call A3A_fnc_log;
 };
 
-//Server only from here on out.
-if (!isServer) exitWith {};
+if (savingServer) exitWith {["Save Game", "Server data save is still in progress"] remoteExecCall ["A3A_fnc_customHint",theBoss]};
+savingServer = true;
+[2, "Starting persistent save", _filename] call A3A_fnc_log;
 
 // Save each player with global flag
 {
 	[getPlayerUID _x, _x, true] call A3A_fnc_savePlayer;
 } forEach (call A3A_fnc_playableUnits);
-
-if (savingServer) exitWith {["Save Game", "Server data save is still in progress"] remoteExecCall ["A3A_fnc_customHint",theBoss]};
-savingServer = true;
 
 // Check if this campaign is already in the save list
 private _saveList = [profileNamespace getVariable "antistasiSavedGames"] param [0, [], [[]]];
@@ -236,4 +234,4 @@ saveProfileNamespace;
 savingServer = false;
 _saveHintText = format ["Savegame Done.<br/><br/>You won't lose your stats in the event of a game update.<br/><br/>Remember: if you want to preserve any vehicle, it must be near the HQ Flag with no AI inside.<br/>If AI are inside, you will save the funds you spent on it.<br/><br/>AI will be refunded<br/><br/>Stolen and purchased Static Weapons need to be ASSEMBLED in order to be saved. You can save disassembled Static Weapons in the ammo box.<br/><br/>Mounted Statics (Mortar/AA/AT squads) won't get saved, but you will be able to recover the cost.<br/><br/>Same for assigned vehicles more than 50m away from HQ.<br/><br/>%1 fund count:<br/>HR: %2<br/>Money: %3 €",nameTeamPlayer,_hrBackground,_resourcesBackground];
 [petros,"hint",_saveHintText, "Save"] remoteExec ["A3A_fnc_commsMP", 0];
-diag_log format ["%1: [Antistasi] | INFO | Persistent Save Completed.",servertime];
+[2, "Persistent Save Completed", _filename] call A3A_fnc_log;

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -518,6 +518,7 @@ else
 		private _loadout = [getPlayerUID player, "loadoutPlayer"] call A3A_fnc_retrievePlayerStat;
 		if (!isNil "_loadout") then { player setUnitLoadout _loadout };
 	};
+	player setVariable ["canSave", true];
 };
 
 

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -157,12 +157,13 @@ if (player getVariable ["pvp",false]) exitWith {
 	}];
 };
 
-player setVariable ["score",0,true];
+// Placeholders, should get replaced globally by the server
+player setVariable ["score",0];
+player setVariable ["moneyX",0];
+player setVariable ["rankX",rank player];
+
 player setVariable ["owner",player,true];
 player setVariable ["punish",0,true];
-player setVariable ["moneyX",95,true];
-player setUnitRank "PRIVATE";
-player setVariable ["rankX",rank player,true];
 
 stragglers = creategroup teamPlayer;
 (group player) enableAttack false;
@@ -513,7 +514,9 @@ if (isMultiplayer) then {
 else
 {
 	if (loadLastSave) then {
-		[] spawn A3A_fnc_loadPlayer;
+		// just do this directly, because playerHasSave doesn't work without moneyX
+		private _loadout = [getPlayerUID player, "loadoutPlayer"] call A3A_fnc_retrievePlayerStat;
+		if (!isNil "_loadout") then { player setUnitLoadout _loadout };
 	};
 };
 

--- a/A3-Antistasi/functions/init/fn_initServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initServer.sqf
@@ -232,6 +232,20 @@ distanceXs = [] spawn A3A_fnc_distance;
 [] execVM "Scripts\fn_advancedTowingInit.sqf";
 savingServer = false;
 
+// Autosave loop. Save if there were any players on the server since the last save.
+[] spawn {
+	private _lastPlayerCount = count (call A3A_fnc_playableUnits);
+	while {true} do
+	{
+		uiSleep autoSaveInterval;
+		private _playerCount = count (call A3A_fnc_playableUnits);
+		if (autoSave && (_playerCount > 0 || _lastPlayerCount > 0)) then {
+			[] remoteExecCall ["A3A_fnc_saveLoop", 2];
+		};
+		_lastPlayerCount = _playerCount;
+	};
+};
+
 [] spawn A3A_fnc_spawnDebuggingLoop;
 
 //Enable performance logging

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -109,6 +109,7 @@ server setVariable ["resourcesFIA",1000,true];
 //We shouldn't need to sync these.
 [2,"Setting server only variables",_fileName] call A3A_fnc_log;
 
+playerStartingMoney = 100;			// should probably be a parameter
 
 prestigeOPFOR = [75, 50] select cadetMode;												//Initial % support for NATO on each city
 prestigeBLUFOR = 0;																	//Initial % FIA support on each city

--- a/A3-Antistasi/functions/init/fn_resourcecheck.sqf
+++ b/A3-Antistasi/functions/init/fn_resourcecheck.sqf
@@ -214,15 +214,6 @@ while {true} do
 			};
 		} forEach allUnits;
 		};
-	if (autoSave) then
-	{
-		_countSave = _countSave - 600;
-		if (_countSave <= 0) then
-		{
-			_countSave = autoSaveInterval;
-			[] remoteExecCall ["A3A_fnc_saveLoop", 0, false];
-		};
-	};
 
 	sleep 4;
 	};


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
- Fixes bug where player saves wouldn't load correctly due to multiple global setVariables.
- Fixes bug where player saving could be enabled slightly before their stats were loaded.
- Fixes bug where autosave would spam additional player saves.
- Fixes minor exploit where players could gain money by not loading their previous game.
- Fixes issue where autosave wouldn't trigger unless there was a commander on the server.
- Fixes bug where player loadout wasn't loaded in SP.
- Works around unknown-cause issue where player unit lacked variables on disconnection.
- Adds some save/load logging to diagnose future broken player saves.

The first bug needed a substantial reorganisation so that the global variables related to the player save are always set globally from the server on startup. There's now a resetPlayer function which handles the case of selecting "no" to load previous session. This function sets the player money to the minimum of 100 and the player's previous money, which removes the need for setting the startup money to 95.

### Please specify which Issue this PR Resolves.
closes #1185
closes #1031
maybe closes #1198

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in singleplayer?
2. [X] Have you loaded the mission in LAN host?
3. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Too dangerous to merge without serious testing, especially savePlayer as it's called directly from saveLoop, so if it has any persistent bugs then saves may be blocked in general.

### How can the changes be tested?
Get a server with a bunch of players on it. Have them repeatedly disconnect and reconnect by various methods while using the manual and autosaves heavily. Saves while remote controlling or unconscious should be tested. Make sure there are no script errors logged, and that no-one loses money/rank/garage/loadout inappropriately.
