### PR TITLE
Commanders purchase all vehicles with faction resources

### DIFF
--- a/A3-Antistasi/functions/Garage/fn_vehPlacementCallbacks.sqf
+++ b/A3-Antistasi/functions/Garage/fn_vehPlacementCallbacks.sqf
@@ -143,7 +143,7 @@ switch (_callbackTarget) do {
 					}
 				else
 					{
-					if (player ==	theBoss && ((_typeVehX == SDKMortar) or (_typeVehX == staticATteamPlayer) or (_typeVehX == staticAAteamPlayer) or (_typeVehX == SDKMGStatic))) then
+					if (player == theBoss) then		// && ((_typeVehX == SDKMortar) or (_typeVehX == staticATteamPlayer) or (_typeVehX == staticAAteamPlayer) or (_typeVehX == SDKMGStatic))) then
 						{
 						_nul = [0,(-1 * vehiclePurchase_cost)] remoteExec ["A3A_fnc_resourcesFIA",2]
 						}

--- a/A3-Antistasi/functions/REINF/fn_addFIAveh.sqf
+++ b/A3-Antistasi/functions/REINF/fn_addFIAveh.sqf
@@ -18,7 +18,8 @@ if (!isMultiPlayer) then {_resourcesFIA = server getVariable "resourcesFIA"} els
 		}
 	else
 		{
-		if ((_typeVehX == SDKMortar) or (_typeVehX == staticATteamPlayer) or (_typeVehX == staticAAteamPlayer) or (_typeVehX == SDKMGStatic)) then {_resourcesFIA = server getVariable "resourcesFIA"} else {_resourcesFIA = player getVariable "moneyX"};
+		_resourcesFIA = server getVariable "resourcesFIA";
+		//if ((_typeVehX == SDKMortar) or (_typeVehX == staticATteamPlayer) or (_typeVehX == staticAAteamPlayer) or (_typeVehX == SDKMGStatic)) then {_resourcesFIA = server getVariable "resourcesFIA"} else {_resourcesFIA = player getVariable "moneyX"};
 		};
 	};
 


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Adjusts the vehicle purchase code so that commanders purchase any vehicle with faction resources, not just static weapons. This fixes various early-game learning curve problems where people have to steal resources or share between players to put together enough cash for an undercover vehicle.

Might make it a bit too easy to acquire vehicles, but we'll see. Making them more expensive is an option. The civilian heli becomes much easier to acquire, so we should probably hotfix the undercover sling-load exploit at the same time.

### Please specify which Issue this PR Resolves.
closes #1473

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Not 100% sure how this is going to change player behaviour.
