### PR TITLE
Fix RPT error in wavedCA caused by empty seaAttackSpawn array

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_wavedCA.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_wavedCA.sqf
@@ -322,7 +322,7 @@ while {(_waves > 0)} do
 	};
 
 	_isSea = false;
-	if !(hasIFA) then
+	if (!hasIFA && (count seaAttackSpawn != 0)) then
 		{
 		for "_i" from 0 to 3 do
 			{


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The sea attack code in wavedCA assumes that at least one marker is present in the seaAttackSpawn array. This PR early-outs if this isn't true.

### Please specify which Issue this PR Resolves.
closes #1326

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
