### PR TITLE
Tweak QRF balance

### DIFF
--- a/A3-Antistasi/functions/Base/fn_getVehiclePoolForQRFs.sqf
+++ b/A3-Antistasi/functions/Base/fn_getVehiclePoolForQRFs.sqf
@@ -22,25 +22,30 @@ private _vehicleSelection = [];
 switch (tierWar) do
 {
     //General idea: Send only ground units as players should be able to loot and grab the crate before the enemy arrives with a QRF
+    // JJ: As of 2.3-prerelease, this function is always called with either an air or ground filter, so air/ground balancing is not valid
     case (1):
     {
         if(_side == Occupants) then
         {
             _vehicleSelection =
             [
-                [vehPoliceCar, 50],
+                [vehPoliceCar, 40],
                 [vehFIACar, 30],
-                [vehFIATruck, 15],
-                [vehFIAArmedCar, 5]
+                [vehFIATruck, 20],
+                [vehFIAArmedCar, 10],
+
+                [vehNATOPatrolHeli, 100]
             ];
         };
         if(_side == Invaders) then
         {
             _vehicleSelection =
             [
-                [vehCSATLightUnarmed, 50],
-                [vehCSATTrucks, 30],
-                [vehCSATLight, 20]
+                [vehCSATLightUnarmed, 40],
+                [vehCSATTrucks, 40],
+                [vehCSATLightArmed, 20],
+
+                [vehCSATPatrolHeli, 100]
             ];
         };
     };
@@ -51,22 +56,28 @@ switch (tierWar) do
         {
             _vehicleSelection =
             [
-                [vehPoliceCar, 20],
-                [vehFIAArmedCar, 20],
-                [vehNATOLightUnarmed, 20],
-                [vehNATOTrucks, 20],
+                [vehPoliceCar, 15],
+                [vehFIACar, 15],
+                [vehFIAArmedCar, 10],
+                [vehFIATruck, 10],
+                [vehNATOLightUnarmed, 15],
+                [vehNATOTrucks, 25],
                 [vehNATOLightArmed, 10],
-                [vehNATOPatrolHeli, 10]
+
+                [vehNATOPatrolHeli, 100]
             ];
         };
         if(_side == Invaders) then
         {
             _vehicleSelection =
             [
-                [vehCSATLight, 30],
-                [vehCSATTrucks, 30],
-                [vehCSATLightArmed, 10],
-                [vehCSATPatrolHeli, 30]
+                [vehCSATLightUnarmed, 20],
+                [vehCSATTrucks, 40],
+                [vehCSATLightArmed, 30],
+                [vehCSATAPC, 10],
+
+                [vehCSATPatrolHeli, 80],
+                [vehCSATTransportHelis, 20]
             ];
         };
     };
@@ -77,22 +88,28 @@ switch (tierWar) do
         {
             _vehicleSelection =
             [
+                [vehFIAArmedCar, 10],
+                [vehFIATruck, 10],
                 [vehNATOLightUnarmed, 10],
-                [vehNATOLightArmed, 30],
-                [vehNATOTrucks, 20],
-                [vehNATOPatrolHeli, 35],
-                [vehNATOAPC, 5]
+                [vehNATOLightArmed, 20],
+                [vehNATOTrucks, 40],
+                [vehNATOAPC, 10],
+
+                [vehNATOPatrolHeli, 80],
+                [vehNATOTransportHelis, 20]
             ];
         };
         if(_side == Invaders) then
         {
             _vehicleSelection =
             [
-                [vehCSATLight, 5],
-                [vehCSATTrucks, 20],
-                [vehCSATLightArmed, 25],
-                [vehCSATPatrolHeli, 35],
-                [vehCSATAPC, 15]
+                [vehCSATLightUnarmed, 5],
+                [vehCSATTrucks, 30],
+                [vehCSATLightArmed, 45],
+                [vehCSATAPC, 20],
+
+                [vehCSATPatrolHeli, 60],
+                [vehCSATTransportHelis, 40]
             ];
         };
     };
@@ -103,22 +120,26 @@ switch (tierWar) do
         {
             _vehicleSelection =
             [
-                [vehNATOLightArmed, 15],
-                [vehNATOTrucks, 10],
-                [vehNATOPatrolHeli, 25],
-                [vehNATOAPC, 35],
-                [vehNATOTransportHelis, 15]
+                [vehNATOLightArmed, 35],
+                [vehNATOTrucks, 40],
+                [vehNATOAPC, 25],
+
+                [vehNATOPatrolHeli, 50],
+                [vehNATOTransportHelis, 50]
             ];
         };
         if(_side == Invaders) then
         {
             _vehicleSelection =
             [
-                [vehCSATTrucks, 5],
-                [vehCSATLightArmed, 15],
-                [vehCSATPatrolHeli, 25],
-                [vehCSATAPC, 30],
-                [vehCSATTransportHelis, 25]
+                [vehCSATTrucks, 10],
+                [vehCSATLightArmed, 40],
+                [vehCSATAPC, 40],
+                [vehCSATTank, 10],
+
+                [vehCSATPatrolHeli, 40],
+                [vehCSATTransportHelis, 50],
+                [vehCSATAttackHelis, 10]
             ];
         };
     };
@@ -129,20 +150,29 @@ switch (tierWar) do
         {
             _vehicleSelection =
             [
-                [vehNATOLightArmed, 10],
-                [vehNATOPatrolHeli, 20],
-                [vehNATOAPC, 45],
-                [vehNATOTransportHelis, 25]
+                [vehNATOLightArmed, 30],
+                [vehNATOTrucks, 25],
+                [vehNATOAPC, 35],
+                [vehNATOTank, 10],
+
+                [vehNATOPatrolHeli, 30],
+                [vehNATOTransportHelis, 60],
+                [vehNATOAttackHelis, 10]
             ];
         };
         if(_side == Invaders) then
         {
             _vehicleSelection =
             [
-                [vehCSATPatrolHeli, 15],
-                [vehCSATAPC, 35],
-                [vehCSATTransportHelis, 35],
-                [vehCSATAA, 15]
+                [vehCSATTruck, 10],
+                [vehCSATLightArmed, 30],
+                [vehCSATAPC, 40],
+                [vehCSATTank, 20],
+
+                [vehCSATPatrolHeli, 25],
+                [vehCSATTransportHelis, 50],
+                [vehCSATTransportPlanes, 10],
+                [vehCSATAttackHelis, 15]
             ];
         };
     };
@@ -153,20 +183,30 @@ switch (tierWar) do
         {
             _vehicleSelection =
             [
-                [vehNATOPatrolHeli, 15],
-                [vehNATOAPC, 35],
-                [vehNATOTransportHelis, 40],
-                [vehNATOAA, 10]
+                [vehNATOLightArmed, 25],
+                [vehNATOTrucks, 15],
+                [vehNATOAPC, 45],
+                [vehNATOTank, 15],
+
+                [vehNATOPatrolHeli, 20],
+                [vehNATOTransportHelis, 60],
+                [vehNATOTransportPlanes, 10],
+                [vehNATOAttackHelis, 10]
             ];
         };
         if(_side == Invaders) then
         {
             _vehicleSelection =
             [
-                [vehCSATPatrolHeli, 5],
-                [vehCSATAPC, 30],
-                [vehCSATTransportHelis, 30],
-                [vehCSATAA, 15],
+                [vehCSATTruck, 5],
+                [vehCSATLightArmed, 25],
+                [vehCSATAPC, 45],
+                [vehCSATAA, 5],
+                [vehCSATTank, 20],
+
+                [vehCSATPatrolHeli, 15],
+                [vehCSATTransportHelis, 50],
+                [vehCSATTransportPlanes, 15],
                 [vehCSATAttackHelis, 20]
             ];
         };
@@ -178,9 +218,15 @@ switch (tierWar) do
         {
             _vehicleSelection =
             [
-                [vehNATOAPC, 30],
-                [vehNATOTransportHelis, 40],
-                [vehNATOAA, 15],
+                [vehNATOTruck, 10],
+                [vehNATOLightArmed, 20],
+                [vehNATOAPC, 50],
+                [vehNATOAA, 5],
+                [vehNATOTank, 15],
+
+                [vehNATOPatrolHeli, 10],
+                [vehNATOTransportHelis, 55],
+                [vehNATOTransportPlanes, 20],
                 [vehNATOAttackHelis, 15]
             ];
         };
@@ -188,12 +234,16 @@ switch (tierWar) do
         {
             _vehicleSelection =
             [
-                [vehCSATAPC, 15],
-                [vehCSATTransportHelis, 15],
-                [vehCSATAA, 15],
-                [vehCSATAttackHelis, 20],
-                [vehCSATTank, 15],
-                [vehCSATTransportPlanes, 20]
+                [vehCSATTruck, 5],
+                [vehCSATLightArmed, 25],
+                [vehCSATAPC, 40],
+                [vehCSATAA, 5],
+                [vehCSATTank, 25],
+
+                [vehCSATPatrolHeli, 10],
+                [vehCSATTransportHelis, 40],
+                [vehCSATTransportPlanes, 25],
+                [vehCSATAttackHelis, 25]
             ];
         };
     };
@@ -204,24 +254,33 @@ switch (tierWar) do
         {
             _vehicleSelection =
             [
-                [vehNATOAPC, 20],
-                [vehNATOTransportHelis, 25],
-                [vehNATOAA, 10],
-                [vehNATOAttackHelis, 30],
-                [vehNATOTank, 15]
+                [vehNATOTruck, 10],
+                [vehNATOLightArmed, 15],
+                [vehNATOAPC, 50],
+                [vehNATOAA, 5],
+                [vehNATOTank, 20],
+
+                [vehNATOPatrolHeli, 10],
+                [vehNATOTransportHelis, 40],
+                [vehNATOTransportPlanes, 25],
+                [vehNATOAttackHelis, 20],
+                [vehNATOPlaneAA, 5]
             ];
         };
         if(_side == Invaders) then
         {
             _vehicleSelection =
             [
-                [vehCSATAPC, 15],
-                [vehCSATTransportHelis, 10],
-                [vehCSATAA, 15],
-                [vehCSATAttackHelis, 15],
-                [vehCSATTank, 20],
-                [vehCSATTransportPlanes, 15],
-                [vehCSATPlane, 5],
+                [vehCSATTruck, 5],
+                [vehCSATLightArmed, 20],
+                [vehCSATAPC, 40],
+                [vehCSATAA, 10],
+                [vehCSATTank, 25],
+
+                [vehCSATPatrolHeli, 5],
+                [vehCSATTransportHelis, 40],
+                [vehCSATTransportPlanes, 25],
+                [vehCSATAttackHelis, 25],
                 [vehCSATPlaneAA, 5]
             ];
         };
@@ -233,13 +292,17 @@ switch (tierWar) do
         {
             _vehicleSelection =
             [
-                [vehNATOAPC, 15],
-                [vehNATOTransportHelis, 10],
+                [vehNATOTruck, 5],
+                [vehNATOLightArmed, 10],
+                [vehNATOAPC, 50],
                 [vehNATOAA, 10],
-                [vehNATOAttackHelis, 20],
-                [vehNATOTank, 15],
-                [vehNATOTransportPlanes, 15],
-                [vehNATOPlane, 10],
+                [vehNATOTank, 25],
+
+                [vehNATOPatrolHeli, 5],
+                [vehNATOTransportHelis, 35],
+                [vehNATOTransportPlanes, 25],
+                [vehNATOAttackHelis, 25],
+                [vehNATOPlane, 5],
                 [vehNATOPlaneAA, 5]
             ];
         };
@@ -247,14 +310,18 @@ switch (tierWar) do
         {
             _vehicleSelection =
             [
-                [vehCSATAPC, 10],
-                [vehCSATTransportHelis, 5],
+                [vehCSATTruck, 5],
+                [vehCSATLightArmed, 10],
+                [vehCSATAPC, 40],
                 [vehCSATAA, 10],
-                [vehCSATAttackHelis, 20],
-                [vehCSATTank, 20],
-                [vehCSATTransportPlanes, 15],
-                [vehCSATPlane, 10],
-                [vehCSATPlaneAA, 10]
+                [vehCSATTank, 30],
+
+                [vehCSATPatrolHeli, 5],
+                [vehCSATTransportHelis, 35],
+                [vehCSATTransportPlanes, 25],
+                [vehCSATAttackHelis, 30],
+                [vehCSATPlane, 5],
+                [vehCSATPlaneAA, 5]
             ];
         };
     };
@@ -265,27 +332,36 @@ switch (tierWar) do
         {
             _vehicleSelection =
             [
-                [vehNATOAPC, 10],
-                [vehNATOTransportHelis, 10],
-                [vehNATOAA, 5],
-                [vehNATOAttackHelis, 20],
-                [vehNATOTank, 20],
-                [vehNATOTransportPlanes, 15],
+                [vehNATOTruck, 5],
+                [vehNATOLightArmed, 5],
+                [vehNATOAPC, 50],
+                [vehNATOAA, 10],
+                [vehNATOTank, 30],
+
+                [vehNATOPatrolHeli, 5],
+                [vehNATOTransportHelis, 30],
+                [vehNATOTransportPlanes, 25],
+                [vehNATOAttackHelis, 25],
                 [vehNATOPlane, 10],
-                [vehNATOPlaneAA, 10]
+                [vehNATOPlaneAA, 5]
             ];
         };
         if(_side == Invaders) then
         {
             _vehicleSelection =
             [
-                [vehCSATAPC, 10],
+                [vehCSATTruck, 5],
+                [vehCSATLightArmed, 5],
+                [vehCSATAPC, 45],
                 [vehCSATAA, 10],
-                [vehCSATAttackHelis, 25],
-                [vehCSATTank, 25],
-                [vehCSATTransportPlanes, 15],
-                [vehCSATPlane, 5],
-                [vehCSATPlaneAA, 10]
+                [vehCSATTank, 35],
+
+                [vehCSATPatrolHeli, 5],
+                [vehCSATTransportHelis, 30],
+                [vehCSATTransportPlanes, 25],
+                [vehCSATAttackHelis, 30],
+                [vehCSATPlane, 10],
+                [vehCSATPlaneAA, 5]
             ];
         };
     };

--- a/A3-Antistasi/functions/CREATE/fn_createQRF.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createQRF.sqf
@@ -456,6 +456,6 @@ else
 
 
 // After a delay, remove the fencing mark
-sleep (60 * (20 - (tierWar + difficultyCoef))) max 0;		// 10-20 min delay. Maybe uisleep?
+sleep (60 * (30 - (tierWar + difficultyCoef))) max 0;		// 20-30 min delay. Maybe uisleep?
 [_target, "remove"] remoteExecCall ["A3A_fnc_updateCAMark", 2];
 

--- a/A3-Antistasi/functions/CREATE/fn_patrolCA.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_patrolCA.sqf
@@ -140,7 +140,25 @@ if (!_forced) then
 	};
 	if (_bases isEqualTo []) exitWith {_exit = true};
 
-	_source = [_bases, _posDest] call BIS_fnc_nearestPosition;
+	// Use closest base outside spawn range of rebels. If none, allow bases further than half spawn range.
+	private _spawners = allUnits select { side group _x == teamPlayer && {_x getVariable ["spawner",false]} };
+	private _source = "";
+	private _closeDist = 1000000;
+	{
+		private _basePos = getMarkerPos _x;
+		private _dist = _basePos distance2D _posDest;
+		if (_dist < _closeDist) then {
+			private _closeSpwn = _spawners inAreaArray [getMarkerPos _x, distanceSPWN, distanceSPWN];
+			private _closeSpwn2 = _closeSpwn inAreaArray [getMarkerPos _x, distanceSPWN2, distanceSPWN2];
+			if (count _closeSpwn2 > 0) exitWith {};
+			if (count _closeSpwn > 0) then { _dist = distanceForLandAttack + _dist};
+			if (_dist > _closeDist) exitWith {};
+			_closeDist = _dist;
+			_source = _x;
+		};
+	} forEach _bases;
+
+	if (_source == "") exitWith {_exit = true};
 	_posOrigin = getMarkerPos _source;
 };
 

--- a/A3-Antistasi/functions/CREATE/fn_patrolCA.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_patrolCA.sqf
@@ -142,7 +142,7 @@ if (!_forced) then
 
 	// Use closest base outside spawn range of rebels. If none, allow bases further than half spawn range.
 	private _spawners = allUnits select { side group _x == teamPlayer && {_x getVariable ["spawner",false]} };
-	private _source = "";
+	private _closeMrk = "";
 	private _closeDist = 1000000;
 	{
 		private _basePos = getMarkerPos _x;
@@ -154,12 +154,13 @@ if (!_forced) then
 			if (count _closeSpwn > 0) then { _dist = distanceForLandAttack + _dist};
 			if (_dist > _closeDist) exitWith {};
 			_closeDist = _dist;
-			_source = _x;
+			_closeMrk = _x;
 		};
 	} forEach _bases;
 
-	if (_source == "") exitWith {_exit = true};
-	_posOrigin = getMarkerPos _source;
+	if (_closeMrk == "") exitWith {_exit = true};
+	_source = _closeMrk;
+	_posOrigin = getMarkerPos _closeMrk;
 };
 
 if (_exit) exitWith {

--- a/A3-Antistasi/functions/CREATE/fn_patrolCA.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_patrolCA.sqf
@@ -198,23 +198,16 @@ if (_typeOfAttack == "") then
 
 
 // Determine vehicle count from aggression & attack type
-private _vehicleCount = if(_sideX == Occupants) then
-{
-    (aggressionOccupants/16)
-    + ([0, 2] select _super)
-}
-else
-{
-    (aggressionInvaders/16)
-    + ([0, 3] select _super)
-};
-
-_vehicleCount = _vehicleCount + ((skillMult - 2) / 2);			// skillMult range 1-3
-if !(_isMarker) then { _vehicleCount = _vehicleCount / 2 };
-_vehicleCount = (round (_vehicleCount)) max 1;
-
 private _aggro = if(_sideX == Occupants) then {aggressionOccupants} else {aggressionInvaders};
-[3, format ["Due to %1 aggression, sending %2 vehicles", _aggro, _vehicleCount], _fileName] call A3A_fnc_log;
+private _vehicleCount = 0.5 + random (1.5) + _aggro/33;
+
+if (_super) then { _vehicleCount = _vehicleCount + 2 };
+_vehicleCount = _vehicleCount + ((skillMult - 2) / 2);			// skillMult range 1-3
+if (_sideX == Invaders) then { _vehicleCount = _vehicleCount * 1.2 };
+if !(_isMarker) then { _vehicleCount = _vehicleCount / 2 };
+
+_vehicleCount = (round (_vehicleCount)) max 1;
+[3, format ["With %1 aggression, sending %2 vehicles", _aggro, _vehicleCount], _fileName] call A3A_fnc_log;
 
 
 // Going ahead with the attack. Add it to the appropriate fencing array


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Various issues related to QRF balance:

#### Limited QRF spawning close to rebels
Prevented QRF spawning closer than half spawn distance from rebels. Outposts and airports beyond spawn distance are preferred. Note that the check applies to the the marker, not the spawn point, so airports may be a bit weird.

#### Increased QRF delay
Increased the delay between QRFs to/near the same marker to 20-30 mins from 10-20 as requested.

#### Softened the aggro -> vehicle count relationship
I thought this was over-adjusted given that QRFs are also being multiplied by AOs, and the constant one-vehicle QRFs in SP are pitiful. Replaced some aggro adjustment with a bit of randomness.  The range is now more like 1.25 to 5 vehicles rather than 0-6 min 1.

Should be re-examined if we stop multiplying QRFs by AOs, but it's not a strong change anyway.

#### Rebalanced QRF vehicle selection
- Advanced vehicles are available earlier, probabilities increased more gradually.
- Basic vehicles retained at higher war levels but at low probabilities.
- Proportion of squad-carrying vehicles increased, especially at higher war levels.
- Attempt to balance air vs land removed, as this is not how the function is used.

The method still has the old flaws, although these should be mitigated somewhat by using a wider vehicle selection:
- There's no reasonable way to adjust for missing vehicle categories, either due to the modset (AFRF lacking air transports) or due to economicsAI (eg. government running out of APCs).
- Single available vehicles can be used multiple times for a single QRF.

### Please specify which Issue this PR Resolves.
closes #1307 

### How can the changes be tested?
See the previous QRF PR (#1200).
