### PR TITLE
Various template fixes

### DIFF
--- a/A3-Antistasi/Templates/3CB_Inv_Sov_Temp.sqf
+++ b/A3-Antistasi/Templates/3CB_Inv_Sov_Temp.sqf
@@ -124,7 +124,7 @@ vehCSATAttack = vehCSATAPC + [vehCSATTank];
 //Boats
 vehCSATBoat = "UK3CB_TKA_O_RHIB_Gunboat";
 vehCSATRBoat = "UK3CB_CW_SOV_O_LATE_MTLB_PKT";
-vehCSATBoats = [vehCSATBoat,vehCSATRBoat] + [vehCSATAPC];
+vehCSATBoats = [vehCSATBoat,vehCSATRBoat,"UK3CB_CW_SOV_O_LATE_BTR80"];
 //Planes
 vehCSATPlane = "UK3CB_CW_SOV_O_LATE_Su25SM";
 vehCSATPlaneAA = "UK3CB_CW_SOV_O_LATE_MIG29S";

--- a/A3-Antistasi/Templates/RHS_Inv_AFRF_Arid.sqf
+++ b/A3-Antistasi/Templates/RHS_Inv_AFRF_Arid.sqf
@@ -115,7 +115,7 @@ vehCSATAmmoTruck = "rhs_gaz66_ammo_vmf";
 vehCSATRepairTruck = "rhs_gaz66_repair_vdv";
 vehCSATLight = vehCSATLightArmed + vehCSATLightUnarmed;
 //Armored
-vehCSATAPC = ["rhs_bmd1r","rhs_bmp1p_vdv","rhs_bmd1p","rhs_bmd2m","rhs_bmp1p_vdv","rhs_bmp2k_vdv","rhs_btr80a_vdv","rhs_bmp3mera_msv","rhs_bmd1PK"];
+vehCSATAPC = ["rhs_bmd1r","rhs_bmp1p_vdv","rhs_bmd1p","rhs_bmd2m","rhs_bmp1p_vdv","rhs_bmp2k_vdv","rhs_btr80a_vdv","rhs_bmp3mera_msv","rhs_bmd1pk"];
 vehCSATTank = "rhs_t90sab_tv";
 vehCSATAA = "rhs_zsu234_aa";
 vehCSATAttack = vehCSATAPC + [vehCSATTank];

--- a/A3-Antistasi/Templates/RHS_Inv_AFRF_Temp.sqf
+++ b/A3-Antistasi/Templates/RHS_Inv_AFRF_Temp.sqf
@@ -115,7 +115,7 @@ vehCSATAmmoTruck = "rhs_gaz66_ammo_vmf";
 vehCSATRepairTruck = "rhs_gaz66_repair_vdv";
 vehCSATLight = vehCSATLightArmed + vehCSATLightUnarmed;
 //Armored
-vehCSATAPC = ["rhs_bmd1r","rhs_bmp1p_vdv","rhs_bmd1p","rhs_bmd2m","rhs_bmp1p_vdv","rhs_bmp2k_vdv","rhs_btr80a_vdv","rhs_bmp3mera_msv","rhs_bmd1PK"];
+vehCSATAPC = ["rhs_bmd1r","rhs_bmp1p_vdv","rhs_bmd1p","rhs_bmd2m","rhs_bmp1p_vdv","rhs_bmp2k_vdv","rhs_btr80a_vdv","rhs_bmp3mera_msv","rhs_bmd1pk"];
 vehCSATTank = "rhs_t90sab_tv";
 vehCSATAA = "rhs_zsu234_aa";
 vehCSATAttack = vehCSATAPC + [vehCSATTank];

--- a/A3-Antistasi/Templates/RHS_Inv_AFRF_Trop.sqf
+++ b/A3-Antistasi/Templates/RHS_Inv_AFRF_Trop.sqf
@@ -115,7 +115,7 @@ vehCSATAmmoTruck = "rhs_gaz66_ammo_vmf";
 vehCSATRepairTruck = "rhs_gaz66_repair_vdv";
 vehCSATLight = vehCSATLightArmed + vehCSATLightUnarmed;
 //Armored
-vehCSATAPC = ["rhs_bmd1r","rhs_bmp1p_vdv","rhs_bmd1p","rhs_bmd2m","rhs_bmp1p_vdv","rhs_bmp2k_vdv","rhs_btr80a_vdv","rhs_bmp3mera_msv","rhs_bmd1PK"];
+vehCSATAPC = ["rhs_bmd1r","rhs_bmp1p_vdv","rhs_bmd1p","rhs_bmd2m","rhs_bmp1p_vdv","rhs_bmp2k_vdv","rhs_btr80a_vdv","rhs_bmp3mera_msv","rhs_bmd1pk"];
 vehCSATTank = "rhs_t90sab_tv";
 vehCSATAA = "rhs_zsu234_aa";
 vehCSATAttack = vehCSATAPC + [vehCSATTank];

--- a/A3-Antistasi/Templates/RHS_Occ_CDF_Arid.sqf
+++ b/A3-Antistasi/Templates/RHS_Occ_CDF_Arid.sqf
@@ -127,7 +127,7 @@ groupsNATOGen = [policeOfficer,policeGrunt];
 //Military Vehicles
 //Lite
 vehNATOBike = "I_Quadbike_01_F";
-vehNATOLightArmed = ["rhsgref_cdf_uaz_ags","rhsgref_cdf_reg_uaz_dshkm","rhsgref_cdf_reg_uaz_spg9","rhsgref_BRDM2_HQ"];
+vehNATOLightArmed = ["rhsgref_cdf_reg_uaz_ags","rhsgref_cdf_reg_uaz_dshkm","rhsgref_cdf_reg_uaz_spg9","rhsgref_BRDM2_HQ"];
 vehNATOLightUnarmed = ["rhsgref_cdf_reg_uaz","rhsgref_cdf_reg_uaz_open","rhsgref_BRDM2UM"];
 vehNATOTrucks = ["rhsgref_cdf_gaz66","rhsgref_cdf_ural","rhsgref_cdf_ural_open","rhsgref_cdf_gaz66o","rhsgref_cdf_zil131","rhsgref_cdf_zil131_open"];
 vehNATOCargoTrucks = [];
@@ -179,7 +179,7 @@ vehPoliceCar = "rhsgref_un_uaz";
 NATOMG = "rhsgref_cdf_DSHKM";
 staticATOccupants = "rhsgref_cdf_SPG9M";
 staticAAOccupants = "rhsgref_cdf_Igla_AA_pod";
-NATOMortar = "rhsgref_cdf_reg_m252";
+NATOMortar = "rhsgref_cdf_reg_M252";
 
 //Static Weapon Bags
 MGStaticNATOB = "RHS_DShkM_Gun_Bag";

--- a/A3-Antistasi/Templates/RHS_Occ_CDF_Temp.sqf
+++ b/A3-Antistasi/Templates/RHS_Occ_CDF_Temp.sqf
@@ -179,7 +179,7 @@ vehPoliceCar = "rhsgref_un_uaz";
 NATOMG = "rhsgref_cdf_DSHKM";
 staticATOccupants = "rhsgref_cdf_SPG9M";
 staticAAOccupants = "rhsgref_cdf_Igla_AA_pod";
-NATOMortar = "rhsgref_cdf_reg_m252";
+NATOMortar = "rhsgref_cdf_reg_M252";
 
 //Static Weapon Bags
 MGStaticNATOB = "RHS_DShkM_Gun_Bag";

--- a/A3-Antistasi/Templates/Vanilla_Inv_CSAT_Altis.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Inv_CSAT_Altis.sqf
@@ -45,10 +45,10 @@ vehCSATPVP = ["O_MRAP_02_F","O_LSV_02_unarmed_F","O_MRAP_02_hmg_F","O_LSV_02_arm
 ////////////////////////////////////
 //Military Units
 CSATGrunt = "O_Soldier_F";
-CSATOfficer = "O_Officer_F";
+CSATOfficer = "O_officer_F";
 CSATBodyG = "O_V_Soldier_hex_F";
-CSATCrew = "O_Crew_F";
-CSATMarksman = "O_Soldier_M_F";
+CSATCrew = "O_crew_F";
+CSATMarksman = "O_soldier_M_F";
 staticCrewInvaders = "O_support_MG_F";
 CSATPilot = "O_Pilot_F";
 
@@ -64,24 +64,24 @@ if (gameMode == 4) then
 ////////////////////////////////////
 //Military Groups
 //Teams
-groupsCSATSentry = ["O_soldier_GL_F","O_soldier_F"];
+groupsCSATSentry = ["O_Soldier_GL_F","O_Soldier_F"];
 groupsCSATSniper = ["O_sniper_F","O_spotter_F"];
 groupsCSATsmall = [groupsCSATSentry,["O_recon_M_F","O_recon_F"],groupsCSATSniper];
 //Fireteams
-groupsCSATAA = ["O_soldier_TL_F","O_soldier_AA_F","O_soldier_AA_F","O_soldier_AAA_F"];
-groupsCSATAT = ["O_soldier_TL_F","O_soldier_AT_F","O_soldier_AT_F","O_soldier_AAT_F"];
-groupsCSATmid = [["O_soldier_TL_F","O_soldier_AR_F","O_soldier_GL_F","O_soldier_LAT_F"],groupsCSATAA,groupsCSATAT];
+groupsCSATAA = ["O_Soldier_TL_F","O_Soldier_AA_F","O_Soldier_AA_F","O_Soldier_AAA_F"];
+groupsCSATAT = ["O_Soldier_TL_F","O_Soldier_AT_F","O_Soldier_AT_F","O_Soldier_AAT_F"];
+groupsCSATmid = [["O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_GL_F","O_Soldier_LAT_F"],groupsCSATAA,groupsCSATAT];
 //Squads
-CSATSquad = ["O_soldier_SL_F","O_soldier_F","O_soldier_LAT_F","O_soldier_M_F","O_soldier_TL_F","O_soldier_AR_F","O_soldier_A_F","O_medic_F"];
+CSATSquad = ["O_Soldier_SL_F","O_Soldier_F","O_Soldier_LAT_F","O_soldier_M_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_medic_F"];
 CSATSpecOp = ["O_V_Soldier_TL_hex_F","O_V_Soldier_JTAC_hex_F","O_V_Soldier_M_hex_F","O_V_Soldier_Exp_hex_F","O_V_Soldier_LAT_hex_F","O_V_Soldier_Medic_hex_F"];
 groupsCSATSquad =
 	[
 	CSATSquad,
-	["O_soldier_SL_F","O_soldier_AR_F","O_soldier_GL_F","O_soldier_M_F","O_soldier_AT_F","O_soldier_AAT_F","O_soldier_A_F","O_medic_F"],
-	["O_soldier_SL_F","O_soldier_LAT_F","O_soldier_TL_F","O_soldier_AR_F","O_soldier_A_F","O_Support_Mort_F","O_Support_AMort_F","O_medic_F"],
-	["O_soldier_SL_F","O_soldier_LAT_F","O_soldier_TL_F","O_soldier_AR_F","O_soldier_A_F","O_Support_MG_F","O_Support_AMG_F","O_medic_F"],
-	["O_soldier_SL_F","O_soldier_LAT_F","O_soldier_TL_F","O_soldier_AR_F","O_soldier_A_F","O_soldier_AA_F","O_soldier_AAA_F","O_medic_F"],
-	["O_soldier_SL_F","O_soldier_LAT_F","O_soldier_TL_F","O_soldier_AR_F","O_soldier_A_F","O_engineer_F","O_engineer_F","O_medic_F"]
+	["O_Soldier_SL_F","O_Soldier_AR_F","O_Soldier_GL_F","O_soldier_M_F","O_Soldier_AT_F","O_Soldier_AAT_F","O_Soldier_A_F","O_medic_F"],
+	["O_Soldier_SL_F","O_Soldier_LAT_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_support_Mort_F","O_support_AMort_F","O_medic_F"],
+	["O_Soldier_SL_F","O_Soldier_LAT_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_support_MG_F","O_support_AMG_F","O_medic_F"],
+	["O_Soldier_SL_F","O_Soldier_LAT_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_Soldier_AA_F","O_Soldier_AAA_F","O_medic_F"],
+	["O_Soldier_SL_F","O_Soldier_LAT_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_engineer_F","O_engineer_F","O_medic_F"]
 	];
 
 //Militia Groups

--- a/A3-Antistasi/Templates/Vanilla_Inv_CSAT_Enoch.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Inv_CSAT_Enoch.sqf
@@ -45,10 +45,10 @@ vehCSATPVP = ["O_MRAP_02_F","O_LSV_02_unarmed_F","O_MRAP_02_hmg_F","O_LSV_02_arm
 ////////////////////////////////////
 //Military Units
 CSATGrunt = "O_Soldier_F";
-CSATOfficer = "O_Officer_F";
+CSATOfficer = "O_officer_F";
 CSATBodyG = "O_V_Soldier_hex_F";
-CSATCrew = "O_Crew_F";
-CSATMarksman = "O_Soldier_M_F";
+CSATCrew = "O_crew_F";
+CSATMarksman = "O_soldier_M_F";
 staticCrewInvaders = "O_support_MG_F";
 CSATPilot = "O_Pilot_F";
 
@@ -64,24 +64,24 @@ if (gameMode == 4) then
 ////////////////////////////////////
 //Military Groups
 //Teams
-groupsCSATSentry = ["O_soldier_GL_F","O_soldier_F"];
+groupsCSATSentry = ["O_Soldier_GL_F","O_Soldier_F"];
 groupsCSATSniper = ["O_sniper_F","O_spotter_F"];
 groupsCSATsmall = [groupsCSATSentry,["O_recon_M_F","O_recon_F"],groupsCSATSniper];
 //Fireteams
-groupsCSATAA = ["O_soldier_TL_F","O_soldier_AA_F","O_soldier_AA_F","O_soldier_AAA_F"];
-groupsCSATAT = ["O_soldier_TL_F","O_soldier_AT_F","O_soldier_AT_F","O_soldier_AAT_F"];
-groupsCSATmid = [["O_soldier_TL_F","O_soldier_AR_F","O_soldier_GL_F","O_soldier_LAT_F"],groupsCSATAA,groupsCSATAT];
+groupsCSATAA = ["O_Soldier_TL_F","O_Soldier_AA_F","O_Soldier_AA_F","O_Soldier_AAA_F"];
+groupsCSATAT = ["O_Soldier_TL_F","O_Soldier_AT_F","O_Soldier_AT_F","O_Soldier_AAT_F"];
+groupsCSATmid = [["O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_GL_F","O_Soldier_LAT_F"],groupsCSATAA,groupsCSATAT];
 //Squads
-CSATSquad = ["O_soldier_SL_F","O_soldier_F","O_soldier_LAT_F","O_soldier_M_F","O_soldier_TL_F","O_soldier_AR_F","O_soldier_A_F","O_medic_F"];
+CSATSquad = ["O_Soldier_SL_F","O_Soldier_F","O_Soldier_LAT_F","O_soldier_M_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_medic_F"];
 CSATSpecOp = ["O_V_Soldier_TL_hex_F","O_V_Soldier_JTAC_hex_F","O_V_Soldier_M_hex_F","O_V_Soldier_Exp_hex_F","O_V_Soldier_LAT_hex_F","O_V_Soldier_Medic_hex_F"];
 groupsCSATSquad =
 	[
 	CSATSquad,
-	["O_soldier_SL_F","O_soldier_AR_F","O_soldier_GL_F","O_soldier_M_F","O_soldier_AT_F","O_soldier_AAT_F","O_soldier_A_F","O_medic_F"],
-	["O_soldier_SL_F","O_soldier_LAT_F","O_soldier_TL_F","O_soldier_AR_F","O_soldier_A_F","O_Support_Mort_F","O_Support_AMort_F","O_medic_F"],
-	["O_soldier_SL_F","O_soldier_LAT_F","O_soldier_TL_F","O_soldier_AR_F","O_soldier_A_F","O_Support_MG_F","O_Support_AMG_F","O_medic_F"],
-	["O_soldier_SL_F","O_soldier_LAT_F","O_soldier_TL_F","O_soldier_AR_F","O_soldier_A_F","O_soldier_AA_F","O_soldier_AAA_F","O_medic_F"],
-	["O_soldier_SL_F","O_soldier_LAT_F","O_soldier_TL_F","O_soldier_AR_F","O_soldier_A_F","O_engineer_F","O_engineer_F","O_medic_F"]
+	["O_Soldier_SL_F","O_Soldier_AR_F","O_Soldier_GL_F","O_soldier_M_F","O_Soldier_AT_F","O_Soldier_AAT_F","O_Soldier_A_F","O_medic_F"],
+	["O_Soldier_SL_F","O_Soldier_LAT_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_support_Mort_F","O_support_AMort_F","O_medic_F"],
+	["O_Soldier_SL_F","O_Soldier_LAT_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_support_MG_F","O_support_AMG_F","O_medic_F"],
+	["O_Soldier_SL_F","O_Soldier_LAT_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_Soldier_AA_F","O_Soldier_AAA_F","O_medic_F"],
+	["O_Soldier_SL_F","O_Soldier_LAT_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_engineer_F","O_engineer_F","O_medic_F"]
 	];
 
 //Militia Groups

--- a/A3-Antistasi/Templates/Vanilla_Inv_CSAT_Tanoa.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Inv_CSAT_Tanoa.sqf
@@ -49,7 +49,7 @@ CSATOfficer = "O_T_Officer_F";
 CSATBodyG = "O_V_Soldier_ghex_F";
 CSATCrew = "O_T_Crew_F";
 CSATMarksman = "O_T_Soldier_M_F";
-staticCrewInvaders = "O_T_support_MG_F";
+staticCrewInvaders = "O_T_Support_MG_F";
 CSATPilot = "O_T_Pilot_F";
 
 //Militia Units
@@ -64,24 +64,24 @@ if (gameMode == 4) then
 ////////////////////////////////////
 //Military Groups
 //Teams
-groupsCSATSentry = ["O_T_soldier_GL_F","O_T_soldier_F"];
-groupsCSATSniper = ["O_T_sniper_F","O_T_spotter_F"];
-groupsCSATsmall = [groupsCSATSentry,["O_T_recon_M_F","O_T_recon_F"],groupsCSATSniper];
+groupsCSATSentry = ["O_T_Soldier_GL_F","O_T_Soldier_F"];
+groupsCSATSniper = ["O_T_Sniper_F","O_T_Spotter_F"];
+groupsCSATsmall = [groupsCSATSentry,["O_T_Recon_M_F","O_T_Recon_F"],groupsCSATSniper];
 //Fireteams
-groupsCSATAA = ["O_T_soldier_TL_F","O_T_soldier_AA_F","O_T_soldier_AA_F","O_T_soldier_AAA_F"];
-groupsCSATAT = ["O_T_soldier_TL_F","O_T_soldier_AT_F","O_T_soldier_AT_F","O_T_soldier_AAT_F"];
-groupsCSATmid = [["O_T_soldier_TL_F","O_T_soldier_AR_F","O_T_soldier_GL_F","O_T_soldier_LAT_F"],groupsCSATAA,groupsCSATAT];
+groupsCSATAA = ["O_T_Soldier_TL_F","O_T_Soldier_AA_F","O_T_Soldier_AA_F","O_T_Soldier_AAA_F"];
+groupsCSATAT = ["O_T_Soldier_TL_F","O_T_Soldier_AT_F","O_T_Soldier_AT_F","O_T_Soldier_AAT_F"];
+groupsCSATmid = [["O_T_Soldier_TL_F","O_T_Soldier_AR_F","O_T_Soldier_GL_F","O_T_Soldier_LAT_F"],groupsCSATAA,groupsCSATAT];
 //Squads
-CSATSquad = ["O_T_soldier_SL_F","O_T_soldier_F","O_T_soldier_LAT_F","O_T_soldier_M_F","O_T_soldier_TL_F","O_T_soldier_AR_F","O_T_soldier_A_F","O_T_medic_F"];
+CSATSquad = ["O_T_Soldier_SL_F","O_T_Soldier_F","O_T_Soldier_LAT_F","O_T_Soldier_M_F","O_T_Soldier_TL_F","O_T_Soldier_AR_F","O_T_Soldier_A_F","O_T_Medic_F"];
 CSATSpecOp = ["O_V_Soldier_TL_ghex_F","O_V_Soldier_JTAC_ghex_F","O_V_Soldier_M_ghex_F","O_V_Soldier_Exp_ghex_F","O_V_Soldier_LAT_ghex_F","O_V_Soldier_Medic_ghex_F"];
 groupsCSATSquad =
 	[
 	CSATSquad,
-	["O_T_soldier_SL_F","O_T_soldier_AR_F","O_T_soldier_GL_F","O_T_soldier_M_F","O_T_soldier_AT_F","O_T_soldier_AAT_F","O_T_soldier_A_F","O_T_medic_F"],
-	["O_T_soldier_SL_F","O_T_soldier_LAT_F","O_T_soldier_TL_F","O_T_soldier_AR_F","O_T_soldier_A_F","O_T_Support_Mort_F","O_T_Support_AMort_F","O_T_medic_F"],
-	["O_T_soldier_SL_F","O_T_soldier_LAT_F","O_T_soldier_TL_F","O_T_soldier_AR_F","O_T_soldier_A_F","O_T_Support_MG_F","O_T_Support_AMG_F","O_T_medic_F"],
-	["O_T_soldier_SL_F","O_T_soldier_LAT_F","O_T_soldier_TL_F","O_T_soldier_AR_F","O_T_soldier_A_F","O_T_soldier_AA_F","O_T_soldier_AAA_F","O_T_medic_F"],
-	["O_T_soldier_SL_F","O_T_soldier_LAT_F","O_T_soldier_TL_F","O_T_soldier_AR_F","O_T_soldier_A_F","O_T_Engineer_F","O_T_Engineer_F","O_T_medic_F"]
+	["O_T_Soldier_SL_F","O_T_Soldier_AR_F","O_T_Soldier_GL_F","O_T_Soldier_M_F","O_T_Soldier_AT_F","O_T_Soldier_AAT_F","O_T_Soldier_A_F","O_T_Medic_F"],
+	["O_T_Soldier_SL_F","O_T_Soldier_LAT_F","O_T_Soldier_TL_F","O_T_Soldier_AR_F","O_T_Soldier_A_F","O_T_Support_Mort_F","O_T_Support_AMort_F","O_T_Medic_F"],
+	["O_T_Soldier_SL_F","O_T_Soldier_LAT_F","O_T_Soldier_TL_F","O_T_Soldier_AR_F","O_T_Soldier_A_F","O_T_Support_MG_F","O_T_Support_AMG_F","O_T_Medic_F"],
+	["O_T_Soldier_SL_F","O_T_Soldier_LAT_F","O_T_Soldier_TL_F","O_T_Soldier_AR_F","O_T_Soldier_A_F","O_T_Soldier_AA_F","O_T_Soldier_AAA_F","O_T_Medic_F"],
+	["O_T_Soldier_SL_F","O_T_Soldier_LAT_F","O_T_Soldier_TL_F","O_T_Soldier_AR_F","O_T_Soldier_A_F","O_T_Engineer_F","O_T_Engineer_F","O_T_Medic_F"]
 	];
 
 //Militia Groups
@@ -162,7 +162,7 @@ if (gameMode == 4) then
 ////////////////////////////////////
 //Assembled Statics
 CSATMG = "I_G_HMG_02_high_F";
-staticATInvaders = "O_T_static_AT_F";
+staticATInvaders = "O_static_AT_F";
 staticAAInvaders = "O_static_AA_F";
 CSATMortar = "O_Mortar_01_F";
 

--- a/A3-Antistasi/Templates/Vanilla_Occ_AAF_Altis.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Occ_AAF_Altis.sqf
@@ -162,7 +162,7 @@ if (gameMode != 4) then
 	{
 	vehFIAArmedCar = "I_C_Offroad_02_LMG_F";
 	vehFIATruck = "I_C_Van_01_transport_F";
-	vehFIACar = "C_Offroad_01_F";
+	vehFIACar = "I_C_Offroad_02_unarmed_F";
 	};
 
 //Police Vehicles

--- a/A3-Antistasi/Templates/Vanilla_Occ_AAF_Altis.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Occ_AAF_Altis.sqf
@@ -46,15 +46,15 @@ vehNATOPVP = ["I_MRAP_03_F","I_MRAP_03_hmg_F"];
 //             UNITS             ///
 ////////////////////////////////////
 //Military Units
-NATOGrunt = "I_Soldier_F";
-NATOOfficer = "I_Officer_F";
+NATOGrunt = "I_soldier_F";
+NATOOfficer = "I_officer_F";
 NATOOfficer2 = "I_G_officer_F";
 NATOBodyG = "I_Soldier_SL_F";
-NATOCrew = "I_Crew_F";
+NATOCrew = "I_crew_F";
 NATOUnarmed = "I_G_Survivor_F";
 NATOMarksman = "I_Soldier_M_F";
 staticCrewOccupants = "I_support_MG_F";
-NATOPilot = "I_Helipilot_F";
+NATOPilot = "I_helipilot_F";
 
 //Militia Units
 if (gameMode != 4) then
@@ -73,23 +73,23 @@ policeGrunt = FIARifleman;
 //Military Groups
 //Teams
 groupsNATOSentry = ["I_Soldier_GL_F","I_soldier_F"];
-groupsNATOSniper = ["I_sniper_F","I_spotter_F"];
+groupsNATOSniper = ["I_Sniper_F","I_Spotter_F"];
 groupsNATOsmall = [groupsNATOSentry,groupsNATOSniper];
 //Fireteams
 groupsNATOAA = ["I_Soldier_TL_F","I_Soldier_AA_F","I_Soldier_AA_F","I_Soldier_AAA_F"];
-groupsNATOAT = ["I_soldier_TL_F","I_soldier_AT_F","I_soldier_AT_F","I_soldier_AAT_F"];
+groupsNATOAT = ["I_Soldier_TL_F","I_Soldier_AT_F","I_Soldier_AT_F","I_Soldier_AAT_F"];
 groupsNATOmid = [["I_Soldier_TL_F","I_Soldier_GL_F","I_Soldier_AR_F","I_Soldier_LAT_F"],groupsNATOAA,groupsNATOAT];
 //Squads
-NATOSquad = ["I_soldier_SL_F",NATOGrunt,"I_soldier_LAT_F","I_Soldier_GL_F","I_Soldier_M_F","I_Soldier_AR_F","I_soldier_A_F","I_medic_F"];
-NATOSpecOp = ["I_soldier_SL_F",NATOGrunt,"I_soldier_LAT_F","I_Soldier_GL_F","I_soldier_TL_F","I_soldier_AR_F","I_soldier_A_F","I_medic_F"];
+NATOSquad = ["I_Soldier_SL_F",NATOGrunt,"I_Soldier_LAT_F","I_Soldier_GL_F","I_Soldier_M_F","I_Soldier_AR_F","I_Soldier_A_F","I_medic_F"];
+NATOSpecOp = ["I_Soldier_SL_F",NATOGrunt,"I_Soldier_LAT_F","I_Soldier_GL_F","I_Soldier_TL_F","I_Soldier_AR_F","I_Soldier_A_F","I_medic_F"];
 groupsNATOSquad =
 	[
 	NATOSquad,
-	["I_soldier_SL_F",NATOGrunt,"I_soldier_TL_F","I_soldier_AR_F","I_soldier_A_F","I_support_Mort_F","I_support_AMort_F","I_medic_F"],
-	["I_soldier_SL_F",NATOGrunt,"I_soldier_TL_F","I_soldier_AR_F","I_soldier_A_F","I_support_MG_F","I_support_AMG_F","I_medic_F"],
-	["I_soldier_SL_F",NATOGrunt,"I_soldier_TL_F","I_soldier_AR_F","I_soldier_A_F","I_soldier_AA_F","I_soldier_AAA_F","I_medic_F"],
-	["I_soldier_SL_F",NATOGrunt,"I_soldier_TL_F","I_soldier_AR_F","I_soldier_A_F","I_soldier_AT_F","I_soldier_AAT_F","I_medic_F"],
-	["I_soldier_SL_F",NATOGrunt,"I_soldier_TL_F","I_soldier_AR_F","I_soldier_A_F","I_engineer_F","I_engineer_F","I_medic_F"]
+	["I_Soldier_SL_F",NATOGrunt,"I_Soldier_TL_F","I_Soldier_AR_F","I_Soldier_A_F","I_support_Mort_F","I_support_AMort_F","I_medic_F"],
+	["I_Soldier_SL_F",NATOGrunt,"I_Soldier_TL_F","I_Soldier_AR_F","I_Soldier_A_F","I_support_MG_F","I_support_AMG_F","I_medic_F"],
+	["I_Soldier_SL_F",NATOGrunt,"I_Soldier_TL_F","I_Soldier_AR_F","I_Soldier_A_F","I_Soldier_AA_F","I_Soldier_AAA_F","I_medic_F"],
+	["I_Soldier_SL_F",NATOGrunt,"I_Soldier_TL_F","I_Soldier_AR_F","I_Soldier_A_F","I_Soldier_AT_F","I_Soldier_AAT_F","I_medic_F"],
+	["I_Soldier_SL_F",NATOGrunt,"I_Soldier_TL_F","I_Soldier_AR_F","I_Soldier_A_F","I_engineer_F","I_engineer_F","I_medic_F"]
 	];
 
 //Militia Groups
@@ -162,7 +162,7 @@ if (gameMode != 4) then
 	{
 	vehFIAArmedCar = "I_C_Offroad_02_LMG_F";
 	vehFIATruck = "I_C_Van_01_transport_F";
-	vehFIACar = "I_C_Offroad_01_F";
+	vehFIACar = "C_Offroad_01_F";
 	};
 
 //Police Vehicles

--- a/A3-Antistasi/Templates/Vanilla_Occ_NATO_Altis.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Occ_NATO_Altis.sqf
@@ -47,10 +47,10 @@ vehNATOPVP = ["B_MRAP_01_F","B_MRAP_01_hmg_F"];
 ////////////////////////////////////
 //Military Units
 NATOGrunt = "B_Soldier_F";
-NATOOfficer = "B_Officer_F";
+NATOOfficer = "B_officer_F";
 NATOOfficer2 = "B_G_officer_F";
 NATOBodyG = "B_Patrol_Soldier_TL_F";
-NATOCrew = "B_Crew_F";
+NATOCrew = "B_crew_F";
 NATOUnarmed = "B_G_Survivor_F";
 NATOMarksman = "B_Sharpshooter_F";
 staticCrewOccupants = "B_support_MG_F";
@@ -72,24 +72,24 @@ policeGrunt = "B_GEN_Soldier_F";
 ////////////////////////////////////
 //Military Groups
 //Teams
-groupsNATOSentry = ["B_soldier_GL_F",NATOGrunt];
+groupsNATOSentry = ["B_Soldier_GL_F",NATOGrunt];
 groupsNATOSniper = ["B_sniper_F","B_spotter_F"];
 groupsNATOsmall = [groupsNATOSentry,groupsNATOSniper,["B_recon_JTAC_F","B_recon_F"]];
 //Fireteams
 groupsNATOAA = ["B_Soldier_TL_F","B_soldier_AA_F","B_soldier_AA_F","B_soldier_AAA_F"];
-groupsNATOAT = ["B_soldier_TL_F","B_soldier_AT_F","B_soldier_AT_F","B_soldier_AAT_F"];
-groupsNATOmid = [["B_soldier_TL_F","B_soldier_AR_F","B_soldier_GL_F","B_soldier_LAT_F"],groupsNATOAA,groupsNATOAT];
+groupsNATOAT = ["B_Soldier_TL_F","B_soldier_AT_F","B_soldier_AT_F","B_soldier_AAT_F"];
+groupsNATOmid = [["B_Soldier_TL_F","B_soldier_AR_F","B_Soldier_GL_F","B_soldier_LAT_F"],groupsNATOAA,groupsNATOAT];
 //Squads
-NATOSquad = ["B_soldier_SL_F",NATOGrunt,"B_soldier_LAT_F",NATOMarksman,"B_soldier_TL_F","B_soldier_AR_F","B_soldier_A_F","B_medic_F"];
+NATOSquad = ["B_Soldier_SL_F",NATOGrunt,"B_soldier_LAT_F",NATOMarksman,"B_Soldier_TL_F","B_soldier_AR_F","B_Soldier_A_F","B_medic_F"];
 NATOSpecOp = ["B_CTRG_Soldier_TL_tna_F","B_CTRG_Soldier_M_tna_F",NATOBodyG,"B_CTRG_Soldier_LAT_tna_F","B_CTRG_Soldier_JTAC_tna_F","B_CTRG_Soldier_Exp_tna_F","B_CTRG_Soldier_AR_tna_F","B_CTRG_Soldier_Medic_tna_F"];
 groupsNATOSquad =
 	[
 	NATOSquad,
-	["B_soldier_SL_F",NATOGrunt,"B_soldier_TL_F","B_soldier_AR_F","B_soldier_A_F","B_support_Mort_F","B_support_AMort_F","B_medic_F"],
-	["B_soldier_SL_F",NATOGrunt,"B_soldier_TL_F","B_soldier_AR_F","B_soldier_A_F","B_support_MG_F","B_support_AMG_F","B_medic_F"],
-	["B_soldier_SL_F",NATOGrunt,"B_soldier_TL_F","B_soldier_AR_F","B_soldier_A_F","B_soldier_AA_F","B_soldier_AAA_F","B_medic_F"],
-	["B_soldier_SL_F",NATOGrunt,"B_soldier_TL_F","B_soldier_AR_F","B_soldier_A_F","B_soldier_AT_F","B_soldier_AAT_F","B_medic_F"],
-	["B_soldier_SL_F",NATOGrunt,"B_soldier_TL_F","B_soldier_AR_F","B_soldier_A_F","B_engineer_F","B_engineer_F","B_medic_F"]
+	["B_Soldier_SL_F",NATOGrunt,"B_Soldier_TL_F","B_soldier_AR_F","B_Soldier_A_F","B_support_Mort_F","B_support_AMort_F","B_medic_F"],
+	["B_Soldier_SL_F",NATOGrunt,"B_Soldier_TL_F","B_soldier_AR_F","B_Soldier_A_F","B_support_MG_F","B_support_AMG_F","B_medic_F"],
+	["B_Soldier_SL_F",NATOGrunt,"B_Soldier_TL_F","B_soldier_AR_F","B_Soldier_A_F","B_soldier_AA_F","B_soldier_AAA_F","B_medic_F"],
+	["B_Soldier_SL_F",NATOGrunt,"B_Soldier_TL_F","B_soldier_AR_F","B_Soldier_A_F","B_soldier_AT_F","B_soldier_AAT_F","B_medic_F"],
+	["B_Soldier_SL_F",NATOGrunt,"B_Soldier_TL_F","B_soldier_AR_F","B_Soldier_A_F","B_engineer_F","B_engineer_F","B_medic_F"]
 	];
 
 //Militia Groups
@@ -133,7 +133,7 @@ vehNATOLightUnarmed = ["B_MRAP_01_F"];
 vehNATOTrucks = ["B_Truck_01_transport_F","B_Truck_01_covered_F"];
 vehNATOCargoTrucks = ["B_Truck_01_cargo_F", "B_Truck_01_flatbed_F"];
 vehNATOAmmoTruck = "B_Truck_01_ammo_F";
-vehNATORepairTruck = "B_Truck_01_repair_F";
+vehNATORepairTruck = "B_Truck_01_Repair_F";
 vehNATOLight = vehNATOLightArmed + vehNATOLightUnarmed;
 //Armored
 vehNATOAPC = ["B_APC_Wheeled_01_cannon_F","B_APC_Tracked_01_rcws_F"];
@@ -171,7 +171,7 @@ if ((gameMode != 4) and (!hasFFAA)) then
 	};
 
 //Police Vehicles
-vehPoliceCar = "B_GEN_OFFROAD_01_gen_F";
+vehPoliceCar = "B_GEN_Offroad_01_gen_F";
 
 ////////////////////////////////////
 //        STATIC WEAPONS         ///

--- a/A3-Antistasi/Templates/Vanilla_Occ_NATO_Tanoa.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Occ_NATO_Tanoa.sqf
@@ -52,8 +52,8 @@ NATOOfficer2 = "B_G_officer_F";
 NATOBodyG = "B_CTRG_Soldier_tna_F";
 NATOCrew = "B_T_Crew_F";
 NATOUnarmed = "B_G_Survivor_F";
-NATOMarksman = "B_T_Soldier_M_F";
-staticCrewOccupants = "B_T_support_MG_F";
+NATOMarksman = "B_T_soldier_M_F";
+staticCrewOccupants = "B_T_Support_MG_F";
 NATOPilot = "B_T_Pilot_F";
 
 //Militia Units
@@ -72,23 +72,23 @@ policeGrunt = "B_GEN_Soldier_F";
 ////////////////////////////////////
 //Military Groups
 //Teams
-groupsNATOSentry = ["B_T_soldier_GL_F",NATOGrunt];
-groupsNATOSniper = ["B_T_sniper_F","B_T_spotter_F"];
-groupsNATOsmall = [groupsNATOSentry,groupsNATOSniper,["B_T_recon_M_F","B_T_recon_F"]];
+groupsNATOSentry = ["B_T_Soldier_GL_F",NATOGrunt];
+groupsNATOSniper = ["B_T_Sniper_F","B_T_Spotter_F"];
+groupsNATOsmall = [groupsNATOSentry,groupsNATOSniper,["B_T_Recon_M_F","B_T_Recon_F"]];
 //Fireteams
-groupsNATOAA = ["B_T_soldier_TL_F","B_T_soldier_AA_F","B_T_soldier_AA_F","B_T_soldier_AAA_F"];
-groupsNATOAT = ["B_T_soldier_TL_F","B_T_soldier_AT_F","B_T_soldier_AT_F","B_T_soldier_AAT_F"];
-groupsNATOmid = [["B_T_soldier_TL_F","B_T_soldier_AR_F","B_T_soldier_GL_F","B_T_soldier_LAT_F"],groupsNATOAA,groupsNATOAT];
+groupsNATOAA = ["B_T_Soldier_TL_F","B_T_Soldier_AA_F","B_T_Soldier_AA_F","B_T_Soldier_AAA_F"];
+groupsNATOAT = ["B_T_Soldier_TL_F","B_T_Soldier_AT_F","B_T_Soldier_AT_F","B_T_Soldier_AAT_F"];
+groupsNATOmid = [["B_T_Soldier_TL_F","B_T_Soldier_AR_F","B_T_Soldier_GL_F","B_T_Soldier_LAT_F"],groupsNATOAA,groupsNATOAT];
 //Squads
-NATOSquad = ["B_T_soldier_SL_F",NATOGrunt,"B_T_soldier_LAT_F",NATOMarksman,"B_T_soldier_TL_F","B_T_soldier_AR_F","B_T_soldier_A_F","B_T_medic_F"];
+NATOSquad = ["B_T_Soldier_SL_F",NATOGrunt,"B_T_Soldier_LAT_F",NATOMarksman,"B_T_Soldier_TL_F","B_T_Soldier_AR_F","B_T_Soldier_A_F","B_T_Medic_F"];
 NATOSpecOp = ["B_CTRG_Soldier_TL_tna_F","B_CTRG_Soldier_M_tna_F",NATOBodyG,"B_CTRG_Soldier_LAT_tna_F","B_CTRG_Soldier_JTAC_tna_F","B_CTRG_Soldier_Exp_tna_F","B_CTRG_Soldier_AR_tna_F","B_CTRG_Soldier_Medic_tna_F"];
 groupsNATOSquad =
 	[
 	NATOSquad,
-	["B_T_soldier_SL_F","B_T_soldier_AR_F","B_T_soldier_GL_F",NATOMarksman,"B_T_soldier_AT_F","B_T_soldier_AAT_F","B_T_soldier_A_F","B_T_medic_F"],
-	["B_T_soldier_SL_F","B_T_soldier_LAT_F","B_T_soldier_TL_F","B_T_soldier_AR_F","B_T_soldier_A_F","B_T_Support_Mort_F","B_support_AMort_F","B_T_medic_F"],
-	["B_T_soldier_SL_F","B_T_soldier_AR_F","B_T_soldier_GL_F",NATOMarksman,"B_T_soldier_AA_F","B_T_soldier_AAA_F","B_T_soldier_A_F","B_T_medic_F"],
-	["B_T_soldier_SL_F","B_T_soldier_AR_F","B_T_soldier_GL_F",NATOMarksman,"B_T_engineer_F","B_T_engineer_F","B_T_soldier_A_F","B_T_medic_F"]
+	["B_T_Soldier_SL_F","B_T_Soldier_AR_F","B_T_Soldier_GL_F",NATOMarksman,"B_T_Soldier_AT_F","B_T_Soldier_AAT_F","B_T_Soldier_A_F","B_T_Medic_F"],
+	["B_T_Soldier_SL_F","B_T_Soldier_LAT_F","B_T_Soldier_TL_F","B_T_Soldier_AR_F","B_T_Soldier_A_F","B_T_Support_Mort_F","B_support_AMort_F","B_T_Medic_F"],
+	["B_T_Soldier_SL_F","B_T_Soldier_AR_F","B_T_Soldier_GL_F",NATOMarksman,"B_T_Soldier_AA_F","B_T_Soldier_AAA_F","B_T_Soldier_A_F","B_T_Medic_F"],
+	["B_T_Soldier_SL_F","B_T_Soldier_AR_F","B_T_Soldier_GL_F",NATOMarksman,"B_T_Engineer_F","B_T_Engineer_F","B_T_Soldier_A_F","B_T_Medic_F"]
 	];
 
 //Militia Groups
@@ -109,11 +109,11 @@ if ((gameMode != 4) and (!hasFFAA)) then
 		["B_G_Soldier_TL_F","B_G_Soldier_LAT_F","B_G_Soldier_LAT_F","B_G_Soldier_LAT_F"]
 		];
 	//Squads
