### PR TITLE
Fix loadgame functionality broken by #1234

### DIFF
--- a/A3-Antistasi/functions/init/fn_initServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initServer.sqf
@@ -10,6 +10,7 @@ flagX allowDamage false;
 vehicleBox allowDamage false;
 fireX allowDamage false;
 mapX allowDamage false;
+teamPlayer = side group petros; 				// moved here because it must be initialized before accessing any saved vars
 
 //Load server id
 serverID = profileNameSpace getVariable ["ss_ServerID",nil];

--- a/A3-Antistasi/functions/init/fn_initVarCommon.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarCommon.sqf
@@ -19,7 +19,7 @@ debug = false;
 //     BEGIN SIDES AND COLORS    ///
 ////////////////////////////////////
 [2,"Generating sides",_fileName] call A3A_fnc_log;
-teamPlayer = side group petros;
+if (isNil "teamPlayer") then { teamPlayer = side group petros };
 if (teamPlayer == independent) then
 	{
 	Occupants = west;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Moved teamPlayer definition to the top of initServer so that it's available for the loadgame selection code.

Short term fix. We can argue about the organisational options later.

### Please specify which Issue this PR Resolves.
closes #1271

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in singleplayer?
2. [X] Have you loaded the mission in LAN host?
3. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Load a game.
