### PR TITLE
Fix arsenal empty-slot selection

### DIFF
--- a/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal.sqf
@@ -1582,7 +1582,7 @@ switch _mode do {
 		private _ctrlListHandgun = _display displayctrl (IDC_RSCDISPLAYARSENAL_LIST + IDC_RSCDISPLAYARSENAL_TAB_HANDGUN);
 
 		// Prevent equipping item when there aren't any left
-		if (_amount == 0) exitWith{
+		if (_amount == 0 and _item != "") exitWith{
 			if(missionnamespace getvariable ["jna_reselect_item",true])then{//prefent loop when unavalable item was worn and a other unavalable item was selected
 				missionnamespace setvariable ["jna_reselect_item",false];
 				["ListSelectCurrent",[_display,_index]] call jn_fnc_arsenal;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Added an exception for the empty item row in the arsenal, because it has count 0 and so the previous patch prevents it from being selected.

### Please specify which Issue this PR Resolves.
closes #1460

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

Well, it's possible I missed something else. I did click on a lot of stuff this time though.

### How can the changes be tested?
Open arsenal, select empty slot, select something else. Check left side items and weapon accessories.