-	FIASquad = ["B_G_soldier_SL_F","B_G_soldier_F","B_G_soldier_LAT_F","B_G_Soldier_M_F","B_G_soldier_TL_F","B_G_soldier_AR_F","B_G_Soldier_A_F","B_G_medic_F"];
+	FIASquad = ["B_G_Soldier_SL_F","B_G_Soldier_F","B_G_Soldier_LAT_F","B_G_Soldier_M_F","B_G_Soldier_TL_F","B_G_Soldier_AR_F","B_G_Soldier_A_F","B_G_medic_F"];
 	groupsFIASquad =
 		[
 		FIASquad,
-		["B_G_soldier_SL_F","B_G_soldier_LAT_F","B_G_Soldier_M_F","B_G_soldier_TL_F","B_G_Soldier_A_F","B_support_MG_F","B_support_AMG_F","B_G_medic_F"]
+		["B_G_Soldier_SL_F","B_G_Soldier_LAT_F","B_G_Soldier_M_F","B_G_Soldier_TL_F","B_G_Soldier_A_F","B_support_MG_F","B_support_AMG_F","B_G_medic_F"]
 		];
 	};
 
@@ -132,7 +132,7 @@ vehNATOLightUnarmed = ["B_T_MRAP_01_F","B_T_LSV_01_unarmed_F"];
 vehNATOTrucks = ["B_T_Truck_01_transport_F","B_T_Truck_01_covered_F"];
 vehNATOCargoTrucks = ["B_T_Truck_01_cargo_F","B_T_Truck_01_flatbed_F"];
 vehNATOAmmoTruck = "B_T_Truck_01_ammo_F";
-vehNATORepairTruck = "B_T_Truck_01_repair_F";
+vehNATORepairTruck = "B_T_Truck_01_Repair_F";
 vehNATOLight = vehNATOLightArmed + vehNATOLightUnarmed;
 //Armored
 vehNATOAPC = ["B_T_APC_Wheeled_01_cannon_F","B_T_APC_Tracked_01_rcws_F"];
@@ -165,20 +165,20 @@ vehNATOAir = vehNATOTransportHelis + vehNATOAttackHelis + [vehNATOPlane,vehNATOP
 if ((gameMode != 4) and (!hasFFAA)) then
 	{
 	vehFIAArmedCar = "B_G_Offroad_01_armed_F";
-	vehFIATruck = "B_G_van_01_transport_F";
+	vehFIATruck = "B_G_Van_01_transport_F";
 	vehFIACar = "B_G_Offroad_01_F";
 	};
 
 //Police Vehicles
-vehPoliceCar = "B_GEN_OFFROAD_01_gen_F";
+vehPoliceCar = "B_GEN_Offroad_01_gen_F";
 
 ////////////////////////////////////
 //        STATIC WEAPONS         ///
 ////////////////////////////////////
 //Assembled Statics
 NATOMG = "I_G_HMG_02_high_F";
-staticATOccupants = "B_T_static_AT_F";
-staticAAOccupants = "B_static_AA_F";
+staticATOccupants = "B_T_Static_AT_F";
+staticAAOccupants = "B_T_Static_AA_F";
 NATOMortar = "B_T_Mortar_01_F";
 
 //Static Weapon Bags

--- a/A3-Antistasi/Templates/Vanilla_Occ_NATO_Temp.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Occ_NATO_Temp.sqf
@@ -133,7 +133,7 @@ vehNATOLightUnarmed = ["B_MRAP_01_F"];
 vehNATOTrucks = ["B_Truck_01_transport_F","B_Truck_01_covered_F"];
 vehNATOCargoTrucks = ["B_Truck_01_cargo_F", "B_Truck_01_flatbed_F"];
 vehNATOAmmoTruck = "B_Truck_01_ammo_F";
-vehNATORepairTruck = "B_Truck_01_repair_F";
+vehNATORepairTruck = "B_Truck_01_Repair_F";
 vehNATOLight = vehNATOLightArmed + vehNATOLightUnarmed;
 //Armored
 vehNATOAPC = ["B_APC_Wheeled_01_cannon_F","B_APC_Tracked_01_rcws_F"];
@@ -171,7 +171,7 @@ if ((gameMode != 4) and (!hasFFAA)) then
 	};
 
 //Police Vehicles
