### PR TITLE
added folding bikes from tcgm_bikebackpack

### DIFF
--- a/A3-Antistasi/Templates/AddonVics/tcgm_Civ.sqf
+++ b/A3-Antistasi/Templates/AddonVics/tcgm_Civ.sqf
@@ -1,0 +1,13 @@
+civVehCommonData append [
+            "TCGM_Bike_oli",0.0     // Folding Bike (Olive)
+			,"TCGM_Bike_snd",0.0    // Folding Bike (Sand)
+			,"TCGM_Bike_nht",0.0    // Folding Bike (Black)
+			,"TCGM_Bike_win",0.0    // Folding Bike (White)
+			,"TCGM_Bike_hex",0.0    // Folding Bike (Hex Green)
+			,"TCGM_Bike_hexa",0.0   // Folding Bike (Hex Arid)
+			,"TCGM_Bike_hexw",0.0   // Folding Bike (Hex Winter)
+			,"TCGM_Bike_blk",1.0    // Folding Bike (Black)
+			,"TCGM_Bike_blu",1.0    // Folding Bike (Blue)
+			,"TCGM_Bike_wht",1.0    // Folding Bike (White)
+			,"TCGM_Bike_red",1.0    // Folding Bike (Red)
+];

--- a/A3-Antistasi/Templates/detector.sqf
+++ b/A3-Antistasi/Templates/detector.sqf
@@ -11,6 +11,7 @@ hasIFA = false;
 has3CB = false;
 hasIvory = false;
 hasUNSUNG = false;
+hasTCGM = false;
 
 //Actual Detection
 //IFA Detection
@@ -40,3 +41,6 @@ if (isClass (configfile >> "CfgPatches" >> "ffaa_armas")) then {hasFFAA = true; 
 
 //Ivory Car Pack Detection
 if (isClass (configfile >> "CfgPatches" >> "Ivory_Data")) then {hasIvory = true; diag_log format ["%1: [Antistasi] | INFO | initVar | Ivory Cars Detected.",servertime];};
+
+//TCGM_BikeBackpack Detection
+if (isClass (configfile >> "CfgPatches" >> "TCGM_BikeBackpack")) then {hasTCGM = true; diag_log format ["%1: [Antistasi] | INFO | initVar | TCGM_BikeBackpack Detected.",servertime];};

--- a/A3-Antistasi/Templates/selector.sqf
+++ b/A3-Antistasi/Templates/selector.sqf
@@ -336,6 +336,10 @@ if (hasIvory) then {
   call compile preProcessFileLineNumbers "Templates\AddonVics\ivory_Civ.sqf";
   [2, "Using Addon Ivory Cars Template", _filename] call A3A_fnc_log;
 };
+if (hasTCGM) then {
+  call compile preProcessFileLineNumbers "Templates\AddonVics\tcgm_Civ.sqf";
+  [2, "Using Addon TCGM_BikeBackPack Template", _filename] call A3A_fnc_log;
+};
 
 //JNL node loading is done here
 [2,"Reading JNL Node files.",_fileName] call A3A_fnc_log;


### PR DESCRIPTION

## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information:

- added all bikes to civ vehicle array so you can be undercover in any bike
- disabled spawning of military variants (the once that actually fold into backpacks) for civs
- added military variants to the light vehicle arrays of nato and csat

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [ ] Have you loaded the mission in LAN host?
3. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
- look for spawned bikes :)
********************************************************
Notes:
I actually only checked civ spawning and undercover yet. Didn't have a look for NATO or CSAT spawning with bikes.