### PR TITLE
CS-1479-FF-Exempt-Same-Veh

### DIFF
--- a/A3-Antistasi/functions/Punishment/fn_punishment_FF.sqf
+++ b/A3-Antistasi/functions/Punishment/fn_punishment_FF.sqf
@@ -5,45 +5,33 @@ Function:
 Description:
     Checks if incident reported is indeed a rebel Friendly Fire event.
     Refer to A3A_fnc_punishment.sqf for actual punishment logic.
-    NOTE: Collisions are a guaranteed exemption, logged but with no notification for the victim.
     NOTE: When called from an Hit type of EH, use Example 2 in order to detect collisions.
 
 Scope:
     <LOCAL> Execute on player you wish to verify for FF. (For 'BIS_fnc_admin' and 'isServer').
 
 Environment:
-    <UNSCHEDULED>
+    <UNSCHEDULED> Suspension may cause undefined behaviour.
 
-Parameters 1:
-    <OBJECT> Player that is being verified for FF.
+Parameters:
+    <OBJECT> Player that is being verified for FF. | <ARRAY<OBJECT,OBJECT>> Suspected instigator and source/killer returned from EH. The unit that caused the damage is collisions is the source/killer.
     <NUMBER> The amount of time to add to the players total sentence time.
     <NUMBER> Raise the player's total offence level by this percentage. (100% total = Ocean Gulag).
-    <OBJECT> [OPTIONAL=objNull] The victim of the player's FF.
-    <STRING> [OPTIONAL] Custom message to be displayed to FFer
-
-Parameters 2:
-    <ARRAY<OBJECT,OBJECT>> Suspected instigator and source/killer returned from EH. The unit that caused the damage is collisions is the source/killer.
-    <NUMBER> The amount of time to add to the players total sentence time.
-    <NUMBER> Raise the player's total offence level by this percentage. (100% total = Ocean Gulag).
-    <OBJECT> [OPTIONAL=objNull] The victim of the player's FF.
-    <STRING> [OPTIONAL] Custom message to be displayed to FFer
+    <OBJECT> The victim of the player's FF. [DEFAULT=objNull]
+    <STRING> Custom message to be displayed to FFer [DEFAULT=""]
 
 Returns:
-    <STRING> Either a exemption type or return from fn_punishment.sqf.
+    <STRING> Either a exemption type or "PROSECUTED".
 
-Examples 1:
-    [_instigator, 60, 0.4, _unit] remoteExec ["A3A_fnc_punishment_FF",_instigator,false]; // How it should be called from another function.
+Examples <OBJECT>:
+    [_instigator, 60, 0.4, _unit] remoteExec ["A3A_fnc_punishment_FF",_instigator,false]; // How it should be called from another object.
     // Unit Tests:
     [player, 0, 0, objNull] call A3A_fnc_punishment_FF;             // Test self with no victim
     [player, 0, 0, cursorObject] call A3A_fnc_punishment_FF;        // Test self with victim
-    [player,"forgive"] remoteExec ["A3A_fnc_punishment_release",2]; // Self forgive all sins
+    [getPlayerUID player,"forgive"] remoteExec ["A3A_fnc_punishment_release",2]; // Self forgive all sins
 
-Examples 2:
+Examples <ARRAY<OBJECT,OBJECT>>:
     [[_instigator,_source], 60, 0.4, _unit] remoteExec ["A3A_fnc_punishment_FF",[_source,_instigator] select (isPlayer _instigator),false]; // How it should be called from an EH.
-    // Unit Tests:
-    [[objNull,player], 0, 0, objNull] call A3A_fnc_punishment_FF;      // Test self with no victim
-    [[objNull,player], 0, 0, cursorObject] call A3A_fnc_punishment_FF; // Test self with victim
-
 Author: Caleb Serafin
 License: MIT License, Copyright (c) 2019 Barbolani & The Official AntiStasi Community
 */
@@ -55,19 +43,18 @@ params [
     ["_customMessage","", [""], [] ]
 ];
 private _filename = "fn_punishment_FF.sqf";