-vehPoliceCar = "B_GEN_OFFROAD_01_gen_F";
+vehPoliceCar = "B_GEN_Offroad_01_gen_F";
 
 ////////////////////////////////////
 //        STATIC WEAPONS         ///

--- a/A3-Antistasi/Templates/Vanilla_Reb_FIA_Altis.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_FIA_Altis.sqf
@@ -49,7 +49,7 @@ vehSDKAT = "I_G_Offroad_01_AT_F";
 vehSDKLightUnarmed = "I_G_Offroad_01_F";
 vehSDKTruck = "I_G_Van_01_transport_F";
 //vehSDKHeli = "I_C_Heli_Light_01_civil_F";
-vehSDKPlane = "I_C_Plane_civil_01_F";
+vehSDKPlane = "I_C_Plane_Civil_01_F";
 vehSDKBoat = "I_G_Boat_Transport_01_F";
 vehSDKRepair = "I_G_Offroad_01_repair_F";
 
@@ -64,8 +64,8 @@ civBoat = "C_Boat_Transport_02_F";
 ////////////////////////////////////
 //Assembled Static Weapons
 SDKMGStatic = "I_G_HMG_02_high_F";
-staticATteamPlayer = "I_Static_AT_F";
-staticAAteamPlayer = "I_Static_AA_F";
+staticATteamPlayer = "I_static_AT_F";
+staticAAteamPlayer = "I_static_AA_F";
 SDKMortar = "I_G_Mortar_01_F";
 SDKMortarHEMag = "8Rnd_82mm_Mo_shells";
 SDKMortarSmokeMag = "8Rnd_82mm_Mo_Smoke_white";

