### PR TITLE
BUG-FIX 3CB Factions Radio

### DIFF
--- a/A3-Antistasi/Templates/3CB_Reb_TPGM_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_TPGM_Arid.sqf
@@ -109,4 +109,4 @@ initialRebelEquipment append ["rhs_acc_2dpZenit","Binocular","UK3CB_BAF_Flashlig
 allRebelUniforms append ["UK3CB_TKM_B_U_01","UK3CB_TKM_B_U_01_B","UK3CB_TKM_B_U_01_C","UK3CB_TKM_B_U_03","UK3CB_TKM_B_U_03_B","UK3CB_TKM_B_U_03_C","UK3CB_TKM_B_U_04","UK3CB_TKM_B_U_04_B","UK3CB_TKM_B_U_04_C","UK3CB_TKM_B_U_05","UK3CB_TKM_B_U_05_B","UK3CB_TKM_B_U_05_C","UK3CB_TKM_B_U_06","UK3CB_TKM_B_U_06_B","UK3CB_TKM_B_U_06_C"];
 //TFAR Unlocks
 if (hasTFAR) then {initialRebelEquipment append ["tf_microdagr","tf_rf7800str"]};
-if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "UK3CB_B_B_Radio_Backpack"};
+if (hasTFAR && startWithLongRangeRadio) then {initialRebelEquipment pushBack "tf_rt1523g_big_rhs"};


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Removed "UK3CB_B_B_Radio_Backpack" and replaced it with "tf_rt1523g_big_rhs".
The 3CB Faction Radio doesent work with TFAR at the moment and its unknown when its fixed so its removed for the time being.

Additional: There is "UK3CB_B_O_Radio_Backpack" in TKM_Teamleader but its PVP and i dont realy care, not as important.

### Please specify which Issue this PR Resolves.
closes #1448 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [X] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
