### PR TITLE
Fix some minor undercover bugs

### DIFF
--- a/A3-Antistasi/functions/Undercover/fn_goUndercover.sqf
+++ b/A3-Antistasi/functions/Undercover/fn_goUndercover.sqf
@@ -196,15 +196,18 @@ do {
 				if (_typeX == civHeli) then {
 					_base = [_airportsX1, _player] call BIS_fnc_nearestPosition;
 					_size = [_base] call A3A_fnc_sizeMarker;
-					if ((_player distance2d getMarkerPos _base < _size * 3) and((sidesX getVariable[_base, sideUnknown] == Occupants) or(sidesX getVariable[_base, sideUnknown] == Invaders))) then {
+					if ((_player distance2d getMarkerPos _base < _size * 3) and((sidesX getVariable[_base, sideUnknown] == Occupants) or(sidesX getVariable[_base, sideUnknown] == Invaders))) exitWith {
 						_changeX = "NoFly";
+					};
+					_base = [outposts, _player] call BIS_fnc_nearestPosition;
+					if ((_player distance getMarkerPos _base < 100) and((sidesX getVariable[_base, sideUnknown] == Occupants) or(sidesX getVariable[_base, sideUnknown] == Invaders))) exitWith {
+						_changeX = "distanceX";
 					};
 				};
 			};
 		};
 	};
 };
-diag_log format["[Antistasi] Player detected in %1 (undercover.sqf)", _onDetectionMarker];
 
 if (captive _player) then {
 	[_player, false] remoteExec["setCaptive"];

--- a/A3-Antistasi/functions/init/fn_initACEUnconsciousHandler.sqf
+++ b/A3-Antistasi/functions/init/fn_initACEUnconsciousHandler.sqf
@@ -22,6 +22,7 @@ private _fileName = "initACEUnconsciousHandler.sqf";
 
 //	[3, format ["Unit type %1, side %2, realside %3, captive %4, lifestate %5 waking up", typeof _unit, side _unit, _realSide, str (captive _unit), lifestate _unit], ace_unconscious handler] call A3A_fnc_log;
 	_unit setVariable ["incapacitated", false, true];
+	[_unit, false] remoteExec ["setCaptive", _unit];			// match vanilla behaviour
 
 	if (isPlayer _unit) exitWith {};					// don't force surrender with players
 	if (_realSide != Occupants && _realSide != Invaders) exitWith {};


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
- Fixed an exploit where undercover civ helis could sling-load outpost crates. This is also addressed in a much larger patch (#1075) that needs a rebase, but it's a trivial hotfix to the current code and will be necessary with #1484.
- Fixed a client script error in some broken undercover debug output. Easiest way to demonstrate this is to get in and out of a civilian vehicle quickly. Not sure if it had any side effects, but they're fixed now.
- Fixed a display inconsistency with undercover and ACE unconsciousness. It was possible for the HUD bar to report "undercover off" while the player was conscious and undercover. There were various ways of handling this but given a lack of interest I've made it work like the vanilla revive, so you lose undercover on regaining consciousness.

### Please specify which Issue this PR Resolves.
closes #1158
closes #1310
partially handles #331

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
1. Buy civ heli, try to steal an outpost crate.
2. Get knocked out while undercover, cause a stats bar update and then wake up.
3. Get in and out of a civilian vehicle quickly.
