### PR TITLE
Added logging for unlocks

### DIFF
--- a/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_addItem.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_addItem.sqf
@@ -3,6 +3,7 @@
 #include "\A3\Ui_f\hpp\defineResinclDesign.inc"
 
 private _array = [[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]];
+private _filename = "JN_fnc_arsenal_addItem";
 
 if(typeName (_this select 0) isEqualTo "SCALAR")then{//[_index, _item] and [_index, _item, _amount];
 	params["_index","_item",["_amount",1]];
@@ -19,6 +20,7 @@ if(typeName (_this select 0) isEqualTo "SCALAR")then{//[_index, _item] and [_ind
 	{
 		private _item = _x select 0;
 		private _amount = _x select 1;
+		if ((!isNil "serverInitDone") && (_amount isEqualTo -1)) then {[3, format ["Item unlocked: %1", _item], _filename] call A3A_fnc_log};
 		if (_item isEqualType "") then
 			{
 			if !(_item isEqualTo "")then{

--- a/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_addItem.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_addItem.sqf
@@ -3,7 +3,6 @@
 #include "\A3\Ui_f\hpp\defineResinclDesign.inc"
 
 private _array = [[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]];
-private _filename = "JN_fnc_arsenal_addItem";
 
 if(typeName (_this select 0) isEqualTo "SCALAR")then{//[_index, _item] and [_index, _item, _amount];
 	params["_index","_item",["_amount",1]];
@@ -20,7 +19,6 @@ if(typeName (_this select 0) isEqualTo "SCALAR")then{//[_index, _item] and [_ind
 	{
 		private _item = _x select 0;
 		private _amount = _x select 1;
-		if ((!isNil "serverInitDone") && (_amount isEqualTo -1)) then {[3, format ["Item unlocked: %1", _item], _filename] call A3A_fnc_log};
 		if (_item isEqualType "") then
 			{
 			if !(_item isEqualTo "")then{

--- a/A3-Antistasi/functions/Ammunition/fn_unlockEquipment.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_unlockEquipment.sqf
@@ -14,6 +14,7 @@
 **/
 
 params ["_className", ["_dontAddToArsenal", false]];
+private _filename = "A3A_fnc_unlockEquipment";
 
 private _categories = _className call A3A_fnc_equipmentClassToCategories;
 
@@ -21,6 +22,7 @@ if (!_dontAddToArsenal) then {
 	//Add the equipment to the arsenal.
 	private _arsenalTab = _className call jn_fnc_arsenal_itemType;
 	[_arsenalTab,_className,-1] call jn_fnc_arsenal_addItem;
+	if (!isNil "serverInitDone") then {[3, format ["Item unlocked: %1", _item], _filename] remoteExec ["A3A_fnc_log", 2]};
 };
 
 {

--- a/A3-Antistasi/functions/Ammunition/fn_unlockEquipment.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_unlockEquipment.sqf
@@ -14,7 +14,7 @@
 **/
 
 params ["_className", ["_dontAddToArsenal", false]];
-private _filename = "A3A_fnc_unlockEquipment";
+private _filename = "fn_unlockEquipment";
 
 private _categories = _className call A3A_fnc_equipmentClassToCategories;
 


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    all unlocks after server init is now logged
![unlockItemLogging](https://user-images.githubusercontent.com/61709767/94477833-b10b4d80-01d2-11eb-80b8-8de3dbd2fa3d.png)

### Please specify which Issue this PR Resolves.
Bob request no issue made for it

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
start a new campaign and unlock a few items, check the logs, then load a previous save and do the same. it should only log when you unlock stuff and not when initializing the arsenal
********************************************************
Notes:
