### PR TITLE
Jeroen compatibility for supply crate

### DIFF
--- a/A3-Antistasi/JeroenArsenal/JNL/fn_logistics_init.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNL/fn_logistics_init.sqf
@@ -538,7 +538,7 @@ jnl_attachmentOffset = [
 	//medium size crate												//location				//rotation				//type 	//discription
 	["A3\Weapons_F\Ammoboxes\AmmoVeh_F",							[0,0,0.85],				[1,0,0],				1],		//Vehicle ammo create
  	 ["\A3\Supplies_F_Exp\Ammoboxes\Equipment_Box_F.p3d",							[0,0,0.85],				[1,0,0],				1],		//Equipment box
-	["\A3\Props_F_Orange\Humanitarian\Supplies\PaperBox_01_open_boxes_F.p3d", [0,0,0.85],	[1,0,0],				1], 	//Stef test supplybox
+	["\A3\Props_F_Orange\Humanitarian\Supplies\FoodSacks_01_cargonet_F.p3d", [0,0,0.85],	[1,0,0],				1], 	//Stef test supplybox
 	["\A3\Structures_F_Heli\Items\Luggage\PlasticCase_01_medium_F.p3d", [0,0,0.85],			[1,0,0],				1], 	//Stef test Devin crate1
 	["\A3\Weapons_F\Ammoboxes\Proxy_UsBasicAmmoBox.p3d",			[0,0,0.85],				[1,0,0],				1], 	//Stef test Devin crate2
 	["\A3\Weapons_F\Ammoboxes\Proxy_UsBasicExplosives.p3d",			[0,0,0.85],				[1,0,0],				1], 	//Stef test Devin crate3


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
What:
    I forgot to change the model path for the new city supply object in JNL.
Why:
    It doesn't want to be a good pallet and jump into the back of the car if this doesn't get added. Pallet wants treat.

### Please specify which Issue this PR Resolves.
closes #1451 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in singleplayer?
2. [ ] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
    Get a city supply mission and a vehicle that can load crates onto the flatbed of it.
********************************************************