### PR TITLE
CS-1236-punish-pass-reason

### DIFF
--- a/A3-Antistasi/functions/Punishment/fn_punishment.sqf
+++ b/A3-Antistasi/functions/Punishment/fn_punishment.sqf
@@ -34,7 +34,7 @@ Author: Caleb Serafin
 Date Updated: 14 June 2020
 License: MIT License, Copyright (c) 2019 Barbolani & The Official AntiStasi Community
 */
-params ["_instigator","_timeAdded","_offenceAdded",["_victim",objNull]];
+params ["_instigator","_timeAdded","_offenceAdded",["_victim",objNull],["_customMessage",""]];
 private _filename = "fn_punishment.sqf";
 
 if (!isServer) exitWith {
@@ -92,7 +92,7 @@ private _keyPairs = [["timeTotal",_timeTotal],["offenceTotal",_offenceTotal],["l
 private _playerStats = format["Player: %1 [%2], _timeAdded: %3, _timeTotal: %4, _offenceAdded: %7, _overhead: %5, _offenceTotal: %6", _name, _UID, str _timeAdded, str _timeTotal, str _offenceAdded, str _overhead, str _offenceTotal];
 if (_offenceTotal < 1) exitWith {
     _instigator = [_UID] call BIS_fnc_getUnitByUid;
-    private _message = "Watch your fire!";
+    private _message = format ["Watch your fire!%1%2","<br/>",_customMessage];
     if (isPlayer _victim) then { _message = _message + format ["<br/><br/>Injured comrade: %1",name _victim]; };
 	["FF Warning", _message] remoteExec ["A3A_fnc_customHint", _instigator, false]; // This may or may not work for remoteControl depending on deSync.
 	[2, format ["WARNING | %1", _playerStats], _filename] call A3A_fnc_log;

--- a/A3-Antistasi/functions/Punishment/fn_punishment_FF.sqf
+++ b/A3-Antistasi/functions/Punishment/fn_punishment_FF.sqf
@@ -100,7 +100,7 @@ private _logPvPKill = {
 private _isCollision = false;
 
 ///////////////Checks if is FF//////////////
-private _exemption = "";switch (true) do {
+private _exemption = switch (true) do {
     case (!tkPunish):                                  {"FF PUNISH IS DISABLED"};
     case (isDedicated || isServer):                    {"FF BY SERVER"};
     case (!isMultiplayer):                             {"IS NOT MULTIPLAYER"};

--- a/A3-Antistasi/functions/Punishment/fn_punishment_FF.sqf
+++ b/A3-Antistasi/functions/Punishment/fn_punishment_FF.sqf
@@ -50,7 +50,8 @@ params [
     ["_instigator",objNull, [objNull,[]], [] ],
     "_timeAdded",
     "_offenceAdded",
-    ["_victim",objNull]
+    ["_victim",objNull],
+    ["_customMessage","", [""], [] ]
 ];
 private _filename = "fn_punishment_FF.sqf";
 
@@ -75,10 +76,10 @@ private _notifyVictim = {
     if (isPlayer _victim) then {["FF Notification", format["%1 hurt you!",name _instigator]] remoteExec ["A3A_fnc_customHint", _victim, false];};
 };
 private _notifyInstigator = {
-    params ["_message"];
+    params ["_exempMessage"];
     private _victimStats = "";
-    if (isPlayer _victim) then { _victimStats = format ["<br/><br/>Injured comrade: %1",name _victim]; };
-    ["FF Notification", _message + _victimStats] remoteExec ["A3A_fnc_customHint", _instigator, false];
+    if (isPlayer _victim) then { _victimStats = format ["<br/><br/>Injured comrade: %1<br/><br/>",name _victim]; };
+    ["FF Notification", _exempMessage+ _victimStats + _customMessage] remoteExec ["A3A_fnc_customHint", _instigator, false];
 };
 private _gotoExemption = {
     params [ ["_exemptionDetails", "" ,[""]] ];
@@ -99,7 +100,7 @@ private _logPvPKill = {
 private _isCollision = false;
 
 ///////////////Checks if is FF//////////////
-private _exemption = switch (true) do {
+private _exemption = "";switch (true) do {
     case (!tkPunish):                                  {"FF PUNISH IS DISABLED"};
     case (isDedicated || isServer):                    {"FF BY SERVER"};
     case (!isMultiplayer):                             {"IS NOT MULTIPLAYER"};
@@ -151,7 +152,7 @@ if (_exemption != "") exitWith {
 };
 
 ///////////////Drop The Hammer//////////////
-[_instigator,_timeAdded,_offenceAdded,_victim] remoteExec ["A3A_fnc_punishment",2,false];
+[_instigator,_timeAdded,_offenceAdded,_victim,_customMessage] remoteExec ["A3A_fnc_punishment",2,false];
 "PROSECUTED";
 
 

--- a/A3-Antistasi/functions/Punishment/fn_punishment_FF_checkNearHQ.sqf
+++ b/A3-Antistasi/functions/Punishment/fn_punishment_FF_checkNearHQ.sqf
@@ -46,8 +46,7 @@ if !(_distancePetros <= 100) exitWith {false};
 
 deleteVehicle _projectile;
 if (_distancePetros < 10) then {
-	[_unit, 60, 0.4, objNull] call A3A_fnc_punishment_FF; // Call to override hint later.
+	[_unit, 60, 0.4, objNull, "You cannot throw grenades or place explosives within 100m of base."] call A3A_fnc_punishment_FF; // Call to override hint later.
 };
-["FF Warning", "You cannot throw grenades or place explosives within 100m of base."] call A3A_fnc_customHint;
 [2, format ["EXPLOSIVE DISCHARGE HQ | %1 [%2] distance from Petros: %3", name _unit, getPlayerUID _unit, _distancePetros], _filename] call A3A_fnc_log;
 true;

--- a/A3-Antistasi/functions/Punishment/fn_punishment_FF_checkNearHQ.sqf
+++ b/A3-Antistasi/functions/Punishment/fn_punishment_FF_checkNearHQ.sqf
@@ -42,11 +42,9 @@ private _fileName = "fn_punishment_FF_checkNearHQ.sqf";
 
 if !(_weapon in ["Put","Throw"]) exitWith {false};
 private _distancePetros = _unit distance petros;
-if !(_distancePetros <= 100) exitWith {false};
+if !(_distancePetros <= 75) exitWith {false};
 
 deleteVehicle _projectile;
-if (_distancePetros < 10) then {
-	[_unit, 60, 0.4, objNull, "You cannot throw grenades or place explosives within 100m of base."] call A3A_fnc_punishment_FF; // Call to override hint later.
-};
+[_unit, 60, 0.4, objNull, "You cannot throw grenades or place explosives within 75m of base."] call A3A_fnc_punishment_FF;
 [2, format ["EXPLOSIVE DISCHARGE HQ | %1 [%2] distance from Petros: %3", name _unit, getPlayerUID _unit, _distancePetros], _filename] call A3A_fnc_log;
 true;


### PR DESCRIPTION
## What type of PR is this.
* Bug
* Change
* [x] Enhancement

### What have you changed and why?
Information:
Reason can be passed to punishment function to display to the instigator.
Explosive delete and warn distance unified to 75m

### Please specify which Issue this PR Resolves.
closes [#1236](https://github.com/official-antistasi-community/A3-Antistasi/issues/1236)
closes [#1239](https://github.com/official-antistasi-community/A3-Antistasi/issues/1239)

### Please verify the following and ensure all checks are completed.

* [x] Have you loaded the mission in LAN host?
* [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
* [x] No
* Yes (Please provide further detail below.)
(Please see one section above)

### How can the changes be tested?
Steps: 
1. Shoot player and confirm basic FF detection works
**Repeat below for Ace and without Ace**
**Test with throwing grenade as well**
1. Place explosive >75m away from Petros => {No explosive  deleted and no warning issued};
2. Place explosive <75m away from Petros => {explosive deleted and warning issued};