### PR TITLE
Get killzones into working condition

### DIFF
--- a/A3-Antistasi/functions/Base/fn_markerChange.sqf
+++ b/A3-Antistasi/functions/Base/fn_markerChange.sqf
@@ -96,6 +96,18 @@ else
 [_markerX, [_looser, _winner]] call A3A_fnc_updateReinfState;
 [3, format ["Garrison set for %1", _markerX], _fileName] call A3A_fnc_log;
 
+if !(_markerX in airportsX) then
+{
+	// clear killzones from nearest friendly airfield to enable reinforcements
+	private _friendlyAirports = airportsX select { _winner == sidesX getVariable [_x, sideUnknown] };
+	if (count _friendlyAirports > 0) then
+	{
+		private _nearAirport = [_friendlyAirports, _markerX] call BIS_fnc_nearestPosition;
+		private _kzlist = killZones getVariable [_nearAirport, []];
+		_kzlist = _kzlist - [_markerX];
+		killZones setVariable [_nearAirport, _kzlist, true];
+	};
+};
 
 _nul = [_markerX] call A3A_fnc_mrkUpdate;
 _sides = _sides - [_winner,_looser];

--- a/A3-Antistasi/functions/CREATE/fn_createQRF.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createQRF.sqf
@@ -424,9 +424,9 @@ else
 	else {waitUntil {sleep 5; (_timeX < time) or (call _fnc_lowStrength)}};
 	if (call _fnc_lowStrength) then
 	{
-		_markersX = resourcesX + factories + airportsX + outposts + seaports select {getMarkerPos _x distance _posDest < distanceSPWN};
+		private _nearMrk = [(resourcesX + factories + airportsX + outposts + seaports),_posDest] call BIS_fnc_nearestPosition;
 		_killZones = killZones getVariable [_source,[]];
-		_killZones append _markersX;
+		_killZones pushBack _nearMrk;
 		killZones setVariable [_source,_killZones,true];
 		[3, format ["QRF from %1 on position %2 defeated", _source, _target], _filename] call A3A_fnc_log;
 	}

--- a/A3-Antistasi/functions/CREATE/fn_reinforcementsAI.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_reinforcementsAI.sqf
@@ -1,3 +1,31 @@
+
+// Remove a random killzone if the aggression-based accumulator hits >1
+
+if (isNil "killZoneRemove") then {killZoneRemove = 0};
+killZoneRemove = killZoneRemove + 0.2 + 0.4 * (aggressionOccupants + aggressionInvaders) / 100;
+
+if (killZoneRemove >= 1) then
+{
+	// convert killzones into [base, target] array
+	private _allKillzones = [];
+	{
+		private _base = _x;
+		private _kzlist = killZones getVariable [_base, []];
+		{ _allKillzones pushBack [_base, _x] } forEach _kzlist;
+	} forEach (outposts + airportsX);
+
+	killZoneRemove = killZoneRemove - 1;
+	if (count _allKillzones == 0) exitWith {};
+
+	// Remove a random killzone entry from the real killzones
+	(selectRandom _allKillzones) params ["_base", "_target"];
+	private _kzlist = killZones getVariable [_base, []];
+	_kzlist deleteAt (_kzlist find _target);
+	killZones setVariable [_base, _kzlist, true];
+};
+
+// Handle the old reinforcements
+
 private ["_airportsX","_reinfPlaces","_airportX","_numberX","_numGarr","_numReal","_sideX","_potentials","_countX","_siteX","_positionX"];
 _airportsX = airportsX select {(sidesX getVariable [_x,sideUnknown] != teamPlayer) and (spawner getVariable _x == 2)};
 if (count _airportsX == 0) exitWith {};

--- a/A3-Antistasi/functions/Garrison/fn_shouldReinforce.sqf
+++ b/A3-Antistasi/functions/Garrison/fn_shouldReinforce.sqf
@@ -20,6 +20,9 @@ if(!_isAirport && {(getMarkerPos _base) distance2D (getMarkerPos _target) > dist
 //To far away for air convoy
 if(_isAirport && {(getMarkerPos _base) distance2D (getMarkerPos _target) > distanceForAirAttack}) exitWith {false};
 
+//Base/target combination is in killzones (other reinforcements or attacks failed recently)
+if (_target in (killZones getVariable [_base, []])) exitWith {false};
+
 _targetIsBase = _target in outposts;
 _reinfMarker = if(_side == Occupants) then {reinforceMarkerOccupants} else {reinforceMarkerInvader};
 


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Intro: Killzones are Antistasi's method of preventing the AI from repeatedly suiciding units into the same position. The implementation had a number of problems but wasn't totally retarded in concept, so I fixed it up.

The changes:
- Reinforcements tick now gradually removes killzones, aggro dependent. Previously killzones were near-permanent, so an outpost could easily get stuck in a state where no reinforcements or QRFs were sent, so you could farm it forever for crates.
- New reinf convoys now obey killzones and generate them. Previous behaviour was to ignore killzones, causing infinite pileups when players camped on a road.
- Position QRFs now only generate killzone on nearest marker. Previous behaviour was to generate killzones for all nearby markers, which was way out of proportion.
- Killzones now removed from nearest airport on location capture. This allows the enemy to reinforce locations after capturing them.

### Please specify which Issue this PR Resolves.
closes #1414 

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
You can get a list of all active killzones (base, target pairs) with this code snippet:
```
	private _allKillzones = [];
	{
		private _base = _x;
		private _kzlist = killZones getVariable [_base, []];
		{ _allKillzones pushBack [_base, _x] } forEach _kzlist;
	} forEach (outposts + airportsX);
	_allKillzones;
```
Destroying reinfPatrols, new reinf convoys, QRFs or attack waves will add killZones (they do have to count as failed though - a reinfPatrol that reaches the target and then dies is a success). Time and enemy captures will remove them. 