### PR TITLE
added an exit case if arty piece spawned badly and was destroyed

### DIFF
--- a/A3-Antistasi/functions/AI/fn_artillery.sqf
+++ b/A3-Antistasi/functions/AI/fn_artillery.sqf
@@ -1,6 +1,7 @@
 if (!isServer and hasInterface) exitWith{};
 
 private ["_mrkOrigin","_pos","_attackingSide","_countX","_mrkDestination","_veh","_posOrigin","_sideTargets","_posDestination","_typeVehX","_typeAmmunition","_size","_vehicle","_vehCrew","_groupVeh","_roundsX","_objectiveX","_objectivesX","_timeX"];
+private _filename = "fn_artillery";
 
 _mrkOrigin = _this select 0;
 _posOrigin = if (_mrkOrigin isEqualType "") then {getMarkerPos _mrkOrigin} else {_mrkOrigin};
@@ -24,6 +25,7 @@ _vehCrew = _vehicle select 1;
 _groupVeh = _vehicle select 2;
 _size = [_mrkDestination] call A3A_fnc_sizeMarker;
 
+if (!alive _veh) exitWith {[1, "Arty piece destroyed on spawn, fire mission canceled", _filename] call A3A_fnc_log};
 if (_posDestination inRangeOfArtillery [[_veh], ((getArtilleryAmmo [_veh]) select 0)]) then
 	{
 	while {(alive _veh) and ({_x select 0 == _typeAmmunition} count magazinesAmmo _veh > 0) and (_mrkDestination in forcedSpawn)} do


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information: if the arty piece of fn_artillery is destroyed on spawn it freaks out when trying to get the artillery ammo and breaks, now it exits out with a proper error log when this happens
    

### Please specify which Issue this PR Resolves.
closes #1510

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:  comment out ln 14, add this after ln 21 : `_veh setDamage 1;` and spawn in an arty mission, it should blow up on spawn and this line should be logged instead of an error: ``` [Antistasi] | ERROR | fn_artillery | Arty piece destroyed on spawn, fire mission canceled"```

********************************************************
Notes:
