### PR TITLE
Fix some arsenal magazine bugs

### DIFF
--- a/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_loadInventory.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_loadInventory.sqf
@@ -395,6 +395,7 @@ _addItemToContainer = {
 						_arrayMissing = [_arrayMissing,[_item,(_amount - _amountAvailable)]] call jn_fnc_arsenal_addToArray;
 						_amount = _amountAvailable max 0;
 					};
+					if (_amount == 0) exitWith {};				// Don't add empty mags
 					[_arrayTaken,_index,_item,_amount] call _addToArray;
 					[_availableItems,_index,_item,_amount] call _removeFromArray;
 					_container addMagazineAmmoCargo  [_item,1, _amount];


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
- Workaround BIS bug with setUnitLoadout that caused mags to be incorrectly refilled on entering arsenal
- Prevent adding empty magazines when loading loadout with unavailable items
- Fix non-member magazine limits for vehicle arsenal
- Sanitize other non-member limit routines for coherency

### Please specify which Issue this PR Resolves.
closes #1563

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
