### PR TITLE
Expand vehicle selling and fix related static weapon unlock exploit

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_arsenalManage.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_arsenalManage.sqf
@@ -40,39 +40,38 @@ private _count = objNull;
 private _allExceptNVs = _weapons + _explosives + _backpacks + _items + _optics + _helmets + _vests + _magazine;
 
 {
-	private _item = _x select 0;
-	if (_x select 1 >= minWeaps) then {
+	call {
+		if (_x select 1 < minWeaps) exitWith {};
+		private _item = _x select 0;
+
 		private _categories = _item call A3A_fnc_equipmentClassToCategories;
-		
-		if ((allowGuidedLaunchers isEqualTo 1 || {!("MissileLaunchers" in _categories)}) &&
-		    (allowUnlockedExplosives isEqualTo 1 || !("Explosives" in _categories))) then {
-			
-			_item call A3A_fnc_unlockEquipment;
-			
-			private _name = switch (true) do {
-				case ("Magazines" in _categories): {getText (configFile >> "CfgMagazines" >> _item >> "displayName")};
-				case ("Backpacks" in _categories): {getText (configFile >> "CfgVehicles" >> _item >> "displayName")};
-				default {getText (configFile >> "CfgWeapons" >> _item >> "displayName")};
-			};
-			
-			//Update the 'Updated' text with the name of the new item.
-			_updated = format ["%1%2<br/>",_updated,_name];
-			
-			//Unlock ammo for guns, if appropriate.
-			if (unlockedUnlimitedAmmo == 1 && ("Weapons" in _categories)) then {
-				private _weaponMagazine = (getArray (configFile / "CfgWeapons" / _item / "magazines") select 0);
-				if (!isNil "_weaponMagazine") then {
-					if (not(_weaponMagazine in unlockedMagazines)) then {
-						_updated = format ["%1%2<br/>",_updated,getText (configFile >> "CfgMagazines" >> _weaponMagazine >> "displayName")];
-						[_weaponMagazine] call A3A_fnc_unlockEquipment;
-					};
+		if ("MissileLaunchers" in _categories && {allowGuidedLaunchers == 0}) exitWith {};
+		if ("Explosives" in _categories && {allowUnlockedExplosives == 0}) exitWith {};
+		if ("Backpacks" in _categories && {_item in allBackpacksTool}) exitWith {};			// should be UAV & static backpacks
+		if ("StaticWeaponParts" in _categories) exitWith {};
+
+		_item call A3A_fnc_unlockEquipment;
+
+		private _name = switch (true) do {
+			case ("Magazines" in _categories): {getText (configFile >> "CfgMagazines" >> _item >> "displayName")};
+			case ("Backpacks" in _categories): {getText (configFile >> "CfgVehicles" >> _item >> "displayName")};
+			default {getText (configFile >> "CfgWeapons" >> _item >> "displayName")};
+		};
+
+		//Update the 'Updated' text with the name of the new item.
+		_updated = format ["%1%2<br/>",_updated,_name];
+
+		//Unlock ammo for guns, if appropriate.
+		if (unlockedUnlimitedAmmo == 1 && ("Weapons" in _categories)) then {
+			private _weaponMagazine = (getArray (configFile / "CfgWeapons" / _item / "magazines") select 0);
+			if (!isNil "_weaponMagazine") then {
+				if (not(_weaponMagazine in unlockedMagazines)) then {
+					_updated = format ["%1%2<br/>",_updated,getText (configFile >> "CfgMagazines" >> _weaponMagazine >> "displayName")];
+					[_weaponMagazine] call A3A_fnc_unlockEquipment;
 				};
 			};
-			
-			
 		};
 	};
-
 } forEach _allExceptNVs;
 
 call A3A_fnc_checkRadiosUnlocked;

--- a/A3-Antistasi/functions/Base/fn_sellVehicle.sqf
+++ b/A3-Antistasi/functions/Base/fn_sellVehicle.sqf
@@ -23,10 +23,10 @@ _typeX = typeOf _veh;
 _costs = call {
 	if (_veh isKindOf "StaticWeapon") exitWith {100};			// in case rebel static is same as enemy statics
 	if (_typeX in vehFIA) exitWith { ([_typeX] call A3A_fnc_vehiclePrice) / 2 };
-	if ((_typeX in arrayCivVeh) or (_typeX in civBoats)) exitWith {25};
+	if ((_typeX in arrayCivVeh) or (_typeX in civBoats) or (_typeX in [civBoat,civCar,civTruck])) exitWith {25};
 	if ((_typeX in vehNormal) or (_typeX in vehBoats) or (_typeX in vehAmmoTrucks)) exitWith {100};
-	if (_typeX in [vehCSATPatrolHeli, vehNATOPatrolHeli]) exitWith {500};
-	if ((_typeX in vehAPCs) || (_typeX in vehTransportAir)) exitWith {1000};
+	if (_typeX in [vehCSATPatrolHeli, vehNATOPatrolHeli, civHeli]) exitWith {500};
+	if ((_typeX in vehAPCs) || (_typeX in vehTransportAir) || (_typeX in vehUAVs)) exitWith {1000};
 	if ((_typeX in vehAttackHelis) or (_typeX in vehTanks) or (_typeX in vehAA) or (_typeX in vehMRLS)) exitWith {3000};
 	if (_typeX in [vehNATOPlane,vehNATOPlaneAA,vehCSATPlane,vehCSATPlaneAA]) exitWith {4000};
 	0;

--- a/A3-Antistasi/functions/Base/fn_sellVehicle.sqf
+++ b/A3-Antistasi/functions/Base/fn_sellVehicle.sqf
@@ -20,62 +20,16 @@ if (!isNil "_owner") then
 if (_exit) exitWith {["Sell Vehicle", "You are not owner of this vehicle and you cannot sell it"] call A3A_fnc_customHint;};
 
 _typeX = typeOf _veh;
-_costs = 0;
-
-if (_typeX in vehFIA) then
-{
-	_costs = round (([_typeX] call A3A_fnc_vehiclePrice)/2)
-}
-else
-{
-	if (_typeX in arrayCivVeh) then
-	{
-		//This is for selling supply trucks, but currently is unused.
-		_destinationX = _veh getVariable "destinationX";
-		if (isNil "_destinationX") then
-		{
-			if (_typeX == "C_Van_01_fuel_F") then {_costs = 50} else {_costs = 25};
-		}
-		else
-		{
-			_costs = 200;
-		};
-	}
-	else
-	{
-		if ((_typeX in vehNormal) or (_typeX in vehBoats) or (_typeX in vehAmmoTrucks)) then
-		{
-			_costs = 100;
-		}
-		else
-		{
-			if (_typeX in vehAPCs) then
-			{
-				_costs = 1000;
-			}
-			else
-			{
-				if (_typeX isKindOf "Plane") then
-				{
-					_costs = 4000;
-				}
-				else
-				{
-					if ((_typeX in vehAttackHelis) or (_typeX in vehTanks) or (_typeX in vehAA) or (_typeX in vehMRLS)) then
-					{
-						_costs = 3000;
-					}
-					else
-					{
-						if (_typeX in vehTransportAir) then
-						{
-							_costs = 500;
-						};
-					};
-				};
-			};
-		};
-	};
+_costs = call {
+	if (_veh isKindOf "StaticWeapon") exitWith {100};			// in case rebel static is same as enemy statics
+	if (_typeX in vehFIA) exitWith { ([_typeX] call A3A_fnc_vehiclePrice) / 2 };
+	if ((_typeX in arrayCivVeh) or (_typeX in civBoats)) exitWith {25};
+	if ((_typeX in vehNormal) or (_typeX in vehBoats) or (_typeX in vehAmmoTrucks)) exitWith {100};
+	if (_typeX in [vehCSATPatrolHeli, vehNATOPatrolHeli]) exitWith {500};
+	if ((_typeX in vehAPCs) || (_typeX in vehTransportAir)) exitWith {1000};
+	if ((_typeX in vehAttackHelis) or (_typeX in vehTanks) or (_typeX in vehAA) or (_typeX in vehMRLS)) exitWith {3000};
+	if (_typeX in [vehNATOPlane,vehNATOPlaneAA,vehCSATPlane,vehCSATPlaneAA]) exitWith {4000};
+	0;
 };
 
 if (_costs == 0) exitWith {["Sell Vehicle", "The vehicle you are looking is not suitable in our marketplace"] call A3A_fnc_customHint;};

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -603,7 +603,7 @@ DECLARE_SERVER_VAR(sniperGroups, _sniperGroups);
 
 private _vehNormal = vehNATONormal + vehCSATNormal + vehNATOCargoTrucks;
 _vehNormal append [vehFIACar,vehFIATruck,vehFIAArmedCar,vehPoliceCar,vehNATOBike,vehCSATBike];
-_vehNormal append [vehSDKTruck,vehSDKLightArmed,vehSDKBike,vehSDKRepair];
+_vehNormal append [vehSDKTruck,vehSDKLightArmed,vehSDKAT,vehSDKBike,vehSDKRepair];
 DECLARE_SERVER_VAR(vehNormal, _vehNormal);
 
 private _vehBoats = [vehNATOBoat,vehNATORBoat,vehCSATBoat,vehCSATRBoat,vehSDKBoat];
@@ -651,7 +651,7 @@ DECLARE_SERVER_VAR(vehFastRope, _vehFastRope);
 private _vehUnlimited = vehNATONormal + vehCSATNormal + [vehNATORBoat,vehNATOPatrolHeli,vehCSATRBoat,vehCSATPatrolHeli,vehNATOUAV,vehNATOUAVSmall,NATOMG,NATOMortar,vehCSATUAV,vehCSATUAVSmall,CSATMG,CSATMortar];
 DECLARE_SERVER_VAR(vehUnlimited, _vehUnlimited);
 
-private _vehFIA = [vehSDKBike,vehSDKLightArmed,SDKMGStatic,vehSDKLightUnarmed,vehSDKTruck,vehSDKBoat,SDKMortar,staticATteamPlayer,staticAAteamPlayer,vehSDKRepair];
+private _vehFIA = [vehSDKBike,vehSDKAT,vehSDKLightArmed,SDKMGStatic,vehSDKLightUnarmed,vehSDKTruck,vehSDKBoat,SDKMortar,staticATteamPlayer,staticAAteamPlayer,vehSDKRepair];
 DECLARE_SERVER_VAR(vehFIA, _vehFIA);
 
 ///////////////////////////

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -600,10 +600,13 @@ DECLARE_SERVER_VAR(sniperGroups, _sniperGroups);
 //   CLASSING TEMPLATE VEHICLES  ///
 ////////////////////////////////////
 [2,"Identifying vehicle types",_fileName] call A3A_fnc_log;
-private _vehNormal = (vehNATONormal + vehCSATNormal + [vehFIATruck,vehSDKTruck,vehSDKLightArmed,vehSDKBike,vehSDKRepair]);
+
+private _vehNormal = vehNATONormal + vehCSATNormal + vehNATOCargoTrucks;
+_vehNormal append [vehFIACar,vehFIATruck,vehFIAArmedCar,vehPoliceCar,vehNATOBike,vehCSATBike];
+_vehNormal append [vehSDKTruck,vehSDKLightArmed,vehSDKBike,vehSDKRepair];
 DECLARE_SERVER_VAR(vehNormal, _vehNormal);
 
-private _vehBoats = [vehNATOBoat,vehCSATBoat,vehSDKBoat];
+private _vehBoats = [vehNATOBoat,vehNATORBoat,vehCSATBoat,vehCSATRBoat,vehSDKBoat];
 DECLARE_SERVER_VAR(vehBoats, _vehBoats);
 
 private _vehAttack = vehNATOAttack + vehCSATAttack;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Expanded the vehicle selling capability to include anything reasonable, so that commanders can do something with surplus MRAPs littering the HQ.

Because this would significantly expand the previous exploit of unlocking static weapon parts and then selling the (unlimited) assembled weapons, I've fixed that at the same time, so static weapon parts and backpacks are now prevented from unlocking.

### Please specify which Issue this PR Resolves.
closes #1488

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Testing unlocking:
`cursorObject addItemCargoGlobal ["ace_cws_staticATCarry", 40]`
`cursorObject addBackpackCargoGlobal ["B_Mortar_01_weapon_F", 40]`

Testing vehicle selling:
`vehPoliceCar createVehicle (position player)`
