### PR TITLE
CS-1504-PurgeBSLoop

### DIFF
--- a/A3-Antistasi/functions/UI/fn_customHint.sqf
+++ b/A3-Antistasi/functions/UI/fn_customHint.sqf
@@ -42,8 +42,8 @@ Authors: Michael Phillips(original customHint), Caleb Serafin
 License: MIT License, Copyright (c) 2019 Barbolani & The Official AntiStasi Community
 */
 params [
-    ["_headerText", "", [""]],
-    ["_bodyText", "", ["",parseText""]],
+    ["_headerText", "headermissingno", [""]],
+    ["_bodyText", "bodymissingno", ["",parseText""]],
     ["_isSilent", false, [false]],
     ["_iconData", ["functions\UI\images\logo.paa",4], [ [] ], 2]
 ];
@@ -75,7 +75,6 @@ if (A3A_customHintEnable) then {
         A3A_customHint_Queue set [_index,[_headerText,_structuredText,_isSilent]];
     };
     if (A3A_customHint_Queue #0#0 isEqualTo _headerText) then {A3A_customHint_LastDismiss = serverTime;};
-    A3A_customHint_CanRender = true;
 } else {
     if (_isSilent) then {
         hintSilent _structuredText;
@@ -86,4 +85,3 @@ if (A3A_customHintEnable) then {
 true;
 
 // TODO: remove all `hintSilent ""` used in boot processes.
-// TODO: Get colour from Loaded Arma 3 profile (Might be done when actual GUI is designed)

--- a/A3-Antistasi/functions/UI/fn_customHintInit.sqf
+++ b/A3-Antistasi/functions/UI/fn_customHintInit.sqf
@@ -29,29 +29,24 @@ private _filename = "fn_customHintInit.sqf";
 if (!hasInterface) exitWith {false;}; // Disabled for server & HC.
 if !(isNil {A3A_customHint_InitComplete}) exitWith {false;};
 
-A3A_customHint_Queue = [];
+A3A_customHint_Queue = [];  // These var names don't need to be limited to 16chars for performance as they are not public.
 A3A_customHint_DismissKeyDown = false;
 A3A_customHint_LastDismiss = 0;
-A3A_customHint_CanRender = false;
+A3A_customHint_RenderFrameCount = 1;
 if (isNil {A3A_customHintEnable}) then {A3A_customHintEnable = true}; // isNil check in case value was set before this initialises.
 
 A3A_customHint_hexChars = ["0","1","2","3","4","5","6","7","8","9","A","B","C","D","E","F"];
-
-private _renderLoop = [
-    "A3A_fnc_customHintInit/_renderLoop",
-    A3A_fnc_customHintRender,
-    15,
-    "frames",
-    {A3A_customHint_CanRender},
-    {false},
-    false
-];
-["itemAdd", _renderLoop] call BIS_fnc_loop;
 
 addMissionEventHandler ["EachFrame", {
     if ((inputAction "User12" isEqualTo 0) isEqualTo A3A_customHint_DismissKeyDown) then {  // This is probably the fastest edge/Xor & key-down detector you can get. ~0.0034ms total execution time on non-edges (`inputAction "User12"` alone uses ~0.0017ms)(The case most of the time when key-state is not changing.).
         A3A_customHint_DismissKeyDown = !A3A_customHint_DismissKeyDown;                     // user action slot Will be selectable when client-side preferences, Soon™.
         if (A3A_customHint_DismissKeyDown) then { [] call A3A_fnc_customHintDismiss; };
+    };
+    if (A3A_customHint_RenderFrameCount >= 15) then {  // Render loop does not need to run every frame.
+        A3A_customHint_RenderFrameCount = 1;
+        [] call A3A_fnc_customHintRender;
+    } else {
+        A3A_customHint_RenderFrameCount = A3A_customHint_RenderFrameCount + 1;
     };
 }];
 

--- a/A3-Antistasi/functions/UI/fn_customHintRender.sqf
+++ b/A3-Antistasi/functions/UI/fn_customHintRender.sqf
@@ -28,7 +28,6 @@ if (!hasInterface || !A3A_customHintEnable) exitWith {false;}; // Disabled for s
 
 if (count A3A_customHint_Queue isEqualTo 0) then {
     hintSilent "";
-    A3A_customHint_CanRender = false;
 } else{
     private _autoDismiss = 15; // seconds
     if (serverTime - A3A_customHint_LastDismiss > _autoDismiss) exitWith {


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
* Change
* Enhancement

### What have you changed and why?
* A3A_fnc_customHintRender will be called every 15 frames regardless of whether the queue is empty.
  * This removes the rare chance that a dismiss call and new hint happen at the same time -> queue is not empty, but render does not run.
* BIS_fnc_loop has being replaced by OnEachFrame and a 15 frame counter (for calling A3A_fnc_customHintRender ).
  * It is a large function that has more functionality than needed for this task.
  * It isn't efficient. 
  * BIS_fnc_loop is not to be trusted, sometimes it does not to run the code added to it.

### Please specify which Issue this PR Resolves.
closes [#1504](https://github.com/official-antistasi-community/A3-Antistasi/issues/1504)

### Please verify the following and ensure all checks are completed.

2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
* Yes (Please provide further detail below.)

## How to Test?
There is no known/consistent way to reproduce the old bug.
Refer to old PR to confirm that functionality remains the same.

### A Zip of the PBO is Provided 
[Antistasi-TEST-CS-1504-PurgeBSLoop-2-3-1.Altis.pbo.zip](https://github.com/official-antistasi-community/A3-Antistasi/files/5313180/Antistasi-TEST-CS-1504-PurgeBSLoop-2-3-1.Altis.pbo.zip)
