### PR TITLE
Prevent occupants launching airstrikes instead of QRFs on cities

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_patrolCA.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_patrolCA.sqf
@@ -78,7 +78,11 @@ if ((!_isMarker) and (_typeOfAttack != "Air") and (!_super) and ({sidesX getVari
 
 	// Government have much broader definition of "friendlies" than invaders do
 	private _friendlies = if (_sideX == Occupants) then {allUnits select {(_x distance _posDest < 200) and (alive _x) and ((side (group _x) == _sideX) or (side (group _x) == civilian))}} else {allUnits select {(_x distance _posDest < 100) and ([_x] call A3A_fnc_canFight) and (side (group _x) == _sideX)}};
-	if (count _friendlies == 0) then
+	private _nearCity = [citiesX, _posDest] call BIS_fnc_nearestPosition;
+	private _citySize = [_nearCity] call A3A_fnc_sizeMarker;
+	private _withinCity = _posDest inArea [getMarkerPos _nearCity, _citySize/2, _citySize/2, 0, false];
+
+	if (count _friendlies == 0 and !(_withinCity and _sideX == Occupants)) then
 	{
 		// select ordnance to use
 		private _bombType = if (napalmEnabled) then {"NAPALM"} else {"HE"};		// anti-infantry default. why?


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
In rare cases (no civs or friendly patrols anywhere near), occupants will launch airstrikes on cities, notably during city supply missions. This seems a little unreasonable.

This PR prevents patrolCA calls being resolved as airstrikes when given a position target within half a town's marker radius, regardless of current friendly/civilian presence. Some other sort of QRF will be sent instead.

### Please specify which Issue this PR Resolves.
closes #1508

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
You'd need to set up a situation where you're in a town with no occupant troops or civilians within 200m, which is normally not easy without Zeus abuse. Then order a patrolCA on your position like this:

`[position player, Occupants, "", false] remoteExec ["A3A_fnc_patrolCA", 2];`

An airstrike should not be sent.