--- a/A3-Antistasi/Templates/Vanilla_Reb_FIA_B_Altis.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_FIA_B_Altis.sqf
@@ -64,8 +64,8 @@ civBoat = "C_Boat_Transport_02_F";
 ////////////////////////////////////
 //Assembled Static Weapons
 SDKMGStatic = "I_G_HMG_02_high_F";
-staticATteamPlayer = "B_Static_AT_F";
-staticAAteamPlayer = "B_Static_AA_F";
+staticATteamPlayer = "B_static_AT_F";
+staticAAteamPlayer = "B_static_AA_F";
 SDKMortar = "B_G_Mortar_01_F";
 SDKMortarHEMag = "8Rnd_82mm_Mo_shells";
 SDKMortarSmokeMag = "8Rnd_82mm_Mo_Smoke_white";

--- a/A3-Antistasi/Templates/Vanilla_Reb_FIA_Enoch.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_FIA_Enoch.sqf
@@ -49,7 +49,7 @@ vehSDKAT = "I_G_Offroad_01_AT_F";
 vehSDKLightUnarmed = "I_G_Offroad_01_F";
 vehSDKTruck = "I_G_Van_01_transport_F";
 //vehSDKHeli = "I_C_Heli_Light_01_civil_F";
-vehSDKPlane = "I_C_Plane_civil_01_F";
+vehSDKPlane = "I_C_Plane_Civil_01_F";
 vehSDKBoat = "I_G_Boat_Transport_01_F";
 vehSDKRepair = "I_G_Offroad_01_repair_F";
 
