### PR TITLE
Prevent saveplayer reporting an error for PvP players

### DIFF
--- a/A3-Antistasi/functions/Save/fn_savePlayer.sqf
+++ b/A3-Antistasi/functions/Save/fn_savePlayer.sqf
@@ -15,10 +15,6 @@ if (isNil "_playerUnit" || { isNull _playerUnit }) exitWith {
 	[1, format ["Not saving player %1 due to missing unit", _playerId], _filename] call A3A_fnc_log;
 };
 
-if (isNil { _playerUnit getVariable "moneyX" }) exitWith {
-	[1, format ["Not saving player %1 due to missing variables. What happened here?", _playerId], _filename] call A3A_fnc_log;
-};
-
 //Only save rebel players.
 if (side group _playerUnit != teamPlayer && side group _playerUnit != sideUnknown) exitWith {
 	[2, format ["Not saving player %1 due to them being on the wrong team.", _playerId], _filename] call A3A_fnc_log;
@@ -27,6 +23,10 @@ if (side group _playerUnit != teamPlayer && side group _playerUnit != sideUnknow
 //Used to disable saving while the player initialises. Otherwise they might disconnect, and overwrite their own save prematurely.
 if !(_playerUnit getVariable ['canSave', false]) exitWith {
 	[2, format ["Not saving player %1 due to canSave being false.", _playerId], _filename] call A3A_fnc_log;
+};
+
+if (isNil { _playerUnit getVariable "moneyX" }) exitWith {
+	[1, format ["Not saving player %1 due to missing variables. What happened here?", _playerId], _filename] call A3A_fnc_log;
 };
 
 [2, format ["Saving player %1 on side %2", _playerId, side group _playerUnit], _filename] call A3A_fnc_log;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
In savePlayer, moved the catch-all sanity check for the moneyX variable after the known do-not-save cases, notably for PvP players, so that error messages are reserved for actual errors.

Not too happy about the side check for PvP here, but it'll do until #1520 is resolved.

Not critical for 2.3.1 as it only affects logging, although it's also trivial.

### Please specify which Issue this PR Resolves.
closes #1522

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
