### PR TITLE
Fix some road search bugs

### DIFF
--- a/A3-Antistasi/functions/Base/fn_findNearestGoodRoad.sqf
+++ b/A3-Antistasi/functions/Base/fn_findNearestGoodRoad.sqf
@@ -1,19 +1,16 @@
-private ["_pos","_roads","_road","_radiusX"];
+params ["_pos"];
 
-_pos = _this select 0;
+private _badSurfaces = ["#GdtForest", "#GdtRock", "#GdtGrassTall"];
+private _radiusX = 10;
+private _road = objNull;
 
-_roads = [];
-_radiusX = 10;
-_road = objNull;
 while {isNull _road} do
+{
+	private _nearRoads = _pos nearRoads _radiusX;
 	{
-	_roads = _pos nearRoads _radiusX;
-	if (count _roads > 0) then
-		{
-		{
-		if ((surfaceType (position _x)!= "#GdtForest") and (surfaceType (position _x)!= "#GdtRock") and (surfaceType (position _x)!= "#GdtGrassTall")) exitWith {_road = _x};
-		} forEach _roads;
-		};
+		private _surfType = surfaceType (position _x);
+		if (!(_surfType in _badSurfaces) && { count roadsConnectedTo _x != 0 }) exitWith {_road = _x};
+	} forEach _nearRoads;
 	_radiusX = _radiusX + 10;
-	};
-_road
+};
+_road;

--- a/A3-Antistasi/functions/Utility/fn_getRoadDirection.sqf
+++ b/A3-Antistasi/functions/Utility/fn_getRoadDirection.sqf
@@ -1,8 +1,10 @@
 params ["_road"];
 
-if (isNull _road) exitWith {private _direction = random 360; _direction};
+if (isNull _road) exitWith { random 360 };
 
 private _roadConnectedTo = roadsConnectedTo _road;
+if (count _roadConnectedTo == 0) exitWith { random 360 };
+
 private _connectedRoad = _roadConnectedTo select 0;
 private _direction = [_road, _connectedRoad] call BIS_fnc_DirTo;
 _direction;

--- a/A3-Antistasi/functions/init/fn_initZones.sqf
+++ b/A3-Antistasi/functions/init/fn_initZones.sqf
@@ -399,7 +399,14 @@ if (count _posBank > 0) then {
 	};
 };
 
-blackListDest = (markersX - controlsX - ["Synd_HQ"] - citiesX) select {!((position ([getMarkerPos _x] call A3A_fnc_findNearestGoodRoad)) inArea _x)};
+// Make list of markers that don't have a proper road nearby
+blackListDest = (markersX - controlsX - ["Synd_HQ"] - citiesX) select {
+	private _nearRoads = (getMarkerPos _x) nearRoads (([_x] call A3A_fnc_sizeMarker) * 1.5);
+//	_nearRoads = _nearRoads inAreaArray _x;
+	private _badSurfaces = ["#GdtForest", "#GdtRock", "#GdtGrassTall"];
+	private _idx = _nearRoads findIf { !(surfaceType (position _x) in _badSurfaces) && { count roadsConnectedTo _x != 0 } };
+	if (_idx == -1) then {true} else {false};
+};
 
 publicVariable "blackListDest";
 publicVariable "markersX";


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed some some road-searching issues:

- Prevented getRoadDirection from crashing out when passed an unconnected road.
- Prevented findNearestGoodRoad from returning unconnected roads.
- Made initZones road-attack blacklist more generous, so it doesn't contain outposts right next to roads.

The latter two should be replaced with navgrid-based logic at some point, but that's more of a project.

### Please specify which Issue this PR Resolves.
closes #1373 

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

