### PR TITLE
made crash pos origin respect map boundaries

### DIFF
--- a/A3-Antistasi/functions/Missions/fn_DES_Heli.sqf
+++ b/A3-Antistasi/functions/Missions/fn_DES_Heli.sqf
@@ -16,7 +16,8 @@ private _dist = if (_difficult) then {2000} else {3000};
 private _posCrashOrigin = [];
 while {true} do {
 	_posCrashOrigin = _missionOriginPos getPos [_dist,_ang];
-	if ((!surfaceIsWater _posCrashOrigin) and (_posCrashOrigin distance (getMarkerPos respawnTeamPlayer) < 4000) and (_posCrashOrigin distance (getMarkerPos respawnTeamPlayer) > 1000)) exitWith {};
+	private _notOutOfBounds = (_posCrashOrigin select [0,2]) findIf { (_x < 0 + 1000) || (_x > worldSize -1000)} isEqualTo -1; //1k grace for refinement search later
+	if ((!surfaceIsWater _posCrashOrigin) and (_posCrashOrigin distance (getMarkerPos respawnTeamPlayer) < 4000) and (_posCrashOrigin distance (getMarkerPos respawnTeamPlayer) > 1000) and _notOutOfBounds) exitWith {};
 	_ang = _ang + 1;
 	_countX = _countX + 1;
 	if (_countX > 360) then


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information: on maps not surrounded with water, Des_Heli could spawn outside the map, as players are no longer able to leave the map this blocked completion (for the most part) of this mission, to resolve this the mission will now always spawn within the map boundaries, spawning in the worst case at the border
    

### Please specify which Issue this PR Resolves.
closes #1558

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: [["airport"],"A3A_fnc_DES_Heli"] remoteExec ["A3A_fnc_scheduler",2]
on kunduz as it had a high tendency to spawn out of bounds.
dismiss the mission with ''[0,"DES"] spawn A3A_fnc_deleteTask;'' and repeat.

********************************************************
Notes:
