### PR TITLE
Slingloadable supplies & working non-member countdown

### DIFF
--- a/A3-Antistasi/functions/Missions/fn_LOG_Supplies.sqf
+++ b/A3-Antistasi/functions/Missions/fn_LOG_Supplies.sqf
@@ -119,7 +119,7 @@ else
 
 _ecpos = getpos _truckX;
 deleteVehicle _truckX;
-_emptybox = "Land_FoodSacks_01_cargo_brown_F" createVehicle _ecpos;
+_emptybox = "Land_Pallet_F" createVehicle _ecpos;
 [_emptybox] spawn A3A_fnc_postmortem;
 
 //sleep (600 + random 1200);

--- a/A3-Antistasi/functions/Missions/fn_LOG_Supplies.sqf
+++ b/A3-Antistasi/functions/Missions/fn_LOG_Supplies.sqf
@@ -49,7 +49,7 @@ _truckX setVariable ["destinationX",_nameDest,true];
 
 [_truckX,"Supply Box"] spawn A3A_fnc_inmuneConvoy;
 
-waitUntil {sleep 1; (dateToNumber date > _dateLimitNum) or ((_truckX distance _positionX < 40) and (isNull attachedTo _truckX)) or (isNull _truckX)};
+waitUntil {sleep 1; (dateToNumber date > _dateLimitNum) or ((_truckX distance _positionX < 40) and (isNull attachedTo _truckX) and (isNull ropeAttachedTo _truckX)) or (isNull _truckX)};
 _bonus = if (_difficultX) then {2} else {1};
 if ((dateToNumber date > _dateLimitNum) or (isNull _truckX)) then
 	{
@@ -119,7 +119,7 @@ else
 
 _ecpos = getpos _truckX;
 deleteVehicle _truckX;
-_emptybox = "Land_PaperBox_01_open_empty_F" createVehicle _ecpos;
+_emptybox = "Land_FoodSacks_01_cargo_brown_F" createVehicle _ecpos;
 [_emptybox] spawn A3A_fnc_postmortem;
 
 //sleep (600 + random 1200);

--- a/A3-Antistasi/functions/Missions/fn_LOG_Supplies.sqf
+++ b/A3-Antistasi/functions/Missions/fn_LOG_Supplies.sqf
@@ -27,7 +27,8 @@ missionsX pushBack ["LOG","CREATED"]; publicVariable "missionsX";
 _pos = (getMarkerPos respawnTeamPlayer) findEmptyPosition [1,50,"C_Van_01_box_F"];
 
 //Creating the box
-_truckX = "Land_PaperBox_01_open_boxes_F" createVehicle _pos;
+_truckX = "Land_FoodSacks_01_cargo_brown_F" createVehicle _pos;
+_truckX enableRopeAttach true;
 _truckX allowDamage false;
 _truckX call jn_fnc_logistics_addAction;
 _truckX addAction ["Delivery infos",
@@ -125,4 +126,3 @@ _emptybox = "Land_PaperBox_01_open_empty_F" createVehicle _ecpos;
 
 //_nul = [_tsk,true] call BIS_fnc_deleteTask;
 _nul = [1200,"LOG"] spawn A3A_fnc_deleteTask;
-

--- a/A3-Antistasi/orgPlayers/nonMemberDistance.sqf
+++ b/A3-Antistasi/orgPlayers/nonMemberDistance.sqf
@@ -29,7 +29,7 @@ while {!([player] call A3A_fnc_isMember)} do
 		};
 	if (_countX != INITIAL_COUNT_TIME) then
 		{
-		["Member Distance", format ["You have to get closer to the HQ or the closest server member in seconds. <br/><br/> After this timeout you will be teleported to your HQ", _countX]] call A3A_fnc_customHint;
+		["Member Distance", format ["You have to get closer to the HQ or the closest server member in %1 seconds. <br/><br/> After this timeout you will be teleported to your HQ", _countX]] call A3A_fnc_customHint;
 		sleep 1;
 		if (_countX == 0) then
 			{

--- a/A3-Antistasi/orgPlayers/nonMemberDistance.sqf
+++ b/A3-Antistasi/orgPlayers/nonMemberDistance.sqf
@@ -29,12 +29,12 @@ while {!([player] call A3A_fnc_isMember)} do
 		};
 	if (_countX != INITIAL_COUNT_TIME) then
 		{
-		["Member Distance", "You have to get closer to the HQ or the closest server member in %1 seconds. <br/><br/> After this timeout you will be teleported to your HQ"] call A3A_fnc_customHint;
+		["Member Distance", "You have to get closer to the HQ or the closest server member in %1 seconds. <br/><br/> After this timeout you will be teleported to your HQ", _countX] call A3A_fnc_customHint;
 		sleep 1;
-		if (_countX == 0) then 
+		if (_countX == 0) then
 			{
 			private _possibleVehicle = vehicle player;
-			if (_possibleVehicle != player && (driver _possibleVehicle) == player) then 
+			if (_possibleVehicle != player && (driver _possibleVehicle) == player) then
 				{
 				[_possibleVehicle] call A3A_fnc_teleportVehicleToBase;
 				};

--- a/A3-Antistasi/orgPlayers/nonMemberDistance.sqf
+++ b/A3-Antistasi/orgPlayers/nonMemberDistance.sqf
@@ -29,7 +29,7 @@ while {!([player] call A3A_fnc_isMember)} do
 		};
 	if (_countX != INITIAL_COUNT_TIME) then
 		{
-		["Member Distance", "You have to get closer to the HQ or the closest server member in %1 seconds. <br/><br/> After this timeout you will be teleported to your HQ"] call A3A_fnc_customHint;
+		["Member Distance", format ["You have to get closer to the HQ or the closest server member in seconds. <br/><br/> After this timeout you will be teleported to your HQ", _countX]] call A3A_fnc_customHint;
 		sleep 1;
 		if (_countX == 0) then
 			{

--- a/A3-Antistasi/orgPlayers/nonMemberDistance.sqf
+++ b/A3-Antistasi/orgPlayers/nonMemberDistance.sqf
@@ -29,7 +29,7 @@ while {!([player] call A3A_fnc_isMember)} do
 		};
 	if (_countX != INITIAL_COUNT_TIME) then
 		{
-		["Member Distance", "You have to get closer to the HQ or the closest server member in %1 seconds. <br/><br/> After this timeout you will be teleported to your HQ", _countX] call A3A_fnc_customHint;
+		["Member Distance", "You have to get closer to the HQ or the closest server member in %1 seconds. <br/><br/> After this timeout you will be teleported to your HQ"] call A3A_fnc_customHint;
 		sleep 1;
 		if (_countX == 0) then
 			{


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
**City supplies**
Made the crate slingloadable, plus needed to not be slingloaded to start countdown. Changed the supplies to be more fitting than a crate with IDAP boxes.
**Non-members fleeing, basically.**
Fixed the countdown number, so it actually updates instead of just saying "%1".

### Please specify which Issue this PR Resolves.
closes #1391 
closes #1422 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [x] Have you loaded the mission in LAN host?
3. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
#1391 : Get yourself a city supplies mission, spawn in a heli and slingload it to the city.
#1422 : Get a server running, get someone on who doesn't have membership, and throw them off into the abyss. 
********************************************************
Notes: Thank you to very specific norwegian. And happy now @Bob-Murphy?
