### PR TITLE
Fix unintentional use of Arma 1.95+ SQF feature

### DIFF
--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -453,7 +453,7 @@ private _badCaseVars = [];
 		if (isNil "_var") exitWith { [1, "Missing template var " + _varName, _filename] call A3A_fnc_log };
 
 		if !(_var isEqualType []) then {_var = [_var]};									// plain string case, eg factions, some units
-		if ("breachingExplosives" in _varName) then { _var = _var apply {_x#0} };		// ["class", n] case for breaching explosives
+		if (_varname find "breachingExplosives" != -1) then { _var = _var apply {_x#0} };		// ["class", n] case for breaching explosives
 		if (_var#0 isEqualType []) then {												// arrays of arrays case, used for infantry groups
 			private _classes = [];
 			{ _classes append _x } forEach _var;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Sanity-checker crashed out on Arma versions below 1.95 due to use of `substring in string`. I don't think we care much about supporting older Arma versions but this was an unnecessary incompatibility.

### Please specify which Issue this PR Resolves.
closes #1344 

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
