### PR TITLE
Group leader now gets passed when the SL is not longer capable

### DIFF
--- a/A3-Antistasi/functions/AI/fn_surrenderAction.sqf
+++ b/A3-Antistasi/functions/AI/fn_surrenderAction.sqf
@@ -14,6 +14,15 @@ _unit disableAI "ANIM";
 _unit setSkill 0;
 _unit setVariable ["surrendered", true, true];			// usually set by caller, just making sure
 
+//Make sure to pass group lead if unit is the leader
+if (_unit == leader (group _unit)) then
+{
+    private _index = (units (group _unit)) findIf {[_x] call A3A_fnc_canFight};
+    if(_index != -1) then
+    {
+        (group _unit) selectLeader ((units (group _unit)) select _index);
+    };
+};
 // make sure that the unit is actually alive & conscious before we start creating boxes
 sleep 3;
 if (!alive _unit) exitWith {};

--- a/A3-Antistasi/functions/Revive/fn_handleDamageAAF.sqf
+++ b/A3-Antistasi/functions/Revive/fn_handleDamageAAF.sqf
@@ -53,6 +53,16 @@ if (hasACEMedical) exitWith {};
 private _makeUnconscious =
 {
 	params ["_unit", "_injurer"];
+    //Make sure to pass group lead if unit is the leader
+    if (_unit == leader (group _unit)) then
+    {
+        private _index = (units (group _unit)) findIf {[_x] call A3A_fnc_canFight};
+        if(_index != -1) then
+        {
+            (group _unit) selectLeader ((units (group _unit)) select _index);
+        };
+    };
+
 	_unit setVariable ["incapacitated",true,true];
 	_unit setUnconscious true;
 	if (vehicle _unit != _unit) then
@@ -125,4 +135,3 @@ if (side _injurer == teamPlayer) then
 };
 
 _damage
-

--- a/A3-Antistasi/functions/Revive/fn_handleDamageAAF.sqf
+++ b/A3-Antistasi/functions/Revive/fn_handleDamageAAF.sqf
@@ -53,16 +53,7 @@ if (hasACEMedical) exitWith {};
 private _makeUnconscious =
 {
 	params ["_unit", "_injurer"];
-    //Make sure to pass group lead if unit is the leader
-    if (_unit == leader (group _unit)) then
-    {
-        private _index = (units (group _unit)) findIf {[_x] call A3A_fnc_canFight};
-        if(_index != -1) then
-        {
-            (group _unit) selectLeader ((units (group _unit)) select _index);
-        };
-    };
-
+   
 	_unit setVariable ["incapacitated",true,true];
 	_unit setUnconscious true;
 	if (vehicle _unit != _unit) then
@@ -70,6 +61,17 @@ private _makeUnconscious =
 		moveOut _unit;
 	};
 	if (isPlayer _unit) then {_unit allowDamage false};
+	
+	 //Make sure to pass group lead if unit is the leader
+    	if (_unit == leader (group _unit)) then
+    	{
+		private _index = (units (group _unit)) findIf {[_x] call A3A_fnc_canFight};
+		if(_index != -1) then
+       		{
+        		(group _unit) selectLeader ((units (group _unit)) select _index);
+        	}
+	};
+	
 	[_unit,_injurer] spawn A3A_fnc_unconsciousAAF;
 };
 

--- a/A3-Antistasi/functions/init/fn_initACEUnconsciousHandler.sqf
+++ b/A3-Antistasi/functions/init/fn_initACEUnconsciousHandler.sqf
@@ -8,6 +8,16 @@ private _fileName = "initACEUnconsciousHandler.sqf";
 	if (_knockout) exitWith {
 //		[3, format ["Unit type %1, side %2, realside %3, captive %4 knocked out", typeof _unit, side _unit, _realSide, str (captive _unit)], "ace_unconscious handler"] call A3A_fnc_log;
 		_unit setVariable ["incapacitated", true, true];	// for canFight tests
+
+        //Make sure to pass group lead if unit is the leader
+        if (_unit == leader (group _unit)) then
+        {
+            private _index = (units (group _unit)) findIf {[_x] call A3A_fnc_canFight};
+            if(_index != -1) then
+            {
+                (group _unit) selectLeader ((units (group _unit)) select _index);
+            };
+        };
 	};
 
 //	[3, format ["Unit type %1, side %2, realside %3, captive %4 waking up", typeof _unit, side _unit, _realSide, str (captive _unit)], "ace_unconscious handler"] call A3A_fnc_log;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [X] Change
3. [X] Enhancement

### What have you changed and why?
Information:
The squad leader is important for AI groups as he does most of the calculations and is also the one calculating the path and the waypoints. When he dies, the engine passes command to the second unit. However Antistasi has to cases in which the leader does not die, but still get incapable of executing commands, these being surrendering or going uncon.

In that two cases, the group stops to move and gets more or less useless until the SL dies. To avoid that behaviour, the squad lead is now passed onto the next active unit in the group, keeping the group active until no AI left in fighting state.

For the support rework: If the SL calls for help and dies, then passing command to the next one, the call for support is aborted, as the new squadleader is different which is checked. The new squad leader can instantly call another support, unless the group called support in the last 10 minutes.

### Please specify which Issue this PR Resolves.
closes #1173 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [X] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Spawn in an outposts by teleporting there.
Check in the zeus interface which unit is a squadleader (static gunners are best)
Shoot the unit uncon
Check in zeus again and see that the SL has been passed on

********************************************************
Notes: Might not work with ACE, havent tested that, as ACE uncon is way different
