### PR TITLE
Hack-fix for civilian convoy objective markers

### DIFF
--- a/A3-Antistasi/functions/AI/fn_vehicleMarkers.sqf
+++ b/A3-Antistasi/functions/AI/fn_vehicleMarkers.sqf
@@ -42,7 +42,8 @@ if ((_side == teamPlayer) or (_side == sideUnknown)) then
 	}
 else
 	{
-	if (_side == Occupants) then
+	// Civilian hack to prevent errors with convoy missions. Replace once we have proper vehicle spawning functions.
+	if ((_side == Occupants) or (_side == civilian)) then
 		{
 		_formatX = "b";
 		}


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Supply and money convoys generate civilian objective vehicles with civilian crew, and vehicleMarkers doesn't know what to do with civilian vehicles. This patch uses the occupant markers for civilian groups as a temporary fix.

At some point we should have our own vehicle/crew spawning functions to prevent bad-faction crew issues (for example FIA AT/AA vehicles with the wrong uniforms), but not before 2.3.

### Please specify which Issue this PR Resolves.
closes #1299 

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Create a supply convoy with:
`[destMrk, originMrk, "Supplies"] remoteExec ["A3A_fnc_convoy", 2]`
