### PR TITLE
Fix captive state being stripped from handcuffed units waking from unconscious

### DIFF
--- a/A3-Antistasi/functions/init/fn_initACEUnconsciousHandler.sqf
+++ b/A3-Antistasi/functions/init/fn_initACEUnconsciousHandler.sqf
@@ -22,7 +22,10 @@ private _fileName = "initACEUnconsciousHandler.sqf";
 
 //	[3, format ["Unit type %1, side %2, realside %3, captive %4, lifestate %5 waking up", typeof _unit, side _unit, _realSide, str (captive _unit), lifestate _unit], ace_unconscious handler] call A3A_fnc_log;
 	_unit setVariable ["incapacitated", false, true];
-	[_unit, false] remoteExec ["setCaptive", _unit];			// match vanilla behaviour
+
+	if !(_unit getVariable ["ACE_captives_isHandcuffed", false]) then {
+		[_unit, false] remoteExec ["setCaptive", _unit];			// match vanilla behaviour
+	};
 
 	if (isPlayer _unit) exitWith {};					// don't force surrender with players
 	if (_realSide != Occupants && _realSide != Invaders) exitWith {};


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed case where handcuffed units would lose their captive state on waking from unconscious, causing them to be shot by enemy AIs.

This is only one of many compatibility problems that ACE handcuffs has with Antistasi's undercover system, but it probably accounts for 90%+ of the issues in practice, so it's worth quickfixing.

### Please specify which Issue this PR Resolves.
Partial fix for #1540

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
