### PR TITLE
Performance and bugfix adjustments to spawning enemies

### DIFF
--- a/A3-Antistasi/functions/AI/fn_airstrike.sqf
+++ b/A3-Antistasi/functions/AI/fn_airstrike.sqf
@@ -93,8 +93,8 @@ _planefn = [_origpos, _ang, _typePlane, _sideX] call bis_fnc_spawnvehicle;
 _plane = _planefn select 0;
 _planeCrew = _planefn select 1;
 _groupPlane = _planefn select 2;
-{_x setVariable ["spawner",true,true]} forEach _planeCrew;
 [_plane, _sideX] call A3A_fnc_AIVEHinit;
+{[_x] call A3A_fnc_NATOinit} forEach _planeCrew;
 
 _plane setPosATL [getPosATL _plane select 0, getPosATL _plane select 1, 1000];
 _plane setVelocityModelSpace (velocityModelSpace _plane vectorAdd [0, 150, 50]);

--- a/A3-Antistasi/functions/Base/fn_rebelAttack.sqf
+++ b/A3-Antistasi/functions/Base/fn_rebelAttack.sqf
@@ -232,7 +232,7 @@ if (count _availableTargets == 0) exitWith
     private _nearbyStatics = staticsToSave select {(_x distance2D (getMarkerPos _target)) < distanceSPWN};
     _targetPoints = _targetPoints + (50 * (count _garrison) + (200 * (count _nearbyStatics)));
 
-    if((count _garrison <= 8) && {(count _nearbyStatics <= 2) && {!(_target in citiesX)}}) then
+    if((_targetSide == teamPlayer) && {(count _garrison <= 8) && {(count _nearbyStatics <= 2) && {!(_target in citiesX)}}}) then
     {
         //Only minimal garrison, consider it an easy target
         [3, format ["%1 has only minimal garrison, considering easy target", _target], _fileName] call A3A_fnc_log;

--- a/A3-Antistasi/functions/CREATE/fn_AAFroadPatrol.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_AAFroadPatrol.sqf
@@ -117,7 +117,8 @@ _veh = _vehicle select 0;
 [_veh, _sideX] call A3A_fnc_AIVEHinit;
 [_veh,"Patrol"] spawn A3A_fnc_inmuneConvoy;
 _vehCrew = _vehicle select 1;
-{[_x] call A3A_fnc_NATOinit} forEach _vehCrew;
+// Forced non-spawner for performance reasons. They can travel a lot through rebel territory.
+{[_x,"",false] call A3A_fnc_NATOinit} forEach _vehCrew;
 _groupVeh = _vehicle select 2;
 _soldiers = _soldiers + _vehCrew;
 _groups = _groups + [_groupVeh];
@@ -128,14 +129,14 @@ if (_typeCar in vehNATOLightUnarmed) then
 	{
 	sleep 1;
 	_groupX = [_posbase, _sideX, groupsNATOSentry] call A3A_fnc_spawnGroup;
-	{_x assignAsCargo _veh;_x moveInCargo _veh; _soldiers pushBack _x; [_x] joinSilent _groupVeh; [_x] call A3A_fnc_NATOinit} forEach units _groupX;
+	{_x assignAsCargo _veh;_x moveInCargo _veh; _soldiers pushBack _x; [_x] joinSilent _groupVeh; [_x,"",false] call A3A_fnc_NATOinit} forEach units _groupX;
 	deleteGroup _groupX;
 	};
 if (_typeCar in vehCSATLightUnarmed) then
 	{
 	sleep 1;
 	_groupX = [_posbase, _sideX, groupsCSATSentry] call A3A_fnc_spawnGroup;
-	{_x assignAsCargo _veh;_x moveInCargo _veh; _soldiers pushBack _x; [_x] joinSilent _groupVeh; [_x] call A3A_fnc_NATOinit} forEach units _groupX;
+	{_x assignAsCargo _veh;_x moveInCargo _veh; _soldiers pushBack _x; [_x] joinSilent _groupVeh; [_x,"",false] call A3A_fnc_NATOinit} forEach units _groupX;
 	deleteGroup _groupX;
 	};
 

--- a/A3-Antistasi/functions/CREATE/fn_createAICities.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAICities.sqf
@@ -75,7 +75,8 @@ while {(spawner getVariable _markerX != 2) and (_countX < _num)} do
 if ((_esAAF) or (_markerX in destroyedSites)) then
 	{
 	{_grp = _x;
-	{[_x,""] call A3A_fnc_NATOinit; _soldiers pushBack _x} forEach units _grp;} forEach _groups;
+	// Forced non-spawner for performance and consistency with other garrison patrols
+	{[_x,"",false] call A3A_fnc_NATOinit; _soldiers pushBack _x} forEach units _grp;} forEach _groups;
 	}
 else
 	{

--- a/A3-Antistasi/functions/CREATE/fn_createAIcontrols.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAIcontrols.sqf
@@ -113,7 +113,8 @@ if (_isControl) then
 				[_dog,_groupX] spawn A3A_fnc_guardDog;
 				};
 			_nul = [leader _groupX, _markerX, "SAFE","SPAWNED","NOVEH2","NOFOLLOW"] execVM "scripts\UPSMON.sqf";//TODO need delete UPSMON link
-			{[_x,""] call A3A_fnc_NATOinit; _soldiers pushBack _x} forEach units _groupX;
+			// Forced non-spawner as they're very static.
+			{[_x,"",false] call A3A_fnc_NATOinit; _soldiers pushBack _x} forEach units _groupX;
 			};
 		}
 	else
@@ -130,7 +131,7 @@ if (_isControl) then
 			{
 			_unit = [_groupX, FIARifleman, _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
 			_unit moveInGunner _veh;
-			{_soldiers pushBack _x; [_x,""] call A3A_fnc_NATOinit} forEach units _groupX;
+			{_soldiers pushBack _x; [_x,"", false] call A3A_fnc_NATOinit} forEach units _groupX;
 			};
 		};
 	}


### PR DESCRIPTION

### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Removed spawner variable from units where it was unintentional or had a poor simulation/performance tradeoff:

- Added optional isSpawner parameter to NATOinit for forcing special cases.
- Fixed bug where cargo units were spawners while still cargo.
- Fixed bug where simulation disabling could be permanently applied to static crew.
- Switched airstrikes to use NATOinit. Should be fine.
- Removed spawner status by default for fixed-wing aircraft pilots.
- Removed spawner status from roadblock garrisons.
- Removed spawner status from road patrols (vehicle).
- Removed spawner status from city patrols.

Also disabled the 4x patrolCA option for major attacks in the Gov vs Inv case, restoring
the former behaviour. This was a massive performance hog for as long as the attackers
stayed alive, frequently spawning four separate sets of locations on the opposite side of
the map.
    
### Please specify which Issue this PR Resolves.
closes #1213

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Play the game. Watch on Zeus.
