### PR TITLE
Classify ace gadgets and add them to loot crates

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_categoryOverrides.sqf
@@ -101,6 +101,10 @@ private _categoryOverrideTable = [
 ["ace_dragon_super", ["MissileLaunchers","Weapons","AT"]],
 ["ace_dragon_sight", ["Binoculars","Items"]],
 
+["ACE_Kestrel4500", ["Gadgets","Items"]],
+["ACE_ATragMX", ["Gadgets","Items"]],
+["ACE_HuntIR_monitor", ["Gadgets","Items"]],
+
 ["LIB_PTRD", ["Unknown", "Weapons"]],
 ["LIB_M2_Flamethrower", ["Unknown", "Weapons"]],			// don't want these two being chosen randomly by AIs
 ["LIB_Bagpipes", ["Unknown","Weapons"]],					// wat

--- a/A3-Antistasi/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_categoryOverrides.sqf
@@ -104,6 +104,8 @@ private _categoryOverrideTable = [
 ["ACE_Kestrel4500", ["Gadgets","Items"]],
 ["ACE_ATragMX", ["Gadgets","Items"]],
 ["ACE_HuntIR_monitor", ["Gadgets","Items"]],
+["ACE_microDAGR", ["Gadgets","Items"]],
+["ACE_DAGR", ["Gadgets","Items"]],
 
 ["LIB_PTRD", ["Unknown", "Weapons"]],
 ["LIB_M2_Flamethrower", ["Unknown", "Weapons"]],			// don't want these two being chosen randomly by AIs

--- a/A3-Antistasi/functions/Ammunition/fn_loot.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_loot.sqf
@@ -11,7 +11,7 @@ lootNVG append allNVGs;
 /////////////////////
 // Assigned Items ///
 /////////////////////
-lootItem append allUAVTerminals + allMineDetectors + allGPS + allRadios + allLaserDesignators + allBinoculars + allLaserBatteries + lootNVG;
+lootItem append allUAVTerminals + allMineDetectors + allGPS + allRadios + allLaserDesignators + allBinoculars + allLaserBatteries + lootNVG + allGadgets;
 
 ////////////////////
 //    Weapons    ///

--- a/A3-Antistasi/functions/Templates/fn_aceModCompat.sqf
+++ b/A3-Antistasi/functions/Templates/fn_aceModCompat.sqf
@@ -61,7 +61,7 @@ if (hasACEMedical) then {
 	initialRebelEquipment append aceMedItems;
 };
 
-lootItem append ["ACE_acc_pointer_green_IR","ACE_Chemlight_Shield","ACE_VMH3","ACE_VMM3","ACE_HuntIR_monitor"];
+lootItem append ["ACE_acc_pointer_green_IR","ACE_Chemlight_Shield","ACE_VMH3","ACE_VMM3"];
 
 lootMagazine deleteAt (lootMagazine find "ACE_PreloadedMissileDummy");
 allLightAttachments deleteAt (allLightAttachments find "ACE_acc_pointer_green");

--- a/A3-Antistasi/functions/init/fn_initVarCommon.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarCommon.sqf
@@ -49,7 +49,7 @@ colorInvaders = "colorOPFOR";
 [2,"Declaring item categories",_fileName] call A3A_fnc_log;
 
 weaponCategories = ["Rifles", "Handguns", "MachineGuns", "MissileLaunchers", "Mortars", "RocketLaunchers", "Shotguns", "SMGs", "SniperRifles"];
-itemCategories = ["Bipods", "MuzzleAttachments", "PointerAttachments", "Optics", "Binoculars", "Compasses", "FirstAidKits", "GPS", "LaserDesignators",
+itemCategories = ["Gadgets", "Bipods", "MuzzleAttachments", "PointerAttachments", "Optics", "Binoculars", "Compasses", "FirstAidKits", "GPS", "LaserDesignators",
 	"Maps", "Medikits", "MineDetectors", "NVGs", "Radios", "Toolkits", "UAVTerminals", "Watches", "Glasses", "Headgear", "Vests", "Uniforms", "Backpacks"];
 
 magazineCategories = ["MagArtillery", "MagBullet", "MagFlare", "Grenades", "MagLaser", "MagMissile", "MagRocket", "MagShell", "MagShotgun", "MagSmokeShell"];


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Created a category for ACE electronic gadgets (none of the previous categories fitted) and added the Kestrel, AtragMX and HuntIR to it. The HuntIR was already force-added to lootItem in the ACE compat template, so that was removed to avoid double entries.

### Please specify which Issue this PR Resolves.
closes #1392 

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

May want to increase the number of different items dropped in crates for a better chance of finding this stuff. There are around 40 different classes in lootItem in ACE/RHS, and a maximum of four different items by default.

### How can the changes be tested?
Check what's in the following vars:
```
allGadgets
unlockedGadgets
allItems
unlockedItems
lootItem
```
