### PR TITLE
Restrict loot crate respawns

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_createAIAirplane.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAIAirplane.sqf
@@ -323,9 +323,10 @@ private _ammoBox = if (garrison getVariable [_markerX + "_lootCD", 0] == 0) then
 {
 	private _ammoBoxType = if (_sideX == Occupants) then {NATOAmmoBox} else {CSATAmmoBox};
 	private _ammoBox = _ammoBoxType createVehicle _positionX;
+	// Otherwise when destroyed, ammoboxes sink 100m underground and are never cleared up
+	_ammoBox addEventHandler ["Killed", { [_this#0] spawn { sleep 10; deleteVehicle (_this#0) } }];
 	[_ammoBox] spawn A3A_fnc_fillLootCrate;
 	_ammoBox call jn_fnc_logistics_addAction;
-	// ammoBox treated separately from other objects, don't add to _vehiclesX
 
 	[_ammoBox] spawn {
 		sleep 1;    //make sure fillLootCrate finished clearing the crate
@@ -415,8 +416,8 @@ deleteMarker _mrk;
 
 // If loot crate was stolen, set the cooldown
 if (!isNil "_ammoBox") then {
-	if (_ammoBox distance2d _positionX < 100) exitWith { deleteVehicle _ammoBox };
-	[_ammoBox] spawn A3A_fnc_VEHdespawner;
+	if ((alive _ammoBox) and (_ammoBox distance2d _positionX < 100)) exitWith { deleteVehicle _ammoBox };
+	if (alive _ammoBox) then { [_ammoBox] spawn A3A_fnc_VEHdespawner };
 	private _lootCD = 120*16 / ([_markerX] call A3A_fnc_garrisonSize);
 	garrison setVariable [_markerX + "_lootCD", _lootCD, true];
 };

--- a/A3-Antistasi/functions/CREATE/fn_createAIOutposts.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAIOutposts.sqf
@@ -136,11 +136,25 @@ _flagX allowDamage false;
 [_flagX,"take"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_flagX];
 _vehiclesX pushBack _flagX;
 
-private _ammoBoxType = if (_sideX == Occupants) then {NATOAmmoBox} else {CSATAmmoBox};
-private _ammoBox = _ammoBoxType createVehicle _positionX;
-[_ammoBox] spawn A3A_fnc_fillLootCrate;
-_ammoBox call jn_fnc_logistics_addAction;
-_vehiclesX pushBack _ammoBox;
+// Only create ammoBox if it's been recharged (see reinforcementsAI)
+private _ammoBox = if (garrison getVariable [_markerX + "_lootCD", 0] == 0) then
+{
+	private _ammoBoxType = if (_sideX == Occupants) then {NATOAmmoBox} else {CSATAmmoBox};
+	private _ammoBox = _ammoBoxType createVehicle _positionX;
+	[_ammoBox] spawn A3A_fnc_fillLootCrate;
+	_ammoBox call jn_fnc_logistics_addAction;
+	// ammoBox treated separately from other objects, don't add to _vehiclesX
+
+	if ((_markerX in seaports) and !hasIFA) then {
+		[_ammoBox] spawn {
+			sleep 1;    //make sure fillLootCrate finished clearing the crate
+			{
+				_this#0 addItemCargoGlobal [_x, round random [2,6,8]];
+			} forEach diveGear;
+		};
+	};
+	_ammoBox;
+};
 
 _roads = _positionX nearRoads _size;
 
@@ -169,10 +183,6 @@ if ((_markerX in seaports) and !hasIFA) then
 			diag_log format ["createAIOutposts: Could not find seaSpawn marker on %1!", _markerX];
 		};
 	};
-	sleep 1;    //make sure fillLootCrate finished clearing the crate
-	{
-		 _ammoBox addItemCargoGlobal [_x, round random [2,6,8]];
-	} forEach diveGear;
 }
 else
 {
@@ -346,3 +356,11 @@ deleteMarker _mrk;
 		else { if !(_x isKindOf "StaticWeapon") then { [_x] spawn A3A_fnc_VEHdespawner } };
 	};
 } forEach _vehiclesX;
+
+// If loot crate was stolen, set the cooldown
+if (!isNil "_ammoBox") then {
+	if (_ammoBox distance2d _positionX < 100) exitWith { deleteVehicle _ammoBox };
+	[_ammoBox] spawn A3A_fnc_VEHdespawner;
+	private _lootCD = 120*16 / ([_markerX] call A3A_fnc_garrisonSize);
+	garrison setVariable [_markerX + "_lootCD", _lootCD, true];
+};

--- a/A3-Antistasi/functions/CREATE/fn_createAIOutposts.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAIOutposts.sqf
@@ -141,9 +141,10 @@ private _ammoBox = if (garrison getVariable [_markerX + "_lootCD", 0] == 0) then
 {
 	private _ammoBoxType = if (_sideX == Occupants) then {NATOAmmoBox} else {CSATAmmoBox};
 	private _ammoBox = _ammoBoxType createVehicle _positionX;
+	// Otherwise when destroyed, ammoboxes sink 100m underground and are never cleared up
+	_ammoBox addEventHandler ["Killed", { [_this#0] spawn { sleep 10; deleteVehicle (_this#0) } }];
 	[_ammoBox] spawn A3A_fnc_fillLootCrate;
 	_ammoBox call jn_fnc_logistics_addAction;
-	// ammoBox treated separately from other objects, don't add to _vehiclesX
 
 	if ((_markerX in seaports) and !hasIFA) then {
 		[_ammoBox] spawn {
@@ -359,8 +360,8 @@ deleteMarker _mrk;
 
 // If loot crate was stolen, set the cooldown
 if (!isNil "_ammoBox") then {
-	if (_ammoBox distance2d _positionX < 100) exitWith { deleteVehicle _ammoBox };
-	[_ammoBox] spawn A3A_fnc_VEHdespawner;
+	if ((alive _ammoBox) and (_ammoBox distance2d _positionX < 100)) exitWith { deleteVehicle _ammoBox };
+	if (alive _ammoBox) then { [_ammoBox] spawn A3A_fnc_VEHdespawner };
 	private _lootCD = 120*16 / ([_markerX] call A3A_fnc_garrisonSize);
 	garrison setVariable [_markerX + "_lootCD", _lootCD, true];
 };

--- a/A3-Antistasi/functions/CREATE/fn_reinforcementsAI.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_reinforcementsAI.sqf
@@ -105,6 +105,18 @@ _reinfPlaces = [];
 if ((count _reinfPlaces == 0) and (AAFpatrols <= 3)) then {[] spawn A3A_fnc_AAFroadPatrol};
 
 
+// Reduce loot crate cooldown if garrison is complete
+{
+	call {
+		private _lootCD = garrison getVariable [_x + "_lootCD", 0];
+		if (_lootCD == 0) exitWith {};							// don't update unless changed
+		private _realSize = count (garrison getVariable [_x, []]);
+		if (_realSize < [_x] call A3A_fnc_garrisonSize) exitWith {};
+		garrison setVariable [_x + "_lootCD", 0 max (_lootCD - 10), true];
+	};
+} forEach (airportsX + outposts + seaports);
+
+
 {
 		//Setting the number of recruitable units per ticks per airport
     garrison setVariable [format ["%1_recruit", _x], 12, true];

--- a/A3-Antistasi/functions/Save/fn_loadStat.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadStat.sqf
@@ -147,8 +147,10 @@ if (_varName in _specialVarLoads) then {
 		};
 	};
 	if (_varName == 'garrison') then {
-		//_markersX = markersX - outpostsFIA - controlsX - citiesX;
-		{garrison setVariable [[_x select 0] call _translateMarker,_x select 1,true]} forEach _varvalue;
+		{
+			garrison setVariable [[_x select 0] call _translateMarker, _x select 1, true];
+			if (count _x > 2) then { garrison setVariable [(_x select 0) + "_lootCD", _x select 2, true] };
+		} forEach _varvalue;
 	};
 	if (_varName == 'wurzelGarrison') then {
 		{

--- a/A3-Antistasi/functions/Save/fn_saveLoop.sqf
+++ b/A3-Antistasi/functions/Save/fn_saveLoop.sqf
@@ -150,7 +150,7 @@ _garrison = [];
 _wurzelGarrison = [];
 
 {
-	_garrison pushBack [_x,garrison getVariable [_x,[]]];
+	_garrison pushBack [_x,garrison getVariable [_x,[]],garrison getVariable [_x + "_lootCD", 0]];
 	_wurzelGarrison pushBack [
 		_x,
 		garrison getVariable [format ["%1_garrison",_x], []],


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Loot crates no longer respawn every time an outpost/seaport/airport garrison is spawned. Instead, stealing or destroying a crate adds a cooldown variable to that garrison, which is decreased on ticks only if the garrison is full. Hence a garrison that isn't being reinforced will not respawn loot crates. Locations with larger garrisons have shorter cooldowns, typically an hour for a large outpost, two hours for a small one or half an hour for an airfield.

This prevents farming a near-empty outpost that's reinforcement-blocked by killzones, and reduces (but doesn't prevent) exploiting outposts that are relatively easy to steal crates from for geographical reasons. It's also logical, because outposts don't send out patrols (to confiscate loot, or whatever the hell they're doing to get those weapons) unless they're at capacity.

### Please specify which Issue this PR Resolves.
closes #1446

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Code to return garrison capacity, real garrison count (can be larger) and crate cooldown for a garrison:

```
_marker = "outpost_25";
[[_marker] call A3A_fnc_garrisonSize, count (garrison getVariable _marker), garrison getVariable [_marker+"_lootCD", 0]]
```