### PR TITLE
CS-1520-FFChecksLocalPvp

### DIFF
--- a/A3-Antistasi/functions/Punishment/fn_punishment_FF.sqf
+++ b/A3-Antistasi/functions/Punishment/fn_punishment_FF.sqf
@@ -104,8 +104,8 @@ private _exemption = switch (true) do {
     case (!hasInterface):                              {"FF BY SERVER/HC"};
     case (!(player isEqualTo _instigator)):            {"NOT EXEC ON INSTIGATOR"}; // Must be local for 'BIS_fnc_admin'
     case (_victim isEqualTo _instigator):              {"SUICIDE"}; // Local AI victims will be different.
-    case (_victim getVariable ["pvp",false]):          {call _logPvPHurt; "VICTIM NOT REBEL"};
-    case (_instigator getVariable ["pvp",false]):      {call _logPvPAttack; "INSTIGATOR NOT REBEL"};
+    case (!(side group _victim isEqualTo teamPlayer)):      {call _logPvPHurt; "VICTIM NOT REBEL"};
+    case (!(side group _instigator isEqualTo teamPlayer)):  {call _logPvPAttack; "INSTIGATOR NOT REBEL"};
     default                                            {""};
 };
 


### PR DESCRIPTION
## What type of PR is this.
* [x] Bug
* Change
* Enhancement

### Changes
* Inside Punishment_FF: Pvp was previously checked by the "Pvp" variable. However, this variable is not implemented to be JIP compatible.
  * Solution: Pvp is now checked by side group of the _instegator/_victim.

*PS: The brackets will be lined up later for those OCD among us.*

### The big issue that this PR Resolves.
closes [#1520](https://github.com/official-antistasi-community/A3-Antistasi/issues/1520)

### Personal Testing Checks.
2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
* Yes

## Testing Steps
1. Rebel Shoot Rebel -> Warning & FF Log
2. Rebel Shoot Pvp -> No Notification & PVPHURT log
3. Pvp Shoot Rebel -> No Notification & PVPATTACK log

### Zip of PBO is Provided 
*With Updated/Current Mission SQM*
[Antistasi-TEST-CS-1520-FFChecksLocalPvp-2-3-1.Altis.pbo.zip](https://github.com/official-antistasi-community/A3-Antistasi/files/5323352/Antistasi-TEST-CS-1520-FFChecksLocalPvp-2-3-1.Altis.pbo.zip)
