### PR TITLE
CS-Collections: NestedObject: Wrapping for createNamespace

### DIFF
--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -170,6 +170,13 @@ class A3A
 		class vehicleMarkers {};
 	};
 
+	class Collections
+	{
+        class getNestedObject {};
+        class remNestedObject {};
+        class setNestedObject {};
+	};
+
 	class Convoy
 	{
         class cleanConvoyMarker {};

--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -172,9 +172,9 @@ class A3A
 
 	class Collections
 	{
-        class getNestedObject {};
-        class remNestedObject {};
-        class setNestedObject {};
+		class getNestedObject {};
+		class remNestedObject {};
+		class setNestedObject {};
 	};
 
 	class Convoy

--- a/A3-Antistasi/functions/Collections/doc_benchmarksGetSetRem.sqf
+++ b/A3-Antistasi/functions/Collections/doc_benchmarksGetSetRem.sqf
@@ -1,0 +1,98 @@
+
+private _totalTime = 0;
+private _startTime;
+for "_bucket" from 1 to 10 do {
+	_startTime = diag_tickTime;
+	[str _bucket,[]] call A3A_fnc_punishment_dataRem;
+	_totalTime = _totalTime + diag_tickTime - _startTime;
+};
+[str (1000*_totalTime),"ms"] joinString "";  // 1.95313ms  O(n)
+
+
+private _totalTime = 0;
+private _startTime;
+private _keyPairs = [];
+for "_bucket" from 1 to 10 do {
+	for "_i" from 1 to 1000 do {
+		_keyPairs pushBack [str _i,str _i];
+	};
+	_startTime = diag_tickTime;
+	[str _bucket,_keyPairs] call A3A_fnc_punishment_dataSet;
+	_totalTime = _totalTime + diag_tickTime - _startTime;
+};
+[str (1000*_totalTime),"ms"] joinString "";  // 1x1000: 722.168ms; 10x1: 1.95313ms; 10x10: 10.7422ms; 10x100: 432.617ms; 10x1000: 40690.4ms; O(n^2)  O((n-1)^(n-1))  // AKA, train smash
+
+
+private _totalTime = 0;
+private _startTime;
+private _keyPairs = [];
+for "_bucket" from 1 to 10 do {
+	for "_i" from 1 to 1000 do {
+		_keyPairs pushBack [str _i,str _i];
+	};
+	_startTime = diag_tickTime;
+	[str _bucket,_keyPairs] call A3A_fnc_punishment_dataGet;
+	_totalTime = _totalTime + diag_tickTime - _startTime;
+};
+[str (1000*_totalTime),"ms"] joinString "";  // 1x1000: 698.73ms; 10x1: 0.976563ms; 10x10: 9.27734ms; 10x100: 423.828ms; 10x1000: 38228.5ms  O((n-1)^(n-1))  // AKA, train smash
+
+
+private _totalTime = 0;
+private _startTime;
+private _out = [];
+private _bucket;
+private _keyPairs;
+for "_i" from 1 to 1000*100 do {
+	_bucket = floor(random 10) + 1;
+	_keyPairs = [[str (floor(random 1000) + 1),"0"]];
+	_startTime = diag_tickTime;
+	_out pushBack ([str _bucket, _var] call A3A_fnc_punishment_dataGet);
+	_totalTime = _totalTime + diag_tickTime - _startTime;
+};
+[str (1000*_totalTime),"ms"] joinString "";  // 1_000: 48.3398ms; 1_0000: 591.797ms; 100_000: 5410.64ms  O(n)
+
+
+
+// Everything from this point on is less than O(n)
+
+private _startTime = diag_tickTime;
+for "_bucket" from 1 to 1000 do {
+	[missionNamespace getVariable [str _bucket,locationNull]] call A3A_fnc_remNestedObject;
+};
+[str (1000*(diag_tickTime - _startTime)),"ms"] joinString "";  // 100x1000: 562.988ms; 1000x1000: 5624.02ms;
+
+
+private _startTime = diag_tickTime;
+for "_bucket" from 1 to 1000 do {
+	private _varspace = [missionNamespace, str _bucket, "0", "0"] call A3A_fnc_setNestedObject;
+	for "_i" from 1 to 1000 do {
+		_varspace setVariable [str _i,str _i];
+	};
+};
+[str (1000*(diag_tickTime - _startTime)),"ms"] joinString "";  // 100x1000: 302.734ms; 1000x1000: 2861.33ms;
+
+
+private _startTime = diag_tickTime;
+private _out = [];
+for "_bucket" from 1 to 1000 do {
+	private _varspace = missionNamespace getVariable [str _bucket,locationNull];
+	for "_i" from 1 to 1000 do {
+		_out pushBack (_varspace getVariable [str _i,str _i]);
+	};
+};
+[str (1000*(diag_tickTime - _startTime)),"ms"] joinString "";  // 100x1000: 314.941ms; 1000x1000: 3106.93ms;
+
+
+private _totalTime = 0;
+private _startTime;
+private _out = [];
+private _bucket;
+private _var;
+for "_i" from 1 to 1000*1000 do {
+	_bucket = floor(random 1000) + 1;
+	_var = floor(random 1000) + 1;
+	_startTime = diag_tickTime;
+	_out pushBack ([missionNamespace, str _bucket, str _var, "0"] call A3A_fnc_getNestedObject);
+	_totalTime = _totalTime + diag_tickTime - _startTime;
+};
+[str (1000*_totalTime),"ms"] joinString "";  // 100_000: 1857.91ms; 1_000_000: 17996.6ms;

--- a/A3-Antistasi/functions/Collections/fn_getNestedObject.sqf
+++ b/A3-Antistasi/functions/Collections/fn_getNestedObject.sqf
@@ -1,29 +1,24 @@
 /*
-Function:
-    A3A_fnc_getNestedObject
-
-Description:
+Author: Caleb Serafin
     Exactly the same as nesting getVariables.
     Allows something similar in effect to a dynamic config.
     missionNamespace > "A3A_UIDPlayers" > "1234567890123456" > "equipment" > "weapon".
 
-Scope:
-    <LOCAL> Interacts with many objects. Should not be networked.
-
-Environment:
-    <UNSCHEDULED> Recommended as it queries global data. | <SCHEDULED> Not recommended.
-
-Parameters:
+Arguments:
     <VARSPACE/OBJECT> Parent variable space
     <STRING> Names of nested objects {0 ≤ repeat this param < ∞}
     ...
     <STRING> Name of variable.
     <ANY> Default value.
 
-Returns:
+Return Value:
     <ANY> Queried value or default;
 
-Examples:
+Scope: Local, Interacts with many objects. Should not be networked.
+Environment: Unscheduled, Recommended as it queries possibly changing data. | Scheduled will work, but may cause race conditions.
+Public: Yes
+
+Example:
     _lootNo = [player, "lootBoxesOpened", 0] call A3A_fnc_getNestedObject;
         // is equal to _lootNo = player getVariable ["lootBoxesOpened", 0, false];
 
@@ -33,9 +28,6 @@ Examples:
         // _2 = _1 getVariable ["1234567890123456", *];
         // _3 = _2 getVariable ["equipment", *];
         // _lootNo = _3 getVariable ["weapon", "hgun_Pistol_heavy_01_F"];
-
-Author: Caleb Serafin
-License: MIT License, Copyright (c) 2019 Barbolani & The Official AntiStasi Community
 */
 private _count = count _this;
 private _varSpace = _this#0;

--- a/A3-Antistasi/functions/Collections/fn_getNestedObject.sqf
+++ b/A3-Antistasi/functions/Collections/fn_getNestedObject.sqf
@@ -42,7 +42,7 @@ private _varSpace = _this#0;
 for "_i" from 1 to _count - 3 do {
     _varSpace = _varSpace getVariable [_this#_i, false];
     if (!(_varSpace isEqualType locationNull) || {isNull _varSpace}) exitWith {
-        _varSpace = _this#0;
+        _varSpace = locationNull;
     };
 };
 _varSpace getVariable [_this#(_count-2), _this#(_count-1)];

--- a/A3-Antistasi/functions/Collections/fn_getNestedObject.sqf
+++ b/A3-Antistasi/functions/Collections/fn_getNestedObject.sqf
@@ -37,13 +37,12 @@ Examples:
 Author: Caleb Serafin
 License: MIT License, Copyright (c) 2019 Barbolani & The Official AntiStasi Community
 */
-// filename: "Collections\fn_getNestedObject.sqf"
-
-private _last = count _this -1; // -1 is the last item in the list.
-private _value = _this#0 getVariable [_this#1, _this#_last];
-if (_last isEqualTo 2) exitWith {_value;}; // Final key-value is expected, return value or default.
-if (_value isEqualType locationNull && {!isNull _value}) then {
-        ([_value] + (_this select [2,_last-1])) call A3A_fnc_getNestedObject; // Exclude current varspace, Exclude string name of new varspace, Include everything after that.
-} else {
-    _this#_last; // If no further recursion, return default.
+private _count = count _this;
+private _varSpace = _this#0;
+for "_i" from 1 to _count - 3 do {
+    _varSpace = _varSpace getVariable [_this#_i, false];
+    if (!(_varSpace isEqualType locationNull) || {isNull _varSpace}) exitWith {
+        _this#(_count-1);
+    };
 };
+_varSpace getVariable [_this#(_count-2), _this#(_count-1)];

--- a/A3-Antistasi/functions/Collections/fn_getNestedObject.sqf
+++ b/A3-Antistasi/functions/Collections/fn_getNestedObject.sqf
@@ -1,0 +1,50 @@
+/*
+Function:
+    A3A_fnc_getNestedObject
+
+Description:
+    Exactly the same as nesting getVariables.
+    Allows something similar in effect to a dynamic config.
+    missionNamespace > "A3A_UIDPlayers" > "1234567890123456" > "equipment" > "weapon".
+    DO NOT QUERY SELF REFERENCING OBJECTS.
+
+Scope:
+    <LOCAL> Interacts with many objects. Should not be networked.
+
+Environment:
+    <UNSCHEDULED> Recommended as it queries global data. | <SCHEDULED> Not recommended.
+
+Parameters:
+    <VARSPACE/OBJECT> Parent variable space
+    <STRING> Names of nested objects {0 ≤ repeat this param < ∞}
+    ...
+    <STRING> Name of variable.
+    <ANY> Default value.
+
+Returns:
+    <ANY> Queried value or default;
+
+Examples:
+    _lootNo = [player, "lootBoxesOpened", 0] call A3A_fnc_setNestedObject;
+        // is equal to _lootNo = player getVariable ["lootBoxesOpened", 0, false];
+
+    _gun = [missionNamespace, "A3A_UIDPlayers", "1234567890123456", "equipment", "weapon", "hgun_Pistol_heavy_01_F"] call A3A_fnc_getNestedObject;
+        // Is almost Equal to:    (* returns default if any namespaces is not defined)
+        // _1 = missionNamespace getVariable ["A3A_UIDPlayers", *];
+        // _2 = _1 getVariable ["1234567890123456", *];
+        // _3 = _2 getVariable ["equipment", *];
+        // _lootNo = _3 getVariable ["weapon", "hgun_Pistol_heavy_01_F"];
+
+Author: Caleb Serafin
+License: MIT License, Copyright (c) 2019 Barbolani & The Official AntiStasi Community
+*/
+// filename: "Collections\fn_getNestedObject.sqf"
+
+private _last = count _this -1; // -1 Saves a possible calculation.
+private _value = _this#0 getVariable [_this#1, _this#_last];
+if (_last isEqualTo 2) exitWith {_value;}; // Last key expected, return value or default.
+if (_value isEqualType locationNull && {!isNull _value}) then {
+        ([_value] + (_this select [2,_last-1])) call A3A_fnc_getNestedObject;
+} else {
+    _this#_last; // If no further recursion, return default.
+};

--- a/A3-Antistasi/functions/Collections/fn_getNestedObject.sqf
+++ b/A3-Antistasi/functions/Collections/fn_getNestedObject.sqf
@@ -6,7 +6,6 @@ Description:
     Exactly the same as nesting getVariables.
     Allows something similar in effect to a dynamic config.
     missionNamespace > "A3A_UIDPlayers" > "1234567890123456" > "equipment" > "weapon".
-    DO NOT QUERY SELF REFERENCING OBJECTS.
 
 Scope:
     <LOCAL> Interacts with many objects. Should not be networked.
@@ -40,11 +39,11 @@ License: MIT License, Copyright (c) 2019 Barbolani & The Official AntiStasi Comm
 */
 // filename: "Collections\fn_getNestedObject.sqf"
 
-private _last = count _this -1; // -1 Saves a possible calculation.
+private _last = count _this -1; // -1 is the last item in the list.
 private _value = _this#0 getVariable [_this#1, _this#_last];
-if (_last isEqualTo 2) exitWith {_value;}; // Last key expected, return value or default.
+if (_last isEqualTo 2) exitWith {_value;}; // Final key-value is expected, return value or default.
 if (_value isEqualType locationNull && {!isNull _value}) then {
-        ([_value] + (_this select [2,_last-1])) call A3A_fnc_getNestedObject;
+        ([_value] + (_this select [2,_last-1])) call A3A_fnc_getNestedObject; // Exclude current varspace, Exclude string name of new varspace, Include everything after that.
 } else {
     _this#_last; // If no further recursion, return default.
 };

--- a/A3-Antistasi/functions/Collections/fn_getNestedObject.sqf
+++ b/A3-Antistasi/functions/Collections/fn_getNestedObject.sqf
@@ -24,7 +24,7 @@ Returns:
     <ANY> Queried value or default;
 
 Examples:
-    _lootNo = [player, "lootBoxesOpened", 0] call A3A_fnc_setNestedObject;
+    _lootNo = [player, "lootBoxesOpened", 0] call A3A_fnc_getNestedObject;
         // is equal to _lootNo = player getVariable ["lootBoxesOpened", 0, false];
 
     _gun = [missionNamespace, "A3A_UIDPlayers", "1234567890123456", "equipment", "weapon", "hgun_Pistol_heavy_01_F"] call A3A_fnc_getNestedObject;

--- a/A3-Antistasi/functions/Collections/fn_getNestedObject.sqf
+++ b/A3-Antistasi/functions/Collections/fn_getNestedObject.sqf
@@ -42,7 +42,7 @@ private _varSpace = _this#0;
 for "_i" from 1 to _count - 3 do {
     _varSpace = _varSpace getVariable [_this#_i, false];
     if (!(_varSpace isEqualType locationNull) || {isNull _varSpace}) exitWith {
-        _this#(_count-1);
+        _varSpace = _this#0;
     };
 };
 _varSpace getVariable [_this#(_count-2), _this#(_count-1)];

--- a/A3-Antistasi/functions/Collections/fn_remNestedObject.sqf
+++ b/A3-Antistasi/functions/Collections/fn_remNestedObject.sqf
@@ -6,6 +6,7 @@ Description:
     Recursively deletes nested child objects.
     Can delete self-referencing trees.
     Trying to do this by hand may cause memory leaks.
+    NB: It will not remove the reference to the parent, it will hold locationNull.
 
 Scope:
     <LOCAL> Interacts with many objects. Should not be networked.
@@ -23,16 +24,17 @@ Returns:
 Examples:
     [[missionNamespace, "A3A_UIDPlayers", "1234567890123456", "equipment", "weapon", "SMG_02_F"] call A3A_fnc_setNestedObject, "helmet", "H_Hat_grey"] call A3A_fnc_setNestedObject;
         // missionNamespace > "A3A_UIDPlayers" > "1234567890123456" > "equipment" > [multiple end values]
-    _parent = [missionNamespace, "A3A_UIDPlayers", locationNull] call A3A_fnc_getNestedObject; // returns a <location> that's referenced by "1234567890123456";
+    _parent = [missionNamespace, "A3A_UIDPlayers", locationNull] call A3A_fnc_getNestedObject; // returns a <location> that's referenced by "A3A_UIDPlayers" in missionNamespace;
     [_parent] call A3A_fnc_remNestedObject;
-        // missionNamespace > "A3A_UIDPlayers" <LocationNull>
+        // missionNamespace > "A3A_UIDPlayers" will have value locationNull.
 
-    // Recursive
-    _parent = [missionNamespace, "A3A_parent", "loop back", locationNull] call A3A_fnc_setNestedObject;
+    // Recursive (NB: There are not many good reasons to have self-referencing trees. However, if you wanted to delete the entire tree by deleting any sub node, this "practice" will achieve that.)
+    _parent = [false] call A3A_fnc_createNamespace;
+    [missionNamespace, "A3A_parent", _parent] call A3A_fnc_setNestedObject;
     [missionNamespace, "A3A_parent", "recursion", _parent] call A3A_fnc_setNestedObject;
         // missionNamespace > "A3A_parent" > "recursion" > "recursion" > "recursion" > "recursion" > "recursion" > "recursion" > "recursion"...
     [_parent] call A3A_fnc_remNestedObject;
-        // missionNamespace > "A3A_parent" <LocationNull>
+        // missionNamespace > "A3A_parent" will have value locationNull
 
 Author: Caleb Serafin
 License: MIT License, Copyright (c) 2019 Barbolani & The Official AntiStasi Community

--- a/A3-Antistasi/functions/Collections/fn_remNestedObject.sqf
+++ b/A3-Antistasi/functions/Collections/fn_remNestedObject.sqf
@@ -1,27 +1,22 @@
 /*
-Function:
-    A3A_fnc_remNestedObject
-
-Description:
+Author: Caleb Serafin
     Recursively deletes nested child objects.
     Can delete self-referencing trees.
     Trying to do this by hand may cause memory leaks.
     NB: It will not remove the reference to the parent, it will hold locationNull.
 
-Scope:
-    <LOCAL> Interacts with many objects. Should not be networked.
-
-Environment:
-    <SCHEDULED> Recurses over entire sub-tree. Could be resource heavy.
-
-Parameters:
+Arguments:
     <VARSPACE/OBJECT> Parent variable space
     <BOOLEAN> Full object purge? Will delete objects as well. [DEFAULT=true]
 
-Returns:
+Return Value:
     <BOOLEAN> true if success; false if access denied; nil if crashed;
 
-Examples:
+Scope: Local, Interacts with many objects. Should not be networked.
+Environment: Scheduled, Recommended as it recurses over entire sub-tree. Could be resource heavy.
+Public: Yes
+
+Example:
     [[missionNamespace, "A3A_UIDPlayers", "1234567890123456", "equipment", "weapon", "SMG_02_F"] call A3A_fnc_setNestedObject, "helmet", "H_Hat_grey"] call A3A_fnc_setNestedObject;
         // missionNamespace > "A3A_UIDPlayers" > "1234567890123456" > "equipment" > [multiple end values]
     _parent = [missionNamespace, "A3A_UIDPlayers", locationNull] call A3A_fnc_getNestedObject; // returns a <location> that's referenced by "A3A_UIDPlayers" in missionNamespace;
@@ -35,9 +30,6 @@ Examples:
         // missionNamespace > "A3A_parent" > "recursion" > "recursion" > "recursion" > "recursion" > "recursion" > "recursion" > "recursion"...
     [_parent] call A3A_fnc_remNestedObject;
         // missionNamespace > "A3A_parent" will have value locationNull
-
-Author: Caleb Serafin
-License: MIT License, Copyright (c) 2019 Barbolani & The Official AntiStasi Community
 */
 params [["_parent",locationNull],["_purge",true]];
 private _filename = "Collections\fn_remNestedObject.sqf";

--- a/A3-Antistasi/functions/Collections/fn_remNestedObject.sqf
+++ b/A3-Antistasi/functions/Collections/fn_remNestedObject.sqf
@@ -40,9 +40,6 @@ License: MIT License, Copyright (c) 2019 Barbolani & The Official AntiStasi Comm
 params [["_parent",locationNull],["_purge",true]];
 private _filename = "Collections\fn_remNestedObject.sqf";
 
-[3, ["_parent: ",_parent] joinString "",_filename] call A3A_fnc_log;
-[3, ["_purge: ",_purge] joinString "",_filename] call A3A_fnc_log;
-
 if (_parent isEqualType missionNamespace || {isNull _parent}) exitWith {false}; // Deleting all Namespace contents will cause great trouble.
 private _childrenNames = allVariables _parent;
 private _childrenLocations = [];

--- a/A3-Antistasi/functions/Collections/fn_remNestedObject.sqf
+++ b/A3-Antistasi/functions/Collections/fn_remNestedObject.sqf
@@ -28,8 +28,8 @@ Examples:
         // missionNamespace > "A3A_UIDPlayers" <LocationNull>
 
     // Recursive
-    _parent = [missionNamespace, "A3A_parent", "loop back", locationNull] call A3A_fnc_setNestedObject
-    [missionNamespace, "A3A_parent", "recursion", _parent] call A3A_fnc_setNestedObject
+    _parent = [missionNamespace, "A3A_parent", "loop back", locationNull] call A3A_fnc_setNestedObject;
+    [missionNamespace, "A3A_parent", "recursion", _parent] call A3A_fnc_setNestedObject;
         // missionNamespace > "A3A_parent" > "recursion" > "recursion" > "recursion" > "recursion" > "recursion" > "recursion" > "recursion"...
     [_parent] call A3A_fnc_remNestedObject;
         // missionNamespace > "A3A_parent" <LocationNull>

--- a/A3-Antistasi/functions/Collections/fn_remNestedObject.sqf
+++ b/A3-Antistasi/functions/Collections/fn_remNestedObject.sqf
@@ -4,60 +4,64 @@ Function:
 
 Description:
     Recursively deletes nested child objects.
-    Doing this by hand may cause memory leaks.
-    DO NOT DELETE SELF REFERENCING OBJECTS.
+    Can delete self-referencing trees.
+    Trying to do this by hand may cause memory leaks.
 
 Scope:
     <LOCAL> Interacts with many objects. Should not be networked.
 
 Environment:
-    <SCHEDULED> Recurses over entire sub-tree.
+    <SCHEDULED> Recurses over entire sub-tree. Could be resource heavy.
 
 Parameters:
     <VARSPACE/OBJECT> Parent variable space
-    <BOOLEAN> Include parent? [DEFAULT=false]
     <BOOLEAN> Full object purge? Will delete objects as well. [DEFAULT=true]
 
 Returns:
     <BOOLEAN> true if success; false if access denied; nil if crashed;
 
 Examples:
-    [player, "lootBoxesOpened", 5] call A3A_fnc_remNestedObject;
-        // is equal to player setVariable ["lootBoxesOpened", 5, false];
+    [[missionNamespace, "A3A_UIDPlayers", "1234567890123456", "equipment", "weapon", "SMG_02_F"] call A3A_fnc_setNestedObject, "helmet", "H_Hat_grey"] call A3A_fnc_setNestedObject;
+        // missionNamespace > "A3A_UIDPlayers" > "1234567890123456" > "equipment" > [multiple end values]
+    _parent = [missionNamespace, "A3A_UIDPlayers", locationNull] call A3A_fnc_getNestedObject; // returns a <location> that's referenced by "1234567890123456";
+    [_parent] call A3A_fnc_remNestedObject;
+        // missionNamespace > "A3A_UIDPlayers" <LocationNull>
 
-    [missionNamespace, "A3A_UIDPlayers", "1234567890123456", "equipment", "weapon", "SMG_02_F"] call A3A_fnc_setNestedObject;
-    [missionNamespace, "A3A_UIDPlayers", "1234567890123456", "equipment", "helmet", "H_Hat_grey"] call A3A_fnc_setNestedObject;
-        // You now have missionNamespace > "A3A_UIDPlayers" > "1234567890123456" > "equipment" > [multiple end values]
-    _varSpace = [missionNamespace, "A3A_UIDPlayers", locationNull] call A3A_fnc_getNestedObject; // returns a <location> that's referenced by "1234567890123456";
-    [_varSpace,false] call A3A_fnc_remNestedObject;
-        // You now have missionNamespace > "A3A_UIDPlayers" > []
-    [_varSpace] call A3A_fnc_remNestedObject;
-        // You now have missionNamespace > "A3A_UIDPlayers <LocationNull>"
+    // Recursive
+    _parent = [missionNamespace, "A3A_parent", "loop back", locationNull] call A3A_fnc_setNestedObject
+    [missionNamespace, "A3A_parent", "recursion", _parent] call A3A_fnc_setNestedObject
+        // missionNamespace > "A3A_parent" > "recursion" > "recursion" > "recursion" > "recursion" > "recursion" > "recursion" > "recursion"...
+    [_parent] call A3A_fnc_remNestedObject;
+        // missionNamespace > "A3A_parent" <LocationNull>
 
 Author: Caleb Serafin
 License: MIT License, Copyright (c) 2019 Barbolani & The Official AntiStasi Community
 */
-params ["_varSpace",["_incParent",true],["_purge",true]];
+params [["_parent",locationNull],["_purge",true]];
 private _filename = "Collections\fn_remNestedObject.sqf";
 
-[3, ["_varSpace: ",_varSpace] joinString "",_filename] call A3A_fnc_log;
-[3, ["_incParent: ",_incParent] joinString "",_filename] call A3A_fnc_log;
+[3, ["_parent: ",_parent] joinString "",_filename] call A3A_fnc_log;
 [3, ["_purge: ",_purge] joinString "",_filename] call A3A_fnc_log;
 
-if !(_varSpace isEqualType locationNull) exitWith {false}; // Deleting all missionNamespace contents will cause great trouble.
-private _children = allVariables _varSpace;
+if (_parent isEqualType missionNamespace || {isNull _parent}) exitWith {false}; // Deleting all Namespace contents will cause great trouble.
+private _childrenNames = allVariables _parent;
+private _childrenLocations = [];
+private _childrenObjects = [];
 private _item = false;
 {
-    _item = _varSpace getVariable [_x, false];
+    _item = _parent getVariable [_x, false];
     if (_item isEqualType locationNull) then {
-        [_item,true,_purge] call A3A_fnc_remNestedObject;
-        _varSpace setVariable [_x,nil];
-    } else {if (_purge && _item isEqualType objNull) then {
-        deleteVehicle _item;
-        _varSpace setVariable [_x,nil];
+        _childrenLocations pushBack _item;
+    } else {if (_purge && {_item isEqualType objNull}) then {
+        _childrenObjects pushBack _item;
     };};
-} forEach _children;
-if (_incParent) then {
-    deleteLocation _varSpace;
-};
+} forEach _childrenNames;
+_childrenNames = nil;  // clear redundant names-list memory before recursing.
+deleteLocation _parent;  // Deleting the parent before recursing prevents infinite loop from self-referencing trees.
+{
+    deleteVehicle _x;
+} forEach _childrenObjects;
+{
+    [_x,_purge] call A3A_fnc_remNestedObject;
+} forEach _childrenLocations;
 true;

--- a/A3-Antistasi/functions/Collections/fn_remNestedObject.sqf
+++ b/A3-Antistasi/functions/Collections/fn_remNestedObject.sqf
@@ -1,0 +1,63 @@
+/*
+Function:
+    A3A_fnc_remNestedObject
+
+Description:
+    Recursively deletes nested child objects.
+    Doing this by hand may cause memory leaks.
+    DO NOT DELETE SELF REFERENCING OBJECTS.
+
+Scope:
+    <LOCAL> Interacts with many objects. Should not be networked.
+
+Environment:
+    <SCHEDULED> Recurses over entire sub-tree.
+
+Parameters:
+    <VARSPACE/OBJECT> Parent variable space
+    <BOOLEAN> Include parent? [DEFAULT=false]
+    <BOOLEAN> Full object purge? Will delete objects as well. [DEFAULT=true]
+
+Returns:
+    <BOOLEAN> true if success; false if access denied; nil if crashed;
+
+Examples:
+    [player, "lootBoxesOpened", 5] call A3A_fnc_remNestedObject;
+        // is equal to player setVariable ["lootBoxesOpened", 5, false];
+
+    [missionNamespace, "A3A_UIDPlayers", "1234567890123456", "equipment", "weapon", "SMG_02_F"] call A3A_fnc_setNestedObject;
+    [missionNamespace, "A3A_UIDPlayers", "1234567890123456", "equipment", "helmet", "H_Hat_grey"] call A3A_fnc_setNestedObject;
+        // You now have missionNamespace > "A3A_UIDPlayers" > "1234567890123456" > "equipment" > [multiple end values]
+    _varSpace = [missionNamespace, "A3A_UIDPlayers", locationNull] call A3A_fnc_getNestedObject; // returns a <location> that's referenced by "1234567890123456";
+    [_varSpace,false] call A3A_fnc_remNestedObject;
+        // You now have missionNamespace > "A3A_UIDPlayers" > []
+    [_varSpace] call A3A_fnc_remNestedObject;
+        // You now have missionNamespace > "A3A_UIDPlayers <LocationNull>"
+
+Author: Caleb Serafin
+License: MIT License, Copyright (c) 2019 Barbolani & The Official AntiStasi Community
+*/
+params ["_varSpace",["_incParent",true],["_purge",true]];
+private _filename = "Collections\fn_remNestedObject.sqf";
+
+[3, ["_varSpace: ",_varSpace] joinString "",_filename] call A3A_fnc_log;
+[3, ["_incParent: ",_incParent] joinString "",_filename] call A3A_fnc_log;
+[3, ["_purge: ",_purge] joinString "",_filename] call A3A_fnc_log;
+
+if !(_varSpace isEqualType locationNull) exitWith {false}; // Deleting all missionNamespace contents will cause great trouble.
+private _children = allVariables _varSpace;
+private _item = false;
+{
+    _item = _varSpace getVariable [_x, false];
+    if (_item isEqualType locationNull) then {
+        [_item,true,_purge] call A3A_fnc_remNestedObject;
+        _varSpace setVariable [_x,nil];
+    } else {if (_purge && _item isEqualType objNull) then {
+        deleteVehicle _item;
+        _varSpace setVariable [_x,nil];
+    };};
+} forEach _children;
+if (_incParent) then {
+    deleteLocation _varSpace;
+};
+true;

--- a/A3-Antistasi/functions/Collections/fn_setNestedObject.sqf
+++ b/A3-Antistasi/functions/Collections/fn_setNestedObject.sqf
@@ -24,6 +24,9 @@ Parameters:
 Returns:
     <LOCATION> last varSpace; locationNull if issue.
 
+Exceptions:
+    ["nameAlreadyInUse",_details] If the desired name of a new nested location already holds another value type other than locationNull.
+
 Examples:
     [player, "lootBoxesOpened", 5] call A3A_fnc_setNestedObject;
         // is equal to player setVariable ["lootBoxesOpened", 5, false];
@@ -43,8 +46,11 @@ private _varSpace = _this#0;
 private _lastVarSpace = _varSpace;
 for "_i" from 1 to _count - 3 do {
     _lastVarSpace = _varSpace;
-    _varSpace = _lastVarSpace getVariable [_this#_i, false];
-    if (!(_varSpace isEqualType locationNull) || {isNull _varSpace}) then {
+    _varSpace = _lastVarSpace getVariable [_this#_i, locationNull];
+    if (!(_varSpace isEqualType locationNull)) exitWith {
+        throw ["nameAlreadyInUse",["Variable '",_this#_i,"' in (",(_this select [0,_i]) joinString " > ",") already has <",typeName _varSpace,"> '",str _varSpace,"'."] joinString ""];
+    };
+    if (isNull _varSpace) then {
         _varSpace = [false] call A3A_fnc_createNamespace;
         _lastVarSpace setVariable [_this#_i,_varSpace];
     };

--- a/A3-Antistasi/functions/Collections/fn_setNestedObject.sqf
+++ b/A3-Antistasi/functions/Collections/fn_setNestedObject.sqf
@@ -1,33 +1,30 @@
 /*
-Function:
-    A3A_fnc_setNestedObject
-
-Description:
+Author: Caleb Serafin
     Exactly the same as nesting getVariables to find final object to set variable on.
     Allows something similar in effect to a dynamic config.
     missionNamespace > "A3A_UIDPlayers" > "1234567890123456" > "equipment" > "weapon".
-    Will create tree as it works towards final value.
+    Will try create tree as it works towards final value. Will throw exception if issue.
 
-Scope:
-    <LOCAL> Interacts with many objects. Should not be networked.
-
-Environment:
-    <UNSCHEDULED> Recommended as it queries global data. | <SCHEDULED> Not recommended.
-
-Parameters:
+Arguments:
     <VARSPACE/OBJECT> Parent variable space
     <STRING> Names of nested locations {0 ≤ repeat this param < ∞}
     ...
     <STRING> Name of variable.
     <ANY> Default value.
 
-Returns:
+Return Value:
     <LOCATION> last varSpace; locationNull if issue.
 
 Exceptions:
     ["nameAlreadyInUse",_details] If the desired name of a new nested location already holds another value type other than locationNull.
 
-Examples:
+Scope: Local, Interacts with many objects. Should not be networked.
+Environment: Unscheduled, Recommended as it queries possibly changing data. | Scheduled will work, but may cause race conditions.
+Public: Yes
+Dependencies:
+    <CODE<LOCATION,BOOLEAN>> A3A_fnc_createNamespace
+
+Example:
     [player, "lootBoxesOpened", 5] call A3A_fnc_setNestedObject;
         // is equal to player setVariable ["lootBoxesOpened", 5, false];
 
@@ -37,9 +34,6 @@ Examples:
         // _2 = _1 getVariable ["1234567890123456", *];
         // _3 = _2 getVariable ["equipment", *];
         // _3 setVariable ["weapon", "SMG_02_F"];
-
-Author: Caleb Serafin
-License: MIT License, Copyright (c) 2019 Barbolani & The Official AntiStasi Community
 */
 private _count = count _this;
 private _varSpace = _this#0;

--- a/A3-Antistasi/functions/Collections/fn_setNestedObject.sqf
+++ b/A3-Antistasi/functions/Collections/fn_setNestedObject.sqf
@@ -7,7 +7,6 @@ Description:
     Allows something similar in effect to a dynamic config.
     missionNamespace > "A3A_UIDPlayers" > "1234567890123456" > "equipment" > "weapon".
     Will create tree as it works towards final value.
-    DO NOT CREATE SELF REFERENCING OBJECTS.
 
 Scope:
     <LOCAL> Interacts with many objects. Should not be networked.
@@ -17,13 +16,13 @@ Environment:
 
 Parameters:
     <VARSPACE/OBJECT> Parent variable space
-    <STRING> Names of nested objects {0 ≤ repeat this param < ∞}
+    <STRING> Names of nested locations {0 ≤ repeat this param < ∞}
     ...
     <STRING> Name of variable.
     <ANY> Default value.
 
 Returns:
-    <BOOLEAN> true if success; false is failure; nil if crashed;
+    <LOCATION> last varSpace; locationNull if issue.
 
 Examples:
     [player, "lootBoxesOpened", 5] call A3A_fnc_setNestedObject;
@@ -43,6 +42,7 @@ private _args = _this;
 private _filename = "Collections\fn_setNestedObject.sqf";
 
 private _count = count _args;
+private _lastVarSpace = _args#0;  // Default expects that this is the last recurse.
 if (_count isEqualTo 3) then {
     _args#0 setVariable [_args#1, _args#2];
 } else {
@@ -51,6 +51,6 @@ if (_count isEqualTo 3) then {
         _varSpace = [false] call A3A_fnc_createNamespace;
         _args#0 setVariable [_args#1,_varSpace];
     };
-    ([_varSpace] + (_args select [2,_count-2])) call A3A_fnc_setNestedObject;
+    _lastVarSpace = ([_varSpace] + (_args select [2,_count-2])) call A3A_fnc_setNestedObject;
 };
-true;
+_lastVarSpace;

--- a/A3-Antistasi/functions/Collections/fn_setNestedObject.sqf
+++ b/A3-Antistasi/functions/Collections/fn_setNestedObject.sqf
@@ -1,0 +1,56 @@
+/*
+Function:
+    A3A_fnc_setNestedObject
+
+Description:
+    Exactly the same as nesting getVariables to find final object to set variable on.
+    Allows something similar in effect to a dynamic config.
+    missionNamespace > "A3A_UIDPlayers" > "1234567890123456" > "equipment" > "weapon".
+    Will create tree as it works towards final value.
+    DO NOT CREATE SELF REFERENCING OBJECTS.
+
+Scope:
+    <LOCAL> Interacts with many objects. Should not be networked.
+
+Environment:
+    <UNSCHEDULED> Recommended as it queries global data. | <SCHEDULED> Not recommended.
+
+Parameters:
+    <VARSPACE/OBJECT> Parent variable space
+    <STRING> Names of nested objects {0 ≤ repeat this param < ∞}
+    ...
+    <STRING> Name of variable.
+    <ANY> Default value.
+
+Returns:
+    <BOOLEAN> true if success; false is failure; nil if crashed;
+
+Examples:
+    [player, "lootBoxesOpened", 5] call A3A_fnc_setNestedObject;
+        // is equal to player setVariable ["lootBoxesOpened", 5, false];
+
+    [missionNamespace, "A3A_UIDPlayers", "1234567890123456", "equipment", "weapon", "SMG_02_F"] call A3A_fnc_setNestedObject;
+        // Is almost Equal to:    (* creates namespaces if not already defined)
+        // _1 = missionNamespace getVariable ["A3A_UIDPlayers", *];
+        // _2 = _1 getVariable ["1234567890123456", *];
+        // _3 = _2 getVariable ["equipment", *];
+        // _3 setVariable ["weapon", "SMG_02_F"];
+
+Author: Caleb Serafin
+License: MIT License, Copyright (c) 2019 Barbolani & The Official AntiStasi Community
+*/
+private _args = _this;
+private _filename = "Collections\fn_setNestedObject.sqf";
+
+private _count = count _args;
+if (_count isEqualTo 3) then {
+    _args#0 setVariable [_args#1, _args#2];
+} else {
+    private _varSpace = _args#0 getVariable [_args#1, false];
+    if (!(_varSpace isEqualType locationNull) || {isNull _varSpace}) then {
+        _varSpace = [false] call A3A_fnc_createNamespace;
+        _args#0 setVariable [_args#1,_varSpace];
+    };
+    ([_varSpace] + (_args select [2,_count-2])) call A3A_fnc_setNestedObject;
+};
+true;

--- a/A3-Antistasi/functions/Collections/fn_setNestedObject.sqf
+++ b/A3-Antistasi/functions/Collections/fn_setNestedObject.sqf
@@ -40,7 +40,7 @@ License: MIT License, Copyright (c) 2019 Barbolani & The Official AntiStasi Comm
 */
 private _count = count _this;
 private _varSpace = _this#0;
-private _lastVarSpace;
+private _lastVarSpace = _varSpace;
 for "_i" from 1 to _count - 3 do {
     _lastVarSpace = _varSpace;
     _varSpace = _lastVarSpace getVariable [_this#_i, false];

--- a/A3-Antistasi/functions/Collections/fn_setNestedObject.sqf
+++ b/A3-Antistasi/functions/Collections/fn_setNestedObject.sqf
@@ -38,19 +38,16 @@ Examples:
 Author: Caleb Serafin
 License: MIT License, Copyright (c) 2019 Barbolani & The Official AntiStasi Community
 */
-private _args = _this;
-private _filename = "Collections\fn_setNestedObject.sqf";
-
-private _count = count _args;
-private _lastVarSpace = _args#0;  // Default expects that this is the last recurse.
-if (_count isEqualTo 3) then {
-    _args#0 setVariable [_args#1, _args#2];
-} else {
-    private _varSpace = _args#0 getVariable [_args#1, false];
+private _count = count _this;
+private _varSpace = _this#0;
+private _lastVarSpace;
+for "_i" from 1 to _count - 3 do {
+    _lastVarSpace = _varSpace;
+    _varSpace = _lastVarSpace getVariable [_this#_i, false];
     if (!(_varSpace isEqualType locationNull) || {isNull _varSpace}) then {
         _varSpace = [false] call A3A_fnc_createNamespace;
-        _args#0 setVariable [_args#1,_varSpace];
+        _lastVarSpace setVariable [_this#_i,_varSpace];
     };
-    _lastVarSpace = ([_varSpace] + (_args select [2,_count-2])) call A3A_fnc_setNestedObject;
 };
-_lastVarSpace;
+_varSpace setVariable [_this#(_count-2), _this#(_count-1)];
+_varSpace;


### PR DESCRIPTION
# What type of PR is this.
* Bug
* Change
* [x] Enhancement

## What have you changed and why?
### Information:
* Ability to create nested data object trees. 
  *(Locations that reference other locations with values) 
  *(Is basically encapsulation of namespaces.)
* Nested Data object trees are speedier to access and update than using arrays.
* Support for self-referencing trees (Shouldn't be a usual use case, but it works with them fine.)

### What does this solve?
* Allow dropping slow punishData functions.
* Can be used to optimise/pre-cache commonly accessed data.

### Future Plans:
* Converting to and from arrays for long-term storage.
* Efficient way to transfer/fetch data across the network.

### Performance comparison:
* Punishment_data get&set ran at O(n^n)
* This runs less than O(n) (Due to hashmap implementation of get&set variable)
* Can create 1_000_000 entries in 2861.33ms;
* See benchmarks file for info.

Closes [#1598](https://github.com/official-antistasi-community/A3-Antistasi/issues/1598)

### Please verify the following and ensure all checks are completed.

* [x] Have you loaded the mission in LAN host?
* [ ] Have you loaded the mission on a dedicated server?

## Is further testing or are further changes required?
* [ ] No
* Yes (Needs independent testing)

## How can the changes be tested?
Use `count (nearestLocations [position player, ["Invisible"], 1000000000000000]);` in watch field to count of locations.

### Standard Use
(Execute in order)
`
[missionNamespace, "A3A_UIDPlayers", "1234567890123456", "equipment", "weapon", "hgun_Pistol_heavy_01_F"] call A3A_fnc_getNestedObject; 
`
└ Should return `hgun_Pistol_heavy_01_F`

`
[missionNamespace, "A3A_UIDPlayers", "1234567890123456", "equipment", "weapon", "SMG_02_F"] call A3A_fnc_setNestedObject; 
`
└ Should return `Location Invisible at -10, -10`; Location count increase by 3.

`
[missionNamespace, "A3A_UIDPlayers", "1234567890123456", "equipment", "helmet", "H_Hat_grey"] call A3A_fnc_setNestedObject; 
`
└ Should return `Location Invisible at -10, -10`; Location count should not increase.

`
[missionNamespace, "A3A_UIDPlayers", "1234567890123456", "equipment", "weapon", "hgun_Pistol_heavy_01_F"] call A3A_fnc_getNestedObject; 
`
└ Should return `SMG_02_F`

```
_parent = [missionNamespace, "A3A_UIDPlayers", locationNull] call A3A_fnc_getNestedObject; 
[_parent] call A3A_fnc_remNestedObject; 
[missionNamespace, "A3A_UIDPlayers", "1234567890123456", "equipment", "weapon", "hgun_Pistol_heavy_01_F"] call A3A_fnc_getNestedObject; 
```
└ Should return `hgun_Pistol_heavy_01_F`; Location count decrases by 3;

### Recursion
(Execute in order)

```
_parent = [missionNamespace, "A3A_parent", "loop back", locationNull] call A3A_fnc_setNestedObject;
[missionNamespace, "A3A_parent", "recursion", _parent] call A3A_fnc_setNestedObject; 
[missionNamespace, "A3A_parent", "recursion", "recursion", "recursion", "recursion", "recursion", "recursion", "recursion", "recursion", "recursion", locationNull] call A3A_fnc_getNestedObject;
```
└ Should return `Location Invisible at -10, -10`;  Location count increases by 1;

```
_parent  = [missionNamespace, "A3A_parent", locationNull] call A3A_fnc_getNestedObject;
[_parent] call A3A_fnc_remNestedObject;
[missionNamespace, "A3A_parent", "recursion", "recursion", "recursion", "recursion", "recursion", "recursion", "recursion", "recursion", "recursion", locationNull] call A3A_fnc_getNestedObject;
```
└ Should return `No location`; Location count decreases by 1;

# Zip of PBO is provided
[Antistasi-TEST-CS-Collections-NestedObject-2-3.Altis.pbo.zip](https://github.com/official-antistasi-community/A3-Antistasi/files/5190467/Antistasi-TEST-CS-Collections-NestedObject-2-3.Altis.pbo.zip)
