### PR TITLE
block players from garraging while being engaged by hostiles within 500m

### DIFF
--- a/A3-Antistasi/functions/Garage/fn_garageVehicle.sqf
+++ b/A3-Antistasi/functions/Garage/fn_garageVehicle.sqf
@@ -31,6 +31,13 @@ if !(_veh isKindOf "AllVehicles") exitWith {["Garage", "The vehicle you are look
 if (_pool and (count vehInGarage >= (tierWar *5))) exitWith {["Garage", "You cannot garage more vehicles at your current War Level"] call A3A_fnc_customHint;};
 private _personalGarage = player getVariable ["personalGarage", []];
 if (!((count _personalGarage < personalGarageMax) or (personalGarageMax isEqualTo 0)) and !_pool) exitWith {["Garage", "Personal garage is full, you can't add more vehicles to it"] call A3A_fnc_customHint};
+if (
+	{
+    	_condition = player in (_x targets [true, 500]);
+		if (_condition) exitWith {_condition};
+		_condition
+	} forEach (player nearEntities 500)
+) exitWith {["Garage", "Can't garage while in combat."] call A3A_fnc_customHint};
 
 _exit = false;
 if (!_pool) then

--- a/A3-Antistasi/functions/Garage/fn_garageVehicle.sqf
+++ b/A3-Antistasi/functions/Garage/fn_garageVehicle.sqf
@@ -27,12 +27,14 @@ if (_veh isKindOf "Man") exitWith {["Garage", "Are you kidding?"] call A3A_fnc_c
 
 if !(_veh isKindOf "AllVehicles") exitWith {["Garage", "The vehicle you are looking cannot be stored in our Garage"] call A3A_fnc_customHint;};
 
+_units = (player nearEntities ["Man",300]) select {([_x] call A3A_fnc_CanFight) && (side _x isEqualTo Occupants || side _x isEqualTo Invaders)};
+if (_units findIf {_unit = _x; _players = allPlayers select {(side _x isEqualTo teamPlayer) && (player distance _x < 300)}; _players findIf {_x in (_unit targets [true, 300])} != -1} != -1) exitWith {["Garage", "You can't garage vehicles while enemies are engageing you"] call A3A_fnc_customHint};
+if (_units findIf{player distance _x < 100} != -1) exitWith {["Garage", "You can't garage vehicles while enemies are near you"] call A3A_fnc_customHint};
 
 if (_pool and (count vehInGarage >= (tierWar *5))) exitWith {["Garage", "You cannot garage more vehicles at your current War Level"] call A3A_fnc_customHint;};
 private _personalGarage = player getVariable ["personalGarage", []];
 if (!((count _personalGarage < personalGarageMax) or (personalGarageMax isEqualTo 0)) and !_pool) exitWith {["Garage", "Personal garage is full, you can't add more vehicles to it"] call A3A_fnc_customHint};
-_units = (player nearEntities ["Man",300]) select {([_x] call A3A_fnc_CanFight) && side _x != civilian};
-if (_units findIf {_unit = _x; _players = allPlayers select {(side _x isEqualTo teamPlayer) && (player distance _x < 300)}; _players findIf {_x in (_unit targets [true, 500])} != -1} != -1) exitWith {["Garage", "You can't garage vehicles while enemies are engageing you"] call A3A_fnc_customHint};
+
 
 _exit = false;
 if (!_pool) then

--- a/A3-Antistasi/functions/Garage/fn_garageVehicle.sqf
+++ b/A3-Antistasi/functions/Garage/fn_garageVehicle.sqf
@@ -31,7 +31,7 @@ if !(_veh isKindOf "AllVehicles") exitWith {["Garage", "The vehicle you are look
 if (_pool and (count vehInGarage >= (tierWar *5))) exitWith {["Garage", "You cannot garage more vehicles at your current War Level"] call A3A_fnc_customHint;};
 private _personalGarage = player getVariable ["personalGarage", []];
 if (!((count _personalGarage < personalGarageMax) or (personalGarageMax isEqualTo 0)) and !_pool) exitWith {["Garage", "Personal garage is full, you can't add more vehicles to it"] call A3A_fnc_customHint};
-if ((player nearEntities 500) findIf {player in (_x targets [true, 500])} != -1) exitWith {["Garage", "Can't garage while in combat."] call A3A_fnc_customHint};
+if ((player nearEntities 300) findIf {_unit = _x; _players = allPlayers select {(side _x isEqualTo teamPlayer) && (player distance _x < 300)}; _players findIf {_x in (_unit targets [true, 500])} != -1} != -1);
 
 _exit = false;
 if (!_pool) then

--- a/A3-Antistasi/functions/Garage/fn_garageVehicle.sqf
+++ b/A3-Antistasi/functions/Garage/fn_garageVehicle.sqf
@@ -31,7 +31,8 @@ if !(_veh isKindOf "AllVehicles") exitWith {["Garage", "The vehicle you are look
 if (_pool and (count vehInGarage >= (tierWar *5))) exitWith {["Garage", "You cannot garage more vehicles at your current War Level"] call A3A_fnc_customHint;};
 private _personalGarage = player getVariable ["personalGarage", []];
 if (!((count _personalGarage < personalGarageMax) or (personalGarageMax isEqualTo 0)) and !_pool) exitWith {["Garage", "Personal garage is full, you can't add more vehicles to it"] call A3A_fnc_customHint};
-if ((player nearEntities 300) findIf {_unit = _x; _players = allPlayers select {(side _x isEqualTo teamPlayer) && (player distance _x < 300)}; _players findIf {_x in (_unit targets [true, 500])} != -1} != -1);
+_units = (player nearEntities ["Man",300]) select {([_x] call A3A_fnc_CanFight) && side _x != civilian};
+if (_units findIf {_unit = _x; _players = allPlayers select {(side _x isEqualTo teamPlayer) && (player distance _x < 300)}; _players findIf {_x in (_unit targets [true, 500])} != -1} != -1) exitWith {["Garage", "You can't garage vehicles while enemies are engageing you"] call A3A_fnc_customHint};
 
 _exit = false;
 if (!_pool) then

--- a/A3-Antistasi/functions/Garage/fn_garageVehicle.sqf
+++ b/A3-Antistasi/functions/Garage/fn_garageVehicle.sqf
@@ -31,13 +31,7 @@ if !(_veh isKindOf "AllVehicles") exitWith {["Garage", "The vehicle you are look
 if (_pool and (count vehInGarage >= (tierWar *5))) exitWith {["Garage", "You cannot garage more vehicles at your current War Level"] call A3A_fnc_customHint;};
 private _personalGarage = player getVariable ["personalGarage", []];
 if (!((count _personalGarage < personalGarageMax) or (personalGarageMax isEqualTo 0)) and !_pool) exitWith {["Garage", "Personal garage is full, you can't add more vehicles to it"] call A3A_fnc_customHint};
-if (
-	{
-    	_condition = player in (_x targets [true, 500]);
-		if (_condition) exitWith {_condition};
-		_condition
-	} forEach (player nearEntities 500)
-) exitWith {["Garage", "Can't garage while in combat."] call A3A_fnc_customHint};
+if ((player nearEntities 500) findIf {player in (_x targets [true, 500])} != -1) exitWith {["Garage", "Can't garage while in combat."] call A3A_fnc_customHint};
 
 _exit = false;
 if (!_pool) then


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information:
    blocks players from garaging when they are being engaged by enemies within 500m of the player

### Please specify which Issue this PR Resolves.
closes #1242

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in singleplayer?
2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
go and try to garage while in combat
********************************************************
Notes:
