### PR TITLE
fixed fast reverse towing exploit

### DIFF
--- a/A3-Antistasi/Scripts/fn_advancedTowingInit.sqf
+++ b/A3-Antistasi/Scripts/fn_advancedTowingInit.sqf
@@ -247,7 +247,7 @@ SA_Simulate_Towing = {
 			_lastMovedCargoPosition = _cargoPosition;
 
 			_massAdjustedMaxSpeed = _vehicle getVariable ["SA_Max_Tow_Speed",_maxVehicleSpeed];
-			if(speed _vehicle > (_massAdjustedMaxSpeed)+0.1) then {
+			if(speed _vehicle^2 > _massAdjustedMaxSpeed^2+0.1) then { //square to ensure positive number
 				_vehicle setVelocity ((vectorNormalized (velocity _vehicle)) vectorMultiply (_massAdjustedMaxSpeed/3.6));
 			};
 

--- a/A3-Antistasi/Scripts/fn_advancedTowingInit.sqf
+++ b/A3-Antistasi/Scripts/fn_advancedTowingInit.sqf
@@ -247,7 +247,7 @@ SA_Simulate_Towing = {
 			_lastMovedCargoPosition = _cargoPosition;
 
 			_massAdjustedMaxSpeed = _vehicle getVariable ["SA_Max_Tow_Speed",_maxVehicleSpeed];
-			if(speed _vehicle^2 > _massAdjustedMaxSpeed^2+0.1) then { //square to ensure positive number
+			if(speed _vehicle^2 > (_massAdjustedMaxSpeed+0.1)^2) then { //square to ensure positive number
 				_vehicle setVelocity ((vectorNormalized (velocity _vehicle)) vectorMultiply (_massAdjustedMaxSpeed/3.6));
 			};
 


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    squared the speed and max speed to ensure positive number for the comparison conditional

### Please specify which Issue this PR Resolves.
closes #1501

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: get a quad and a tank, start towing the tank with the quad, then turn the quad around and start reversing, you should have the same speed limit

********************************************************
Notes:
