### PR TITLE
CS-1516-HintQueueToStack

### DIFF
--- a/A3-Antistasi/functions/UI/fn_customHint.sqf
+++ b/A3-Antistasi/functions/UI/fn_customHint.sqf
@@ -42,8 +42,8 @@ Authors: Michael Phillips(original customHint), Caleb Serafin
 License: MIT License, Copyright (c) 2019 Barbolani & The Official AntiStasi Community
 */
 params [
-    ["_headerText", "", [""]],
-    ["_bodyText", "", ["",parseText""]],
+    ["_headerText", "headermissingno", [""]],
+    ["_bodyText", "bodymissingno", ["",parseText""]],
     ["_isSilent", false, [false]],
     ["_iconData", ["functions\UI\images\logo.paa",4], [ [] ], 2]
 ];
@@ -75,7 +75,6 @@ if (A3A_customHintEnable) then {
         A3A_customHint_Queue set [_index,[_headerText,_structuredText,_isSilent]];
     };
     if (A3A_customHint_Queue #0#0 isEqualTo _headerText) then {A3A_customHint_LastDismiss = serverTime;};
-    A3A_customHint_CanRender = true;
 } else {
     if (_isSilent) then {
         hintSilent _structuredText;
@@ -86,4 +85,3 @@ if (A3A_customHintEnable) then {
 true;
 
 // TODO: remove all `hintSilent ""` used in boot processes.
-// TODO: Get colour from Loaded Arma 3 profile (Might be done when actual GUI is designed)

--- a/A3-Antistasi/functions/UI/fn_customHint.sqf
+++ b/A3-Antistasi/functions/UI/fn_customHint.sqf
@@ -12,7 +12,7 @@ Scope:
     <LOCAL> Execute on each player to add a global notification.
 
 Environment:
-    <UNSCHEDULED> Simultaneous modification may cause trampling of items in A3A_customHint_Queue.
+    <UNSCHEDULED> Simultaneous modification may cause trampling of items in A3A_customHint_MSGs.
 
 Parameters:
     <STRING> Heading of your notification.
@@ -68,13 +68,16 @@ if (_bodyText isEqualType parseText"") then {
 }; //
 
 if (A3A_customHintEnable) then {
-    private _index = A3A_customHint_Queue findIf {(_x #0) isEqualTo _headerText}; // Temporary solution until an programming-interface is added for counters and timers.
+    private _index = A3A_customHint_MSGs findIf {(_x #0) isEqualTo _headerText}; // Temporary solution until an programming-interface is added for counters and timers.
     if (_index isEqualTo -1) then {
-        A3A_customHint_Queue pushBack [_headerText,_structuredText,_isSilent];
+        A3A_customHint_MSGs pushBack [_headerText,_structuredText,_isSilent];
     } else {
-        A3A_customHint_Queue set [_index,[_headerText,_structuredText,_isSilent]];
+        A3A_customHint_MSGs set [_index,[_headerText,_structuredText,_isSilent]];
     };
-    if (A3A_customHint_Queue #0#0 isEqualTo _headerText) then {A3A_customHint_LastDismiss = serverTime;};
+    private _lastMSGIndex = count A3A_customHint_MSGs - 1;
+    if (A3A_customHint_MSGs #(_lastMSGIndex)#0 isEqualTo _headerText) then {
+        A3A_customHint_LastMSG = serverTime;
+    };
 } else {
     if (_isSilent) then {
         hintSilent _structuredText;

--- a/A3-Antistasi/functions/UI/fn_customHintDismiss.sqf
+++ b/A3-Antistasi/functions/UI/fn_customHintDismiss.sqf
@@ -30,12 +30,13 @@ private _filename = "fn_customHintDismiss.sqf";
 
 if (!hasInterface || !A3A_customHintEnable) exitWith {false;}; // Disabled for server & HC.
 if (_dismissAll) then {
-    A3A_customHint_Queue = [];
+    A3A_customHint_MSGs = [];
 } else {
-    if !(count A3A_customHint_Queue isEqualTo 0) then {
-        A3A_customHint_Queue deleteAt 0
-    }
+    if !(count A3A_customHint_MSGs isEqualTo 0) then {
+        private _lastMSGIndex = count A3A_customHint_MSGs - 1;
+        A3A_customHint_MSGs deleteAt _lastMSGIndex;
+    };
 };
-A3A_customHint_LastDismiss = serverTime;
+A3A_customHint_LastMSG = serverTime;
 [] call A3A_fnc_customHintRender;  // Instant update will be preffered when user is dismissing notifications.
 true;

--- a/A3-Antistasi/functions/UI/fn_customHintInit.sqf
+++ b/A3-Antistasi/functions/UI/fn_customHintInit.sqf
@@ -29,29 +29,24 @@ private _filename = "fn_customHintInit.sqf";
 if (!hasInterface) exitWith {false;}; // Disabled for server & HC.
 if !(isNil {A3A_customHint_InitComplete}) exitWith {false;};
 
-A3A_customHint_Queue = [];
+A3A_customHint_Queue = [];  // These var names don't need to be limited to 16chars for performance as they are not public.
 A3A_customHint_DismissKeyDown = false;
 A3A_customHint_LastDismiss = 0;
-A3A_customHint_CanRender = false;
+A3A_customHint_RenderFrameCount = 1;
 if (isNil {A3A_customHintEnable}) then {A3A_customHintEnable = true}; // isNil check in case value was set before this initialises.
 
 A3A_customHint_hexChars = ["0","1","2","3","4","5","6","7","8","9","A","B","C","D","E","F"];
-
-private _renderLoop = [
-    "A3A_fnc_customHintInit/_renderLoop",
-    A3A_fnc_customHintRender,
-    15,
-    "frames",
-    {A3A_customHint_CanRender},
-    {false},
-    false
-];
-["itemAdd", _renderLoop] call BIS_fnc_loop;
 
 addMissionEventHandler ["EachFrame", {
     if ((inputAction "User12" isEqualTo 0) isEqualTo A3A_customHint_DismissKeyDown) then {  // This is probably the fastest edge/Xor & key-down detector you can get. ~0.0034ms total execution time on non-edges (`inputAction "User12"` alone uses ~0.0017ms)(The case most of the time when key-state is not changing.).
         A3A_customHint_DismissKeyDown = !A3A_customHint_DismissKeyDown;                     // user action slot Will be selectable when client-side preferences, Soon™.
         if (A3A_customHint_DismissKeyDown) then { [] call A3A_fnc_customHintDismiss; };
+    };
+    if (A3A_customHint_RenderFrameCount >= 15) then {  // Render loop does not need to run every frame.
+        A3A_customHint_RenderFrameCount = 1;
+        [] call A3A_fnc_customHintRender;
+    } else {
+        A3A_customHint_RenderFrameCount = A3A_customHint_RenderFrameCount + 1;
     };
 }];
 

--- a/A3-Antistasi/functions/UI/fn_customHintInit.sqf
+++ b/A3-Antistasi/functions/UI/fn_customHintInit.sqf
@@ -28,10 +28,10 @@ private _filename = "fn_customHintInit.sqf";
 
 if (!hasInterface) exitWith {false;}; // Disabled for server & HC.
 if !(isNil {A3A_customHint_InitComplete}) exitWith {false;};
-
-A3A_customHint_Queue = [];  // These var names don't need to be limited to 16chars for performance as they are not public.
+// These var names don't need to be limited to 16chars for performance as they are not public.
+A3A_customHint_MSGs = [];  // Operates as a upside-down stack (new messages pushed-Back are displayed.)
 A3A_customHint_DismissKeyDown = false;
-A3A_customHint_LastDismiss = 0;
+A3A_customHint_LastMSG = 0;
 A3A_customHint_RenderFrameCount = 1;
 if (isNil {A3A_customHintEnable}) then {A3A_customHintEnable = true}; // isNil check in case value was set before this initialises.
 

--- a/A3-Antistasi/functions/UI/fn_customHintRender.sqf
+++ b/A3-Antistasi/functions/UI/fn_customHintRender.sqf
@@ -28,7 +28,6 @@ if (!hasInterface || !A3A_customHintEnable) exitWith {false;}; // Disabled for s
 
 if (count A3A_customHint_Queue isEqualTo 0) then {
     hintSilent "";
-    A3A_customHint_CanRender = false;
 } else{
     private _autoDismiss = 15; // seconds
     if (serverTime - A3A_customHint_LastDismiss > _autoDismiss) exitWith {

--- a/A3-Antistasi/functions/UI/fn_customHintRender.sqf
+++ b/A3-Antistasi/functions/UI/fn_customHintRender.sqf
@@ -26,12 +26,12 @@ private _filename = "fn_customHintRender.sqf";
 
 if (!hasInterface || !A3A_customHintEnable) exitWith {false;}; // Disabled for server & HC.
 
-if (count A3A_customHint_MSGs isEqualTo 0) then {
+if (A3A_customHint_MSGs isEqualTo []) then {
     hintSilent "";
 } else{
     private _autoDismiss = 15;  // Number of seconds for message lifetime  // Constant Value
     if (serverTime - A3A_customHint_LastMSG > _autoDismiss) exitWith {
-        [] call A3A_fnc_customHintDismiss;
+        [true] call A3A_fnc_customHintDismiss;
     };
     private _alphaHex = [(((_autoDismiss + A3A_customHint_LastMSG - serverTime) min (_autoDismiss-5)) / (_autoDismiss-5)) ] call A3A_fnc_shader_ratioToHex;
     private _dismissKey = actionKeysNames ["User12",1];

--- a/A3-Antistasi/functions/UI/fn_customHintRender.sqf
+++ b/A3-Antistasi/functions/UI/fn_customHintRender.sqf
@@ -26,24 +26,25 @@ private _filename = "fn_customHintRender.sqf";
 
 if (!hasInterface || !A3A_customHintEnable) exitWith {false;}; // Disabled for server & HC.
 
-if (count A3A_customHint_Queue isEqualTo 0) then {
+if (count A3A_customHint_MSGs isEqualTo 0) then {
     hintSilent "";
 } else{
-    private _autoDismiss = 15; // seconds
-    if (serverTime - A3A_customHint_LastDismiss > _autoDismiss) exitWith {
+    private _autoDismiss = 15;  // Number of seconds for message lifetime  // Constant Value
+    if (serverTime - A3A_customHint_LastMSG > _autoDismiss) exitWith {
         [] call A3A_fnc_customHintDismiss;
     };
-    private _alphaHex = [(((_autoDismiss + A3A_customHint_LastDismiss - serverTime) min (_autoDismiss-5)) / (_autoDismiss-5)) ] call A3A_fnc_shader_ratioToHex;
+    private _alphaHex = [(((_autoDismiss + A3A_customHint_LastMSG - serverTime) min (_autoDismiss-5)) / (_autoDismiss-5)) ] call A3A_fnc_shader_ratioToHex;
     private _dismissKey = actionKeysNames ["User12",1];
     _dismissKey = [_dismissKey,"""Use Action 12"""] select (_dismissKey isEqualTo "");
-    private _footer = parseText (["<br/><t size='0.8' color='#",_alphaHex,"e5b348' shadow='1' shadowColor='#",_alphaHex,"000000' valign='top' >Press <t color='#",_alphaHex,"f0d498' >",_dismissKey,"</t> to dismiss notification. +",str((count A3A_customHint_Queue) -1),"</t>"] joinString ""); // Needs to be added to string table.
+    private _footer = parseText (["<br/><t size='0.8' color='#",_alphaHex,"e5b348' shadow='1' shadowColor='#",_alphaHex,"000000' valign='top' >Press <t color='#",_alphaHex,"f0d498' >",_dismissKey,"</t> to dismiss notification. +",str((count A3A_customHint_MSGs) -1),"</t>"] joinString ""); // Needs to be added to string table.
 
-    _structuredText = composeText [A3A_customHint_Queue #0#1, _footer];
-    if (A3A_customHint_Queue #0#2) then {
+    private _lastMSGIndex = count A3A_customHint_MSGs - 1;
+    _structuredText = composeText [A3A_customHint_MSGs #(_lastMSGIndex)#1, _footer];
+    if (A3A_customHint_MSGs #(_lastMSGIndex)#2) then {
         hintSilent _structuredText;
     } else {
         hint _structuredText;
-        A3A_customHint_Queue #0 set [2,true]; // so it does not ping more than once.
+        A3A_customHint_MSGs #(_lastMSGIndex) set [2,true]; // so it does not ping more than once.
     };
 };
 true;


### PR DESCRIPTION
## What type of PR is this.
* Bug
* [x] Change
* [x] Enhancement

### What have I changed and why?
* A3A_customHint_Queue refactored to A3A_customHint_MSGs
  * This will differentiate it from other notification systems in the future.
* A3A_customHint_MSGs is treated as an upside-down stack.
  * Newest messages are pushed to the back. The last message is rendered.
* **INCLUDES CHANGES IN [#1505](https://github.com/official-antistasi-community/A3-Antistasi/pull/1505)**

### Please specify which Issue this PR Resolves.
closes [#1516](https://github.com/official-antistasi-community/A3-Antistasi/issues/1516)

### Please verify the following and ensure all checks are completed.

2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
* Yes


## Testing Steps
* Make sure this change works nicely with the counters/timers in FF_punishment or supply missions.
* Make sure it feels good when interacting with items at HQ like "Map Info". 

### A Zip of the PBO is Provided
[Antistasi-TEST-CS-1516-HintQueueToStack-2-3-1.Altis.pbo.zip](https://github.com/official-antistasi-community/A3-Antistasi/files/5321836/Antistasi-TEST-CS-1516-HintQueueToStack-2-3-1.Altis.pbo.zip)
