### PR TITLE
CargoSeats rewrite

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_cargoSeats.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_cargoSeats.sqf
@@ -1,60 +1,32 @@
-private ["_veh","_sideX","_return","_totalSeats","_crewSeats","_cargoSeats","_countX"];
-_veh = _this select 0;
-_sideX = _this select 1;
+private _filename = "fn_cargoSeats";
+params ["_veh", "_sideX"];
 
-_return = "";
-_totalSeats = [_veh, true] call BIS_fnc_crewCount; // Number of total seats: crew + non-FFV cargo/passengers + FFV cargo/passengers
-_crewSeats = [_veh, false] call BIS_fnc_crewCount; // Number of crew seats only
-_cargoSeats = _totalSeats - _crewSeats;
+private _isMilitia = _veh in [vehFIAArmedCar, vehFIATruck, vehFIACar];
 
-if (_cargoSeats <= 2) exitwith {diag_log format ["Error en cargoseats al intentar buscar para un %1",_veh];_return};
-if ((_cargoSeats >= 2) and (_cargoSeats < 4)) then
-	{
-	switch (_sideX) do
-		{
-		case Occupants: {_return = groupsNATOSentry};
-		case Invaders: {_return = groupsCSATSentry};
-		};
-	}
-else
-	{
-	if ((_cargoSeats >= 4) and (_cargoSeats < 8)) then
-		{
-		switch (_sideX) do
-			{
-			case Occupants: {_return = selectRandom groupsNATOmid};
-			case Invaders: {_return = selectRandom groupsCSATmid};
-			};
-		}
-	else
-		{
-		switch (_sideX) do
-			{
-			case Occupants:
-				{
-				_return = selectRandom groupsNATOSquad;
-/*				if (_cargoSeats > 8) then
-					{
-					_countX = _cargoSeats - (count _return);
-					for "_i" from 1 to _countX do
-						{
-						if (random 10 < (tierWar + difficultyCoef)) then {_return pushBack NATOGrunt};
-						};
-					};
-*/				};
-			case Invaders:
-				{
-				_return = selectRandom groupsCSATSquad;
-/*				if (_cargoSeats > 8) then
-					{
-					_countX = _cargoSeats - (count _return);
-					for "_i" from 1 to _countX do
-						{
-						if (random 10 < (tierWar + difficultyCoef)) then {_return pushBack CSATGrunt};
-						};
-					};
-*/				};
-			};
-		};
-	};
-_return
+private _totalSeats = [_veh, true] call BIS_fnc_crewCount; // Number of total seats: crew + non-FFV cargo/passengers + FFV cargo/passengers
+private _crewSeats = [_veh, false] call BIS_fnc_crewCount; // Number of crew seats only
+private _cargoSeats = _totalSeats - _crewSeats;
+if (_veh == vehPoliceCar) then { _cargoSeats = 4 min _cargoSeats };
+
+if (_cargoSeats < 2) exitwith { [1, format ["Cargoseats misused for vehicle %1", _veh], _filename]; [] };
+
+if (_cargoSeats < 4) exitWith
+{
+	if (_isMilitia) exitWith { selectRandom groupsFIASmall };
+	if (_veh == vehPoliceCar) exitWith { [policeOfficer, policeGrunt] };
+	if (_sideX == Occupants) then { groupsNATOSentry } else { groupsCSATSentry };
+};
+
+if (_cargoSeats < 7) exitWith			// fudge for Warrior
+{
+	if (_isMilitia) exitWith { selectRandom groupsFIAMid };
+	if (_veh == vehPoliceCar) exitWith { [policeOfficer, policeGrunt, policeGrunt, policeGrunt] };
+	if (_sideX == Occupants) then { selectRandom groupsNATOmid } else { selectRandom groupsCSATmid };
+};
+
+private _squad = call {
+	if (_isMilitia) exitWith { selectRandom groupsFIASquad };
+	if (_sideX == Occupants) then { selectRandom groupsNATOSquad } else {selectRandom groupsCSATSquad };
+};
+if (_cargoSeats == 7) then { _squad deleteAt 7 };
+_squad;


### PR DESCRIPTION

### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Rewrote the cargoSeats function which takes vehicle input and spits out an array of cargo units:

- Now generates appropriate squads for militia and police vehicles.
- Now generates 8(-1) man squads for Warriors (7-seat problem).
- Fix case where it incorrectly errored out with two cargo seats.
- Rewrote no-cargo error message in english.

Currently the militia vehicle functionality is unused but it's easy to test.

### Please specify which Issue this PR Resolves.
closes #1295 
closes #1205

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Debug console abuse:

`[vehPoliceCar, Occupants] call A3A_fnc_cargoSeats`
Returns array with squad members suitable for police car, whatever that is.

`[vehFIACar, Occupants] call A3A_fnc_cargoSeats`
Returns array with squad members suitable for militia unarmed car.

`[vehCSATAPC#0, Invaders] call A3A_fnc_cargoSeats`
Returns array with squad members suitable for first invader APC.
