### PR TITLE
Make the load personal save dialog default to loading

### DIFF
--- a/A3-Antistasi/dialogs.hpp
+++ b/A3-Antistasi/dialogs.hpp
@@ -79,7 +79,7 @@ class should_load_personal_save {
 			y = 0.317959 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
-			action = "closeDialog 0; [true] spawn A3A_fnc_loadPreviousSession;";
+			action = "[true] call A3A_fnc_loadPreviousSession; closeDialog 0;";
 		};
 		class HQ_button_Gstatic: RscButton
 		{
@@ -90,7 +90,7 @@ class should_load_personal_save {
 			y = 0.317959 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
-			action = "closeDialog 0; [false] spawn A3A_fnc_loadPreviousSession;";
+			action = "[false] call A3A_fnc_loadPreviousSession; closeDialog 0;";
 		};
 	};
 };

--- a/A3-Antistasi/functions/Dialogs/fn_createDialog_shouldLoadPersonalSave.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_createDialog_shouldLoadPersonalSave.sqf
@@ -4,4 +4,9 @@ waitUntil {dialog};
 ["W A R N I N G", "READ THIS!!!<br/><br/><br/>Antistasi does NOT support vanilla save. Do not expect 100% of functionalities if you Save and Exit and after you come back with Resume option. Both on SP and MP.<br/><br/><br/>Antistasi has an in built save system, GTA alike, which is the system you have to use in order to have full functionalities.<br/><br/>To Save: Go to the Map Board, select ""Game Options"" and hit on ""Persistent Save"" button.<br/><br/>To load: RESTART the game and click YES on this window"] call A3A_fnc_customHint;
 waitUntil {!dialog};
 
+if (isNil "previousSessionLoaded") then {
+	// Dialog closed without selecting a button. Default to loading previous save.
+	[true] call A3A_fnc_loadPreviousSession;
+};
+
 [] spawn A3A_fnc_credits;

--- a/A3-Antistasi/functions/Dialogs/fn_loadPreviousSession.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_loadPreviousSession.sqf
@@ -2,7 +2,8 @@ params ["_load"];
 
 if (_load) then {
 	[getPlayerUID player, player] remoteExecCall ["A3A_fnc_loadPlayer", 2];
+	previousSessionLoaded = true;
 } else {
 	[getPlayerUID player, player] remoteExecCall ["A3A_fnc_resetPlayer", 2];
+	previousSessionLoaded = false;
 };
-


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
I completely forgot that it was possible to close dialogs without clicking on a button, which leaves players with zero money and blocks them from saving. Not critical because they could re-log to retrieve their save, but not good either.

I used loading as the default, because it's reversible and most escape-exits will be accidental.

### Please specify which Issue this PR Resolves.
closes #1284

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in singleplayer?
2. [X] Have you loaded the mission in LAN host?
3. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Press escape when the load previous session dialog comes up.