### PR TITLE
Vanilla Cleanup

### DIFF
--- a/A3-Antistasi/Templates/Vanilla_Inv_CSAT_Altis.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Inv_CSAT_Altis.sqf
@@ -38,7 +38,7 @@ CSATPlayerLoadouts = [
 ];
 
 //PVP Player Vehicles
-vehCSATPVP = ["O_MRAP_02_F","O_LSV_02_unarmed_F","O_MRAP_02_hmg_F","O_LSV_02_armed_F"];
+vehCSATPVP = ["O_MRAP_02_F","O_MRAP_02_hmg_F"];
 
 ////////////////////////////////////
 //             UNITS             ///
@@ -78,8 +78,8 @@ groupsCSATSquad =
 	[
 	CSATSquad,
 	["O_Soldier_SL_F","O_Soldier_AR_F","O_Soldier_GL_F","O_soldier_M_F","O_Soldier_AT_F","O_Soldier_AAT_F","O_Soldier_A_F","O_medic_F"],
-	["O_Soldier_SL_F","O_Soldier_LAT_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_support_Mort_F","O_support_AMort_F","O_medic_F"],
-	["O_Soldier_SL_F","O_Soldier_LAT_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_support_MG_F","O_support_AMG_F","O_medic_F"],
+	["O_Soldier_SL_F","O_Soldier_LAT_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_Soldier_LAT_F","O_Soldier_LAT_F","O_medic_F"],
+	["O_Soldier_SL_F","O_Soldier_LAT_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_Soldier_LAT_F","O_Soldier_LAT_F","O_medic_F"],
 	["O_Soldier_SL_F","O_Soldier_LAT_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_Soldier_AA_F","O_Soldier_AAA_F","O_medic_F"],
 	["O_Soldier_SL_F","O_Soldier_LAT_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_engineer_F","O_engineer_F","O_medic_F"]
 	];
@@ -116,8 +116,8 @@ if (gameMode == 4) then
 //Military Vehicles
 //Lite
 vehCSATBike = "O_Quadbike_01_F";
-vehCSATLightArmed = ["O_MRAP_02_hmg_F","O_MRAP_02_gmg_F","O_LSV_02_armed_F"];
-vehCSATLightUnarmed = ["O_MRAP_02_F","O_LSV_02_unarmed_F"];
+vehCSATLightArmed = ["O_MRAP_02_hmg_F","O_MRAP_02_gmg_F"];
+vehCSATLightUnarmed = ["O_MRAP_02_F"];
 vehCSATTrucks = ["O_Truck_03_transport_F","O_Truck_03_covered_F"];
 vehCSATAmmoTruck = "O_Truck_03_ammo_F";
 vehCSATRepairTruck = "O_Truck_03_repair_F";

--- a/A3-Antistasi/Templates/Vanilla_Inv_CSAT_Enoch.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Inv_CSAT_Enoch.sqf
@@ -5,7 +5,7 @@
 nameInvaders = "CSAT";
 
 //SF Faction
-factionMaleInvaders = "OPF_V_F";
+factionMaleInvaders = "OPF_R_F";
 //Miltia Faction
 if (gameMode == 4) then {factionFIA = ""};
 
@@ -38,7 +38,7 @@ CSATPlayerLoadouts = [
 ];
 
 //PVP Player Vehicles
-vehCSATPVP = ["O_MRAP_02_F","O_LSV_02_unarmed_F","O_MRAP_02_hmg_F","O_LSV_02_armed_F"];
+vehCSATPVP = ["O_MRAP_02_F","O_MRAP_02_hmg_F"];
 
 ////////////////////////////////////
 //             UNITS             ///
@@ -73,13 +73,13 @@ groupsCSATAT = ["O_Soldier_TL_F","O_Soldier_AT_F","O_Soldier_AT_F","O_Soldier_AA
 groupsCSATmid = [["O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_GL_F","O_Soldier_LAT_F"],groupsCSATAA,groupsCSATAT];
 //Squads
 CSATSquad = ["O_Soldier_SL_F","O_Soldier_F","O_Soldier_LAT_F","O_soldier_M_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_medic_F"];
-CSATSpecOp = ["O_V_Soldier_TL_hex_F","O_V_Soldier_JTAC_hex_F","O_V_Soldier_M_hex_F","O_V_Soldier_Exp_hex_F","O_V_Soldier_LAT_hex_F","O_V_Soldier_Medic_hex_F"];
+CSATSpecOp = ["O_R_recon_TL_F","O_R_recon_JTAC_F","O_R_recon_M_F","O_R_recon_exp_F","O_R_recon_LAT_F","O_R_recon_medic_F"];
 groupsCSATSquad =
 	[
 	CSATSquad,
 	["O_Soldier_SL_F","O_Soldier_AR_F","O_Soldier_GL_F","O_soldier_M_F","O_Soldier_AT_F","O_Soldier_AAT_F","O_Soldier_A_F","O_medic_F"],
-	["O_Soldier_SL_F","O_Soldier_LAT_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_support_Mort_F","O_support_AMort_F","O_medic_F"],
-	["O_Soldier_SL_F","O_Soldier_LAT_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_support_MG_F","O_support_AMG_F","O_medic_F"],
+	["O_Soldier_SL_F","O_Soldier_LAT_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_Soldier_LAT_F","O_Soldier_LAT_F","O_medic_F"],
+	["O_Soldier_SL_F","O_Soldier_LAT_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_Soldier_LAT_F","O_Soldier_LAT_F","O_medic_F"],
 	["O_Soldier_SL_F","O_Soldier_LAT_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_Soldier_AA_F","O_Soldier_AAA_F","O_medic_F"],
 	["O_Soldier_SL_F","O_Soldier_LAT_F","O_Soldier_TL_F","O_Soldier_AR_F","O_Soldier_A_F","O_engineer_F","O_engineer_F","O_medic_F"]
 	];
@@ -116,8 +116,8 @@ if (gameMode == 4) then
 //Military Vehicles
 //Lite
 vehCSATBike = "O_Quadbike_01_F";
-vehCSATLightArmed = ["O_MRAP_02_hmg_F","O_MRAP_02_gmg_F","O_LSV_02_armed_F"];
-vehCSATLightUnarmed = ["O_MRAP_02_F","O_LSV_02_unarmed_F"];
+vehCSATLightArmed = ["O_MRAP_02_hmg_F","O_MRAP_02_gmg_F"];
+vehCSATLightUnarmed = ["O_MRAP_02_F"];
 vehCSATTrucks = ["O_Truck_03_transport_F","O_Truck_03_covered_F"];
 vehCSATAmmoTruck = "O_Truck_03_ammo_F";
 vehCSATRepairTruck = "O_Truck_03_repair_F";

--- a/A3-Antistasi/Templates/Vanilla_Inv_CSAT_Tanoa.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Inv_CSAT_Tanoa.sqf
@@ -7,7 +7,7 @@ nameInvaders = "CSAT";
 //SF Faction
 factionMaleInvaders = "OPF_V_F";
 //Miltia Faction
-if (gameMode == 4) then {factionFIA = "OPF_G_F"};
+if (gameMode == 4) then {factionFIA = ""};
 
 //Flag Images
 CSATFlag = "Flag_CSAT_F";
@@ -55,8 +55,8 @@ CSATPilot = "O_T_Pilot_F";
 //Militia Units
 if (gameMode == 4) then
 	{
-	FIARifleman = "O_G_Soldier_F";
-	FIAMarksman = "O_G_Sharpshooter_F";
+	FIARifleman = "O_T_Soldier_F";
+	FIAMarksman = "O_T_Soldier_M_F";
 	};
 
 ////////////////////////////////////
@@ -90,23 +90,23 @@ if (gameMode == 4) then
 	//Teams
 	groupsFIASmall =
 		[
-		["O_G_Soldier_GL_F","O_G_Soldier_F"],
-		["O_G_Soldier_M_F","O_G_Soldier_F"],
-		["O_G_Sharpshooter_F","O_G_Soldier_M_F"]
+		["O_T_Soldier_GL_F","O_T_Soldier_F"],
+		["O_T_Soldier_M_F","O_T_Soldier_F"],
+		["O_T_Soldier_M_F","O_T_Soldier_M_F"]
 		];
 	//Fireteams
 	groupsFIAMid =
 		[
-		["O_G_Soldier_SL_F","O_G_Sharpshooter_F","O_G_Soldier_AR_F","O_G_Soldier_A_F"],
-		["O_G_Soldier_TL_F","O_G_Soldier_AR_F","O_G_Soldier_GL_F","O_G_Soldier_LAT_F"],
-		["O_G_Soldier_TL_F","O_G_Soldier_LAT_F","O_G_Soldier_LAT_F","O_G_Soldier_LAT_F"]
+		["O_T_Soldier_SL_F","O_T_Soldier_M_F","O_T_Soldier_AR_F","O_T_Soldier_A_F"],
+		["O_T_Soldier_TL_F","O_T_Soldier_AR_F","O_T_Soldier_GL_F","O_T_Soldier_LAT_F"],
+		["O_T_Soldier_TL_F","O_T_Soldier_LAT_F","O_T_Soldier_LAT_F","O_T_Soldier_LAT_F"]
 		];
 	//Squads
-	FIASquad = ["O_G_soldier_SL_F","O_G_soldier_F","O_G_soldier_LAT_F","O_G_Soldier_M_F","O_G_soldier_TL_F","O_G_soldier_AR_F","O_G_Soldier_A_F","O_G_medic_F"];
+	FIASquad = ["O_T_Soldier_SL_F","O_T_Soldier_F","O_T_Soldier_LAT_F","O_T_Soldier_M_F","O_T_Soldier_TL_F","O_T_Soldier_AR_F","O_T_Soldier_A_F","O_T_Medic_F"];
 	groupsFIASquad =
 		[
 		FIASquad,
-		["O_G_soldier_SL_F","O_G_soldier_LAT_F","O_G_Soldier_M_F","O_G_soldier_TL_F","O_G_Soldier_A_F","O_support_MG_F","O_support_AMG_F","O_G_medic_F"]
+		["O_T_Soldier_SL_F","O_T_Soldier_LAT_F","O_T_Soldier_M_F","O_T_Soldier_TL_F","O_T_Soldier_A_F","O_T_Soldier_GL_F","O_T_Engineer_F","O_T_Medic_F"]
 		];
 	};
 
@@ -152,9 +152,9 @@ vehCSATAir = vehCSATTransportHelis + vehCSATAttackHelis + [vehCSATPlane,vehCSATP
 //Militia Vehicles
 if (gameMode == 4) then
 	{
-	vehFIAArmedCar = "O_G_Offroad_01_armed_F";
-	vehFIATruck = "O_G_van_01_transport_F";
-	vehFIACar = "O_G_Offroad_01_F";
+	vehFIAArmedCar = "O_MRAP_02_hmg_F";
+	vehFIATruck = "O_Truck_02_transport_F";
+	vehFIACar = "O_MRAP_02_F";
 	};
 
 ////////////////////////////////////

--- a/A3-Antistasi/Templates/Vanilla_Occ_AAF_Altis.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Occ_AAF_Altis.sqf
@@ -5,16 +5,16 @@
 nameOccupants = "AAF";
 
 //Police Faction
-factionGEN = "IND_C_F";
+factionGEN = "";
 //SF Faction
 factionMaleOccupants = "";
 //Miltia Faction
-if (gameMode != 4) then {factionFIA = "IND_C_F"};
+if (gameMode != 4) then {factionFIA = ""};
 
 //Flag Images
-NATOFlag = "Flag_AltisColonial_F";
-NATOFlagTexture = "\A3\Data_F\Flags\Flag_AltisColonial_CO.paa";
-flagNATOmrk = "flag_AltisColonial";
+NATOFlag = "Flag_AAF_F";
+NATOFlagTexture = "a3\data_f\flags\flag_aaf_co.paa";
+flagNATOmrk = "flag_AAF";
 if (isServer) then {"NATO_carrier" setMarkerText "AAF Carrier"};
 
 //Loot Crate
@@ -53,14 +53,14 @@ NATOBodyG = "I_Soldier_SL_F";
 NATOCrew = "I_crew_F";
 NATOUnarmed = "I_G_Survivor_F";
 NATOMarksman = "I_Soldier_M_F";
-staticCrewOccupants = "I_support_MG_F";
+staticCrewOccupants = "I_soldier_F";
 NATOPilot = "I_helipilot_F";
 
 //Militia Units
 if (gameMode != 4) then
 	{
-	FIARifleman = "I_C_Soldier_Para_7_F";
-	FIAMarksman = "I_C_Soldier_Para_2_F";
+	FIARifleman = "I_soldier_F";
+	FIAMarksman = "I_Soldier_M_F";
 	};
 
 //Police Units
@@ -85,8 +85,8 @@ NATOSpecOp = ["I_Soldier_SL_F",NATOGrunt,"I_Soldier_LAT_F","I_Soldier_GL_F","I_S
 groupsNATOSquad =
 	[
 	NATOSquad,
-	["I_Soldier_SL_F",NATOGrunt,"I_Soldier_TL_F","I_Soldier_AR_F","I_Soldier_A_F","I_support_Mort_F","I_support_AMort_F","I_medic_F"],
-	["I_Soldier_SL_F",NATOGrunt,"I_Soldier_TL_F","I_Soldier_AR_F","I_Soldier_A_F","I_support_MG_F","I_support_AMG_F","I_medic_F"],
+	["I_Soldier_SL_F",NATOGrunt,"I_Soldier_TL_F","I_Soldier_AR_F","I_Soldier_A_F","I_Soldier_LAT2_F","I_Soldier_LAT2_F","I_medic_F"],
+	["I_Soldier_SL_F",NATOGrunt,"I_Soldier_TL_F","I_Soldier_AR_F","I_Soldier_A_F","I_Soldier_LAT_F","I_Soldier_LAT_F","I_medic_F"],
 	["I_Soldier_SL_F",NATOGrunt,"I_Soldier_TL_F","I_Soldier_AR_F","I_Soldier_A_F","I_Soldier_AA_F","I_Soldier_AAA_F","I_medic_F"],
 	["I_Soldier_SL_F",NATOGrunt,"I_Soldier_TL_F","I_Soldier_AR_F","I_Soldier_A_F","I_Soldier_AT_F","I_Soldier_AAT_F","I_medic_F"],
 	["I_Soldier_SL_F",NATOGrunt,"I_Soldier_TL_F","I_Soldier_AR_F","I_Soldier_A_F","I_engineer_F","I_engineer_F","I_medic_F"]
@@ -98,18 +98,18 @@ if (gameMode != 4) then
 	//Teams
 	groupsFIASmall =
 		[
-		["I_C_Soldier_Para_6_F",FIARifleman],
+		["I_Soldier_GL_F",FIARifleman],
 		[FIAMarksman,FIARifleman],
 		[FIAMarksman,FIAMarksman]
 		];
 	//Fireteams
 	groupsFIAMid =
 		[
-		["I_C_Soldier_Para_2_F","I_C_Soldier_Para_6_F","I_C_Soldier_Para_7_F","I_C_Soldier_Para_4_F"],
-		["I_C_Soldier_Para_2_F","I_C_Soldier_Para_6_F","I_C_Soldier_Para_7_F","I_C_Soldier_Para_5_F"]
+		["I_Soldier_SL_F","I_Soldier_GL_F","I_soldier_F","I_Soldier_AR_F"],
+		["I_Soldier_SL_F","I_Soldier_GL_F","I_soldier_F","I_Soldier_LAT2_F"]
 		];
 	//Squads
-	FIASquad = ["I_C_Soldier_Para_2_F","I_C_Soldier_Para_6_F","I_C_Soldier_Para_7_F","I_C_Soldier_Para_4_F","I_C_Soldier_Para_1_F","I_C_Soldier_Para_7_F","I_C_Soldier_Para_8_F","I_C_Soldier_Para_3_F"];
+	FIASquad = ["I_Soldier_SL_F","I_Soldier_GL_F","I_soldier_F","I_Soldier_AR_F","I_Soldier_LAT2_F","I_soldier_F","I_Soldier_exp_F","I_medic_F"];
 	groupsFIASquad = [FIASquad];
 	};
 
@@ -154,15 +154,15 @@ vehNATOUAVSmall = "I_UAV_01_F";
 vehNATOMRLS = "I_Truck_02_MRL_F";
 vehNATOMRLSMags = "12Rnd_230mm_rockets";
 //Combined Arrays
-vehNATONormal = vehNATOLight + vehNATOTrucks + [vehNATOAmmoTruck, "I_Truck_02_fuel_F", "I_Truck_02_medical_F", vehNATORepairTruck,"I_APC_tracked_03_cannon_F"];
+vehNATONormal = vehNATOLight + vehNATOTrucks + [vehNATOAmmoTruck, "I_Truck_02_fuel_F", "I_Truck_02_medical_F", vehNATORepairTruck];
 vehNATOAir = vehNATOTransportHelis + vehNATOAttackHelis + [vehNATOPlane,vehNATOPlaneAA] + vehNATOTransportPlanes;
 
 //Militia Vehicles
 if (gameMode != 4) then
 	{
-	vehFIAArmedCar = "I_C_Offroad_02_LMG_F";
-	vehFIATruck = "I_C_Van_01_transport_F";
-	vehFIACar = "I_C_Offroad_02_unarmed_F";
+	vehFIAArmedCar = "I_MRAP_03_hmg_F";
+	vehFIATruck = "I_Truck_02_transport_F";
+	vehFIACar = "I_MRAP_03_F";
 	};
 
 //Police Vehicles

--- a/A3-Antistasi/Templates/Vanilla_Occ_NATO_Altis.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Occ_NATO_Altis.sqf
@@ -49,7 +49,7 @@ vehNATOPVP = ["B_MRAP_01_F","B_MRAP_01_hmg_F"];
 NATOGrunt = "B_Soldier_F";
 NATOOfficer = "B_officer_F";
 NATOOfficer2 = "B_G_officer_F";
-NATOBodyG = "B_Patrol_Soldier_TL_F";
+NATOBodyG = "B_Patrol_Medic_F";
 NATOCrew = "B_crew_F";
 NATOUnarmed = "B_G_Survivor_F";
 NATOMarksman = "B_Sharpshooter_F";
@@ -85,8 +85,8 @@ NATOSpecOp = ["B_CTRG_Soldier_TL_tna_F","B_CTRG_Soldier_M_tna_F",NATOBodyG,"B_CT
 groupsNATOSquad =
 	[
 	NATOSquad,
-	["B_Soldier_SL_F",NATOGrunt,"B_Soldier_TL_F","B_soldier_AR_F","B_Soldier_A_F","B_support_Mort_F","B_support_AMort_F","B_medic_F"],
-	["B_Soldier_SL_F",NATOGrunt,"B_Soldier_TL_F","B_soldier_AR_F","B_Soldier_A_F","B_support_MG_F","B_support_AMG_F","B_medic_F"],
+	["B_Soldier_SL_F",NATOGrunt,"B_Soldier_TL_F","B_soldier_AR_F","B_Soldier_A_F","B_soldier_LAT2_F","B_soldier_LAT2_F","B_medic_F"],
+	["B_Soldier_SL_F",NATOGrunt,"B_Soldier_TL_F","B_soldier_AR_F","B_Soldier_A_F","B_soldier_LAT_F","B_soldier_LAT_F","B_medic_F"],
 	["B_Soldier_SL_F",NATOGrunt,"B_Soldier_TL_F","B_soldier_AR_F","B_Soldier_A_F","B_soldier_AA_F","B_soldier_AAA_F","B_medic_F"],
 	["B_Soldier_SL_F",NATOGrunt,"B_Soldier_TL_F","B_soldier_AR_F","B_Soldier_A_F","B_soldier_AT_F","B_soldier_AAT_F","B_medic_F"],
 	["B_Soldier_SL_F",NATOGrunt,"B_Soldier_TL_F","B_soldier_AR_F","B_Soldier_A_F","B_engineer_F","B_engineer_F","B_medic_F"]

--- a/A3-Antistasi/Templates/Vanilla_Occ_NATO_Tanoa.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Occ_NATO_Tanoa.sqf
@@ -9,7 +9,7 @@ factionGEN = "BLU_GEN_F";
 //SF Faction
 factionMaleOccupants = "BLU_CTRG_F";
 //Miltia Faction
-if (gameMode != 4) then {factionFIA = "BLU_G_F"};
+if (gameMode != 4) then {factionFIA = ""};
 
 //Flag Images
 NATOFlag = "Flag_NATO_F";
@@ -59,8 +59,8 @@ NATOPilot = "B_T_Pilot_F";
 //Militia Units
 if (gameMode != 4) then
 	{
-	FIARifleman = "B_G_Soldier_F";
-	FIAMarksman = "B_G_Sharpshooter_F";
+	FIARifleman = "B_T_Soldier_F";
+	FIAMarksman = "B_T_soldier_M_F";
 	};
 
 //Police Units
@@ -85,10 +85,11 @@ NATOSpecOp = ["B_CTRG_Soldier_TL_tna_F","B_CTRG_Soldier_M_tna_F",NATOBodyG,"B_CT
 groupsNATOSquad =
 	[
 	NATOSquad,
-	["B_T_Soldier_SL_F","B_T_Soldier_AR_F","B_T_Soldier_GL_F",NATOMarksman,"B_T_Soldier_AT_F","B_T_Soldier_AAT_F","B_T_Soldier_A_F","B_T_Medic_F"],
-	["B_T_Soldier_SL_F","B_T_Soldier_LAT_F","B_T_Soldier_TL_F","B_T_Soldier_AR_F","B_T_Soldier_A_F","B_T_Support_Mort_F","B_support_AMort_F","B_T_Medic_F"],
-	["B_T_Soldier_SL_F","B_T_Soldier_AR_F","B_T_Soldier_GL_F",NATOMarksman,"B_T_Soldier_AA_F","B_T_Soldier_AAA_F","B_T_Soldier_A_F","B_T_Medic_F"],
-	["B_T_Soldier_SL_F","B_T_Soldier_AR_F","B_T_Soldier_GL_F",NATOMarksman,"B_T_Engineer_F","B_T_Engineer_F","B_T_Soldier_A_F","B_T_Medic_F"]
+	["B_T_Soldier_SL_F",NATOGrunt,"B_T_Soldier_TL_F","B_T_Soldier_AR_F","B_T_Soldier_A_F","B_T_Soldier_LAT2_F","B_T_Soldier_LAT2_F","B_T_Medic_F"],
+	["B_T_Soldier_SL_F",NATOGrunt,"B_T_Soldier_TL_F","B_T_Soldier_AR_F","B_T_Soldier_A_F","B_T_Soldier_LAT_F","B_T_Soldier_LAT_F","B_T_Medic_F"],
+	["B_T_Soldier_SL_F",NATOGrunt,"B_T_Soldier_TL_F","B_T_Soldier_AR_F","B_T_Soldier_A_F","B_T_Soldier_AA_F","B_T_Soldier_AAA_F","B_T_Medic_F"],
+	["B_T_Soldier_SL_F",NATOGrunt,"B_T_Soldier_TL_F","B_T_Soldier_AR_F","B_T_Soldier_A_F","B_T_Soldier_AT_F","B_T_Soldier_AAT_F","B_T_Medic_F"],
+	["B_T_Soldier_SL_F",NATOGrunt,"B_T_Soldier_TL_F","B_T_Soldier_AR_F","B_T_Soldier_A_F","B_T_Engineer_F","B_T_Engineer_F","B_T_Medic_F"]
 	];
 
 //Militia Groups
@@ -97,23 +98,23 @@ if (gameMode != 4) then
 	//Teams
 	groupsFIASmall =
 		[
-		["B_G_Soldier_GL_F","B_G_Soldier_F"],
-		["B_G_Soldier_M_F","B_G_Soldier_F"],
-		["B_G_Sharpshooter_F","B_G_Soldier_M_F"]
+		["B_T_Soldier_GL_F",FIARifleman],
+		[FIAMarksman,FIARifleman],
+		["B_T_soldier_M_F","B_T_soldier_M_F"]
 		];
 	//Fireteams
 	groupsFIAMid =
 		[
-		["B_G_Soldier_SL_F","B_G_Sharpshooter_F","B_G_Soldier_AR_F","B_G_Soldier_A_F"],
-		["B_G_Soldier_TL_F","B_G_Soldier_AR_F","B_G_Soldier_GL_F","B_G_Soldier_LAT_F"],
-		["B_G_Soldier_TL_F","B_G_Soldier_LAT_F","B_G_Soldier_LAT_F","B_G_Soldier_LAT_F"]
+		["B_T_Soldier_TL_F","B_T_Soldier_GL_F","B_T_Soldier_AR_F","B_T_soldier_M_F"],
+		["B_T_Soldier_TL_F","B_T_Soldier_GL_F","B_T_Soldier_AR_F","B_T_Soldier_LAT2_F"],
+		["B_T_Soldier_TL_F","B_T_Soldier_AR_F","B_T_Soldier_AAA_F","B_T_Soldier_AA_F"]
 		];
 	//Squads
-	FIASquad = ["B_G_Soldier_SL_F","B_G_Soldier_F","B_G_Soldier_LAT_F","B_G_Soldier_M_F","B_G_Soldier_TL_F","B_G_Soldier_AR_F","B_G_Soldier_A_F","B_G_medic_F"];
+	FIASquad = ["B_T_Soldier_TL_F","B_T_Soldier_AR_F","B_T_Soldier_GL_F","B_T_Officer_F","B_T_Officer_F","B_T_soldier_M_F","B_T_Soldier_LAT2_F","B_T_Medic_F"];
 	groupsFIASquad =
 		[
 		FIASquad,
-		["B_G_Soldier_SL_F","B_G_Soldier_LAT_F","B_G_Soldier_M_F","B_G_Soldier_TL_F","B_G_Soldier_A_F","B_support_MG_F","B_support_AMG_F","B_G_medic_F"]
+		["B_T_Soldier_TL_F","B_T_Support_AMG_F","B_T_Soldier_GL_F","B_T_Officer_F","B_T_Support_MG_F","B_T_soldier_M_F","B_T_Soldier_LAT2_F","B_T_Medic_F"]
 		];
 	};
 
@@ -127,7 +128,7 @@ groupsNATOGen = [policeOfficer,policeGrunt];
 //Military Vehicles
 //Lite
 vehNATOBike = "B_T_Quadbike_01_F";
-vehNATOLightArmed = ["B_T_LSV_01_armed_F"];
+vehNATOLightArmed = ["B_T_LSV_01_armed_F","B_T_MRAP_01_hmg_F"];
 vehNATOLightUnarmed = ["B_T_MRAP_01_F","B_T_LSV_01_unarmed_F"];
 vehNATOTrucks = ["B_T_Truck_01_transport_F","B_T_Truck_01_covered_F"];
 vehNATOCargoTrucks = ["B_T_Truck_01_cargo_F","B_T_Truck_01_flatbed_F"];
@@ -164,9 +165,9 @@ vehNATOAir = vehNATOTransportHelis + vehNATOAttackHelis + [vehNATOPlane,vehNATOP
 //Militia Vehicles
 if (gameMode != 4) then
 	{
-	vehFIAArmedCar = "B_G_Offroad_01_armed_F";
-	vehFIATruck = "B_G_Van_01_transport_F";
-	vehFIACar = "B_G_Offroad_01_F";
+	vehFIAArmedCar = "B_T_LSV_01_armed_F";
+	vehFIATruck = "B_T_Truck_01_transport_F";
+	vehFIACar = "B_T_LSV_01_unarmed_F";
 	};
 
 //Police Vehicles

--- a/A3-Antistasi/Templates/Vanilla_Occ_NATO_Temp.sqf
+++ b/A3-Antistasi/Templates/Vanilla_Occ_NATO_Temp.sqf
@@ -48,7 +48,7 @@ vehNATOPVP = ["B_MRAP_01_F","B_MRAP_01_hmg_F","B_Quadbike_01_F"];
 //Military Units
 NATOGrunt = "B_W_Soldier_F";
 NATOOfficer = "B_W_Officer_F";
-NATOOfficer2 = "B_Competitor_F";
+NATOOfficer2 = "B_G_officer_F";
 NATOBodyG = "B_W_Soldier_TL_F";
 NATOCrew = "B_W_Crew_F";
 NATOUnarmed = "B_W_Survivor_F";
@@ -74,7 +74,7 @@ policeGrunt = "B_GEN_Soldier_F";
 //Teams
 groupsNATOSentry = ["B_W_Soldier_GL_F",NATOGrunt];
 groupsNATOSniper = ["B_sniper_F","B_W_Soldier_SL_F"];
-groupsNATOsmall = [groupsNATOSentry,groupsNATOSniper,["B_W_RadioOperator_F","B_W_Officer_F"]];
+groupsNATOsmall = [groupsNATOSentry,groupsNATOSniper,["B_W_soldier_M_F","B_W_Officer_F"]];
 //Fireteams
 groupsNATOAA = ["B_W_Soldier_TL_F","B_W_Soldier_AA_F","B_W_Soldier_AA_F","B_W_Soldier_AAA_F"];
 groupsNATOAT = ["B_W_Soldier_TL_F","B_W_Soldier_AT_F","B_W_Soldier_AT_F","B_W_Soldier_AAT_F"];
@@ -85,8 +85,8 @@ NATOSpecOp = ["B_CTRG_Soldier_TL_tna_F","B_CTRG_Soldier_M_tna_F",NATOBodyG,"B_CT
 groupsNATOSquad =
 	[
 	NATOSquad,
-	["B_W_Soldier_SL_F",NATOGrunt,"B_W_Soldier_TL_F","B_W_Soldier_AR_F","B_W_Soldier_A_F","B_W_Support_Mort_F","B_W_Support_AMort_F","B_W_Medic_F"],
-	["B_W_Soldier_SL_F",NATOGrunt,"B_W_Soldier_TL_F","B_W_Soldier_AR_F","B_W_Soldier_A_F","B_W_Support_MG_F","B_W_Support_AMG_F","B_W_Medic_F"],
+	["B_W_Soldier_SL_F",NATOGrunt,"B_W_Soldier_TL_F","B_W_Soldier_AR_F","B_W_Soldier_A_F","B_W_Soldier_LAT2_F","B_W_Soldier_LAT2_F","B_W_Medic_F"],
+	["B_W_Soldier_SL_F",NATOGrunt,"B_W_Soldier_TL_F","B_W_Soldier_AR_F","B_W_Soldier_A_F","B_W_Soldier_LAT_F","B_W_Soldier_LAT_F","B_W_Medic_F"],
 	["B_W_Soldier_SL_F",NATOGrunt,"B_W_Soldier_TL_F","B_W_Soldier_AR_F","B_W_Soldier_A_F","B_W_Soldier_AA_F","B_W_Soldier_AAA_F","B_W_Medic_F"],
 	["B_W_Soldier_SL_F",NATOGrunt,"B_W_Soldier_TL_F","B_W_Soldier_AR_F","B_W_Soldier_A_F","B_W_Soldier_AT_F","B_W_Soldier_AAT_F","B_W_Medic_F"],
 	["B_W_Soldier_SL_F",NATOGrunt,"B_W_Soldier_TL_F","B_W_Soldier_AR_F","B_W_Soldier_A_F","B_W_Engineer_F","B_W_Engineer_F","B_W_Medic_F"]


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information: 
**Nato Tropical, CSAT Tropical and AAF Template**
Removed Lowtier Factions and replaced Units with Regular Units from that Faction -----> Synd with AAF, Fia with CSAT, FIA with Nato.

**All Vanilla Templates**
Removed Mortar and MG Carriers from 8 Man Groups and Replaced these with LAT Squads as #1364 requested. (Basicly the only stuff i need to be Reviewed by John)
-------> Added 2 LAT2 (Maaws) and 2 LAT (PCML) to Combined Arrays, CSAT got 4 times LAT (RPG32) in 8 man arrays to replace Mortar and MG Carriers.

**Nato Tropical**
Brought 8 Man Squads of Tanoa Nato up to the State of Nato_Altis.

**Nato Altis**
Changed Nato Bodyguard to a Medic, he has the same Equipment exept he doesent get the Forbidden Backpack and his weapon has no Grenade Launcher.

**Nato Temp**
Changed the Traitor of Nato_Temp due to him being Unarmed and it increasing Aggresion.

**Enoch,Tropcal CSAT, Nato Tropical Template**
Removed and Added Light Armed/Unarmed Vehicles due to DLC dependencies and added if they would be allowed/Fitting.
(Most were Apex DLC)

**CSAT_Enoch Template**
**Added Contact DLC Speznas to CSAT Enoch.**
    
**AAF Template**
Changed AAF Flag and FlagTexture to their Factions actual Flag.

Removed AAF Warriror from Combined Arrays due to it being able to spawn at any Progress at Airbases.

### Please specify which Issue this PR Resolves.
closes #1416 
closes #1417 
closes #1418 
closes #1419 
hopefully:
closes #1364 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in singleplayer?
2. [ ] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

#1416 Kill the Traitor on Vanilla in any Woodland Map, before change Aggresion Jumped on Step upon killing, now it shouldnt jump.

#1417 Tropical Templates play on Tanoa, Lowtier Factions should not be Guerilia Units anymore.
For AAF, Altis Bluefor there should be no Syndicate Units anymore.

#1418 Might be Tricky due to Vehicle Markers being Limited in their Vehicle count, Spawn in a Airbase of the AAF Factions, before change there was the chance of the Warrior IFV (FV-720 Mora) at any Progress/Warlevel.

#1419 Nato Altis Template, When spawning a Kill the Tratior Mission, his Bodyguard were a Unit that came with the Combat Patrol Respawn Camp backpack, he is swapped for a Medic, there is no real testing needed, his equipment isnt that different than Before.
********************************************************
Notes:
This PR is set to be Merged into Bugfix branch.