### PR TITLE
Add rebel civilian car & truck to undercover vehicles

### DIFF
--- a/A3-Antistasi/functions/AI/fn_undercoverAI.sqf
+++ b/A3-Antistasi/functions/AI/fn_undercoverAI.sqf
@@ -25,7 +25,7 @@ _unit forceAddUniform (selectRandom allCivilianUniforms);
 while {(captive _LeaderX) and (captive _unit)} do
 	{
 	sleep 1;
-	if ((vehicle _unit != _unit) and (not((typeOf vehicle _unit) in arrayCivVeh))) exitWith {};
+	if ((vehicle _unit != _unit) and (not((typeOf vehicle _unit) in undercoverVehicles))) exitWith {};
 	//_base = [_airportsX,player] call BIS_fnc_nearestPosition;
 	//_size = [_base] call A3A_fnc_sizeMarker;
 	//if ((_unit inArea _base) and (not(sidesX getVariable [_base,sideUnknown] == teamPlayer))) exitWith {[_unit,false] remoteExec ["setCaptive"]};

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -498,6 +498,9 @@ for "_i" from 0 to (count _civVehiclesWeighted - 2) step 2 do {
 	_civVehicles pushBack (_civVehiclesWeighted select _i);
 };
 
+_civVehicles append [civCar, civTruck];			// Civ car/truck from rebel template, in case they're different
+_civVehicles pushBackUnique "C_Van_01_box_F";		// Box van from bank mission. TODO: Define in rebel template
+
 DECLARE_SERVER_VAR(arrayCivVeh, _civVehicles);
 DECLARE_SERVER_VAR(civVehiclesWeighted, _civVehiclesWeighted);
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Added rebel civilian car & truck to undercover vehicles, in case they're not identical classes to the civilian template. Currently happens with 3CB because it has a ton of identical vehicles with different classnames.

Also added the boxer truck from the bank job, as it's not currently defined in the rebel template and may not be in the civilian
template either. The definition for this truck should be moved to the rebel template at some point.

Also fixed an inconsistency with undercover AIs that may have caused them to break undercover in civilian helicopters and boats.    

### Please specify which Issue this PR Resolves.
closes #1237

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
