### PR TITLE
Add Ivory car pack support

### DIFF
--- a/A3-Antistasi/Templates/Ivory_Civ.sqf
+++ b/A3-Antistasi/Templates/Ivory_Civ.sqf
@@ -1,0 +1,44 @@
+
+civVehCommonData append [
+	"ivory_gti",2.0					//VW Golf GTI
+	,"ivory_prius",2.0			//Toyota Prius
+	,"ivory_isf",2.0				//Lexus ISF
+	,"ivory_taurus",2.0			//Ford Taurus
+	,"ivory_e36",1.0				//BMW E36
+	,"ivory_m3",1.0					//BMW M3
+	,"ivory_rs4",1.0				//Audi RS4
+	,"ivory_cv",1.0					//Ford Crown Victoria
+	,"ivory_190e",1.0				//Mercedes Benz 190E
+	,"ivory_wrx",1.0				//Subaru Impretza WRX
+	,"ivory_evox",1.0				//Mitsubishi Evo X
+	,"ivory_lfa",0.5				//Lexus LFA
+	,"ivory_supra",0.5			//Toyota Supra
+	,"ivory_gt500",0.5			//(Shelby) Ford Mustang GT500
+	,"ivory_r34",0.5				//Nissan Skyline R34
+	,"ivory_challenger",0.5	//Dodge Challenger
+	,"ivory_charger",0.5		//Dodge Charger
+	,"ivory_elise",0.25			//Lotus Elise
+	,"ivory_suburban",1.0		//Chevrolet Suburban
+	,"ivory_c",0.1					//Bentley Continental
+	,"ivory_r8_spyder",0.05	//Audi R8 Spyder
+	,"ivory_r8",0.05				//Audi R8
+	,"ivory_ccx",0.05				//Koenigsegg CCX
+	,"ivory_lp560",0.05			//Lamborghini Gallardo
+	,"ivory_rev",0.05				//Lamborghini Reventón
+	,"ivory_f1",0.05				//McLaren F1
+	,"ivory_mp4",0.05				//McLaren MP4
+	,"ivory_911",0.25				//Porsche 911
+	,"ivory_veyron",0.01		//Bugatti Veyron
+
+	,"ivory_rs4_taxi",0.2		//Audi RS4 Taxi
+	,"ivory_cv_taxi",0.2		//Ford Crown Victoria Taxi
+	,"ivory_190e_taxi",0.2	//Mercedes Benz 190E Taxi
+	,"ivory_prius_taxi",0.2	//Toyota Prius Taxi
+];
+
+civVehMedicalData append [
+	"ivory_suburban_ems",0.1						//Chevrolet Suburban EMS
+	,"ivory_suburban_ems_slicktop",0.1	//Chevrolet Suburban EMS
+];
+
+/*This template will include a section for adding police vehicles to templates once they all are set up for arrayed patrol cars.*/

--- a/A3-Antistasi/Templates/selector.sqf
+++ b/A3-Antistasi/Templates/selector.sqf
@@ -2,14 +2,14 @@
     This file controls the selection of templates based on the mods loaded and map used.
     When porting new mods/maps be sure to add them to their respective sections!
 */
-
+_filename = "selector.sqf";
 //Map checker
 aridmaps = ["Altis","Kunduz","Malden","tem_anizay","Tembelan"];
 tropicalmaps = ["Tanoa"];
 temperatemaps = ["Enoch","chernarus_summer","vt7"];
 arcticmaps = ["chernarus_winter"];
-//Mod selector
 
+//Mod selector
 if(teamplayer != independent) then {//This section is for Altis Blufor ONLY!
   switch(true) do {
     case (has3CB): {
@@ -17,18 +17,21 @@ if(teamplayer != independent) then {//This section is for Altis Blufor ONLY!
       call compile preProcessFileLineNumbers "Templates\3CB_Occ_TKA_Arid.sqf";
       call compile preProcessFileLineNumbers "Templates\3CB_Inv_TKM_Arid.sqf";
       call compile preProcessFileLineNumbers "Templates\3CB_Civ.sqf";
+      [2, "Using arid_b TGPM, TKA, TKM, 3CB Civ Templates", _filename] call A3A_fnc_log;
     };
     case (hasRHS): {
       call compile preProcessFileLineNumbers "Templates\RHS_Reb_CDF_Arid.sqf";
       call compile preProcessFileLineNumbers "Templates\RHS_Occ_CDF_Arid.sqf";
       call compile preProcessFileLineNumbers "Templates\RHS_Inv_AFRF_Arid.sqf";
       call compile preProcessFileLineNumbers "Templates\RHS_Civ.sqf";
+      [2, "Using arid_b CDF, CDF, AFRF, RHS Civ Templates", _filename] call A3A_fnc_log;
     };
     default {
       call compile preProcessFileLineNumbers "Templates\Vanilla_Reb_FIA_B_Altis.sqf";
       call compile preProcessFileLineNumbers "Templates\Vanilla_Occ_AAF_Altis.sqf";
       call compile preProcessFileLineNumbers "Templates\Vanilla_Inv_CSAT_Altis.sqf";
       call compile preProcessFileLineNumbers "Templates\Vanilla_Civ.sqf";
+      [2, "Using arid_b FIA_B, AAF, CSAT, Vanilla Civ Templates", _filename] call A3A_fnc_log;
     };
   };
 }else{//This is for non-blufor (THE ONE THAT MATTERS!!)
@@ -39,21 +42,25 @@ if(teamplayer != independent) then {//This section is for Altis Blufor ONLY!
           call compile preProcessFileLineNumbers "Templates\3CB_Reb_CNM_Temp.sqf";
           call compile preProcessFileLineNumbers "Templates\3CB_Occ_BAF_Temp.sqf";
           call compile preProcessFileLineNumbers "Templates\3CB_Inv_SOV_Temp.sqf";
+          [2, "Using arctic CNM, BAF, SOV, 3CB Civ Templates", _filename] call A3A_fnc_log;
         };
         case (worldName in temperatemaps): {
           call compile preProcessFileLineNumbers "Templates\3CB_Reb_CNM_Temp.sqf";
           call compile preProcessFileLineNumbers "Templates\3CB_Occ_BAF_Temp.sqf";
           call compile preProcessFileLineNumbers "Templates\3CB_Inv_SOV_Temp.sqf";
+          [2, "Using temperate CNM, BAF, SOV, 3CB Civ Templates", _filename] call A3A_fnc_log;
         };
         case (worldName in tropicalmaps): {
           call compile preProcessFileLineNumbers "Templates\3CB_Reb_CNM_Trop.sqf";
           call compile preProcessFileLineNumbers "Templates\3CB_Occ_BAF_Trop.sqf";
           call compile preProcessFileLineNumbers "Templates\3CB_Inv_SOV_Temp.sqf";
+          [2, "Using tropical CNM, BAF, SOV, 3CB Civ Templates", _filename] call A3A_fnc_log;
         };
         default {
           call compile preProcessFileLineNumbers "Templates\3CB_Reb_TTF_Arid.sqf";
           call compile preProcessFileLineNumbers "Templates\3CB_Occ_BAF_Arid.sqf";
           call compile preProcessFileLineNumbers "Templates\3CB_Inv_TKM_Arid.sqf";
+          [2, "Using arid TTF, BAF, TKM, 3CB Civ Templates", _filename] call A3A_fnc_log;
         };
       };
       call compile preProcessFileLineNumbers "Templates\3CB_Civ.sqf";
@@ -64,21 +71,25 @@ if(teamplayer != independent) then {//This section is for Altis Blufor ONLY!
           call compile preProcessFileLineNumbers "Templates\RHS_Reb_NAPA_Temp.sqf";
           call compile preProcessFileLineNumbers "Templates\RHS_Occ_USAF_Temp.sqf";
           call compile preProcessFileLineNumbers "Templates\RHS_Inv_AFRF_Temp.sqf";
+          [2, "Using arctic NAPA, USAF, AFRF, RHS Civ Templates", _filename] call A3A_fnc_log;
         };
         case (worldName in temperatemaps): {
           call compile preProcessFileLineNumbers "Templates\RHS_Reb_NAPA_Temp.sqf";
           call compile preProcessFileLineNumbers "Templates\RHS_Occ_USAF_Temp.sqf";
           call compile preProcessFileLineNumbers "Templates\RHS_Inv_AFRF_Temp.sqf";
+          [2, "Using temperate NAPA, USAF, AFRF, RHS Civ Templates", _filename] call A3A_fnc_log;
         };
         case (worldName in tropicalmaps): {
           call compile preProcessFileLineNumbers "Templates\RHS_Reb_NAPA_Temp.sqf";
           call compile preProcessFileLineNumbers "Templates\RHS_Occ_USAF_Temp.sqf";
           call compile preProcessFileLineNumbers "Templates\RHS_Inv_AFRF_Temp.sqf";
+          [2, "Using tropical NAPA, USAF, AFRF, RHS Civ Templates", _filename] call A3A_fnc_log;
         };
         default {
           call compile preProcessFileLineNumbers "Templates\RHS_Reb_NAPA_Arid.sqf";
           call compile preProcessFileLineNumbers "Templates\RHS_Occ_USAF_Arid.sqf";
           call compile preProcessFileLineNumbers "Templates\RHS_Inv_AFRF_Arid.sqf";
+          [2, "Using arid NAPA, USAF, AFRF, RHS Civ Templates", _filename] call A3A_fnc_log;
         };
       };
       call compile preProcessFileLineNumbers "Templates\RHS_Civ.sqf";
@@ -89,21 +100,25 @@ if(teamplayer != independent) then {//This section is for Altis Blufor ONLY!
           call compile preProcessFileLineNumbers "Templates\IFA_Reb_POL_Arct.sqf";
           call compile preProcessFileLineNumbers "Templates\IFA_Inv_SOV_Arct.sqf";
           call compile preProcessFileLineNumbers "Templates\IFA_Occ_WEH_Arct.sqf";
+          [2, "Using arctic POL, SOV, WEH, IFA Civ Templates", _filename] call A3A_fnc_log;
         };
         case (worldName in temperatemaps): {
           call compile preProcessFileLineNumbers "Templates\IFA_Reb_POL_Temp.sqf";
           call compile preProcessFileLineNumbers "Templates\IFA_Inv_SOV_Temp.sqf";
           call compile preProcessFileLineNumbers "Templates\IFA_Occ_WEH_Temp.sqf";
+          [2, "Using temperate POL, SOV, WEH, IFA Civ Templates", _filename] call A3A_fnc_log;
         };
         case (worldName in tropicalmaps): {
           call compile preProcessFileLineNumbers "Templates\IFA_Reb_POL_Temp.sqf";
           call compile preProcessFileLineNumbers "Templates\IFA_Inv_SOV_Temp.sqf";
           call compile preProcessFileLineNumbers "Templates\IFA_Occ_WEH_Temp.sqf";
+          [2, "Using tropical POL, SOV, WEH, IFA Civ Templates", _filename] call A3A_fnc_log;
         };
         default {
           call compile preProcessFileLineNumbers "Templates\IFA_Reb_POL_Arid.sqf";
           call compile preProcessFileLineNumbers "Templates\IFA_Inv_SOV_Arid.sqf";
           call compile preProcessFileLineNumbers "Templates\IFA_Occ_WEH_Arid.sqf";
+          [2, "Using arid POL, SOV, WEH, IFA Civ Templates", _filename] call A3A_fnc_log;
         };
       };
       call compile preProcessFileLineNumbers "Templates\IFA_Civ.sqf";
@@ -114,24 +129,31 @@ if(teamplayer != independent) then {//This section is for Altis Blufor ONLY!
           call compile preProcessFileLineNumbers "Templates\Vanilla_Reb_FIA_Enoch.sqf";
           call compile preProcessFileLineNumbers "Templates\Vanilla_Occ_NATO_Temp.sqf";
           call compile preProcessFileLineNumbers "Templates\Vanilla_Inv_CSAT_Enoch.sqf";
+          [2, "Using Enoch FIA, NATO, CSAT, Vanilla Civ Templates", _filename] call A3A_fnc_log;
         };
         case (worldName == "Tanoa"): {
           call compile preProcessFileLineNumbers "Templates\Vanilla_Reb_SDK_Tanoa.sqf";
           call compile preProcessFileLineNumbers "Templates\Vanilla_Occ_NATO_Tanoa.sqf";
           call compile preProcessFileLineNumbers "Templates\Vanilla_Inv_CSAT_Tanoa.sqf";
+          [2, "Using tanoa SDK, NATO, CSAT, Vanilla Civ Templates", _filename] call A3A_fnc_log;
         };
         case (worldName in temperatemaps): {
           call compile preProcessFileLineNumbers "Templates\Vanilla_Reb_FIA_Altis.sqf";
           call compile preProcessFileLineNumbers "Templates\Vanilla_Occ_NATO_Temp.sqf";
           call compile preProcessFileLineNumbers "Templates\Vanilla_Inv_CSAT_Altis.sqf";
+          [2, "Using temperate FIA, NATO, CSAT, Vanilla Civ Templates", _filename] call A3A_fnc_log;
         };
         default {
           call compile preProcessFileLineNumbers "Templates\Vanilla_Reb_FIA_Altis.sqf";
           call compile preProcessFileLineNumbers "Templates\Vanilla_Occ_NATO_Altis.sqf";
           call compile preProcessFileLineNumbers "Templates\Vanilla_Inv_CSAT_Altis.sqf";
+          [2, "Using arid FIA, NATO, CSAT, Vanilla Civ Templates", _filename] call A3A_fnc_log;
         };
       };
       call compile preProcessFileLineNumbers "Templates\Vanilla_Civ.sqf";
     };
   };
 };
+
+//Addon mod loading
+if (hasIvory) then {call compile preProcessFileLineNumbers "Templates\Ivory_Civ.sqf";[2, "Using Addon Ivory Cars Template", _filename] call A3A_fnc_log;};

--- a/A3-Antistasi/Templates/selector.sqf
+++ b/A3-Antistasi/Templates/selector.sqf
@@ -2,7 +2,7 @@
     This file controls the selection of templates based on the mods loaded and map used.
     When porting new mods/maps be sure to add them to their respective sections!
 */
-_filename = "selector.sqf";
+private _filename = "selector.sqf";
 //Map checker
 aridmaps = ["Altis","Kunduz","Malden","tem_anizay","Tembelan"];
 tropicalmaps = ["Tanoa"];

--- a/A3-Antistasi/Templates/selector.sqf
+++ b/A3-Antistasi/Templates/selector.sqf
@@ -156,4 +156,7 @@ if(teamplayer != independent) then {//This section is for Altis Blufor ONLY!
 };
 
 //Addon mod loading
-if (hasIvory) then {call compile preProcessFileLineNumbers "Templates\Ivory_Civ.sqf";[2, "Using Addon Ivory Cars Template", _filename] call A3A_fnc_log;};
+if (hasIvory) then {
+  call compile preProcessFileLineNumbers "Templates\Ivory_Civ.sqf";
+  [2, "Using Addon Ivory Cars Template", _filename] call A3A_fnc_log;
+};

--- a/A3-Antistasi/functions/init/fn_initVarCommon.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarCommon.sqf
@@ -85,6 +85,7 @@ activeGREF = false;
 hasFFAA = false;
 hasIFA = false;
 has3CB = false;
+hasIvory = false;
 //Systems Mods
 hasACE = false;
 hasACEHearing = false;
@@ -117,6 +118,8 @@ if (activeAFRF && activeUSAF && isClass (configFile >> "CfgFactionClasses" >> "r
 if (activeAFRF && activeUSAF && activeGREF && isClass (configfile >> "CfgPatches" >> "UK3CB_BAF_Weapons")) then {has3CB = true; diag_log format ["%1: [Antistasi] | INFO | initVar | 3CB Detected.",servertime];};
 //FFAA Detection
 if (isClass (configfile >> "CfgPatches" >> "ffaa_armas")) then {hasFFAA = true; diag_log format ["%1: [Antistasi] | INFO | initVar | FFAA Detected.",servertime];};
+//Ivory Car Pack Detection
+if (isClass (configfile >> "CfgPatches" >> "Ivory_Data")) then {hasIvory = true; diag_log format ["%1: [Antistasi] | INFO | initVar | Ivory Cars Detected.",servertime];};
 
 ////////////////////////////////////
 //        BUILDINGS LISTS        ///

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -446,7 +446,7 @@ private _templateVariables = [
 } forEach _templateVariables;
 
 call compile preProcessFileLineNumbers "Templates\selector.sqf";
-
+_fileName = "initVarServer.sqf"; //reset filename to un-confuse the logs
 ////////////////////////////////////
 //      CIVILIAN VEHICLES       ///
 ////////////////////////////////////

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -446,7 +446,7 @@ private _templateVariables = [
 } forEach _templateVariables;
 
 call compile preProcessFileLineNumbers "Templates\selector.sqf";
-_fileName = "initVarServer.sqf"; //reset filename to un-confuse the logs
+
 ////////////////////////////////////
 //      CIVILIAN VEHICLES       ///
 ////////////////////////////////////


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information:
    Worked out how to create an additive civ template,
    Created such a template for Ivory Car Pack,
    Added detection for said pack,
    Added extra logging to the template selection for verifying what loads. (in case there are future issues).

### Please specify which Issue this PR Resolves.
closes #1263 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
  Load into any modset/map with the car pack in your mod list. Check for civilian spawns.
  Optionally, you can look at the output from monitoring civVehiclesWeighted in the debug console for any classnames with ivory_ at the start.
********************************************************
Notes:
  Super/Hypercars are exceedingly rare, during testing i found 1 in the wild. Does make the game look a bit like arma life :)