### PR TITLE
Fix Tanoa attack bugs

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_WPCreate.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_WPCreate.sqf
@@ -44,7 +44,7 @@ if (worldName == "Tanoa") then {
 	{
 		sleep 1;
 		diag_log "WPCreate cannot get the roadsMrk, sleeping 1 second to await marker init!";
-		!(isNil "roadsMrk" || {isNull roadsMrk})
+		!(isNil "roadsMrk")
 	};
 
 	private _arr2 = [];

--- a/A3-Antistasi/functions/CREATE/fn_wavedCA.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_wavedCA.sqf
@@ -180,7 +180,8 @@ while {(_waves > 0)} do
 	{
 		//Attempt land attack if origin is an airport in range
 		_airportIndex = airportsX find _mrkOrigin;
-		if (_airportIndex >= 0 and (_posOrigin distance _posDestination < distanceForLandAttack)) then
+		if (_airportIndex >= 0 and (_posOrigin distance _posDestination < distanceForLandAttack)
+			and ([_posOrigin, _posDestination] call A3A_fnc_isTheSameIsland)) then
 		{
 			_spawnPoint = server getVariable (format ["spawn_%1", _mrkOrigin]);
 			_pos = getMarkerPos _spawnPoint;
@@ -190,7 +191,12 @@ while {(_waves > 0)} do
 		else
 		//Find an outpost we can attack from
 		{
-			_outposts = outposts select {(sidesX getVariable [_x,sideUnknown] == _sideX) and (getMarkerPos _x distance _posDestination < distanceForLandAttack)  and ([_x,false] call A3A_fnc_airportCanAttack)};
+			_outposts = outposts select {
+				(sidesX getVariable [_x,sideUnknown] == _sideX)
+				and (getMarkerPos _x distance _posDestination < distanceForLandAttack)
+				and {[_posDestination, getMarkerPos _x] call A3A_fnc_isTheSameIsland}
+				and {[_x,false] call A3A_fnc_airportCanAttack}			// checks idle, garrison size, spawndist2
+			};
 			if !(_outposts isEqualTo []) then
 			{
 				_outpost = selectRandom _outposts;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
- Fixed a bug added in #417 that caused WPCreate (the old pathfinding function) to crash out on Tanoa.
- Fixed major attacks not checking whether land bases were on the same island.

Second bug will also apply to other multi-island maps.

### Please specify which Issue this PR Resolves.
closes #1401
closes #1405

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [X] Have you loaded the mission in LAN host?
3. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Start a new reb vs gov vs inv game on Tanoa, then run as server:
`["resource_6", "airport_1", 3] spawn A3A_fnc_wavedCA`
Should neither crash out or spawn any ground vehicles. 