-///////////////Checks if is Collision//////////////
+///////////Checks if is Collision///////////
 private _isCollision = false;
 if (_instigator isEqualType []) then {
     _isCollision = !(((_instigator#0) isEqualType objNull) && {isPlayer (_instigator#0)});
-    _instigator = _instigator select _isCollision;      // First one in EH will be unit by default, if its a collision the eh returns the instigator in "source" or "killer"
+    _instigator = _instigator select _isCollision;  // First one in EH will be unit by default, if its a collision the eh returns the instigator in "source" or "killer"
 };
-private _vehicle = typeOf vehicle _instigator;
+private _vehicle = vehicle _instigator;
+private _vehicleType = typeOf _vehicle;
 
-//////Cool down prevents multi-hit spam/////
-    // Doesn't log to avoid RPT spam.
-    // Doesn't use hash table to be as quick as possible.
-if (_instigator getVariable ["punishment_coolDown", 0] > servertime) exitWith {"PUNISHMENT COOL-DOWN ACTIVE"};
-_instigator setVariable ["punishment_coolDown", servertime + 1, false]; // Local Exec faster
+//////////////////Cool-down/////////////////
+if (_instigator getVariable ["A3A_FFPunish_CD ", 0] > servertime) exitWith {"PUNISHMENT COOL-DOWN ACTIVE"};
+_instigator setVariable ["A3A_FFPunish_CD ", servertime + 1, false];  // Will only ever be evaluated from one machine.
 
 /////////////////Definitions////////////////
 private _victimStats = ["",format [" damaged %1 ", name _victim]] select (_victim isKindOf "Man");
@@ -83,18 +70,18 @@ private _notifyInstigator = {
 private _gotoExemption = {
     params [ ["_exemptionDetails", "" ,[""]] ];
     private _playerStats = format["%1 [%2]%3, Avoided-time: %4, Avoided-offence: %5", name _instigator, getPlayerUID _instigator, _victimStats,str _timeAdded, str _offenceAdded];
-    [2, format ["%1 | %2", _exemptionDetails, _playerStats], _filename] remoteExecCall ["A3A_fnc_log",2,false];
+    [2, format ["%1 | %2", _exemptionDetails, _playerStats], _filename,true] remoteExecCall ["A3A_fnc_log",2,false];
     _exemptionDetails;
 };
 private _logPvPHurt = {
     if (!(_victim isKindOf "Man")) exitWith {};
     private _killStats = format ["PVPHURT | Rebel %1 [%2]%3", name _instigator, getPlayerUID _instigator, _victimStats];
-    [2,_killStats,_filename] remoteExecCall ["A3A_fnc_log",2,false];
+    [2,_killStats,_filename,true] remoteExecCall ["A3A_fnc_log",2,false];
 };
 private _logPvPAttack = {
     if (!(_victim isKindOf "Man")) exitWith {};
     private _killStats = format ["PVPATTACK | PvP %1 [%2]%3", name _instigator, getPlayerUID _instigator, _victimStats];
-    [2,_killStats,_filename] remoteExecCall ["A3A_fnc_log",2,false];
+    [2,_killStats,_filename,true] remoteExecCall ["A3A_fnc_log",2,false];
 };
 
 ///////////////Checks if is FF//////////////
@@ -102,8 +89,8 @@ private _exemption = switch (true) do {
     case (!tkPunish):                                  {"FF PUNISH IS DISABLED"};
     case (!isMultiplayer):                             {"IS NOT MULTIPLAYER"};
     case (!hasInterface):                              {"FF BY SERVER/HC"};
-    case (!(player isEqualTo _instigator)):            {"NOT EXEC ON INSTIGATOR"}; // Must be local for 'BIS_fnc_admin'
-    case (_victim isEqualTo _instigator):              {"SUICIDE"}; // Local AI victims will be different.
+    case (!(player isEqualTo _instigator)):            {"NOT EXEC ON INSTIGATOR"};  // Must be local for 'BIS_fnc_admin'
+    case (_vehicle isEqualTo (vehicle _victim)):       {"IN SAME VEHICLE"};  // Also fulfils role of checking whether the instigator and victim is same person.
     case (_victim getVariable ["pvp",false]):          {call _logPvPHurt; "VICTIM NOT REBEL"};
     case (_instigator getVariable ["pvp",false]):      {call _logPvPAttack; "INSTIGATOR NOT REBEL"};
     default                                            {""};
@@ -119,32 +106,31 @@ if (_isCollision) then {
     _customMessage = [_customMessage,"You damaged a friendly as a driver."] joinString "<br/>";
     _timeAdded = 27;
     _offenceAdded = 0.15;
-    [2, format ["COLLISION | %1 [%2]'s %3%4", name _instigator, getPlayerUID _instigator, _vehicle, _victimStats], _filename] remoteExecCall ["A3A_fnc_log",2,false];
+    [2, format ["COLLISION | %1 [%2]'s %3%4", name _instigator, getPlayerUID _instigator, _vehicleType, _victimStats], _filename,true] remoteExecCall ["A3A_fnc_log",2,false];
 };
 
 /////////Checks for important roles/////////
 _exemption = switch (true) do {
     case (call BIS_fnc_admin != 0 || isServer): {
-        ["You damaged a friendly as admin."] call _notifyInstigator; // Admin not reported to victim for Zeus remote control.
+        ["You damaged a friendly as admin."] call _notifyInstigator; // Admin not reported to victim in case of Zeus remote control.
         format ["ADMIN, %1", ["Local Host","Voted","Logged"] select (call BIS_fnc_admin)];
     };
-    case (vehicle _instigator isKindOf "Air"): {
+    case (_vehicle isKindOf "Air"): {
         call _notifyVictim;
         ["You damaged a friendly as CAS support."] call _notifyInstigator;
-        format["AIRCRAFT, %1", _vehicle];
+        format["AIRCRAFT, %1", _vehicleType];
     };
     case (
-        isNumber (configFile >> "CfgVehicles" >> _vehicle >> "artilleryScanner") &&
-        getNumber (configFile >> "CfgVehicles" >> _vehicle >> "artilleryScanner") != 0
+        isNumber (configFile >> "CfgVehicles" >> _vehicleType >> "artilleryScanner") &&
+        getNumber (configFile >> "CfgVehicles" >> _vehicleType >> "artilleryScanner") != 0
     ): {
         call _notifyVictim;
         ["You damaged a friendly as arty support."] call _notifyInstigator;
-        format ["ARTY, %1", _vehicle];
+        format ["ARTY, %1", _vehicleType];
     };
     // TODO: if( remoteControlling(_instigator) ) exitWith
-        // For the meantime do either one of the following: login for Zeus, use the memberList addon;
-        // Or change your player side to enemy faction
-        // Without above: your controls will be free, and you won't die or lose inventory. If you have debug consol you can self forgive.
+        // For the meantime do either one of the following: login as admin for Zeus, or "player setVariable ["PvP",true,true];
+        // Without above: Your AI will be prosecuted for FF. Upon leaving UAV you will be punished. If you have debug console you can self forgive.
     default {""};
 };
 


### PR DESCRIPTION
## What type of PR is this.
* Bug
* Change
* [x] Enhancement

### What have you changed and why?
Information:
- Modified instigator = victim check to see if their vehicles match.
  - The instigator is not punished if he is within the same vehicle as the victim.
- Updated Header.
- Refined some comments.
- All logs go to server.

### Please specify which Issue this PR Resolves.
closes [#1479](https://github.com/official-antistasi-community/A3-Antistasi/issues/1479)

### Please verify the following and ensure all checks are completed.

* [x] Have you loaded the mission in LAN host?
* [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
* Yes

## Testing Steps

Rebel damage itself=> nothing
Rebel  in vehicle damage itself  in vehicle=> nothing  // Grenade/Console recommended  // See further below

Rebel damage Rebel => Punish
Rebel damage Rebel in vehicle => Punish
Rebel in vehicle damage Rebel => Punish
Rebel in vehicle damage Rebel in different vehicle => Punish


Rebel in vehicle damage Rebel in same vehicle => nothing  // Note: you will need to use grenades/explosives or console.
```sqf
// Look at attacker
John = cursorObject;
// Look at victim
Smith = cursorObject;
// Let them climb into vehicle, tem exec
[John, 10, 1, Smith, "No one should see this message."] remoteExec ["A3A_fnc_punishment_FF",John,false];
```

## Zip of PBO is provided
[Antistasi-TEST-CS-1479-FF-Exempt-Same-Veh-2-3-1.Altis.pbo.zip](https://github.com/official-antistasi-community/A3-Antistasi/files/5261739/Antistasi-TEST-CS-1479-FF-Exempt-Same-Veh-2-3-1.Altis.pbo.zip)
