### PR TITLE
changed all pvp units to broadcast pvp variable in all mission sqm's

### DIFF
--- a/Map-Templates/Antistasi-Altis-BLUFOR.Altis/mission.sqm
+++ b/Map-Templates/Antistasi-Altis-BLUFOR.Altis/mission.sqm
@@ -11740,7 +11740,7 @@ class Mission
 					flags=6;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_green_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -11814,7 +11814,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_green_2";
 						description="Medic";
 						isPlayable=1;
@@ -11888,7 +11888,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_green_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -11962,7 +11962,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_green_4";
 						description="Marksman";
 						isPlayable=1;
@@ -12036,7 +12036,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_green_5";
 						description="AT1";
 						isPlayable=1;
@@ -12110,7 +12110,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_green_6";
 						description="AT2";
 						isPlayable=1;
@@ -12222,7 +12222,7 @@ class Mission
 					flags=6;
 					class Attributes
 					{
-						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_red_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -12296,7 +12296,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_red_2";
 						description="Medic";
 						isPlayable=1;
@@ -12371,7 +12371,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_red_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -12446,7 +12446,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_red_4";
 						description="Marksman";
 						isPlayable=1;
@@ -12520,7 +12520,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_red_5";
 						description="AT1";
 						isPlayable=1;
@@ -12594,7 +12594,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_red_6";
 						description="AT2";
 						isPlayable=1;

--- a/Map-Templates/Antistasi-Altis.Altis/mission.sqm
+++ b/Map-Templates/Antistasi-Altis.Altis/mission.sqm
@@ -9347,7 +9347,7 @@ class Mission
 					class Attributes
 					{
 						rank="SERGEANT";
-						init="groupPlayersNATO = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersNATO = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_blue_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -9422,7 +9422,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_blue_2";
 						description="Medic";
 						isPlayable=1;
@@ -9498,7 +9498,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_blue_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -9575,7 +9575,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_blue_4";
 						description="Marksman";
 						isPlayable=1;
@@ -9651,7 +9651,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_blue_5";
 						description="AT1";
 						isPlayable=1;
@@ -9726,7 +9726,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_blue_6";
 						description="AT2";
 						isPlayable=1;
@@ -9821,7 +9821,7 @@ class Mission
 					flags=6;
 					class Attributes
 					{
-						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_red_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -9895,7 +9895,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_red_2";
 						description="Medic";
 						isPlayable=1;
@@ -9970,7 +9970,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_red_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -10045,7 +10045,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_red_4";
 						description="Marksman";
 						isPlayable=1;
@@ -10119,7 +10119,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_red_5";
 						description="AT1";
 						isPlayable=1;
@@ -10193,7 +10193,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_red_6";
 						description="AT2";
 						isPlayable=1;

--- a/Map-Templates/Antistasi-Anizay.tem_anizay/mission.sqm
+++ b/Map-Templates/Antistasi-Anizay.tem_anizay/mission.sqm
@@ -22552,7 +22552,7 @@ class Mission
 					class Attributes
 					{
 						rank="SERGEANT";
-						init="groupPlayersNATO = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersNATO = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_blue_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -22627,7 +22627,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_blue_2";
 						description="Medic";
 						isPlayable=1;
@@ -22703,7 +22703,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_blue_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -22779,7 +22779,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_blue_4";
 						description="Marksman";
 						isPlayable=1;
@@ -22854,7 +22854,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_blue_5";
 						description="AT1";
 						isPlayable=1;
@@ -22929,7 +22929,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_blue_6";
 						description="AT2";
 						isPlayable=1;
@@ -23024,7 +23024,7 @@ class Mission
 					flags=6;
 					class Attributes
 					{
-						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_red_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -23098,7 +23098,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_red_2";
 						description="Medic";
 						isPlayable=1;
@@ -23172,7 +23172,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_red_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -23246,7 +23246,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_red_4";
 						description="Marksman";
 						isPlayable=1;
@@ -23320,7 +23320,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_red_5";
 						description="AT1";
 						isPlayable=1;
@@ -23393,7 +23393,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_red_6";
 						description="AT2";
 						isPlayable=1;

--- a/Map-Templates/Antistasi-Chernarus.chernarus_summer/mission.sqm
+++ b/Map-Templates/Antistasi-Chernarus.chernarus_summer/mission.sqm
@@ -26369,7 +26369,7 @@ class Mission
 					class Attributes
 					{
 						rank="SERGEANT";
-						init="groupPlayersNATO = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersNATO = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_blue_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -26445,7 +26445,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_blue_2";
 						description="Medic";
 						isPlayable=1;
@@ -26521,7 +26521,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_blue_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -26597,7 +26597,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_blue_4";
 						description="Marksman";
 						isPlayable=1;
@@ -26672,7 +26672,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_blue_5";
 						description="AT1";
 						isPlayable=1;
@@ -26747,7 +26747,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_blue_6";
 						description="AT2";
 						isPlayable=1;
@@ -26843,7 +26843,7 @@ class Mission
 					flags=6;
 					class Attributes
 					{
-						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_red_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -26917,7 +26917,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_red_2";
 						description="Medic";
 						isPlayable=1;
@@ -26991,7 +26991,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_red_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -27065,7 +27065,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_red_4";
 						description="Marksman";
 						isPlayable=1;
@@ -27139,7 +27139,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_red_5";
 						description="AT1";
 						isPlayable=1;
@@ -27213,7 +27213,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_red_6";
 						description="AT2";
 						isPlayable=1;

--- a/Map-Templates/Antistasi-ChernarusWinter.chernarus_winter/mission.sqm
+++ b/Map-Templates/Antistasi-ChernarusWinter.chernarus_winter/mission.sqm
@@ -25778,7 +25778,7 @@ class Mission
 					class Attributes
 					{
 						rank="SERGEANT";
-						init="groupPlayersNATO = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersNATO = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_blue_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -25853,7 +25853,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_blue_2";
 						description="Medic";
 						isPlayable=1;
@@ -25929,7 +25929,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_blue_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -26005,7 +26005,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_blue_4";
 						description="Marksman";
 						isPlayable=1;
@@ -26080,7 +26080,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_blue_5";
 						description="AT1";
 						isPlayable=1;
@@ -26155,7 +26155,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_blue_6";
 						description="AT2";
 						isPlayable=1;
@@ -26250,7 +26250,7 @@ class Mission
 					flags=6;
 					class Attributes
 					{
-						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_red_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -26324,7 +26324,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_red_2";
 						description="Medic";
 						isPlayable=1;
@@ -26398,7 +26398,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_red_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -26472,7 +26472,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_red_4";
 						description="Marksman";
 						isPlayable=1;
@@ -26546,7 +26546,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_red_5";
 						description="AT1";
 						isPlayable=1;
@@ -26620,7 +26620,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_red_6";
 						description="AT2";
 						isPlayable=1;

--- a/Map-Templates/Antistasi-Kunduz.Kunduz/mission.sqm
+++ b/Map-Templates/Antistasi-Kunduz.Kunduz/mission.sqm
@@ -10693,7 +10693,7 @@ class Mission
 					class Attributes
 					{
 						rank="SERGEANT";
-						init="groupPlayersNATO = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersNATO = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_blue_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -10768,7 +10768,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_blue_2";
 						description="Medic";
 						isPlayable=1;
@@ -10844,7 +10844,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_blue_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -10920,7 +10920,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_blue_4";
 						description="Marksman";
 						isPlayable=1;
@@ -10995,7 +10995,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_blue_5";
 						description="AT1";
 						isPlayable=1;
@@ -11070,7 +11070,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_blue_6";
 						description="AT2";
 						isPlayable=1;
@@ -11165,7 +11165,7 @@ class Mission
 					flags=6;
 					class Attributes
 					{
-						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_red_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -11239,7 +11239,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_red_2";
 						description="Medic";
 						isPlayable=1;
@@ -11313,7 +11313,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_red_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -11387,7 +11387,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_red_4";
 						description="Marksman";
 						isPlayable=1;
@@ -11461,7 +11461,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_red_5";
 						description="AT1";
 						isPlayable=1;
@@ -11535,7 +11535,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_red_6";
 						description="AT2";
 						isPlayable=1;

--- a/Map-Templates/Antistasi-Livonia.Enoch/mission.sqm
+++ b/Map-Templates/Antistasi-Livonia.Enoch/mission.sqm
@@ -19065,7 +19065,7 @@ class Mission
 					class Attributes
 					{
 						rank="SERGEANT";
-						init="groupPlayersNATO = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersNATO = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_blue_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -19140,7 +19140,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_blue_2";
 						description="Medic";
 						isPlayable=1;
@@ -19216,7 +19216,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_blue_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -19292,7 +19292,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_blue_4";
 						description="Marksman";
 						isPlayable=1;
@@ -19367,7 +19367,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_blue_5";
 						description="AT1";
 						isPlayable=1;
@@ -19442,7 +19442,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_blue_6";
 						description="AT2";
 						isPlayable=1;
@@ -19537,7 +19537,7 @@ class Mission
 					flags=6;
 					class Attributes
 					{
-						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_red_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -19611,7 +19611,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_red_2";
 						description="Medic";
 						isPlayable=1;
@@ -19685,7 +19685,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_red_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -19759,7 +19759,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_red_4";
 						description="Marksman";
 						isPlayable=1;
@@ -19833,7 +19833,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_red_5";
 						description="AT1";
 						isPlayable=1;
@@ -19907,7 +19907,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_red_6";
 						description="AT2";
 						isPlayable=1;

--- a/Map-Templates/Antistasi-Malden.Malden/mission.sqm
+++ b/Map-Templates/Antistasi-Malden.Malden/mission.sqm
@@ -19543,7 +19543,7 @@ class Mission
 					class Attributes
 					{
 						rank="SERGEANT";
-						init="groupPlayersNATO = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersNATO = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_blue_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -19618,7 +19618,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_blue_2";
 						description="Medic";
 						isPlayable=1;
@@ -19694,7 +19694,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_blue_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -19770,7 +19770,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_blue_4";
 						description="Marksman";
 						isPlayable=1;
@@ -19845,7 +19845,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_blue_5";
 						description="AT1";
 						isPlayable=1;
@@ -19920,7 +19920,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_blue_6";
 						description="AT2";
 						isPlayable=1;
@@ -20015,7 +20015,7 @@ class Mission
 					flags=6;
 					class Attributes
 					{
-						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_red_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -20089,7 +20089,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_red_2";
 						description="Medic";
 						isPlayable=1;
@@ -20163,7 +20163,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_red_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -20237,7 +20237,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_red_4";
 						description="Marksman";
 						isPlayable=1;
@@ -20311,7 +20311,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_red_5";
 						description="AT1";
 						isPlayable=1;
@@ -20385,7 +20385,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_red_6";
 						description="AT2";
 						isPlayable=1;

--- a/Map-Templates/Antistasi-Stratis.Stratis/mission.sqm
+++ b/Map-Templates/Antistasi-Stratis.Stratis/mission.sqm
@@ -3820,7 +3820,7 @@ class Mission
 					class Attributes
 					{
 						rank="SERGEANT";
-						init="groupPlayersNATO = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersNATO = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_blue_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -3895,7 +3895,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_blue_2";
 						description="Medic";
 						isPlayable=1;
@@ -3971,7 +3971,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_blue_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -4047,7 +4047,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_blue_4";
 						description="Marksman";
 						isPlayable=1;
@@ -4122,7 +4122,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_blue_5";
 						description="AT1";
 						isPlayable=1;
@@ -4197,7 +4197,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_blue_6";
 						description="AT2";
 						isPlayable=1;
@@ -4292,7 +4292,7 @@ class Mission
 					flags=6;
 					class Attributes
 					{
-						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_red_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -4366,7 +4366,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_red_2";
 						description="Medic";
 						isPlayable=1;
@@ -4440,7 +4440,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_red_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -4514,7 +4514,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_red_4";
 						description="Marksman";
 						isPlayable=1;
@@ -4588,7 +4588,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_red_5";
 						description="AT1";
 						isPlayable=1;
@@ -4662,7 +4662,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_red_6";
 						description="AT2";
 						isPlayable=1;

--- a/Map-Templates/Antistasi-Tembelan-Island.Tembelan/mission.sqm
+++ b/Map-Templates/Antistasi-Tembelan-Island.Tembelan/mission.sqm
@@ -5390,7 +5390,7 @@ class Mission
 					class Attributes
 					{
 						rank="SERGEANT";
-						init="groupPlayersNATO = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersNATO = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_blue_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -5465,7 +5465,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_blue_2";
 						description="Medic";
 						isPlayable=1;
@@ -5541,7 +5541,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_blue_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -5617,7 +5617,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_blue_4";
 						description="Marksman";
 						isPlayable=1;
@@ -5692,7 +5692,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_blue_5";
 						description="AT1";
 						isPlayable=1;
@@ -5767,7 +5767,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_blue_6";
 						description="AT2";
 						isPlayable=1;
@@ -5862,7 +5862,7 @@ class Mission
 					flags=6;
 					class Attributes
 					{
-						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_red_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -5936,7 +5936,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_red_2";
 						description="Medic";
 						isPlayable=1;
@@ -6010,7 +6010,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_red_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -6084,7 +6084,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_red_4";
 						description="Marksman";
 						isPlayable=1;
@@ -6158,7 +6158,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_red_5";
 						description="AT1";
 						isPlayable=1;
@@ -6232,7 +6232,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_red_6";
 						description="AT2";
 						isPlayable=1;

--- a/Map-Templates/Antistasi-Virolahti.vt7/mission.sqm
+++ b/Map-Templates/Antistasi-Virolahti.vt7/mission.sqm
@@ -78402,7 +78402,7 @@ class Mission
 					flags=6;
 					class Attributes
 					{
-						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_red_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -78477,7 +78477,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_red_2";
 						description="Medic";
 						isPlayable=1;
@@ -78551,7 +78551,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_red_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -78625,7 +78625,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_red_4";
 						description="Marksman";
 						isPlayable=1;
@@ -78699,7 +78699,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_red_5";
 						description="AT1";
 						isPlayable=1;
@@ -78773,7 +78773,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_red_6";
 						description="AT2";
 						isPlayable=1;
@@ -78911,7 +78911,7 @@ class Mission
 					class Attributes
 					{
 						rank="SERGEANT";
-						init="groupPlayersNATO = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersNATO = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_blue_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -78986,7 +78986,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_blue_2";
 						description="Medic";
 						isPlayable=1;
@@ -79062,7 +79062,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_blue_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -79138,7 +79138,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_blue_4";
 						description="Marksman";
 						isPlayable=1;
@@ -79213,7 +79213,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_blue_5";
 						description="AT1";
 						isPlayable=1;
@@ -79288,7 +79288,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_blue_6";
 						description="AT2";
 						isPlayable=1;

--- a/Map-Templates/Antistasi-WotP.Tanoa/mission.sqm
+++ b/Map-Templates/Antistasi-WotP.Tanoa/mission.sqm
@@ -5461,7 +5461,7 @@ class Mission
 					class Attributes
 					{
 						rank="SERGEANT";
-						init="groupPlayersNATO = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersNATO = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_blue_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -5536,7 +5536,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_blue_2";
 						description="Medic";
 						isPlayable=1;
@@ -5612,7 +5612,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_blue_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -5688,7 +5688,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_blue_4";
 						description="Marksman";
 						isPlayable=1;
@@ -5763,7 +5763,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_blue_5";
 						description="AT1";
 						isPlayable=1;
@@ -5838,7 +5838,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_blue_6";
 						description="AT2";
 						isPlayable=1;
@@ -5933,7 +5933,7 @@ class Mission
 					flags=6;
 					class Attributes
 					{
-						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
+						init="groupPlayersCSAT = group this; this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 0];";
 						name="pvp_red_1";
 						description="Teamleader";
 						isPlayable=1;
@@ -6007,7 +6007,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 1];";
 						name="pvp_red_2";
 						description="Medic";
 						isPlayable=1;
@@ -6081,7 +6081,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 2];";
 						name="pvp_red_3";
 						description="Machinegunner";
 						isPlayable=1;
@@ -6155,7 +6155,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 3];";
 						name="pvp_red_4";
 						description="Marksman";
 						isPlayable=1;
@@ -6229,7 +6229,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 4];";
 						name="pvp_red_5";
 						description="AT1";
 						isPlayable=1;
@@ -6303,7 +6303,7 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this setVariable [""pvp"",true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
+						init="this setVariable [""pvp"",true,true]; this setVariable [""pvpPlayerUnitNumber"", 5];";
 						name="pvp_red_6";
 						description="AT2";
 						isPlayable=1;


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    the pvp variable defined in the init of pvp units was not being broadcast, as such FF cant see pvp players.

### Please specify which Issue this PR Resolves.
closes #1520

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [ ] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: go on a dedicated server and shot some pvp players, you should not get a FF warning/punishment

********************************************************
Notes:
