### PR TITLE
Fix initClient unintentionally running everything on headless clients

### DIFF
--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -21,21 +21,24 @@ if (!isServer) then {
 	};
 };
 
-if (hasInterface) then {
-	waitUntil {!isNull player};
-	waitUntil {player == player};
-	//Disable player saving until they're fully ready, and have chosen whether to load their save.
-	player setVariable ["canSave", false, true];
+// Headless clients install some support functions, register with the server and bail out
+if (!hasInterface) exitWith {
+	call A3A_fnc_initFuncs;
+	call A3A_fnc_initVar;
+	call A3A_fnc_loadNavGrid;
+	[2,format ["Headless client version: %1",localize "STR_antistasi_credits_generic_version_text"],_fileName] call A3A_fnc_log;
+	[clientOwner] remoteExec ["A3A_fnc_addHC",2];
 };
+
+
+waitUntil {!isNull player};
+waitUntil {player == player};
+//Disable player saving until they're fully ready, and have chosen whether to load their save.
+player setVariable ["canSave", false, true];
 
 if (!isServer) then {
 	call A3A_fnc_initFuncs;
 	call A3A_fnc_initVar;
-	if (!hasInterface) exitWith {
-		[2,format ["Headless client version: %1",localize "STR_antistasi_credits_generic_version_text"],_fileName] call A3A_fnc_log;
-		call A3A_fnc_loadNavGrid;
-		[clientOwner] remoteExec ["A3A_fnc_addHC",2];
-	};
 	[2,format ["MP client version: %1",localize "STR_antistasi_credits_generic_version_text"],_fileName] call A3A_fnc_log;
 }
 else {


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
initClient wasn't intended to run most of its code on headless clients, but it was due to bad exitWith scope. Oddly enough it doesn't seem to matter much, but as changes there won't usually be tested on HCs, it's a bad idea. This patch breaks out where it's supposed to.

I think this bug was introduced in 2.3, and the new initClient code that needs to run on HCs (navgrid, destroyed buildings) is above the break, so everything should be fine. Didn't run into any problems in testing.

### Please specify which Issue this PR Resolves.
closes #1372

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in singleplayer?
2. [ ] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?
4. [X] Have you loaded the mission on a dedicated server with HCs?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
