### PR TITLE
Adds JNL load action to quads spawned through placeEmptyVeh

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_AIVEHinit.sqf
@@ -227,6 +227,8 @@ _veh addEventHandler ["Dammaged", {
 	};
 }];
 
+//add JNL loading to quadbikes
+if(!hasIFA && typeOf _veh in [vehSDKBike,vehNATOBike,vehCSATBike]) then {_veh call jn_fnc_logistics_addAction;};
 
 // deletes vehicle if it exploded on spawn...
 [_veh] spawn A3A_fnc_cleanserVeh;

--- a/A3-Antistasi/functions/Garage/fn_placeEmptyVehicle.sqf
+++ b/A3-Antistasi/functions/Garage/fn_placeEmptyVehicle.sqf
@@ -13,4 +13,6 @@ clearBackpackCargoGlobal _garageVeh;
 _garageVeh allowDamage true;
 _garageVeh enableSimulation true;
 
+if(!hasIFA && ((_vehicletype == vehSDKBike) || (_vehicletype == vehNATOBike) || (_vehicletype == vehCSATBike))) then {_garageVeh call jn_fnc_logistics_addAction;};
+
 _garageVeh;

--- a/A3-Antistasi/functions/Garage/fn_placeEmptyVehicle.sqf
+++ b/A3-Antistasi/functions/Garage/fn_placeEmptyVehicle.sqf
@@ -13,6 +13,4 @@ clearBackpackCargoGlobal _garageVeh;
 _garageVeh allowDamage true;
 _garageVeh enableSimulation true;
 
-if(!hasIFA && ((_vehicletype == vehSDKBike) || (_vehicletype == vehNATOBike) || (_vehicletype == vehCSATBike))) then {_garageVeh call jn_fnc_logistics_addAction;};
-
 _garageVeh;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information:
    Adds the JNL load action to any vehicle matching the quadbike entry in the template when spawned through placeEmptyVehicle.

### Please specify which Issue this PR Resolves.
closes none

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
  Spawn one of each quad, garage and ungarage them, check the scroll menu for "load cargo"
********************************************************
Notes:
Disabled for IFA as that "quadbike" is a Willys Jeep.