@@ -64,8 +64,8 @@ civBoat = "C_Boat_Transport_02_F";
 ////////////////////////////////////
 //Assembled Static Weapons
 SDKMGStatic = "I_G_HMG_02_high_F";
-staticATteamPlayer = "I_Static_AT_F";
-staticAAteamPlayer = "I_Static_AA_F";
+staticATteamPlayer = "I_static_AT_F";
+staticAAteamPlayer = "I_static_AA_F";
 SDKMortar = "I_G_Mortar_01_F";
 SDKMortarHEMag = "8Rnd_82mm_Mo_shells";
 SDKMortarSmokeMag = "8Rnd_82mm_Mo_Smoke_white";

--- a/A3-Antistasi/Templates/Vanilla_Reb_SDK_Tanoa.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_SDK_Tanoa.sqf
@@ -45,11 +45,11 @@ soldiersSDK = sdkTier1 + sdkTier2 + sdkTier3;
 //Military Vehicles
 vehSDKBike = "I_G_Quadbike_01_F";
 vehSDKLightArmed = "I_G_Offroad_01_armed_F";
-vehSDKAT = "I_G_Offroad_02_AT_F";
+vehSDKAT = "I_C_Offroad_02_AT_F";
 vehSDKLightUnarmed = "I_G_Offroad_01_F";
