### PR TITLE
failed findEmptyPosition attempts retry with massively expanded area

### DIFF
--- a/A3-Antistasi/functions/Missions/fn_DES_Heli.sqf
+++ b/A3-Antistasi/functions/Missions/fn_DES_Heli.sqf
@@ -182,6 +182,7 @@ if !(_typeVehH == vehNATOPatrolHeli) then {
 		//creating transport vehicle
 		_typeVeh = if (_sideX == Occupants) then {selectRandom vehNATOTrucks} else {selectRandom vehCSATTrucks};
 		private _posVehHT = _posCrash findEmptyPosition [15, 30 ,_typeVeh];
+		if (_posVehHT isEqualTo []) then {_posVehHT = _posCrash findEmptyPosition [15, 100 ,_typeVeh]}; //if it fails to find a pos expand and try again
 		_vehGuard = _typeVeh createVehicle _posVehHT;
 		[_vehGuard, _sideX] call A3A_fnc_AIVEHinit;
 		_vehicles pushBack _vehGuard;
@@ -252,13 +253,13 @@ if (_vehR distance _heli < 50) then
 		_escortWP setWaypointBehaviour "SAFE";
 
 		[3, format ["Pilots and Guard are RTB"], _filename] call A3A_fnc_log;
-		
+
 		_pilots addVehicle _heli;
 		(units _pilots) orderGetIn true;
 		sleep 1;
 		private _notAlivePilots = true;
 		{if ([_x] call A3A_fnc_canFight) exitWith {_notAlivePilots = false}}forEach units _pilots;
-		
+
 
 		if ((_typeVehH in vehNATOTransportHelis)||(_typeVehH in vehCSATTransportHelis)) then {
 			if !(_typeVehH == vehNATOPatrolHeli) then {


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    if findEmptyPosition fails it returns an empty array, now it will retry with a massive area that should not fail.

### Please specify which Issue this PR Resolves.
closes #1511

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [ ] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: RNG, mass of mission spawns are required

********************************************************
Notes:
