### PR TITLE
Fix non-hosted rebel airstrikes

### DIFF
--- a/A3-Antistasi/functions/AI/fn_airbomb.sqf
+++ b/A3-Antistasi/functions/AI/fn_airbomb.sqf
@@ -1,6 +1,5 @@
-if (not isServer and hasInterface) exitWith {};
 private _filename = "fn_airbomb";
-[3, format ["Executing on: %1", clientOwner], _filename] call A3A_fnc_log;
+[3, format ["Executing on: %1", clientOwner], _filename, true] call A3A_fnc_log;
 private ["_countX","_plane","_typeX","_ammo","_cluster","_sleep","_bomb"];
 _plane = vehicle (_this select 0);
 _typeX = _this select 1;
@@ -25,14 +24,12 @@ switch (_typeX) do {
 	};
 };
 
-if (typeOf _plane == vehSDKPlane) then {_countX = round (_countX / 2); [3, "Rebel Airstrike", _filename] call A3A_fnc_log;};
+if (typeOf _plane == vehSDKPlane) then {_countX = round (_countX / 2)};
 sleep random 5;
 
-[3, format ["Dropping %1 bombs of type %2 at %3 (near %4)", _countX, _typeX, getPos _plane,text nearestLocation [getPos _plane, "NameCity"]], _filename] call A3A_fnc_log;
-private _debugCounter = 0;
+[3, format ["Dropping %1 bombs of type %2 at %3 (near %4)", _countX, _typeX, getPos _plane,text nearestLocation [getPos _plane, "NameCity"]], _filename, true] call A3A_fnc_log;
 for "_i" from 1 to _countX do
 	{
-	_debugCounter = _debugCounter + 1;
 	sleep _sleep;
 	if (alive _plane) then
 		{
@@ -56,5 +53,4 @@ for "_i" from 1 to _countX do
 			};
 		};
 	};
-[3, format ["Bombs dropped: %1", _debugCounter], _filename] call A3A_fnc_log;	
 //_bomba is used to track when napalm bombs hit the ground in order to call the napalm script on the correct position


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Rebel airstrikes stopped spawning bombs when the commander wasn't the host, because they're executed on the commander's client, setWaypointStatements in NATObomb was constrained to only execute locally (to prevent multiplied bomb drops), but airbomb only executes on HC or server.

There were various ways to fix this. I chose to allow NATObomb to execute on clients because otherwise the drop point could get badly desynced if passed off to another machine. The more centralized fix would be to execute rebel airstrikes on the server or HC, but that was fairly complex due to how the airstrike function manages the markers.

Also removed some redundant debugging code from airbomb and made the remainder log to server, as the default for clients is to log locally.

### Please specify which Issue this PR Resolves.
closes #1361

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in singleplayer?
2. [X] Have you loaded the mission in LAN host?
3. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
