### PR TITLE
Fix cargo/passenger truck problems

### DIFF
--- a/A3-Antistasi/JeroenArsenal/JNL/Functions/fn_logistics_classHasCargo.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNL/Functions/fn_logistics_classHasCargo.sqf
@@ -1,0 +1,24 @@
+/*
+	Description:
+	Returns true if the vehicle class input has JNL cargo capability
+
+	Parameter(s):
+	STRING vehicle class
+
+	Returns:
+	True if vehicle class has cargo nodes in JNL, false otherwise
+*/
+
+params ["_vehClass"];
+
+_nodes = [];
+private _model = gettext (configfile >> "CfgVehicles" >> _vehClass >> "model");
+{
+	private _model2 = _x select 0;
+	if(_model isEqualTo _model2)exitWith{
+		_nodes = _x select 1;
+	};
+} forEach jnl_vehicleHardpoints;
+
+// return
+-1 != _nodes findIf { _x select 0 == 1 };

--- a/A3-Antistasi/JeroenArsenal/functions.hpp
+++ b/A3-Antistasi/JeroenArsenal/functions.hpp
@@ -66,6 +66,7 @@ class JN {
 		file = "JeroenArsenal\JNL\Functions";
 		class logistics_addOrRemoveObjectMass {};
 		class logistics_canLoad {};
+		class logistics_classHasCargo {};
 		class logistics_getCargo {};
 		class logistics_getCargoOffsetAndDir {};
 		class logistics_getCargoType {};

--- a/A3-Antistasi/Templates/3CB_Inv_Sov_Temp.sqf
+++ b/A3-Antistasi/Templates/3CB_Inv_Sov_Temp.sqf
@@ -147,7 +147,7 @@ vehCSATAir = vehCSATTransportHelis + vehCSATAttackHelis + [vehCSATPlane,vehCSATP
 if (gameMode == 4) then
 	{
 	vehFIAArmedCar = "UK3CB_CW_SOV_O_EARLY_BRDM2";
-	vehFIATruck = "UK3CB_CW_SOV_O_EARLY_Ural_Recovery";
+	vehFIATruck = "UK3CB_CW_SOV_O_EARLY_Ural_Open";
 	vehFIACar = "UK3CB_CW_SOV_O_EARLY_UAZ_Closed";
 	};
 

--- a/A3-Antistasi/Templates/3CB_Occ_BAF_Arctic.sqf
+++ b/A3-Antistasi/Templates/3CB_Occ_BAF_Arctic.sqf
@@ -160,7 +160,7 @@ vehNATOAir = vehNATOTransportHelis + vehNATOAttackHelis + [vehNATOPlane,vehNATOP
 if ((gameMode != 4) and (!hasFFAA)) then
 	{
 	vehFIAArmedCar = "UK3CB_BAF_LandRover_WMIK_GPMG_FFR_Green_B_DPMT";
-	vehFIATruck = "UK3CB_BAF_MAN_HX60_Cargo_Green_A_Arctic";
+	vehFIATruck = "UK3CB_BAF_MAN_HX60_Transport_Green_DPMT";
 	vehFIACar = "UK3CB_BAF_LandRover_Snatch_FFR_Green_A_DPMT";
 	};
 

--- a/A3-Antistasi/Templates/3CB_Occ_BAF_Temp.sqf
+++ b/A3-Antistasi/Templates/3CB_Occ_BAF_Temp.sqf
@@ -160,7 +160,7 @@ vehNATOAir = vehNATOTransportHelis + vehNATOAttackHelis + [vehNATOPlane,vehNATOP
 if (gameMode != 4) then
 	{
 	vehFIAArmedCar = "UK3CB_BAF_LandRover_WMIK_GPMG_FFR_Green_B_DPMT";
-	vehFIATruck = "UK3CB_BAF_MAN_HX60_Cargo_Green_A_DPMT";
+	vehFIATruck = "UK3CB_BAF_MAN_HX60_Transport_Green_DPMT";
 	vehFIACar = "UK3CB_BAF_LandRover_Snatch_FFR_Green_A_DPMT";
 	};
 

--- a/A3-Antistasi/Templates/3CB_Occ_BAF_Trop.sqf
+++ b/A3-Antistasi/Templates/3CB_Occ_BAF_Trop.sqf
@@ -161,7 +161,7 @@ vehNATOAir = vehNATOTransportHelis + vehNATOAttackHelis + [vehNATOPlane,vehNATOP
 if (gameMode != 4) then
 	{
 	vehFIAArmedCar = "UK3CB_BAF_LandRover_WMIK_GPMG_FFR_Green_B_Tropical";
-	vehFIATruck = "UK3CB_BAF_MAN_HX60_Cargo_Green_A_Tropical";
+	vehFIATruck = "UK3CB_BAF_MAN_HX60_Transport_Green_Tropical";
 	vehFIACar = "UK3CB_BAF_LandRover_Snatch_FFR_Green_A_Tropical";
 	};
 

--- a/A3-Antistasi/functions/CREATE/fn_createAIOutposts.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAIOutposts.sqf
@@ -248,7 +248,9 @@ if (_spawnParameter isEqualType []) then
 {
 	_typeVehX = if (_sideX == Occupants) then
 	{
-		if (!_isFIA) then {vehNATOTrucks + vehNATOCargoTrucks} else {[vehFIATruck]};
+		private _types = if (!_isFIA) then {vehNATOTrucks + vehNATOCargoTrucks} else {[vehFIATruck]};
+		_types = _types select { _x in vehCargoTrucks };
+		if (count _types == 0) then { vehNATOCargoTrucks } else { _types };
 	}
 	else
 	{

--- a/A3-Antistasi/functions/CREATE/fn_createAIResources.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAIResources.sqf
@@ -185,7 +185,9 @@ if (_spawnParameter isEqualType []) then
 {
 	_typeVehX = if (_sideX == Occupants) then
 	{
-		if (!_isFIA) then {vehNATOTrucks + vehNATOCargoTrucks} else {[vehFIATruck]};
+		private _types = if (!_isFIA) then {vehNATOTrucks + vehNATOCargoTrucks} else {[vehFIATruck]};
+		_types = _types select { _x in vehCargoTrucks };
+		if (count _types == 0) then { vehNATOCargoTrucks } else { _types };
 	}
 	else
 	{

--- a/A3-Antistasi/functions/init/fn_initServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initServer.sqf
@@ -118,6 +118,8 @@ call
 publicVariable "loadLastSave";
 publicVariable "campaignID";
 
+//JNA, JNL and UPSMON. Shouldn't have any Antistasi dependencies except on parameters.
+call A3A_fnc_initFuncs;
 
 //Initialise variables needed by the mission.
 _nul = call A3A_fnc_initVar;
@@ -125,7 +127,6 @@ _nul = call A3A_fnc_initVar;
 savingServer = true;
 [2,format ["%1 server version: %2", ["SP","MP"] select isMultiplayer, localize "STR_antistasi_credits_generic_version_text"],_fileName] call A3A_fnc_log;
 bookedSlots = floor ((("memberSlots" call BIS_fnc_getParamValue)/100) * (playableSlotsNumber teamPlayer)); publicVariable "bookedSlots";
-call A3A_fnc_initFuncs;
 if (hasACEMedical) then { call A3A_fnc_initACEUnconsciousHandler };
 call A3A_fnc_loadNavGrid;
 call A3A_fnc_initZones;

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -651,6 +651,9 @@ DECLARE_SERVER_VAR(vehUnlimited, _vehUnlimited);
 private _vehFIA = [vehSDKBike,vehSDKLightArmed,SDKMGStatic,vehSDKLightUnarmed,vehSDKTruck,vehSDKBoat,SDKMortar,staticATteamPlayer,staticAAteamPlayer,vehSDKRepair];
 DECLARE_SERVER_VAR(vehFIA, _vehFIA);
 
+private _vehCargoTrucks = (vehTrucks + vehNATOCargoTrucks) select { _x call jn_fnc_logistics_classHasCargo };
+DECLARE_SERVER_VAR(vehCargoTrucks, _vehCargoTrucks);
+
 ///////////////////////////
 //     MOD TEMPLATES    ///
 ///////////////////////////


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
1. vehFIATruck is required to be a passenger-capable truck by the QRF vehicle selection. Cases where it was not a passenger truck have been changed. Note that before 2.3, vehFIATruck was only used for outpost trucks, so this wasn't a bug until 2.3.

2. 3CB BAF MAN transport trucks are not cargo-capable, unlike every other passenger truck used in Antistasi. Outposts, resources and factories ideally have a truck capable of carrying the loot crate, so I added a filter to make sure that they do. This required adding functionality to JNL and precaching in initVarServer (because it's a very slow check), which led to changing the server init order so that JNL inits before initVar. This is actually the same order as initClient. It's probably fine.

### Please specify which Issue this PR Resolves.
closes #1462 

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

It's possible that something breaks with the initFuncs/initVar reversal. I didn't spot anything yet.