### PR TITLE
Switched the aggro-capture behaviour, low aggro now wins the map

### DIFF
--- a/A3-Antistasi/functions/Base/fn_rebelAttack.sqf
+++ b/A3-Antistasi/functions/Base/fn_rebelAttack.sqf
@@ -301,29 +301,34 @@ if(count _easyTargets >= 4) then
     };
 
     private _aggroChange = (100 - _defenderAggro) - (100 - _attackerAggro);
-    private _loseChange = 50 - (_aggroChange/2);
-    private _winChange = 100 - _loseChange;
-    [3, format ["Counter attack change is %1, aggro of attacker %2, aggro of defender %3", _winChange, _attackerAggro, _defenderAggro], _filename] call A3A_fnc_log;
+    private _winChange = 50 - (_aggroChange/2);
+    private _loseChange = 100 - _winChange;
+    [3, format ["Aggro change is %1, lose change %2, win change %3", _aggroChange, _loseChange, _winChange], _filename] call A3A_fnc_log;
+    [3, format ["Counter attack change is %1, aggro of attacker %2, aggro of defender %3", _loseChange, _attackerAggro, _defenderAggro], _filename] call A3A_fnc_log;
 
     private _attackerWon = selectRandomWeighted [false, _loseChange, true, _winChange];
+    [3, format ["Result was %1", _attackerWon], _filename] call A3A_fnc_log;
     if !(_attackerWon) exitWith
     {
         [3, "Attack failed, starting counter attack again attacker", _filename] call A3A_fnc_log;
         //Attack failed, execute counter attack
         private _targets = (seaports + outposts) select
         {
-            sidesX getVariable _x == _side &&   //Side of the enemy,
-            spawner getVariable _x != 2
+            sidesX getVariable _x == _side &&   //Side of the attacker
+            spawner getVariable _x == 2         //Not spawned in
         };
 
-        if(count _targets == 0) exitWith {};
+        if(count _targets == 0) exitWith
+        {
+            [3, "Found no target to counter attack, abort", _filename] call A3A_fnc_log;
+        };
 
         private _attackOrder = selectRandom _attackList;
         private _origin = _attackOrder select 0;
 
         private _counterAttack = [_targets, getMarkerPos _origin] call BIS_fnc_nearestPosition;
-        [_side, _counterAttack] spawn A3A_fnc_markerChange;
-        [_side, _counterAttacks] spawn
+        [_targetSide, _counterAttack] spawn A3A_fnc_markerChange;
+        [_targetSide, _counterAttack] spawn
         {
             params ["_side", "_target"];
             sleep 10;
@@ -492,26 +497,31 @@ else
             };
 
             private _aggroChange = (100 - _defenderAggro) - (100 - _attackerAggro);
-            private _loseChange = 50 - (_aggroChange/2);
-            private _winChange = 100 - _loseChange;
-            [3, format ["Counter attack change is %1, aggro of attacker %2, aggro of defender %3", _winChange, _attackerAggro, _defenderAggro], _filename] call A3A_fnc_log;
+            private _winChange = 50 - (_aggroChange/2);
+            private _loseChange = 100 - _winChange;
+            [3, format ["Aggro change is %1, lose change %2, win change %3", _aggroChange, _loseChange, _winChange], _filename] call A3A_fnc_log;
+            [3, format ["Counter attack change is %1, aggro of attacker %2, aggro of defender %3", _loseChange, _attackerAggro, _defenderAggro], _filename] call A3A_fnc_log;
 
             private _attackerWon = selectRandomWeighted [false, _loseChange, true, _winChange];
+            [3, format ["Result was %1", _attackerWon], _filename] call A3A_fnc_log;
             if !(_attackerWon) exitWith
             {
                 [3, "Attack failed, starting counter attack again attacker", _filename] call A3A_fnc_log;
                 //Attack failed, execute counter attack
                 private _targets = (seaports + outposts + airportsX) select
                 {
-                    sidesX getVariable _x == _side &&   //Side of the enemy,
-                    spawner getVariable _x != 2
+                    sidesX getVariable _x == _side &&   //Side of the attacker
+                    spawner getVariable _x == 2         //Not spawned in
                 };
 
-                if(count _targets == 0) exitWith {};
+                if(count _targets == 0) exitWith
+                {
+                    [3, "Found no target to counter attack, abort", _filename] call A3A_fnc_log;
+                };
 
                 private _counterAttack = [_targets, getMarkerPos _attackOrigin] call BIS_fnc_nearestPosition;
-                [_side, _counterAttack] spawn A3A_fnc_markerChange;
-                [_side, _counterAttacks] spawn
+                [_targetSide, _counterAttack] spawn A3A_fnc_markerChange;
+                [_targetSide, _counterAttack] spawn
                 {
                     params ["_side", "_target"];
                     sleep 10;

--- a/A3-Antistasi/functions/Base/fn_rebelAttack.sqf
+++ b/A3-Antistasi/functions/Base/fn_rebelAttack.sqf
@@ -462,6 +462,7 @@ else
         if !(_attackerWon) then
         {
             [3, format ["Attack failed, starting counter attack again %1", _targetSide], _filename] call A3A_fnc_log;
+            [3600, _side] call A3A_fnc_timingCA;
 
             //Search for possible targets
             private _targets = (outposts + airportsX) select

--- a/A3-Antistasi/functions/Base/fn_rebelAttack.sqf
+++ b/A3-Antistasi/functions/Base/fn_rebelAttack.sqf
@@ -451,60 +451,6 @@ else
 
     _finalTarget params ["_attackOrigin", "_attackPoints", "_attackTarget"];
 
-    private _attackerAggro = 0;
-    private _defenderAggro = 0;
-    if (_side == Occupants) then
-    {
-        _attackerAggro = aggressionOccupants;
-        _defenderAggro = aggressionInvaders;
-    }
-    else
-    {
-        _attackerAggro = aggressionInvaders;
-        _defenderAggro = aggressionOccupants;
-    };
-
-    private _aggroChange = (100 - _defenderAggro) - (100 - _attackerAggro);
-    private _loseChange = 50 - (_aggroChange/2);
-    private _winChange = 100 - _loseChange;
-    [3, format ["Counter attack change is %1, aggro of attacker %2, aggro of defender %3", _winChange, _attackerAggro, _defenderAggro], _filename] call A3A_fnc_log;
-
-    private _attackerWon = selectRandomWeighted [false, _loseChange, true, _winChange];
-    if !(_attackerWon) exitWith
-    {
-        [3, "Attack failed, starting counter attack again attacker", _filename] call A3A_fnc_log;
-        //Attack failed, execute counter attack
-        private _targets = (seaports + outposts + airportsX) select
-        {
-            sidesX getVariable _x == _side &&   //Side of the enemy,
-            spawner getVariable _x != 2
-        };
-
-        if(count _targets == 0) exitWith {};
-
-        private _counterAttack = [_targets, getMarkerPos _attackOrigin] call BIS_fnc_nearestPosition;
-        [_side, _counterAttack] spawn A3A_fnc_markerChange;
-        [_side, _counterAttacks] spawn
-        {
-            params ["_side", "_target"];
-            sleep 10;
-            private _squads = 4 + round (random 3);
-            private _soldiers = [];
-            for "_i" from 0 to _squads do
-            {
-                if (_side == Occupants) then
-                {
-                    _soldiers append (selectRandom (groupsNATOSquad + groupsNATOmid));
-                }
-                else
-                {
-                    _soldiers append (selectRandom (groupsCSATSquad + groupsCSATmid));
-                };
-            };
-            [_soldiers,_side,_target,0] remoteExec ["A3A_fnc_garrisonUpdate",2];
-        };
-    };
-
     //Maybe have aggro play a role here?
     //Select the number of waves based on the points as higher points mean higher difficulty
     private _waves =
@@ -531,6 +477,61 @@ else
             //Auto win for the attacker, no units or calculation needed
             private _side = sidesX getVariable _attackOrigin;
             [2, format ["Autowin %1 for side %2 to avoid unnecessary calculations", _attackTarget, _side], _fileName] call A3A_fnc_log;
+
+            private _attackerAggro = 0;
+            private _defenderAggro = 0;
+            if (_side == Occupants) then
+            {
+                _attackerAggro = aggressionOccupants;
+                _defenderAggro = aggressionInvaders;
+            }
+            else
+            {
+                _attackerAggro = aggressionInvaders;
+                _defenderAggro = aggressionOccupants;
+            };
+
+            private _aggroChange = (100 - _defenderAggro) - (100 - _attackerAggro);
+            private _loseChange = 50 - (_aggroChange/2);
+            private _winChange = 100 - _loseChange;
+            [3, format ["Counter attack change is %1, aggro of attacker %2, aggro of defender %3", _winChange, _attackerAggro, _defenderAggro], _filename] call A3A_fnc_log;
+
+            private _attackerWon = selectRandomWeighted [false, _loseChange, true, _winChange];
+            if !(_attackerWon) exitWith
+            {
+                [3, "Attack failed, starting counter attack again attacker", _filename] call A3A_fnc_log;
+                //Attack failed, execute counter attack
+                private _targets = (seaports + outposts + airportsX) select
+                {
+                    sidesX getVariable _x == _side &&   //Side of the enemy,
+                    spawner getVariable _x != 2
+                };
+
+                if(count _targets == 0) exitWith {};
+
+                private _counterAttack = [_targets, getMarkerPos _attackOrigin] call BIS_fnc_nearestPosition;
+                [_side, _counterAttack] spawn A3A_fnc_markerChange;
+                [_side, _counterAttacks] spawn
+                {
+                    params ["_side", "_target"];
+                    sleep 10;
+                    private _squads = 4 + round (random 3);
+                    private _soldiers = [];
+                    for "_i" from 0 to _squads do
+                    {
+                        if (_side == Occupants) then
+                        {
+                            _soldiers append (selectRandom (groupsNATOSquad + groupsNATOmid));
+                        }
+                        else
+                        {
+                            _soldiers append (selectRandom (groupsCSATSquad + groupsCSATmid));
+                        };
+                    };
+                    [_soldiers,_side,_target,0] remoteExec ["A3A_fnc_garrisonUpdate",2];
+                };
+            };
+
             [_side, _attackTarget] spawn A3A_fnc_markerChange;
             [3600, _side] call A3A_fnc_timingCA;
             //Add units to the marker to avoid fast recapture

--- a/A3-Antistasi/functions/Base/fn_rebelAttack.sqf
+++ b/A3-Antistasi/functions/Base/fn_rebelAttack.sqf
@@ -268,16 +268,25 @@ private _fnc_flipMarker =
 
 private _attackerAggro = 0;
 private _defenderAggro = 0;
-if (_side == Occupants) then
+if(_targetSide != teamPlayer) then
 {
-    _attackerAggro = aggressionOccupants;
-    _defenderAggro = aggressionInvaders;
+    if (_side == Occupants) then
+    {
+        _attackerAggro = aggressionOccupants;
+        _defenderAggro = aggressionInvaders;
+    }
+    else
+    {
+        _attackerAggro = aggressionInvaders;
+        _defenderAggro = aggressionOccupants;
+    };
 }
 else
 {
-    _attackerAggro = aggressionInvaders;
-    _defenderAggro = aggressionOccupants;
+    _attackerAggro = 0;
+    _defenderAggro = 100;
 };
+
 
 private _aggroChange = (100 - _defenderAggro) - (100 - _attackerAggro);
 private _winChange = 50 - (_aggroChange/2);


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [X] Enhancement

### What have you changed and why?
Information:
Currently the most aggressive faction wins the map as their attacks are way more frequent to fight the player advancing. This however leads to the more fought faction (mostly Occupants) to stop the other faction (mostly Invaders).

Now there is a chance for the attacked faction to defend the attack and counter attack the attacking force, dependent on aggro ratio between them. Lower aggro increases chance of winning attacks/defending attacks.

In the end the faction which is mostly inactive, should take over the map quickly until they are actively fighting the rebels and therefor get active.

### Please specify which Issue this PR Resolves.
None opened

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [X] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
```
[[50, 60], [0, 0]] spawn A3A_fnc_prestige;
[] spawn 
{
    while {true} do 
    {
        [Occupants] spawn A3A_fnc_rebelAttack;
        sleep 50;
        [Invaders] spawn A3A_fnc_rebelAttack;
        sleep 50;
    };
};
```
Execute as server and watch what is happening
********************************************************
Notes: Idea is only a day old, not sure how the balance is in the end
