### PR TITLE
removed the param for gamemode "Reb vs Inv"

### DIFF
--- a/A3-Antistasi/MissionDescription/params.hpp
+++ b/A3-Antistasi/MissionDescription/params.hpp
@@ -10,8 +10,8 @@ class Params
      class gameMode
      {
           title = "Game Mode - Do NOT change this mid mission";
-          values[] = {1,2,3,4};
-          texts[] = {"Reb vs Gov vs Inv","Reb vs Gov & Inv","Reb vs Gov","Reb vs Inv"};
+          values[] = {1,2,3};
+          texts[] = {"Reb vs Gov vs Inv","Reb vs Gov & Inv","Reb vs Gov"};
           default = 1;
      };
      class autoSave


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    to prevent the the borken reb vs inv gamemode form being played

### Please specify which Issue this PR Resolves.
closes #1352

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [ ] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
check the parameters on start
********************************************************
Notes: custom params in say server cfg would still be able to overwrite this, possibly a hard block would be needed