-vehSDKTruck = "I_C_Van_01_Transport_F";
+vehSDKTruck = "I_C_Van_01_transport_F";
 //vehSDKHeli = "I_C_Heli_Light_01_civil_F";
-vehSDKPlane = "I_C_Plane_civil_01_F";
+vehSDKPlane = "I_C_Plane_Civil_01_F";
 vehSDKBoat = "I_C_Boat_Transport_01_F";
 vehSDKRepair = "B_G_Offroad_01_repair_F";
 
@@ -64,8 +64,8 @@ civBoat = "C_Boat_Transport_02_F";
 ////////////////////////////////////
 //Assembled Static Weapons
 SDKMGStatic = "I_G_HMG_02_high_F";
-staticATteamPlayer = "I_Static_AT_F";
-staticAAteamPlayer = "I_Static_AA_F";
+staticATteamPlayer = "I_static_AT_F";
+staticAAteamPlayer = "I_static_AA_F";
 SDKMortar = "I_G_Mortar_01_F";
 SDKMortarHEMag = "8Rnd_82mm_Mo_shells";
 SDKMortarSmokeMag = "8Rnd_82mm_Mo_Smoke_white";


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed a lot of template errors discovered by #1273:

- Fixed broken boats array in 3CB_Inv_Sov_Temp.
- Fixed wrong classname of rhsgref_cdf_reg_uaz_spg9.
- Fixed wrong classname of AT launcher in Vanilla_Inv_CSAT_Tanoa.
- Fixed wrong classname for militia car in Vanilla_Occ_AAF_Altis.
- Fixed wrong classname for rebel AT car in Vanilla_Reb_SDK_Tanoa.
- Fixed a ton of mis-cased classes, mostly in vanilla.

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

Could do with actually identifying an amphibious APC for use in the boats array of 3CB_Inv_Sov_Temp, but it'll do as-is.