### PR TITLE
Removed `side petros` #282 again but hopefully no conflicts

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_itemSort.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_itemSort.sqf
@@ -4,7 +4,7 @@ if (teamPlayer isEqualTo west) then {
 	diveGear append ["U_I_Wetsuit","V_RebreatherIA","G_Diving"];
 };
 
-if (teamPlayer == west) then {
+if (teamPlayer isEqualTo west) then {
 	flyGear pushBack "U_B_PilotCoveralls"
 } else {
 	flyGear pushBack "U_I_pilotCoveralls"

--- a/A3-Antistasi/functions/Ammunition/fn_itemSort.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_itemSort.sqf
@@ -1,10 +1,10 @@
-if (side (group petros) == west) then {
+if (teamPlayer == west) then {
 	diveGear append ["U_B_Wetsuit","V_RebreatherB","G_Diving"];
 } else {
 	diveGear append ["U_I_Wetsuit","V_RebreatherIA","G_Diving"];
 };
 
-if (side (group petros) == west) then {
+if (teamPlayer == west) then {
 	flyGear pushBack "U_B_PilotCoveralls"
 } else {
 	flyGear pushBack "U_I_pilotCoveralls"

--- a/A3-Antistasi/functions/Ammunition/fn_itemSort.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_itemSort.sqf
@@ -1,4 +1,4 @@
-if (teamPlayer == west) then {
+if (teamPlayer isEqualTo west) then {
 	diveGear append ["U_B_Wetsuit","V_RebreatherB","G_Diving"];
 } else {
 	diveGear append ["U_I_Wetsuit","V_RebreatherIA","G_Diving"];

--- a/A3-Antistasi/functions/Save/fn_saveLoop.sqf
+++ b/A3-Antistasi/functions/Save/fn_saveLoop.sqf
@@ -23,7 +23,7 @@ private _saveIndex = -1;
 
 // If not, append a new entry
 if (_saveIndex == -1) then {
-	private _gametype = if (teamPlayer == independent) then {"Greenfor"} else {"Blufor"};
+	private _gametype = if (teamPlayer isEqualTo independent) then {"Greenfor"} else {"Blufor"};
 	_saveList pushBack [campaignID, worldName, _gametype];
 	profileNamespace setVariable ["antistasiSavedGames", _saveList];
 };

--- a/A3-Antistasi/functions/Save/fn_saveLoop.sqf
+++ b/A3-Antistasi/functions/Save/fn_saveLoop.sqf
@@ -23,7 +23,7 @@ private _saveIndex = -1;
 
 // If not, append a new entry
 if (_saveIndex == -1) then {
-	private _gametype = if (side petros == independent) then {"Greenfor"} else {"Blufor"};
+	private _gametype = if (teamPlayer == independent) then {"Greenfor"} else {"Blufor"};
 	_saveList pushBack [campaignID, worldName, _gametype];
 	profileNamespace setVariable ["antistasiSavedGames", _saveList];
 };

--- a/A3-Antistasi/functions/Save/fn_varNameToSaveName.sqf
+++ b/A3-Antistasi/functions/Save/fn_varNameToSaveName.sqf
@@ -4,7 +4,7 @@ params ["_varName", ""];
 if (worldName == "Tanoa") then {
 	format["%1%2%3%4",_varName,serverID,campaignID,"WotP"];
 } else {
-	if (teamPlayer == independent) then {
+	if (teamPlayer isEqualTo independent) then {
 		format["%1%2%3%4%5",_varName,serverID,campaignID,"Antistasi",worldName];
 	} else {
 		format["%1%2%3%4%5",_varName,serverID,campaignID,"AntistasiB",worldName];

--- a/A3-Antistasi/functions/Save/fn_varNameToSaveName.sqf
+++ b/A3-Antistasi/functions/Save/fn_varNameToSaveName.sqf
@@ -4,9 +4,9 @@ params ["_varName", ""];
 if (worldName == "Tanoa") then {
 	format["%1%2%3%4",_varName,serverID,campaignID,"WotP"];
 } else {
-	if (side group petros == independent) then {
+	if (teamPlayer == independent) then {
 		format["%1%2%3%4%5",_varName,serverID,campaignID,"Antistasi",worldName];
 	} else {
-		format["%1%2%3%4%5",_varName,serverID,campaignID,"AntistasiB",worldName]; 
+		format["%1%2%3%4%5",_varName,serverID,campaignID,"AntistasiB",worldName];
 	};
 };

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -81,7 +81,7 @@ else {
 private ["_colourTeamPlayer", "_colorInvaders"];
 _colourTeamPlayer = teamPlayer call BIS_fnc_sideColor;
 _colorInvaders = Invaders call BIS_fnc_sideColor;
-_positionX = if (side player == teamPlayer) then {position petros} else {getMarkerPos "respawn_west"};
+_positionX = if (side player isEqualTo teamPlayer) then {position petros} else {getMarkerPos "respawn_west"};
 
 {
 	_x set [3, 0.33]

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -81,7 +81,7 @@ else {
 private ["_colourTeamPlayer", "_colorInvaders"];
 _colourTeamPlayer = teamPlayer call BIS_fnc_sideColor;
 _colorInvaders = Invaders call BIS_fnc_sideColor;
-_positionX = if (side player == side (group petros)) then {position petros} else {getMarkerPos "respawn_west"};
+_positionX = if (side player == teamPlayer) then {position petros} else {getMarkerPos "respawn_west"};
 
 {
 	_x set [3, 0.33]

--- a/A3-Antistasi/functions/init/fn_initServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initServer.sqf
@@ -88,7 +88,7 @@ call
 
 	// Otherwise, check through the saved game list for matches and build existing ID list
 	private _saveList = [profileNamespace getVariable "antistasiSavedGames"] param [0, [], [[]]];
-	private _gametype = if (teamPlayer == independent) then {"Greenfor"} else {"Blufor"};
+	private _gametype = if (side petros == independent) then {"Greenfor"} else {"Blufor"};
 	private _existingIDs = [campaignID];
 	{
 		if (_x isEqualType [] && {count _x >= 2}) then

--- a/A3-Antistasi/functions/init/fn_initServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initServer.sqf
@@ -88,7 +88,7 @@ call
 
 	// Otherwise, check through the saved game list for matches and build existing ID list
 	private _saveList = [profileNamespace getVariable "antistasiSavedGames"] param [0, [], [[]]];
-	private _gametype = if (side petros == independent) then {"Greenfor"} else {"Blufor"};
+	private _gametype = if (teamPlayer == independent) then {"Greenfor"} else {"Blufor"};
 	private _existingIDs = [campaignID];
 	{
 		if (_x isEqualType [] && {count _x >= 2}) then


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    Attempted to change `side petros` and `side (group petros)` in all checks for player side. Bug was caused by dead petros on check.

### Please specify which Issue this PR Resolves.
closes #282 

### Please verify the following and ensure all checks are completed.

2. [x] Have you loaded the mission in LAN host?
3. [x] Have you loaded the mission on a dedicated server? *by @CalebSerafin*

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Not tested, needs further testing
********************************************************
Notes:
Untested change, found six instances where `side petros` was checked and removed