### PR TITLE
Fix QRF vehicle selection typos from war level 7-10

### DIFF
--- a/A3-Antistasi/functions/Base/fn_getVehiclePoolForQRFs.sqf
+++ b/A3-Antistasi/functions/Base/fn_getVehiclePoolForQRFs.sqf
@@ -218,7 +218,7 @@ switch (tierWar) do
         {
             _vehicleSelection =
             [
-                [vehNATOTruck, 10],
+                [vehNATOTrucks, 10],
                 [vehNATOLightArmed, 20],
                 [vehNATOAPC, 50],
                 [vehNATOAA, 5],
@@ -234,7 +234,7 @@ switch (tierWar) do
         {
             _vehicleSelection =
             [
-                [vehCSATTruck, 5],
+                [vehCSATTrucks, 5],
                 [vehCSATLightArmed, 25],
                 [vehCSATAPC, 40],
                 [vehCSATAA, 5],
@@ -254,7 +254,7 @@ switch (tierWar) do
         {
             _vehicleSelection =
             [
-                [vehNATOTruck, 10],
+                [vehNATOTrucks, 10],
                 [vehNATOLightArmed, 15],
                 [vehNATOAPC, 50],
                 [vehNATOAA, 5],
@@ -271,7 +271,7 @@ switch (tierWar) do
         {
             _vehicleSelection =
             [
-                [vehCSATTruck, 5],
+                [vehCSATTrucks, 5],
                 [vehCSATLightArmed, 20],
                 [vehCSATAPC, 40],
                 [vehCSATAA, 10],
@@ -292,7 +292,7 @@ switch (tierWar) do
         {
             _vehicleSelection =
             [
-                [vehNATOTruck, 5],
+                [vehNATOTrucks, 5],
                 [vehNATOLightArmed, 10],
                 [vehNATOAPC, 50],
                 [vehNATOAA, 10],
@@ -310,7 +310,7 @@ switch (tierWar) do
         {
             _vehicleSelection =
             [
-                [vehCSATTruck, 5],
+                [vehCSATTrucks, 5],
                 [vehCSATLightArmed, 10],
                 [vehCSATAPC, 40],
                 [vehCSATAA, 10],
@@ -332,7 +332,7 @@ switch (tierWar) do
         {
             _vehicleSelection =
             [
-                [vehNATOTruck, 5],
+                [vehNATOTrucks, 5],
                 [vehNATOLightArmed, 5],
                 [vehNATOAPC, 50],
                 [vehNATOAA, 10],
@@ -350,7 +350,7 @@ switch (tierWar) do
         {
             _vehicleSelection =
             [
-                [vehCSATTruck, 5],
+                [vehCSATTrucks, 5],
                 [vehCSATLightArmed, 5],
                 [vehCSATAPC, 45],
                 [vehCSATAA, 10],


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
War levels 7-10 of getVehiclePoolForQRFs used vehNATOTruck and vehCSATTruck. The correct variable names are vehNATOTrucks and vehCSATTrucks.
    
### Please specify which Issue this PR Resolves.
closes #1329 

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Functionality can mostly be tested from the debug console by changing the war tier on each execution:
```
warTier = 7;
[Occupants, ["Air"]] call A3A_fnc_getVehiclePoolForQRFs
```


