### PR TITLE
Expand template sanity check

### DIFF
--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -448,6 +448,55 @@ private _templateVariables = [
 call compile preProcessFileLineNumbers "Templates\selector.sqf";
 
 ////////////////////////////////////
+//     TEMPLATE SANITY CHECK      //
+////////////////////////////////////
+[2,"Sanity-checking templates",_fileName] call A3A_fnc_log;
+
+// modify these appropriately when adding new template vars
+private _nonClassVars = ["nameTeamPlayer", "SDKFlagTexture", "nameOccupants", "NATOPlayerLoadouts", "NATOFlagTexture", "flagNATOmrk", "nameInvaders", "CSATPlayerLoadouts", "CSATFlagTexture", "flagCSATmrk"];
+private _factionVars = ["factionGEN", "factionMaleOccupants", "factionFIA", "factionMaleInvaders"];
+private _magazineVars = ["SDKMortarHEMag", "SDKMortarSmokeMag", "ATMineMag", "APERSMineMag", "vehNATOMRLSMags", "vehCSATMRLSMags", "breachingExplosivesAPC", "breachingExplosivesTank"];
+
+private _missingVars = [];
+private _badCaseVars = [];
+{
+	call {
+		private _varName = _x;
+		private _var = missionNamespace getVariable _varName;
+		if (isNil "_var") exitWith { [1, "Missing template var " + _varName, _filename] call A3A_fnc_log };
+
+		if !(_var isEqualType []) then {_var = [_var]};									// plain string case, eg factions, some units
+		if ("breachingExplosives" in _varName) then { _var = _var apply {_x#0} };		// ["class", n] case for breaching explosives
+		if (_var#0 isEqualType []) then {												// arrays of arrays case, used for infantry groups
+			private _classes = [];
+			{ _classes append _x } forEach _var;
+			_var = _classes;
+		};
+
+		private _section = if (_x in _factionVars) then {"CfgFactionClasses"}
+			else { if (_x in _magazineVars) then {"CfgMagazines"} else {"CfgVehicles"} };
+		{
+			if !(_x isEqualType "") exitWith { [1, "Bad template var " + _varName, _filename] call A3A_fnc_log };
+			if !(_x isEqualTo configName (configFile >> _section >> _x)) then
+			{
+			    if !(isClass (configFile >> _section >> _x)) then {
+			        _missingVars pushBackUnique _x;
+			    } else {
+					_badCaseVars pushBackUnique _x;
+				};
+			};
+		} forEach _var;
+	};
+} forEach (_templateVariables - _nonClassVars);
+
+if (count _missingVars > 0) then {
+	[1, format ["Missing classnames: %1", _missingVars], _filename] call A3A_fnc_log;
+};
+if (count _badCaseVars > 0) then {
+	[1, format ["Miscased classnames: %1", _badCaseVars], _filename] call A3A_fnc_log;
+};
+
+////////////////////////////////////
 //      CIVILIAN VEHICLES       ///
 ////////////////////////////////////
 [2,"Creating civilian vehicles lists",_fileName] call A3A_fnc_log;
@@ -613,18 +662,6 @@ DECLARE_SERVER_VAR(vehUnlimited, _vehUnlimited);
 
 private _vehFIA = [vehSDKBike,vehSDKLightArmed,SDKMGStatic,vehSDKLightUnarmed,vehSDKTruck,vehSDKBoat,SDKMortar,staticATteamPlayer,staticAAteamPlayer,vehSDKRepair];
 DECLARE_SERVER_VAR(vehFIA, _vehFIA);
-
-// sanity check the lists to catch some serious problems early
-private _badVehs = [];
-{
-    if !(isClass (configFile >> "CfgVehicles" >> _x)) then {
-        _badVehs pushBackUnique _x;
-    };
-} forEach (vehNormal + vehBoats + vehAttack + vehPlanes + vehAA + vehMRLS + vehUnlimited + vehFIA);
-
-if (count _badVehs > 0) then {
-	[1, format ["Missing vehicle classnames: %1", str _badVehs], _filename] call A3A_fnc_log;
-};
 
 ///////////////////////////
 //     MOD TEMPLATES    ///

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -360,13 +360,7 @@ private _templateVariables = [
 	"staticATOccupants",
 	"staticAAOccupants",
 	"NATOMortar",
-	"MGStaticNATOB",
-	"ATStaticNATOB",
-	"AAStaticNATOB",
-	"MortStaticNATOB",
-	"supportStaticNATOB",
-	"supportStaticNATOB2",
-	"supportStaticNATOB3",
+
 	//Invaders
 	"nameInvaders",
 	"factionMaleInvaders",
@@ -431,14 +425,7 @@ private _templateVariables = [
 	"CSATMG",
 	"staticATInvaders",
 	"staticAAInvaders",
-	"CSATMortar",
-	"MGStaticCSATB",
-	"ATStaticCSATB",
-	"AAStaticCSATB",
-	"MortStaticCSATB",
-	"supportStaticCSATB",
-	"supportStaticCSATB2",
-	"supportStaticCSATB3"
+	"CSATMortar"
 ];
 
 {


### PR DESCRIPTION

## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Expanded the template sanity check to include almost all template vars, and include mis-cased class values, which break `_vehicle in _typeArray` tests.

### Please specify which Issue this PR Resolves.
closes #1265

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
