### PR TITLE
block adding of action to pvp

### DIFF
--- a/A3-Antistasi/JeroenArsenal/JNL/Actions/fn_logistics_addActionLoad.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNL/Actions/fn_logistics_addActionLoad.sqf
@@ -16,6 +16,9 @@ if (isNil "jnl_initCompleted") then {
 //Check if this vehicle can be loaded with JNL
 if((_object call jn_fnc_logistics_getCargoType) == -1) exitWith {};
 
+//dont add for pvp
+if !((side group player) isEqualTo teamPlayer) exitWith {};
+
 _text = "";
 
 if (_object isKindOf "CAManBase") then {_text = format ["<img image='\A3\ui_f\data\IGUI\Cfg\Actions\arrow_up_gs.paa' />  Load %1 in Vehicle</t>",name _object]} else {_text = "<img image='\A3\ui_f\data\IGUI\Cfg\Actions\arrow_up_gs.paa' />  Load Cargo in Vehicle</t>"};
@@ -92,4 +95,3 @@ _object setUserActionText [
 ];
 
 _object setVariable ["jnl_loadActionID", _loadActionID, false];
-

--- a/A3-Antistasi/JeroenArsenal/JNL/Actions/fn_logistics_addActionLoad.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNL/Actions/fn_logistics_addActionLoad.sqf
@@ -17,6 +17,7 @@ if (isNil "jnl_initCompleted") then {
 if((_object call jn_fnc_logistics_getCargoType) == -1) exitWith {};
 
 //dont add for pvp
+waitUntil { !isNull player }; //wait for player unit to be local and valid
 if !((side group player) isEqualTo teamPlayer) exitWith {};
 
 _text = "";


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information: Stopped pvp players from getting the load action added
    

### Please specify which Issue this PR Resolves.
closes #1512

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [ ] Have you loaded the mission in LAN host?
3. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: Try to load a crate as pvp, you wont have the action, rebels will still have it

********************************************************
Notes:
