### PR TITLE
_FF checks victim side and logs accordingly.

### DIFF
--- a/A3-Antistasi/functions/Punishment/fn_punishment_FF.sqf
+++ b/A3-Antistasi/functions/Punishment/fn_punishment_FF.sqf
@@ -86,9 +86,14 @@ private _gotoExemption = {
     [2, format ["%1 | %2", _exemptionDetails, _playerStats], _filename] remoteExecCall ["A3A_fnc_log",2,false];
     _exemptionDetails;
 };
-private _logPvPKill = {
+private _logPvPHurt = {
     if (!(_victim isKindOf "Man")) exitWith {};
-    private _killStats = format ["PVPKILL | PvP %1 [%2]%3", name _instigator, getPlayerUID _instigator, _victimStats];
+    private _killStats = format ["PVPHURT | Rebel %1 [%2]%3", name _instigator, getPlayerUID _instigator, _victimStats];
+    [2,_killStats,_filename] remoteExecCall ["A3A_fnc_log",2,false];
+};
+private _logPvPAttack = {
+    if (!(_victim isKindOf "Man")) exitWith {};
+    private _killStats = format ["PVPATTACK | PvP %1 [%2]%3", name _instigator, getPlayerUID _instigator, _victimStats];
     [2,_killStats,_filename] remoteExecCall ["A3A_fnc_log",2,false];
 };
 
@@ -99,7 +104,8 @@ private _exemption = switch (true) do {
     case (!hasInterface):                              {"FF BY SERVER/HC"};
     case (!(player isEqualTo _instigator)):            {"NOT EXEC ON INSTIGATOR"}; // Must be local for 'BIS_fnc_admin'
     case (_victim isEqualTo _instigator):              {"SUICIDE"}; // Local AI victims will be different.
-    case (side _instigator in [Invaders, Occupants]):  {call _logPvPKill; "NOT REBEL"};
+    case (_victim getVariable ["pvp",false]):          {call _logPvPHurt; "VICTIM NOT REBEL"};
+    case (_instigator getVariable ["pvp",false]):      {call _logPvPAttack; "INSTIGATOR NOT REBEL"};
     default                                            {""};
 };
 


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
* Change
* Enhancement

### What have you changed and why?
Information:
    Side checks now use getVariable "pvp" to determine whether rebel or not.

### Please specify which Issue this PR Resolves.
closes #[1407](https://github.com/official-antistasi-community/A3-Antistasi/issues/1407)

### Please verify the following and ensure all checks are completed.

2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
* Yes (Test)

### How can the changes be tested?
Steps: 
Rebel damage PvP => Log
Rebel damage rebel => Punish
PvP damage PvP => nothing
PvP damage rebel => Log
********************************************************