### PR TITLE
Enable 5km TFAR radio conversion for everyone, not just squad leaders

### DIFF
--- a/A3-Antistasi/cba_settings.sqf
+++ b/A3-Antistasi/cba_settings.sqf
@@ -1,6 +1,6 @@
 // Task Force Arrowhead Radio
 force TF_give_microdagr_to_soldier = true;
-force TF_give_personal_radio_to_regular_soldier = false;
+force TF_give_personal_radio_to_regular_soldier = true;
 force TF_no_auto_long_range_radio = true;
 force TF_same_dd_frequencies_for_side = false;
 force TF_same_lr_frequencies_for_side = false;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
TFAR settings were set to convert radios differently for squad leaders and everyone else. This was apparently not the intended behaviour.

### Please specify which Issue this PR Resolves.
closes #1238 

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
