### PR TITLE
(ACE) Remove M152 Remote Detonator from Starting Arsenal

### DIFF
--- a/A3-Antistasi/functions/Templates/fn_aceModCompat.sqf
+++ b/A3-Antistasi/functions/Templates/fn_aceModCompat.sqf
@@ -6,7 +6,6 @@ aceItems = [
 	"ACE_EarPlugs",
 	"ACE_RangeCard",
 	"ACE_Clacker",
-	"ACE_M26_Clacker",
 	"ACE_DefusalKit",
 	"ACE_MapTools",
 	"ACE_Flashlight_MX991",


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Removed M152 Firing Device from Starting Arsenal due to people requesting it.
--------> It should be gathered instead of being given at the Start.

### Please specify which Issue this PR Resolves.
closes #1248 

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in singleplayer?
2. [X] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
