### PR TITLE
garageVehicle spelling fix "engaging".

### DIFF
--- a/A3-Antistasi/functions/Garage/fn_garageVehicle.sqf
+++ b/A3-Antistasi/functions/Garage/fn_garageVehicle.sqf
@@ -28,7 +28,7 @@ if (_veh isKindOf "Man") exitWith {["Garage", "Are you kidding?"] call A3A_fnc_c
 if !(_veh isKindOf "AllVehicles") exitWith {["Garage", "The vehicle you are looking cannot be stored in our Garage"] call A3A_fnc_customHint;};
 
 _units = (player nearEntities ["Man",300]) select {([_x] call A3A_fnc_CanFight) && (side _x isEqualTo Occupants || side _x isEqualTo Invaders)};
-if (_units findIf {_unit = _x; _players = allPlayers select {(side _x isEqualTo teamPlayer) && (player distance _x < 300)}; _players findIf {_x in (_unit targets [true, 300])} != -1} != -1) exitWith {["Garage", "You can't garage vehicles while enemies are engageing you"] call A3A_fnc_customHint};
+if (_units findIf {_unit = _x; _players = allPlayers select {(side _x isEqualTo teamPlayer) && (player distance _x < 300)}; _players findIf {_x in (_unit targets [true, 300])} != -1} != -1) exitWith {["Garage", "You can't garage vehicles while enemies are engaging you"] call A3A_fnc_customHint};
 if (_units findIf{player distance _x < 100} != -1) exitWith {["Garage", "You can't garage vehicles while enemies are near you"] call A3A_fnc_customHint};
 
 if (player distance _veh > 25) exitWith {["Garage", "You can't garage vehicles that are more than 25m away from you"] call A3A_fnc_customHint};


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
* Change
* Enhancement

### What have you changed and why?
Changed `engageing` to `engaging`
> "You can't garage vehicles while enemies are engaging you"

### Please specify which Issue this PR Resolves.
closes [#1346](https://github.com/official-antistasi-community/A3-Antistasi/issues/1346)

### Please verify the following and ensure all checks are completed.

2. [x] Have you loaded the mission in LAN host?
3. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
* Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
player AllowDamage false;
spawn vehicle near HQ.
spawn many enemies near HQ so Petros cannot kill them all.
Try garage vehicle and check the spelling of engaging.
********************************************************
Notes:

I doubt this needs a QA review.