### PR TITLE
patrolReinf termination overhaul

### DIFF
--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -91,6 +91,7 @@ class A3A
 		class rebuildAssets {};
 		class rebuildRadioTower {};
 		class relocateHQObjects {};
+		class remUnitCount {};
 		class repairRuinedBuilding {};
 		class resourceCheckSkipTime {};
 		class resourcesFIA {};

--- a/A3-Antistasi/functions/AI/fn_airdrop.sqf
+++ b/A3-Antistasi/functions/AI/fn_airdrop.sqf
@@ -61,7 +61,7 @@ _wp2 setWaypointType "MOVE";
 _wp3 = _groupPilot addWaypoint [_orig, 3];
 _wp3 setWaypointType "MOVE";
 _wp3 setWaypointSpeed "NORMAL";
-_wp3 setWaypointStatements ["true", "deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
+_wp3 setWaypointStatements ["true", "if !(local this) exitWith {}; deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
 
 {removebackpack _x; _x addBackpack "B_Parachute"} forEach units _groupX;
 waitUntil {sleep 1; (currentWaypoint _groupPilot == 3) or (not alive _veh) or (!canMove _veh)};
@@ -90,10 +90,10 @@ if !(_reinf) then
    _posLeader set [2,0];
    _wp5 = _groupX addWaypoint [_posLeader,0];
    _wp5 setWaypointType "MOVE";
-   _wp5 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI"];
+   _wp5 setWaypointStatements ["true", "if !(local this) exitWith {}; (group this) spawn A3A_fnc_attackDrillAI"];
    _wp4 = _groupX addWaypoint [_positionX, 1];
    _wp4 setWaypointType "MOVE";
-   _wp4 setWaypointStatements ["true","{if (side _x != side this) then {this reveal [_x,4]}} forEach allUnits"];
+   _wp4 setWaypointStatements ["true","if !(local this) exitWith {}; {if (side _x != side this) then {this reveal [_x,4]}} forEach allUnits"];
    _wp4 = _groupX addWaypoint [_positionX, 2];
    _wp4 setWaypointType "SAD";
    }
@@ -101,6 +101,5 @@ else
    {
    _wp4 = _groupX addWaypoint [_positionX, 0];
    _wp4 setWaypointType "MOVE";
-   _wp4 setWaypointStatements ["true","nul = [(thisList select {alive _x}),side this,(group this) getVariable [""reinfMarker"",""""],0] remoteExec [""A3A_fnc_garrisonUpdate"",2];[group this] spawn A3A_fnc_groupDespawner; reinfPatrols = reinfPatrols - 1; publicVariable ""reinfPatrols"";"];
    };
 //[_veh] call A3A_fnc_entriesLand;

--- a/A3-Antistasi/functions/AI/fn_fastrope.sqf
+++ b/A3-Antistasi/functions/AI/fn_fastrope.sqf
@@ -86,10 +86,10 @@ if !(_reinf) then
 	{
 	_wp2 = _groupX addWaypoint [(position (leader _groupX)), 0];
 	_wp2 setWaypointType "MOVE";
-	_wp2 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI"];
+	_wp2 setWaypointStatements ["true", "if !(local this) exitWith {}; (group this) spawn A3A_fnc_attackDrillAI"];
 	_wp2 = _groupX addWaypoint [_positionX, 1];
 	_wp2 setWaypointType "MOVE";
-	_wp2 setWaypointStatements ["true","{if (side _x != side this) then {this reveal [_x,4]}} forEach allUnits"];
+	_wp2 setWaypointStatements ["true","if !(local this) exitWith {}; {if (side _x != side this) then {this reveal [_x,4]}} forEach allUnits"];
 	_wp2 = _groupX addWaypoint [_positionX, 2];
 	_wp2 setWaypointType "SAD";
 	}
@@ -97,11 +97,10 @@ else
 	{
 	_wp2 = _groupX addWaypoint [_positionX, 0];
 	_wp2 setWaypointType "MOVE";
-	_wp2 setWaypointStatements ["true","nul = [(thisList select {alive _x}),side this,(group this) getVariable [""reinfMarker"",""""],0] remoteExec [""A3A_fnc_garrisonUpdate"",2];[group this] spawn A3A_fnc_groupDespawner; reinfPatrols = reinfPatrols - 1; publicVariable ""reinfPatrols"";"];
 	};
 _wp3 = _heli addWaypoint [_posOrigin, 1];
 _wp3 setWaypointType "MOVE";
 _wp3 setWaypointSpeed "NORMAL";
 _wp3 setWaypointBehaviour "AWARE";
-_wp3 setWaypointStatements ["true", "deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
+_wp3 setWaypointStatements ["true", "if !(local this) exitWith {}; deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
 {_x setBehaviour "AWARE";} forEach units _heli;

--- a/A3-Antistasi/functions/Base/fn_remUnitCount.sqf
+++ b/A3-Antistasi/functions/Base/fn_remUnitCount.sqf
@@ -1,0 +1,18 @@
+/*
+Params:
+	<SIDE> : Side of units to check.
+
+Returns:
+	Remaining units for that side on this machine.
+*/
+
+params ["_side"];
+
+private _unitCount = {(local _x) and (alive _x)} count allUnits;
+private _remUnitCount = maxUnits - _unitCount;
+if (gameMode < 3) then
+{
+    private _sideCount = {(local _x) and (alive _x) and (side group _x == _side)} count allUnits;
+    _remUnitCount = _remUnitCount min (maxUnits * 0.7 - _sideCount);
+};
+_remUnitCount;

--- a/A3-Antistasi/functions/CREATE/fn_reinforcementsAI.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_reinforcementsAI.sqf
@@ -26,7 +26,7 @@ _reinfPlaces = [];
 	//Self reinforce done
 
 	//Reinforce nearby sides
-	if ((_numberX >= 4) and (reinfPatrols <= 4)) then
+	if (_numberX >= 4) then
 	{
 		_potentials = (outposts + seaports - _reinfPlaces - (killZones getVariable [_airportX,[]])) select {sidesX getVariable [_x,sideUnknown] == _sideX};
 		if (_potentials isEqualTo []) then

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -58,7 +58,6 @@ DECLARE_SERVER_VAR(difficultyCoef, if !(isMultiplayer) then {0} else {floor ((({
 //Mostly state variables, used by various parts of Antistasi.
 DECLARE_SERVER_VAR(bigAttackInProgress, false);
 DECLARE_SERVER_VAR(AAFpatrols,0);
-DECLARE_SERVER_VAR(reinfPatrols, 0);
 DECLARE_SERVER_VAR(smallCAmrk, []);
 DECLARE_SERVER_VAR(smallCApos, []);
 


### PR DESCRIPTION

### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
patrolReinf overhaul, mostly to the termination logic:

- Fixed a lot of related setWaypointStatements locality bugs.
- Added timeout so that reinforcements can't get stuck & spawned forever.
- Fixed issue where reinforcements remained spawners after adding to garrison.
- Fixed issue where arrived reinforcements weren't removed from the garrison on death.
- Removed possibility of single-unit reinforcements.
- Stopped trucks trying to drive right into the middle of outposts.
- Fixed killZones update code.
- Added 'Spawn Performed' logging string.

Most of this code will be stripped out for 2.4, but the setWaypointStatements bugs are so bad that I think it's worth sorting it  out for 2.3.1.

### Please specify which Issue this PR Resolves.
closes #907 
partial fix for #1229

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?

`[["outpost_25", "airport_3", 8, Occupants] spawn A3A_fnc_patrolReinf`
Force creation of air patrolReinf from airport_3 to outpost_25 with 8 troops.

`[] spawn A3A_fnc_reinforcementsAI`
Force execution of the reinforcements logic, topping up airport garrisons and potentially sending one reinforcement patrol from each airport with a full garrison. Will be blocked by killzones. If there are no players near the airport or target then it will cheat and fill the garrison without creating any units.

`garrison setVariable ["outpost_25", [], true]`
Clear garrison from outpost_25 so that the reinforcements AI will attempt to refill it.

`killzones setVariable ["airport_3", [], true]`
Clear killzones for airport_3 so that it will send reinforcements & QRFs to a blocked target. 
