### PR TITLE
CS-1534-JoinHint-AutoSaveTime

### DIFF
--- a/A3-Antistasi/functions/Dialogs/fn_createDialog_setParams.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_createDialog_setParams.sqf
@@ -1,11 +1,12 @@
 _nul=createDialog "set_params";
 
 waitUntil {dialog};
+private _autoSaveInterval = "autoSaveInterval" call BIS_fnc_getParamValue;
 [
 	"W A R N I N G ",
 	["Antistasi has a custom save system similar to other CTIs.<br/><br/>",
 	"To Save: Your commander needs to go to the <t color='#f0d498'>Map Board</t>, scroll-select <t color='#f0d498'>""Game Options""</t> and click on the <t color='#f0d498'>""Persistent Save""</t> button.<br/><br/>",
-	"Current parameters are configured to auto-save every <t color='#f0d498'>",(autoSaveInterval/60) toFixed 0," minutes</t>."] joinString ""
+	"Current parameters are configured to auto-save every <t color='#f0d498'>",(_autoSaveInterval/60) toFixed 0," minutes</t>."] joinString ""
 ] call A3A_fnc_customHint;
 waitUntil {!dialog};
 

--- a/A3-Antistasi/functions/Dialogs/fn_createDialog_shouldLoadPersonalSave.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_createDialog_shouldLoadPersonalSave.sqf
@@ -1,11 +1,12 @@
 _nul=createDialog "should_load_personal_save";
 
 waitUntil {dialog};
+private _autoSaveInterval = "autoSaveInterval" call BIS_fnc_getParamValue;
 [
 	"W A R N I N G ",
 	["Antistasi has a custom save system similar to other CTIs.<br/><br/>",
 	"To Save: Your commander needs to go to the <t color='#f0d498'>Map Board</t>, scroll-select <t color='#f0d498'>""Game Options""</t> and click on the <t color='#f0d498'>""Persistent Save""</t> button.<br/><br/>",
-	"Current parameters are configured to auto-save every <t color='#f0d498'>",(autoSaveInterval/60) toFixed 0," minutes</t>."] joinString ""
+	"Current parameters are configured to auto-save every <t color='#f0d498'>",(_autoSaveInterval/60) toFixed 0," minutes</t>."] joinString ""
 ] call A3A_fnc_customHint;
 waitUntil {!dialog};
 


### PR DESCRIPTION
## What type of PR is this.
* [x] Bug
* Change
* Enhancement

### What have you changed and why?
Information:
 * A local _autoSaveInterval extracted from params on each client.
 * This is used in the hint message.

### Please specify which Issue this PR Resolves.
closes [#1534](https://github.com/official-antistasi-community/A3-Antistasi/issues/1534)

### Please verify the following and ensure all checks are completed.

* [ ] Have you loaded the mission in LAN host?
* [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No (Can be rubber ducked)
* Yes

## Testing Steps
Join DS game as a client.
See the current autosave time appear in the `W A R N I N G` message.

### A Zip of the PBO is Provided 
[Antistasi-TEST-CS-1534-JoinHint-AutoSaveTime-2-3-1.Altis.pbo.zip](https://github.com/official-antistasi-community/A3-Antistasi/files/5356970/Antistasi-TEST-CS-1534-JoinHint-AutoSaveTime-2-3-1.Altis.pbo.zip)
