### PR TITLE
Fix bug where new rebel garrison troops could be added to enemy group

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_createSDKgarrisonsTemp.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createSDKgarrisonsTemp.sqf
@@ -1,9 +1,18 @@
+// Create a new rebel unit in a garrison that's already spawned
+
 _markerX = _this select 0;
 _typeX = _this select 1;
 _positionX = getMarkerPos _markerX;
 if (_typeX isEqualType "") then
 	{
-	_groups = if (_typeX == staticCrewTeamPlayer) then {[]} else {allGroups select {(leader _x getVariable ["markerX",""] == _markerX) and (count units _x < 8) and (vehicle (leader _x) == leader _x)}};
+	// Select a suitable group from the current garrison for this unit
+	_groups = if (_typeX == staticCrewTeamPlayer) then {[]} else {
+		allGroups select {
+			(leader _x getVariable ["markerX",""] == _markerX)
+			and (count units _x < 8) and (vehicle (leader _x) == leader _x)
+			and (side _x == teamPlayer)				// can happen with surrendered enemy garrison
+		};
+	};
 	_groupX = if (_groups isEqualTo []) then
 		{
 		createGroup teamPlayer


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
When adding troops to a spawned garrison, Antistasi searches for nearby groups from the same marker to add them to, but doesn't check the side, so enemy groups from the previous garrison may be used, causing friendly fire incidents.

This PR fixes the problem by checking that the group has the correct side.

### Please specify which Issue this PR Resolves.
closes #1195

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
1. Buy an AI or two. You'll need them later.
2. Capture an isolated enemy marker. Leave a couple of surrendered garrison troops nearby.
3. Defeat the QRF.
4. Leave your AIs near the marker to keep it spawned. Drive back to HQ.
5. Add a few garrison troops from the HQ management menu.
6. Check that they're not exchanging fire with your AIs.
