### PR TITLE
Add seaports to secure bases for undercover

### DIFF
--- a/A3-Antistasi/functions/Undercover/fn_goUndercover.sqf
+++ b/A3-Antistasi/functions/Undercover/fn_goUndercover.sqf
@@ -7,14 +7,13 @@ if (captive _player) exitWith {
 	["Undercover", "You are Undercover already"] call A3A_fnc_customHint;
 };
 
-private["_compromised", "_changeX", "_airportsX", "_roadblocks", "_player", "_size", "_base", "_onDetectionMarker", "_onBaseMarker", "_airportSide"];
+private["_compromised", "_changeX", "_secureBases", "_roadblocks", "_player", "_size", "_base", "_onDetectionMarker", "_onBaseMarker", "_baseSide"];
 
 _changeX = "";
 _roadblocks = (controlsX select {
 	isOnRoad(getMarkerPos _x)
 });
-_airportsX = airportsX + outposts + _roadblocks;
-_airportsX1 = airportsX;
+_secureBases = airportsX + outposts + seaports + _roadblocks;
 _compromised = _player getVariable "compromised";
 
 
@@ -60,10 +59,10 @@ if ({
 	};
 };
 
-_base = [_airportsX, _player] call BIS_fnc_nearestPosition;
+_base = [_secureBases, _player] call BIS_fnc_nearestPosition;
 _size = [_base] call A3A_fnc_sizeMarker;
 if ((_player distance getMarkerPos _base < _size * 2) and(not(sidesX getVariable[_base, sideUnknown] == teamPlayer))) exitWith {
-	["Undercover", "You cannot go Undercover near Airports, Outposts or Roadblocks"] call A3A_fnc_customHint;
+	["Undercover", "You cannot go Undercover near Airports, Outposts, Seaports or Roadblocks"] call A3A_fnc_customHint;
 };
 
 ["Undercover ON", 0, 0, 4, 0, 0, 4] spawn bis_fnc_dynamicText;
@@ -151,17 +150,17 @@ do {
 		};
 		if (_changeX == "") then {
 			if ((_typeX != civHeli) and(!(_typeX in civBoats))) then {
-				_base = [_airportsX, _player] call BIS_fnc_nearestPosition;
+				_base = [_secureBases, _player] call BIS_fnc_nearestPosition;
 				//_size = [_base] call A3A_fnc_sizeMarker;
 				//Following lines are for the detection of players in the detectionAreas
 				_onDetectionMarker = (detectionAreas findIf {
 					_player inArea _x
 				} != -1);
 				_onBaseMarker = (_player inArea _base);
-				_airportSide = (sidesX getVariable[_base, sideUnknown]);
-				_airport = [_airportsX1, _player] call BIS_fnc_nearestPosition;
+				_baseSide = (sidesX getVariable[_base, sideUnknown]);
+				_airport = [airportsX, _player] call BIS_fnc_nearestPosition;
 				if (_onBaseMarker && {
-						_airportSide != teamPlayer
+						_baseSide != teamPlayer
 					} || {
 						_onDetectionMarker && {
 							sidesX getVariable _airport != teamPlayer
@@ -169,13 +168,13 @@ do {
 					}) then {
 					if !(_isInControl) then {
 						_aggro =
-							if (sidesX getVariable[_base, sideUnknown] == Occupants) then {
+							if (_baseSide == Occupants) then {
 								aggressionOccupants + (tierWar * 10)
 							} else {
 								aggressionInvaders + (tierWar * 10)
 							};
 							//Probability	of being spotted. Unless we're in an airfield - then we're always spotted.
-						if (_base in _airportsX1 || _onDetectionMarker || random 100 < _aggro) then {
+						if (_base in airportsX || _onDetectionMarker || random 100 < _aggro) then {
 							if (_base in _roadblocks) then {
 								_changeX = "distanceX";
 							}
@@ -194,12 +193,12 @@ do {
 			}
 			else {
 				if (_typeX == civHeli) then {
-					_base = [_airportsX1, _player] call BIS_fnc_nearestPosition;
+					_base = [airportsX, _player] call BIS_fnc_nearestPosition;
 					_size = [_base] call A3A_fnc_sizeMarker;
 					if ((_player distance2d getMarkerPos _base < _size * 3) and((sidesX getVariable[_base, sideUnknown] == Occupants) or(sidesX getVariable[_base, sideUnknown] == Invaders))) exitWith {
 						_changeX = "NoFly";
 					};
-					_base = [outposts, _player] call BIS_fnc_nearestPosition;
+					_base = [outposts + seaports, _player] call BIS_fnc_nearestPosition;
 					if ((_player distance getMarkerPos _base < 100) and((sidesX getVariable[_base, sideUnknown] == Occupants) or(sidesX getVariable[_base, sideUnknown] == Invaders))) exitWith {
 						_changeX = "distanceX";
 					};


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Put seaports in the same category as outposts for undercover: They have a chance of spotting undercover land units, and automatically detect civ helis within 100m.

Also fixed some misnamed variables that were really bugging me.
    
### Please specify which Issue this PR Resolves.
closes #1491

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
