### PR TITLE
Replace CDF Rebells / Add Rebell Uniforms / Correct Typos

### DIFF
--- a/A3-Antistasi/Templates/3CB_Reb_CNM_Temp.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_CNM_Temp.sqf
@@ -99,7 +99,7 @@ breachingExplosivesTank = [["rhs_ec400_mag", 1], ["rhs_ec400_sand_mag", 1], ["rh
 initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L117A2"];
 initialRebelEquipment append ["UK3CB_Enfield","UK3CB_Enfield_Rail"];
 initialRebelEquipment append ["rhs_weap_rpg75"];
-initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enfield_Mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
+initialRebelEquipment append ["UK3CB_BAF_9_13Rnd","UK3CB_BAF_9_15Rnd","UK3CB_Enfield_Mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK3CB_TKC_C_B_Sidor_MED","UK3CB_CW_SOV_O_LATE_B_Sidor_RIF","UK3CB_CW_SOV_O_EARLY_B_Sidor_RIF"];
 initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_Small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular","UK3CB_BAF_Flashlight_L105A1"];

--- a/A3-Antistasi/Templates/3CB_Reb_CNM_Temp.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_CNM_Temp.sqf
@@ -96,12 +96,12 @@ breachingExplosivesAPC = [["rhs_ec200_mag", 1], ["rhs_ec200_sand_mag", 1], ["rhs
 breachingExplosivesTank = [["rhs_ec400_mag", 1], ["rhs_ec400_sand_mag", 1], ["rhs_ec200_mag", 2], ["rhs_ec200_sand_mag", 2], ["rhsusf_m112x4_mag", 1], ["rhs_charge_M2tet_x2_mag", 1]];
 
 //Starting Unlocks
-initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L117A2","UK3CB_Enfield","UK3CB_Enfield_rail","rhs_weap_rpg75"];
-initialRebelEquipment append ["UK3CB_Enfield","UK3CB_Enfield_rail"];
+initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L117A2"];
+initialRebelEquipment append ["UK3CB_Enfield","UK3CB_Enfield_Rail"];
 initialRebelEquipment append ["rhs_weap_rpg75"];
-initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enfield_mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
+initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enfield_Mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK3CB_TKC_C_B_Sidor_MED","UK3CB_CW_SOV_O_LATE_B_Sidor_RIF","UK3CB_CW_SOV_O_EARLY_B_Sidor_RIF"];
-initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
+initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_Small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular","UK3CB_BAF_Flashlight_L105A1"];
 //Greenfor uniforms
 allRebelUniforms append ["U_IG_Guerilla1_1","U_IG_Guerilla2_1","U_IG_Guerilla2_2","U_IG_Guerilla2_3","U_IG_Guerilla3_1","U_IG_leader","U_IG_Guerrilla_6_1"];

--- a/A3-Antistasi/Templates/3CB_Reb_CNM_Temp.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_CNM_Temp.sqf
@@ -103,6 +103,8 @@ initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enf
 initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK3CB_TKC_C_B_Sidor_MED","UK3CB_CW_SOV_O_LATE_B_Sidor_RIF","UK3CB_CW_SOV_O_EARLY_B_Sidor_RIF"];
 initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular","UK3CB_BAF_Flashlight_L105A1"];
+//Greenfor uniforms
+allRebelUniforms append ["U_IG_Guerilla1_1","U_IG_Guerilla2_1","U_IG_Guerilla2_2","U_IG_Guerilla2_3","U_IG_Guerilla3_1","U_IG_leader","U_IG_Guerrilla_6_1"];
 //TFAR Unlocks
 if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
 if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_anprc155"};

--- a/A3-Antistasi/Templates/3CB_Reb_CNM_Trop.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_CNM_Trop.sqf
@@ -99,7 +99,7 @@ breachingExplosivesTank = [["rhs_ec400_mag", 1], ["rhs_ec400_sand_mag", 1], ["rh
 initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L117A2"];
 initialRebelEquipment append ["UK3CB_Enfield","UK3CB_Enfield_Rail"];
 initialRebelEquipment append ["rhs_weap_rpg75"];
-initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enfield_Mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
+initialRebelEquipment append ["UK3CB_BAF_9_13Rnd","UK3CB_BAF_9_15Rnd","UK3CB_Enfield_Mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK3CB_TKC_C_B_Sidor_MED","UK3CB_CW_SOV_O_LATE_B_Sidor_RIF","UK3CB_CW_SOV_O_EARLY_B_Sidor_RIF"];
 initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_Small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular","UK3CB_BAF_Flashlight_L105A1"];

--- a/A3-Antistasi/Templates/3CB_Reb_CNM_Trop.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_CNM_Trop.sqf
@@ -96,12 +96,12 @@ breachingExplosivesAPC = [["rhs_ec200_mag", 1], ["rhs_ec200_sand_mag", 1], ["rhs
 breachingExplosivesTank = [["rhs_ec400_mag", 1], ["rhs_ec400_sand_mag", 1], ["rhs_ec200_mag", 2], ["rhs_ec200_sand_mag", 2], ["rhsusf_m112x4_mag", 1], ["rhs_charge_M2tet_x2_mag", 1]];
 
 //Starting Unlocks
-initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L117A2","UK3CB_Enfield","UK3CB_Enfield_rail","rhs_weap_rpg75"];
-initialRebelEquipment append ["UK3CB_Enfield","UK3CB_Enfield_rail"];
+initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L117A2"];
+initialRebelEquipment append ["UK3CB_Enfield","UK3CB_Enfield_Rail"];
 initialRebelEquipment append ["rhs_weap_rpg75"];
-initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enfield_mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
+initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enfield_Mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK3CB_TKC_C_B_Sidor_MED","UK3CB_CW_SOV_O_LATE_B_Sidor_RIF","UK3CB_CW_SOV_O_EARLY_B_Sidor_RIF"];
-initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
+initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_Small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular","UK3CB_BAF_Flashlight_L105A1"];
 //Greenfor uniforms
 allRebelUniforms append ["U_IG_Guerilla1_1","U_IG_Guerilla2_1","U_IG_Guerilla2_2","U_IG_Guerilla2_3","U_IG_Guerilla3_1","U_IG_leader","U_IG_Guerrilla_6_1"];

--- a/A3-Antistasi/Templates/3CB_Reb_CNM_Trop.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_CNM_Trop.sqf
@@ -103,6 +103,8 @@ initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enf
 initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK3CB_TKC_C_B_Sidor_MED","UK3CB_CW_SOV_O_LATE_B_Sidor_RIF","UK3CB_CW_SOV_O_EARLY_B_Sidor_RIF"];
 initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular","UK3CB_BAF_Flashlight_L105A1"];
+//Greenfor uniforms
+allRebelUniforms append ["U_IG_Guerilla1_1","U_IG_Guerilla2_1","U_IG_Guerilla2_2","U_IG_Guerilla2_3","U_IG_Guerilla3_1","U_IG_leader","U_IG_Guerrilla_6_1"];
 //TFAR Unlocks
 if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
 if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_anprc155"};

--- a/A3-Antistasi/Templates/3CB_Reb_TPGM_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_TPGM_Arid.sqf
@@ -105,6 +105,8 @@ initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enf
 initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK3CB_TKC_C_B_Sidor_MED","UK3CB_CW_SOV_O_LATE_B_Sidor_RIF","UK3CB_CW_SOV_O_EARLY_B_Sidor_RIF"];
 initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular","UK3CB_BAF_Flashlight_L105A1"];
-//TAFR Unlocks
+//Blue Uniforms
+allRebelUniforms append ["U_BG_Guerilla1_1","U_BG_Guerilla2_1","U_BG_Guerilla2_2","U_BG_Guerilla2_3","U_BG_Guerilla3_1","U_BG_leader","U_BG_Guerrilla_6_1","U_BG_Guerilla3_2"];
+//TFAR Unlocks
 if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_rf7800str"]};
 if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "UK3CB_B_B_Radio_Backpack"};

--- a/A3-Antistasi/Templates/3CB_Reb_TPGM_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_TPGM_Arid.sqf
@@ -98,15 +98,15 @@ breachingExplosivesAPC = [["rhs_ec200_mag", 1], ["rhs_ec200_sand_mag", 1], ["rhs
 breachingExplosivesTank = [["rhs_ec400_mag", 1], ["rhs_ec400_sand_mag", 1], ["rhs_ec200_mag", 2], ["rhs_ec200_sand_mag", 2], ["rhsusf_m112x4_mag", 1], ["rhs_charge_M2tet_x2_mag", 1]];
 
 //Starting Unlocks
-initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L117A2","UK3CB_Enfield","UK3CB_Enfield_rail","rhs_weap_rpg75"];
-initialRebelEquipment append ["UK3CB_Enfield","UK3CB_Enfield_rail"];
+initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L117A2"];
+initialRebelEquipment append ["UK3CB_Enfield","UK3CB_Enfield_Rail"];
 initialRebelEquipment append ["rhs_weap_rpg75"];
-initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enfield_mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
+initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enfield_Mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK3CB_TKC_C_B_Sidor_MED","UK3CB_CW_SOV_O_LATE_B_Sidor_RIF","UK3CB_CW_SOV_O_EARLY_B_Sidor_RIF"];
-initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
+initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_Small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular","UK3CB_BAF_Flashlight_L105A1"];
-//Blue Uniforms
-allRebelUniforms append ["U_BG_Guerilla1_1","U_BG_Guerilla2_1","U_BG_Guerilla2_2","U_BG_Guerilla2_3","U_BG_Guerilla3_1","U_BG_leader","U_BG_Guerrilla_6_1","U_BG_Guerilla3_2"];
+//TKM Uniforms
+allRebelUniforms append ["UK3CB_TKM_B_U_01","UK3CB_TKM_B_U_01_B","UK3CB_TKM_B_U_01_C","UK3CB_TKM_B_U_03","UK3CB_TKM_B_U_03_B","UK3CB_TKM_B_U_03_C","UK3CB_TKM_B_U_04","UK3CB_TKM_B_U_04_B","UK3CB_TKM_B_U_04_C","UK3CB_TKM_B_U_05","UK3CB_TKM_B_U_05_B","UK3CB_TKM_B_U_05_C","UK3CB_TKM_B_U_06","UK3CB_TKM_B_U_06_B","UK3CB_TKM_B_U_06_C"];
 //TFAR Unlocks
 if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_rf7800str"]};
 if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "UK3CB_B_B_Radio_Backpack"};

--- a/A3-Antistasi/Templates/3CB_Reb_TPGM_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_TPGM_Arid.sqf
@@ -101,7 +101,7 @@ breachingExplosivesTank = [["rhs_ec400_mag", 1], ["rhs_ec400_sand_mag", 1], ["rh
 initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L117A2"];
 initialRebelEquipment append ["UK3CB_Enfield","UK3CB_Enfield_Rail"];
 initialRebelEquipment append ["rhs_weap_rpg75"];
-initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enfield_Mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
+initialRebelEquipment append ["UK3CB_BAF_9_13Rnd","UK3CB_BAF_9_15Rnd","UK3CB_Enfield_Mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK3CB_TKC_C_B_Sidor_MED","UK3CB_CW_SOV_O_LATE_B_Sidor_RIF","UK3CB_CW_SOV_O_EARLY_B_Sidor_RIF"];
 initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_Small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular","UK3CB_BAF_Flashlight_L105A1"];

--- a/A3-Antistasi/Templates/3CB_Reb_TTF_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_TTF_Arid.sqf
@@ -99,7 +99,7 @@ breachingExplosivesTank = [["rhs_ec400_mag", 1], ["rhs_ec400_sand_mag", 1], ["rh
 initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L117A2"];
 initialRebelEquipment append ["UK3CB_Enfield","UK3CB_Enfield_Rail"];
 initialRebelEquipment append ["rhs_weap_rpg75"];
-initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enfield_Mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
+initialRebelEquipment append ["UK3CB_BAF_9_13Rnd","UK3CB_BAF_9_15Rnd","UK3CB_Enfield_Mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK3CB_TKC_C_B_Sidor_MED","UK3CB_CW_SOV_O_LATE_B_Sidor_RIF","UK3CB_CW_SOV_O_EARLY_B_Sidor_RIF"];
 initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_Small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular","UK3CB_BAF_Flashlight_L105A1"];

--- a/A3-Antistasi/Templates/3CB_Reb_TTF_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_TTF_Arid.sqf
@@ -96,12 +96,12 @@ breachingExplosivesAPC = [["rhs_ec200_mag", 1], ["rhs_ec200_sand_mag", 1], ["rhs
 breachingExplosivesTank = [["rhs_ec400_mag", 1], ["rhs_ec400_sand_mag", 1], ["rhs_ec200_mag", 2], ["rhs_ec200_sand_mag", 2], ["rhsusf_m112x4_mag", 1], ["rhs_charge_M2tet_x2_mag", 1]];
 
 //Starting Unlocks
-initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L117A2","UK3CB_Enfield","UK3CB_Enfield_rail","rhs_weap_rpg75"];
-initialRebelEquipment append ["UK3CB_Enfield","UK3CB_Enfield_rail"];
+initialRebelEquipment append ["UK3CB_BAF_L9A1","UK3CB_BAF_L117A2"];
+initialRebelEquipment append ["UK3CB_Enfield","UK3CB_Enfield_Rail"];
 initialRebelEquipment append ["rhs_weap_rpg75"];
-initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enfield_mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
+initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enfield_Mag","rhs_grenade_mkii_mag","rhs_grenade_mki_mag","rhs_mag_rdg2_black","rhs_grenade_m15_mag"];
 initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK3CB_TKC_C_B_Sidor_MED","UK3CB_CW_SOV_O_LATE_B_Sidor_RIF","UK3CB_CW_SOV_O_EARLY_B_Sidor_RIF"];
-initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
+initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_Small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular","UK3CB_BAF_Flashlight_L105A1"];
 //Greenfor uniforms
 allRebelUniforms append ["U_IG_Guerilla1_1","U_IG_Guerilla2_1","U_IG_Guerilla2_2","U_IG_Guerilla2_3","U_IG_Guerilla3_1","U_IG_leader","U_IG_Guerrilla_6_1"];

--- a/A3-Antistasi/Templates/3CB_Reb_TTF_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_TTF_Arid.sqf
@@ -103,6 +103,8 @@ initialRebelEquipment append ["UK3CB_BAF_9_13rnd","UK3CB_BAF_9_15rnd","UK3CB_Enf
 initialRebelEquipment append ["UK3CB_CHC_C_B_MED","UK3CB_B_Bedroll_Backpack","UK3CB_TKC_C_B_Sidor_MED","UK3CB_CW_SOV_O_LATE_B_Sidor_RIF","UK3CB_CW_SOV_O_EARLY_B_Sidor_RIF"];
 initialRebelEquipment append ["UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular","UK3CB_BAF_Flashlight_L105A1"];
+//Greenfor uniforms
+allRebelUniforms append ["U_IG_Guerilla1_1","U_IG_Guerilla2_1","U_IG_Guerilla2_2","U_IG_Guerilla2_3","U_IG_Guerilla3_1","U_IG_leader","U_IG_Guerrilla_6_1"];
 //TFAR Unlocks
 if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
 if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_anprc155_coyote"};

--- a/A3-Antistasi/Templates/RHS_Occ_CDF_Temp.sqf
+++ b/A3-Antistasi/Templates/RHS_Occ_CDF_Temp.sqf
@@ -48,7 +48,7 @@ vehNATOPVP = ["rhsgref_ins_g_uaz","rhsgref_ins_g_uaz_open","rhsgref_BRDM2UM_ins_
 //Military Units
 NATOGrunt = "rhsgref_cdf_reg_rifleman";
 NATOOfficer = "rhsgref_cdf_reg_general";
-NATOOfficer2 = "rhsgref_cdf_ngd_commander";
+NATOOfficer2 = "rhsgref_cdf_ngd_officer";
 NATOBodyG = "rhsgref_cdf_ngd_rifleman_lite";
 NATOCrew = "rhsgref_cdf_ngd_crew";
 NATOUnarmed = "I_G_Survivor_F";
@@ -127,7 +127,7 @@ groupsNATOGen = [policeOfficer,policeGrunt];
 //Military Vehicles
 //Lite
 vehNATOBike = "I_Quadbike_01_F";
-vehNATOLightArmed = ["rhsgref_cdf_uaz_ags","rhsgref_cdf_reg_uaz_dshkm","rhsgref_cdf_reg_uaz_spg9","rhsgref_BRDM2_HQ"];
+vehNATOLightArmed = ["rhsgref_cdf_reg_uaz_ags","rhsgref_cdf_reg_uaz_dshkm","rhsgref_cdf_reg_uaz_spg9","rhsgref_BRDM2_HQ"];
 vehNATOLightUnarmed = ["rhsgref_cdf_reg_uaz","rhsgref_cdf_reg_uaz_open","rhsgref_BRDM2UM"];
 vehNATOTrucks = ["rhsgref_cdf_gaz66","rhsgref_cdf_ural","rhsgref_cdf_ural_open","rhsgref_cdf_gaz66o","rhsgref_cdf_zil131","rhsgref_cdf_zil131_open"];
 vehNATOCargoTrucks = [];

--- a/A3-Antistasi/Templates/RHS_Reb_HIDF_Arid.sqf
+++ b/A3-Antistasi/Templates/RHS_Reb_HIDF_Arid.sqf
@@ -4,7 +4,7 @@
 nameTeamPlayer = "Rebels";
 SDKFlag = "Flag_FIA_F";
 SDKFlagTexture = "\A3\Data_F\Flags\Flag_FIA_CO.paa";
-typePetros = "rhsgref_cdf_b_reg_general";
+typePetros = "rhsgref_hidf_teamleader";
 
 ////////////////////////////////////
 //             UNITS             ///
@@ -12,15 +12,15 @@ typePetros = "rhsgref_cdf_b_reg_general";
 //First Entry is Guerilla, Second Entry is Para/Military
 staticCrewTeamPlayer = "B_G_Soldier_unarmed_F";
 SDKUnarmed = "B_G_Survivor_F";
-SDKSniper = ["rhsgref_cdf_b_reg_marksman","rhsgref_hidf_marksman"];
-SDKATman = ["rhsgref_cdf_b_ngd_grenadier_rpg","rhsgref_cdf_b_reg_grenadier_rpg"];
-SDKMedic = ["rhsgref_cdf_b_ngd_medic","rhsgref_cdf_b_para_medic"];
-SDKMG = ["rhsgref_cdf_b_ngd_machinegunner","rhsgref_cdf_b_reg_machinegunner"];
-SDKExp = ["rhsgref_cdf_b_ngd_engineer","rhsgref_cdf_b_reg_engineer"];
-SDKGL = ["rhsgref_cdf_b_ngd_grenadier","rhsgref_cdf_b_reg_grenadier"];
-SDKMil = ["rhsgref_cdf_b_ngd_rifleman_lite","rhsgref_cdf_b_para_rifleman_lite"];
-SDKSL = ["rhsgref_cdf_b_ngd_squadleader","rhsgref_cdf_b_reg_squadleader"];
-SDKEng = ["rhsgref_cdf_b_ngd_engineer","rhsgref_cdf_b_reg_engineer"];
+SDKSniper = ["rhsgref_hidf_marksman","rhsgref_hidf_sniper"];
+SDKATman = ["rhsgref_hidf_rifleman_m72","rhsgref_hidf_rifleman_m72"];
+SDKMedic = ["rhsgref_hidf_medic","rhsgref_hidf_medic"];
+SDKMG = ["rhsgref_hidf_autorifleman","rhsgref_hidf_machinegunner"];
+SDKExp = ["B_G_Soldier_exp_F","B_G_Soldier_exp_F"];
+SDKGL = ["rhsgref_hidf_grenadier","rhsgref_hidf_grenadier_m79"];
+SDKMil = ["rhsgref_hidf_rifleman","rhsgref_hidf_rifleman"];
+SDKSL = ["rhsgref_hidf_teamleader","rhsgref_hidf_squadleader"];
+SDKEng = ["B_G_engineer_F","B_G_engineer_F"];
 
 ////////////////////////////////////
 //            GROUPS             ///
@@ -44,12 +44,12 @@ soldiersSDK = sdkTier1 + sdkTier2 + sdkTier3;
 ////////////////////////////////////
 //Military Vehicles
 vehSDKBike = "B_G_Quadbike_01_F";
-vehSDKLightArmed = "rhsgref_cdf_b_reg_uaz_dshkm";
-vehSDKAT = "rhsgref_cdf_b_reg_uaz_spg9";
-vehSDKLightUnarmed = "rhsgref_cdf_b_reg_uaz_open";
+vehSDKLightArmed = "B_G_Offroad_01_armed_F";
+vehSDKAT = "B_G_Offroad_01_AT_F";
+vehSDKLightUnarmed = "rhsgref_hidf_M998_2dr_fulltop";
 vehSDKTruck = "rhsgref_cdf_b_ural_open";
 //vehSDKHeli = "I_C_Heli_Light_01_civil_F";
-vehSDKPlane = "RHS_AN2_B";
+vehSDKPlane = "rhsgred_hidf_cessna_o3a";
 vehSDKBoat = "B_G_Boat_Transport_01_F";
 vehSDKRepair = "rhsgref_cdf_b_ural_repair";
 
@@ -63,7 +63,7 @@ civBoat = "C_Boat_Transport_02_F";
 //        STATIC WEAPONS         ///
 ////////////////////////////////////
 //Assembled Static Weapons
-SDKMGStatic = "rhsgref_cdf_b_DSHKM";
+SDKMGStatic = "rhsgref_hidf_m2_static";
 staticATteamPlayer = "rhsgref_cdf_b_SPG9";
 staticAAteamPlayer = "rhsgref_cdf_b_ZU23";
 SDKMortar = "rhsgref_cdf_b_reg_M252";
@@ -71,14 +71,14 @@ SDKMortarHEMag = "rhs_12Rnd_m821_HE";
 SDKMortarSmokeMag = "8Rnd_82mm_Mo_Smoke_white";
 
 //Static Weapon Bags
-MGStaticSDKB = "RHS_DShkM_Gun_Bag";
+MGStaticSDKB = "RHS_M2_Gun_Bag";
 ATStaticSDKB = "RHS_SPG9_Gun_Bag";
 AAStaticSDKB = "no_exists";
 MortStaticSDKB = "rhs_M252_Gun_Bag";
 //Short Support
 supportStaticSDKB = "RHS_SPG9_Tripod_Bag";
 //Tall Support
-supportStaticsSDKB2 = "RHS_DShkM_TripodHigh_Bag";
+supportStaticsSDKB2 = "RHS_M2_Tripod_Bag";
 //Mortar Support
 supportStaticsSDKB3 = "rhs_M252_Bipod_Bag";
 

--- a/A3-Antistasi/Templates/RHS_Reb_HIDF_Temp.sqf
+++ b/A3-Antistasi/Templates/RHS_Reb_HIDF_Temp.sqf
@@ -4,7 +4,7 @@
 nameTeamPlayer = "Rebels";
 SDKFlag = "Flag_FIA_F";
 SDKFlagTexture = "\A3\Data_F\Flags\Flag_FIA_CO.paa";
-typePetros = "rhsgref_cdf_b_reg_general";
+typePetros = "rhsgref_hidf_teamleader";
 
 ////////////////////////////////////
 //             UNITS             ///
@@ -12,15 +12,15 @@ typePetros = "rhsgref_cdf_b_reg_general";
 //First Entry is Guerilla, Second Entry is Para/Military
 staticCrewTeamPlayer = "B_G_Soldier_unarmed_F";
 SDKUnarmed = "B_G_Survivor_F";
-SDKSniper = ["rhsgref_cdf_b_reg_marksman","rhsgref_hidf_marksman"];
-SDKATman = ["rhsgref_cdf_b_ngd_grenadier_rpg","rhsgref_cdf_b_reg_grenadier_rpg"];
-SDKMedic = ["rhsgref_cdf_b_ngd_medic","rhsgref_cdf_b_para_medic"];
-SDKMG = ["rhsgref_cdf_b_ngd_machinegunner","rhsgref_cdf_b_reg_machinegunner"];
-SDKExp = ["rhsgref_cdf_b_ngd_engineer","rhsgref_cdf_b_reg_engineer"];
-SDKGL = ["rhsgref_cdf_b_ngd_grenadier","rhsgref_cdf_b_reg_grenadier"];
-SDKMil = ["rhsgref_cdf_b_ngd_rifleman_lite","rhsgref_cdf_b_para_rifleman_lite"];
-SDKSL = ["rhsgref_cdf_b_ngd_squadleader","rhsgref_cdf_b_reg_squadleader"];
-SDKEng = ["rhsgref_cdf_b_ngd_engineer","rhsgref_cdf_b_reg_engineer"];
+SDKSniper = ["rhsgref_hidf_marksman","rhsgref_hidf_sniper"];
+SDKATman = ["rhsgref_hidf_rifleman_m72","rhsgref_hidf_rifleman_m72"];
+SDKMedic = ["rhsgref_hidf_medic","rhsgref_hidf_medic"];
+SDKMG = ["rhsgref_hidf_autorifleman","rhsgref_hidf_machinegunner"];
+SDKExp = ["B_G_Soldier_exp_F","B_G_Soldier_exp_F"];
+SDKGL = ["rhsgref_hidf_grenadier","rhsgref_hidf_grenadier_m79"];
+SDKMil = ["rhsgref_hidf_rifleman","rhsgref_hidf_rifleman"];
+SDKSL = ["rhsgref_hidf_teamleader","rhsgref_hidf_squadleader"];
+SDKEng = ["B_G_engineer_F","B_G_engineer_F"];
 
 ////////////////////////////////////
 //            GROUPS             ///
@@ -44,12 +44,12 @@ soldiersSDK = sdkTier1 + sdkTier2 + sdkTier3;
 ////////////////////////////////////
 //Military Vehicles
 vehSDKBike = "B_G_Quadbike_01_F";
-vehSDKLightArmed = "rhsgref_cdf_b_reg_uaz_dshkm";
-vehSDKAT = "rhsgref_cdf_b_reg_uaz_spg9";
-vehSDKLightUnarmed = "rhsgref_cdf_b_reg_uaz_open";
+vehSDKLightArmed = "B_G_Offroad_01_armed_F";
+vehSDKAT = "B_G_Offroad_01_AT_F";
+vehSDKLightUnarmed = "rhsgref_hidf_M998_2dr_fulltop";
 vehSDKTruck = "rhsgref_cdf_b_ural_open";
 //vehSDKHeli = "I_C_Heli_Light_01_civil_F";
-vehSDKPlane = "RHS_AN2_B";
+vehSDKPlane = "rhsgred_hidf_cessna_o3a";
 vehSDKBoat = "B_G_Boat_Transport_01_F";
 vehSDKRepair = "rhsgref_cdf_b_ural_repair";
 
@@ -63,7 +63,7 @@ civBoat = "C_Boat_Transport_02_F";
 //        STATIC WEAPONS         ///
 ////////////////////////////////////
 //Assembled Static Weapons
-SDKMGStatic = "rhsgref_cdf_b_DSHKM";
+SDKMGStatic = "rhsgref_hidf_m2_static";
 staticATteamPlayer = "rhsgref_cdf_b_SPG9";
 staticAAteamPlayer = "rhsgref_cdf_b_ZU23";
 SDKMortar = "rhsgref_cdf_b_reg_M252";
@@ -71,14 +71,14 @@ SDKMortarHEMag = "rhs_12Rnd_m821_HE";
 SDKMortarSmokeMag = "8Rnd_82mm_Mo_Smoke_white";
 
 //Static Weapon Bags
-MGStaticSDKB = "RHS_DShkM_Gun_Bag";
+MGStaticSDKB = "RHS_M2_Gun_Bag";
 ATStaticSDKB = "RHS_SPG9_Gun_Bag";
 AAStaticSDKB = "no_exists";
 MortStaticSDKB = "rhs_M252_Gun_Bag";
 //Short Support
 supportStaticSDKB = "RHS_SPG9_Tripod_Bag";
 //Tall Support
-supportStaticsSDKB2 = "RHS_DShkM_TripodHigh_Bag";
+supportStaticsSDKB2 = "RHS_M2_Tripod_Bag";
 //Mortar Support
 supportStaticsSDKB3 = "rhs_M252_Bipod_Bag";
 

--- a/A3-Antistasi/Templates/RHS_Reb_NAPA_Arid.sqf
+++ b/A3-Antistasi/Templates/RHS_Reb_NAPA_Arid.sqf
@@ -102,6 +102,8 @@ initialRebelEquipment append ["rhs_mag_6x8mm_mhp","rhs_mag_762x25_8","rhsgref_1R
 initialRebelEquipment append ["B_FieldPack_oli","B_FieldPack_blk","B_FieldPack_ocamo","B_FieldPack_oucamo","B_FieldPack_cbr"];
 initialRebelEquipment append ["rhsgref_chestrig","rhsgref_chicom","rhs_vydra_3m","rhs_vest_pistol_holster","rhs_vest_commander","rhs_6sh46","rhsgref_alice_webbing"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular"];
-//TAFR Unlocks
+//Greenfor uniforms
+allRebelUniforms append ["U_IG_Guerilla1_1","U_IG_Guerilla2_1","U_IG_Guerilla2_2","U_IG_Guerilla2_3","U_IG_Guerilla3_1","U_IG_leader","U_IG_Guerrilla_6_1"];
+//TFAR Unlocks
 if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
 if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_anprc155_coyote"};

--- a/A3-Antistasi/Templates/RHS_Reb_NAPA_Temp.sqf
+++ b/A3-Antistasi/Templates/RHS_Reb_NAPA_Temp.sqf
@@ -102,6 +102,8 @@ initialRebelEquipment append ["rhs_mag_6x8mm_mhp","rhs_mag_762x25_8","rhsgref_1R
 initialRebelEquipment append ["B_FieldPack_oli","B_FieldPack_blk","B_FieldPack_ocamo","B_FieldPack_oucamo","B_FieldPack_cbr"];
 initialRebelEquipment append ["rhsgref_chestrig","rhsgref_chicom","rhs_vydra_3m","rhs_vest_pistol_holster","rhs_vest_commander","rhs_6sh46","rhsgref_alice_webbing"];
 initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular"];
-//TAFR Unlocks
+//Greenfor uniforms
+allRebelUniforms append ["U_IG_Guerilla1_1","U_IG_Guerilla2_1","U_IG_Guerilla2_2","U_IG_Guerilla2_3","U_IG_Guerilla3_1","U_IG_leader","U_IG_Guerrilla_6_1"];
+//TFAR Unlocks
 if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
 if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_anprc155_coyote"};

--- a/A3-Antistasi/Templates/Vanilla_Reb_FIA_Altis.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_FIA_Altis.sqf
@@ -102,6 +102,8 @@ initialRebelEquipment append ["6Rnd_45ACP_Cylinder","16Rnd_9x21_Mag","30Rnd_45AC
 initialRebelEquipment append ["B_FieldPack_oli","B_FieldPack_blk","B_FieldPack_ocamo","B_FieldPack_oucamo","B_FieldPack_cbr","B_FieldPack_khk"];
 initialRebelEquipment append ["V_Chestrig_blk","V_Chestrig_rgr","V_Chestrig_khk","V_Chestrig_oli","V_BandollierB_blk","V_BandollierB_cbr","V_BandollierB_rgr","V_BandollierB_khk","V_BandollierB_oli","V_Rangemaster_belt"];
 initialRebelEquipment append ["Binocular","acc_flashlight","acc_flashlight_smg_01","acc_flashlight_pistol"];
+//Greenfor uniforms
+allRebelUniforms append ["U_IG_Guerilla1_1","U_IG_Guerilla2_1","U_IG_Guerilla2_2","U_IG_Guerilla2_3","U_IG_Guerilla3_1","U_IG_leader","U_IG_Guerrilla_6_1"];
 //TFAR Unlocks
 if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
 if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_anprc155"};

--- a/A3-Antistasi/Templates/Vanilla_Reb_FIA_Enoch.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_FIA_Enoch.sqf
@@ -98,7 +98,7 @@ breachingExplosivesTank = [["SatchelCharge_Remote_Mag", 1], ["DemoCharge_Remote_
 //Starting Unlocks
 initialRebelEquipment append ["hgun_Pistol_heavy_02_F","hgun_Pistol_heavy_01_green_F","sgun_HunterShotgun_01_F","SMG_02_F"];
 initialRebelEquipment append ["SMG_02_F"];
-initialRebelEquipment append ["6Rnd_45ACP_Cylinder","9Rnd_45ACP_Mag","2Rnd_12Gauge_Pellets","2Rnd_12Gauge_Slug","30Rnd_9x21_Mag_SMG_02","MiniGrenade","SmokeShell"];
+initialRebelEquipment append ["6Rnd_45ACP_Cylinder","11Rnd_45ACP_Mag","2Rnd_12Gauge_Pellets","2Rnd_12Gauge_Slug","30Rnd_9x21_Mag_SMG_02","MiniGrenade","SmokeShell"];
 initialRebelEquipment append ["B_FieldPack_blk","B_FieldPack_oucamo","B_FieldPack_cbr","B_FieldPack_oli","B_FieldPack_green_F","B_FieldPack_taiga_F"];
 initialRebelEquipment append ["V_Chestrig_blk","V_Chestrig_rgr","V_Chestrig_khk","V_Chestrig_oli","V_BandollierB_blk","V_SmershVest_01_F","V_BandollierB_rgr","V_SmershVest_01_radio_F","V_BandollierB_oli","V_Rangemaster_belt"];
 initialRebelEquipment append ["Binocular","acc_flashlight"];

--- a/A3-Antistasi/Templates/Vanilla_Reb_FIA_Enoch.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_FIA_Enoch.sqf
@@ -98,7 +98,7 @@ breachingExplosivesTank = [["SatchelCharge_Remote_Mag", 1], ["DemoCharge_Remote_
 //Starting Unlocks
 initialRebelEquipment append ["hgun_Pistol_heavy_02_F","hgun_Pistol_heavy_01_green_F","sgun_HunterShotgun_01_F","SMG_02_F"];
 initialRebelEquipment append ["SMG_02_F"];
-initialRebelEquipment append ["6Rnd_45ACP_Cylinder","9Rnd_45ACP_Mag","2Rnd_12Guage_Pellets","2Rnd_12Guage_Slug","30Rnd_9x21_Mag_SMG_02","MiniGrenade","SmokeShell"];
+initialRebelEquipment append ["6Rnd_45ACP_Cylinder","9Rnd_45ACP_Mag","2Rnd_12Gauge_Pellets","2Rnd_12Gauge_Slug","30Rnd_9x21_Mag_SMG_02","MiniGrenade","SmokeShell"];
 initialRebelEquipment append ["B_FieldPack_blk","B_FieldPack_oucamo","B_FieldPack_cbr","B_FieldPack_oli","B_FieldPack_green_F","B_FieldPack_taiga_F"];
 initialRebelEquipment append ["V_Chestrig_blk","V_Chestrig_rgr","V_Chestrig_khk","V_Chestrig_oli","V_BandollierB_blk","V_SmershVest_01_F","V_BandollierB_rgr","V_SmershVest_01_radio_F","V_BandollierB_oli","V_Rangemaster_belt"];
 initialRebelEquipment append ["Binocular","acc_flashlight"];

--- a/A3-Antistasi/Templates/Vanilla_Reb_FIA_Enoch.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_FIA_Enoch.sqf
@@ -1,7 +1,7 @@
 ////////////////////////////////////
 //       NAMES AND FLAGS         ///
 ////////////////////////////////////
-nameTeamPlayer = if (worldName == "Tanoa") then {"SDK"} else {"FIA"};
+nameTeamPlayer = "FIA";
 SDKFlag = "Flag_FIA_F";
 SDKFlagTexture = "\A3\Data_F\Flags\Flag_Altis_CO.paa";
 typePetros = "I_G_officer_F";
@@ -102,6 +102,8 @@ initialRebelEquipment append ["6Rnd_45ACP_Cylinder","9Rnd_45ACP_Mag","2Rnd_12Gua
 initialRebelEquipment append ["B_FieldPack_blk","B_FieldPack_oucamo","B_FieldPack_cbr","B_FieldPack_oli","B_FieldPack_green_F","B_FieldPack_taiga_F"];
 initialRebelEquipment append ["V_Chestrig_blk","V_Chestrig_rgr","V_Chestrig_khk","V_Chestrig_oli","V_BandollierB_blk","V_SmershVest_01_F","V_BandollierB_rgr","V_SmershVest_01_radio_F","V_BandollierB_oli","V_Rangemaster_belt"];
 initialRebelEquipment append ["Binocular","acc_flashlight"];
+//Greenfor uniforms
+allRebelUniforms append ["U_IG_Guerilla1_1","U_IG_Guerilla2_1","U_IG_Guerilla2_2","U_IG_Guerilla2_3","U_IG_Guerilla3_1","U_IG_leader","U_IG_Guerrilla_6_1"];
 //TFAR Unlocks
 if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
 if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_anprc155"};

--- a/A3-Antistasi/Templates/Vanilla_Reb_SDK_Tanoa.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Reb_SDK_Tanoa.sqf
@@ -1,7 +1,7 @@
 ////////////////////////////////////
 //       NAMES AND FLAGS         ///
 ////////////////////////////////////
-nameTeamPlayer = if (worldName == "Tanoa") then {"SDK"} else {"FIA"};
+nameTeamPlayer = "SDK";
 SDKFlag = "Flag_Syndikat_F";
 SDKFlagTexture = "\A3\Data_F_exp\Flags\Flag_Synd_CO.paa";
 typePetros = "I_C_Soldier_Camo_F";
@@ -102,6 +102,8 @@ initialRebelEquipment append ["10Rnd_9x21_Mag","16Rnd_9x21_Mag","30Rnd_9x21_Mag_
 initialRebelEquipment append ["B_FieldPack_blk","B_FieldPack_oucamo","B_FieldPack_cbr","B_FieldPack_oli","B_FieldPack_ghex_F"];
 initialRebelEquipment append ["V_Chestrig_blk","V_Chestrig_rgr","V_Chestrig_khk","V_Chestrig_oli","V_BandollierB_blk","V_BandollierB_ghex","V_BandollierB_rgr","V_BandollierB_oli","V_Rangemaster_belt","V_TacChestrig_cbr_F","V_TacChestrig_oli_F","V_TacChestrig_grn_F"];
 initialRebelEquipment append ["Binocular","acc_flashlight","acc_flashlight_smg_01","acc_flashlight_pistol"];
+//Greenfor uniforms
+allRebelUniforms append ["U_IG_Guerilla1_1","U_IG_Guerilla2_1","U_IG_Guerilla2_2","U_IG_Guerilla2_3","U_IG_Guerilla3_1","U_IG_leader","U_IG_Guerrilla_6_1"];
 //TFAR unlocks
 if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
 if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_anprc155"};

--- a/A3-Antistasi/Templates/selector.sqf
+++ b/A3-Antistasi/Templates/selector.sqf
@@ -19,7 +19,7 @@ if(teamplayer != independent) then {//This section is for Altis Blufor ONLY!
       call compile preProcessFileLineNumbers "Templates\3CB_Civ.sqf";
     };
     case (hasRHS): {
-      call compile preProcessFileLineNumbers "Templates\RHS_Reb_CDF_Arid.sqf";
+      call compile preProcessFileLineNumbers "Templates\RHS_Reb_HIDF_Arid.sqf";
       call compile preProcessFileLineNumbers "Templates\RHS_Occ_CDF_Arid.sqf";
       call compile preProcessFileLineNumbers "Templates\RHS_Inv_AFRF_Arid.sqf";
       call compile preProcessFileLineNumbers "Templates\RHS_Civ.sqf";

--- a/A3-Antistasi/functions/Ammunition/fn_equipmentIsValidForCurrentModset.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentIsValidForCurrentModset.sqf
@@ -42,11 +42,6 @@ if (_itemIsVanilla && {has3CB || {activeAFRF && activeGREF && activeUSAF}}) then
 						_remove = true;
 					};
 				};
-				case "Uniform": {
-					if (has3CB) then {
-						_remove = true;
-					};
-				};
 				case "Vest": {
 					if (getNumber (_configClass >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Chest" >> "armor") > 5) then {
 						_remove = true;

--- a/A3-Antistasi/functions/Ammunition/fn_equipmentSort.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentSort.sqf
@@ -16,15 +16,17 @@
 		//RHS
 		case "rhsgref_faction_nationalist": {if ((!has3CB) and nameTeamPlayer isEqualTo "NAPA") then {allRebelUniforms pushBack _x};};
 		case "rhsgref_faction_hidf": {if ((!has3CB) and nameTeamPlayer isEqualTo "Rebels") then {allRebelUniforms pushBack _x};};
-		//3CB All used Faction use Civilian Uniforms
+		//3CB These dont actually work, added TKM manually in Template, CCM Uniforms are the same as the Civilian ones.
+		//case "UK3CB_CCM_I": {if (teamPlayer isEqualTo resistance) then {allRebelUniforms pushBack _x};};
+		//case "UK3CB_TKM_B": {if (teamPlayer isEqualTo west) then {allRebelUniforms pushBack _x};};
 		//IFA
 		case "LIB_GUER": {if (hasIFA) then {allRebelUniforms pushBack _x};};
 		//Tanoa/ApexDLC
-		case "IND_C_F": {if (teamPlayer isEqualTo resistance) then {allRebelUniforms pushBack _x};};
+		case "IND_C_F": {if ((!hasIFA) and teamPlayer isEqualTo resistance) then {allRebelUniforms pushBack _x};};
 		//Contact DLC Looters
-		case "IND_L_F": {if (teamPlayer isEqualTo resistance) then {allRebelUniforms pushBack _x};};
-		//BLUFOR used because O/I Gueriilla uniforms 'scope' = 1
-		case "BLU_G_F": {if (teamPlayer isEqualTo west) then {allRebelUniforms pushBack _x};};
+		case "IND_L_F": {if ((!hasIFA) and teamPlayer isEqualTo resistance) then {allRebelUniforms pushBack _x};};
+		//BLUFOR used because O/I Gueriilla uniforms 'scope' = 1 ----> Added Green Via Templates.
+		case "BLU_G_F": {if ((!hasIFA) and teamPlayer isEqualTo west) then {allRebelUniforms pushBack _x};};
 	};
 } forEach allUniforms;
 

--- a/A3-Antistasi/functions/Ammunition/fn_equipmentSort.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentSort.sqf
@@ -15,15 +15,16 @@
 	switch (_uniformFaction) do {
 		//RHS
 		case "rhsgref_faction_nationalist": {if ((!has3CB) and nameTeamPlayer isEqualTo "NAPA") then {allRebelUniforms pushBack _x};};
-		case "rhsgref_faction_cdf_ng_b": {if ((!has3CB) and teamPlayer isEqualTo west) then {allRebelUniforms pushBack _x};};
-		//3CB
-		//case "IND_F": {if ((has3CB) and nameTeamPlayer isEqualTo "TTF") then {allRebelUniforms pushBack _x};};
+		case "rhsgref_faction_hidf": {if ((!has3CB) and nameTeamPlayer isEqualTo "Rebels") then {allRebelUniforms pushBack _x};};
+		//3CB All used Faction use Civilian Uniforms
 		//IFA
 		case "LIB_GUER": {if (hasIFA) then {allRebelUniforms pushBack _x};};
-		//Vanilla
-		case "IND_C_F";
+		//Tanoa/ApexDLC
+		case "IND_C_F": {if (teamPlayer isEqualTo resistance) then {allRebelUniforms pushBack _x};};
+		//Contact DLC Looters
+		case "IND_L_F": {if (teamPlayer isEqualTo resistance) then {allRebelUniforms pushBack _x};};
 		//BLUFOR used because O/I Gueriilla uniforms 'scope' = 1
-		case "BLU_G_F": {allRebelUniforms pushBack _x};
+		case "BLU_G_F": {if (teamPlayer isEqualTo west) then {allRebelUniforms pushBack _x};};
 	};
 } forEach allUniforms;
 
@@ -48,6 +49,10 @@ allCivilianUniforms deleteAt (allCivilianUniforms find "gm_ge_pol_uniform_blouse
 allCivilianUniforms deleteAt (allCivilianUniforms find "gm_ge_ff_uniform_man_80_orn");	//Gmob Firefighter
 allCivilianUniforms deleteAt (allCivilianUniforms find "U_I_L_Uniform_01_camo_F");	//LDF Deserter Jacket
 allCivilianUniforms deleteAt (allCivilianUniforms find "U_I_L_Uniform_01_deserter_F");	//LDF Desserter T-Shirt
+allCivilianUniforms deleteAt (allCivilianUniforms find "U_I_L_Uniform_01_tshirt_olive_F"); //Looter Clothes (T-Shirt Olive)
+allCivilianUniforms deleteAt (allCivilianUniforms find "U_I_L_Uniform_01_tshirt_sport_F"); //Looter Clothes (T-Shirt Sport)
+allCivilianUniforms deleteAt (allCivilianUniforms find "U_I_L_Uniform_01_tshirt_black_F"); //Looter Clothes (T-Shirt Black)
+allCivilianUniforms deleteAt (allCivilianUniforms find "U_I_L_Uniform_01_tshirt_skull_F"); //Looter Clothes (T-Shirt Skull)
 allCivilianUniforms deleteAt (allCivilianUniforms find "U_C_IDAP_Man_shorts_F");	//Idap Worker Uniforms
 allCivilianUniforms deleteAt (allCivilianUniforms find "U_C_IDAP_Man_casual_F");
 allCivilianUniforms deleteAt (allCivilianUniforms find "U_C_IDAP_Man_cargo_F");


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Change
3. [X] Enhancement

### What have you changed and why?
Information:
**Rebell Template**

Renamed RHS_Reb_CDF to HIDF. #1356 

Changed all Possible Units with HIDF and FIA Units.

A few things as Static weapons are still "CDF" but they dont spawn with Default Crew so there is no Issue.

vehSDKAT and the vehSDKLightArmed are FIA variants cause i didnt want to give a Hmmve or an SPG9 UAZ due to Default CDF Crew for the UAZ.
vehSDKPlane is changed to a Reskined variant of the Apex DLC Cesna.

**Uniform stuff**
Changed Equipmentsort to give a few HIDF Rebell Uniforms for the HIDF Template.

Added an Array to each Greenfor Rebell Templates with all FIA_I Uniforms for #1191, i did it this way so possible other Rebell Templates dont have to fight it getting added.

Added a If Teamplayer Side checks to the other Cases in Equipmentsort to ensure no Green Uniforms on Bluefor and no Blue on Green.

Added "IND_L_F" to Equipmentsort for Rebelluniforms, these will only be added if Contact DLC is enabled.

Added more Looter Uniforms to Civilianuniform blacklist, these would be added to the Rebelluniform array if Contact is enabled but also be on the Civlianuniform list which would allow you to go Undercover.

**TKPGM**
Added TKM_B Uniforms Manually in the Template due to Equipmentsort refusing to add them even tho Scope is 2. #1371

**Enoch Vanilla Template**
Since i am allready touching it for Uniforms i added the correction in this PR #1365

Changed 9Rnd_45ACP_Mag to 11Rnd_45ACP_Mag cause the Magazine was not compatible with the Starting Weapons.

**3CB Inital Equipment** #1370 
Corrected miscased Classnames.

### Please specify which Issue this PR Resolves.
closes #1191 
closes #1356 
closes #1365
closes #1370 
closes #1371
### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [X] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
#1371
allRebelUniforms in Debugconsole on all Current Maps and Modsets with Green Rebells you should be getting U_IG instead of U_BG. and UBG on Blue Factions.

#1370 
Miscased Equipment: Equip, leave Arsenal, Open Arsenal Again, if the Problem is solved there are no duplicates.

#1365 
Equipment Should be in Arsenal.

#1356 
Playtesting, Own Faction wears a US Woodland Camo now which is completly different from TTSKO Forest that CDF wears.

#1191 
Equip Rebell Uniforms, Drop them, try to Pick em back up, every should be Possible since Side Filtering is in Place for Playerfaction.
********************************************************
Notes:
Vanilla Tanoa has only these Uniforms, the Syndicate Uniforms are only added if APEX is enabled.