### PR TITLE
Add 3CB Javelin and vanilla PDW2000 to category overrides

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_categoryOverrides.sqf
@@ -46,6 +46,7 @@ private _categoryOverrideTable = [
 ["UK3CB_SVD_OLD", ["SniperRifles","Weapons"]],
 ["UK3CB_M16A1_LSW", ["MachineGuns","Weapons"]],
 
+["UK3CB_BAF_Javelin_Launcher", ["MissileLaunchers","Weapons","AT"]],
 ["UK3CB_BAF_Javelin_CLU", ["Binoculars","Items"]],
 ["UK3CB_BAF_Javelin_Slung_Tube", ["MissileLaunchers","Weapons","AT"]],
 ["UK3CB_M79", ["GrenadeLaunchers","Weapons"]],
@@ -53,6 +54,7 @@ private _categoryOverrideTable = [
 ["UK3CB_BAF_AT4_CS_AP_Launcher", ["RocketLaunchers","Weapons","AT"]],
 
 ["launch_NLAW_F", ["MissileLaunchers","Weapons","AT"]],
+["hgun_PDW2000_F", ["SMGs","Weapons"]],
 
 ["UK3CB_BAF_L86A2", ["MachineGuns","Weapons"]],
 ["UK3CB_BAF_L86A3", ["MachineGuns","Weapons"]],


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
- Override the assembled 3CB Javelin's categories from nothing to AT + MissileLaunchers.
- Override the vanilla PDW2000's categories from Rifles to SMGs.

### Please specify which Issue this PR Resolves.
closes #1257
closes #1258

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
