### PR TITLE
Remove CDF-PVP-Brdms

### DIFF
--- a/A3-Antistasi/Templates/RHS_Occ_CDF_Arid.sqf
+++ b/A3-Antistasi/Templates/RHS_Occ_CDF_Arid.sqf
@@ -40,7 +40,7 @@ NATOPlayerLoadouts = [
 ];
 
 //PVP Player Vehicles
-vehNATOPVP = ["rhsgref_ins_g_uaz","rhsgref_ins_g_uaz_open","rhsgref_BRDM2UM_ins_g","rhsgref_ins_g_uaz_dshkm_chdkz"];
+vehNATOPVP = ["rhsgref_ins_g_uaz","rhsgref_ins_g_uaz_open","rhsgref_ins_g_uaz_dshkm_chdkz"];
 
 ////////////////////////////////////
 //             UNITS             ///

--- a/A3-Antistasi/Templates/RHS_Occ_CDF_Temp.sqf
+++ b/A3-Antistasi/Templates/RHS_Occ_CDF_Temp.sqf
@@ -40,7 +40,7 @@ NATOPlayerLoadouts = [
 ];
 
 //PVP Player Vehicles
-vehNATOPVP = ["rhsgref_ins_g_uaz","rhsgref_ins_g_uaz_open","rhsgref_BRDM2UM_ins_g","rhsgref_ins_g_uaz_dshkm_chdkz"];
+vehNATOPVP = ["rhsgref_ins_g_uaz","rhsgref_ins_g_uaz_open","rhsgref_ins_g_uaz_dshkm_chdkz"];
 
 ////////////////////////////////////
 //             UNITS             ///


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information: The BRDMs given to PVP for CDF are way to heavily armored and come with an AA Launcher in its inventory.
They should be removed.
    

### Please specify which Issue this PR Resolves.
closes #1537 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [ ] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
