### PR TITLE
Add Carrier re-flagging to initGarrisons.

### DIFF
--- a/A3-Antistasi/functions/init/fn_initGarrisons.sqf
+++ b/A3-Antistasi/functions/init/fn_initGarrisons.sqf
@@ -180,6 +180,9 @@ else
 
 if (!(isNil "loadLastSave") && {loadLastSave}) exitWith {};
 
+//Set carrier markers to the same as airbases below.
+if (isServer) then {"NATO_carrier" setMarkertype flagNATOmrk};
+if (isServer) then {"CSAT_carrier" setMarkertype flagCSATmrk};
 
 if (debug) then {
 	diag_log format ["%1: [Antistasi] | DEBUG | initGarrisons.sqf | Setting up Airbase stuff.", servertime];


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information:
    Added 2 lines to initGarrisons that replace the NATO/CSAT markers to the one defined in template.

### Please specify which Issue this PR Resolves.
closes #1335 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
  Load into the mission on a modset other than vanilla, check the markers on map.
********************************************************
Notes:
  Previously tested in initZones, lines are the exact same.