### PR TITLE
Prevent equipping zero-count items from the arsenal

### DIFF
--- a/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal.sqf
@@ -1581,6 +1581,15 @@ switch _mode do {
 		private _ctrlListSecondaryWeapon = _display displayctrl (IDC_RSCDISPLAYARSENAL_LIST + IDC_RSCDISPLAYARSENAL_TAB_SECONDARYWEAPON);
 		private _ctrlListHandgun = _display displayctrl (IDC_RSCDISPLAYARSENAL_LIST + IDC_RSCDISPLAYARSENAL_TAB_HANDGUN);
 
+		// Prevent equipping item when there aren't any left
+		if (_amount == 0) exitWith{
+			if(missionnamespace getvariable ["jna_reselect_item",true])then{//prefent loop when unavalable item was worn and a other unavalable item was selected
+				missionnamespace setvariable ["jna_reselect_item",false];
+				["ListSelectCurrent",[_display,_index]] call jn_fnc_arsenal;
+				missionnamespace setvariable ["jna_reselect_item",true];
+			};
+		};
+
 		//check if weapon is unlocked
 		private _min = jna_minItemMember select _index;
 		if ((_amount <= _min) AND (_amount != -1) AND (_item !="") AND !([player] call A3A_fnc_isMember) AND !_type) exitWith{


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The arsenal allowed items to be equipped when their count was zero, which could be exploited in some cases (ACE/RHS item translation, stealing items from players in the arsenal, two players taking the same items). This patch prevents that.

### Please specify which Issue this PR Resolves.
closes #1421

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Run with ACE. Put some BIS NLAWs in the arsenal. Click on them in the arsenal, and watch what happens.
