### PR TITLE
fixed broken salvage rope, improved functionality

### DIFF
--- a/A3-Antistasi/functions/SalvageRope/fn_salvageRope.sqf
+++ b/A3-Antistasi/functions/SalvageRope/fn_salvageRope.sqf
@@ -36,7 +36,7 @@ A3A_SR_adjustRope = {
     params ["_player", "_vehicle"];
     private _rope = _vehicle getVariable "WinchRope";
     private _helper = _vehicle getVariable ["WinchHelper", objNull];
-    while {!isNull ropeAttachedTo _helper} do {
+    while {!isNull ropeAttachedTo _helper && alive attachedTo _helper} do {
         private _dist = _vehicle distance _player;
         private _optimalDist = _dist + 3;
         private _maxDist = _dist + 7;
@@ -49,7 +49,11 @@ A3A_SR_adjustRope = {
         };
         sleep 0.1;
     };
-    if (!alive _vehicle) then { [_helper, _vehicle] call A3A_SR_cleanHelper };
+    if (alive _helper) then { //vehicle destroyed, rope broken or player died
+        [_helper, _vehicle] call A3A_SR_cleanHelper;
+        ropeDestroy (_vehicle getVariable "WinchRope");
+        _vehicle setVariable ["WinchRope", nil, true];
+    };
 };
 
 //Stow action
@@ -66,9 +70,9 @@ A3A_SR_canStow = { //can stow when the player is not in a vehicle, is within 10m
 A3A_SR_stowRope = {
     params ["_player"];
     private _vehicle = cursorTarget;
-    ropeDestroy (_vehicle getVariable "WinchRope");
     [_vehicle getVariable "WinchHelper", _vehicle] call A3A_SR_cleanHelper;
-    _vehicle setVariable ["WinchRope",nil,true];
+    ropeDestroy (_vehicle getVariable "WinchRope");
+    _vehicle setVariable ["WinchRope", nil, true];
 };
 
 //Attach action
@@ -93,8 +97,8 @@ A3A_SR_attachRope = {
     private _time = time + 5 + (_unwind*2);
 
     //destroy rope between player and boat
-    ropeDestroy (_vehicle getVariable "WinchRope");
     [_helper, _vehicle] call A3A_SR_cleanHelper;
+    ropeDestroy (_vehicle getVariable "WinchRope");
 
     //create rope between cargo and boat
     private _rope = ropeCreate [_vehicle, [0,-2.8,-0.8], _cargo, [0,0,0], _distance];

--- a/A3-Antistasi/functions/SalvageRope/fn_salvageRope.sqf
+++ b/A3-Antistasi/functions/SalvageRope/fn_salvageRope.sqf
@@ -20,15 +20,16 @@ A3A_SR_DeployWinch = {
     _vehicle setVariable ["WinchRope", (ropeCreate [_vehicle, [0,-2.8,-0.8], _helper, [0,0,0], 10]), true];
     _vehicle setVariable ["WinchHelper", _helper, true];
     player setVariable ["WinchHelperObj", _helper];
-    [_player, _vehicle] spawn A3A_SR_adjustRope;
+    [_player, _vehicle] call A3A_SR_adjustRope;
 };
 
 A3A_SR_cleanHelper = {
     params ["_helper", "_vehicle"];
+    private _player = attachedTo _helper;
     detach _helper;
     deleteVehicle _helper;
     _vehicle setVariable ["WinchHelper", nil];
-    player setVariable ["WinchHelperObj", nil];
+    _player setVariable ["WinchHelperObj", nil];
 };
 
 A3A_SR_adjustRope = {
@@ -56,8 +57,9 @@ A3A_SR_canStow = { //can stow when the player is not in a vehicle, is within 10m
     private _vehicle = cursorTarget;
     if (isNull _vehicle) exitWith {false};
     if (isNull (_vehicle getVariable ["WinchRope", objNull])) exitWith {false}; //winch deployed
-    private _attachedPlayer = attachedTo (_vehicle getVariable ["WinchHelper", objNull]);
-    if (isNull _attachedPlayer) exitWith {false};//this is the case when retrieving cargo
+    private _helper = _vehicle getVariable ["WinchHelper", objNull];
+    if (isNull _helper) exitWith {false};//this is the case when retrieving cargo
+    private _attachedPlayer = attachedTo _helper;
     vehicle player == player && player distance _vehicle < 10 && (!alive _attachedPlayer || player == _attachedPlayer); //only attached player unless dead
 };
 
@@ -122,7 +124,7 @@ A3A_SR_addplayerWinchActions = {
     }, nil, 0, false, true, "", "call A3A_SR_canStow"];
 
     player addAction ["Attach Rope", {
-        [player] spawn A3A_SR_attachRope;
+        [player] call A3A_SR_attachRope;
     }, nil, 0, false, true, "", "call A3A_SR_canAttach"];
 
     if (isMultiplayer) then {

--- a/A3-Antistasi/functions/SalvageRope/fn_salvageRope.sqf
+++ b/A3-Antistasi/functions/SalvageRope/fn_salvageRope.sqf
@@ -1,148 +1,136 @@
 private _filename = "fn_salvageRope.sqf";
-//TODO: Remove before final release
-if (isRemoteExecutedJIP) then {[3, format ["Salvage Rope Action added on JIP client: %1", player], _filename, true] call A3A_fnc_log;};
-
 
 //Deploy action
-canDeployWinch = { //can deploy winch if player is not in a vehicle, is within 10m, theres no rope deployed yet and the vehicle can load cargo
-	private _vehicle = cursorTarget;
-	if(_vehicle isKindOf "Ship") then {
-		vehicle player == player && player distance _vehicle < 10 && isNil {_vehicle getVariable "WinchRope"} && [_vehicle, boxX] call jn_fnc_logistics_canLoad != -3;
-	} else {
-		false;
-	};
+A3A_SR_canDeployWinch = { //can deploy winch if player is not in a vehicle, is within 10m, theres no rope deployed yet and the vehicle can load cargo
+    private _vehicle = cursorTarget;
+    if (_vehicle isKindOf "Ship") then {
+        vehicle player == player && player distance _vehicle < 10 && isNil {_vehicle getVariable "WinchRope"} && [_vehicle, boxX] call jn_fnc_logistics_canLoad != -3;
+    } else {
+        false;
+    };
 };
 
-DeployWinch = {
-	if (captive player) then {player setCaptive false};
-	params ["_player"];
-	private _vehicle = cursorTarget;
-	private _helper = "Land_Can_V1_F" createVehicle [random 100,random 100, random 100];
-	_helper hideObjectGlobal true;
-	_helper attachTo [_player,[0,0.1,0], "pelvis"];
-	_vehicle setVariable ["WinchRope", (ropeCreate [_vehicle, [0,-2.8,-0.8], _helper, [0,0,0], 10]), true];
-	_vehicle setVariable ["WinchHelper", _helper, true];
-	player setVariable ["WinchHelperObj", _helper];
-	_vehicle setVariable ["WinchRopeUnit", _player, true];
-	[_player, _vehicle] spawn adjustRope;
+A3A_SR_DeployWinch = {
+    if (captive player) then {player setCaptive false};
+    params ["_player"];
+    private _vehicle = cursorTarget;
+    private _helper = "Land_Can_V1_F" createVehicle [random 100,random 100, random 100];
+    _helper hideObjectGlobal true;
+    _helper attachTo [_player,[0,0.1,0], "pelvis"];
+    _vehicle setVariable ["WinchRope", (ropeCreate [_vehicle, [0,-2.8,-0.8], _helper, [0,0,0], 10]), true];
+    _vehicle setVariable ["WinchHelper", _helper, true];
+    player setVariable ["WinchHelperObj", _helper];
+    [_player, _vehicle] spawn A3A_SR_adjustRope;
 };
 
-adjustRope = {
-	params ["_player", "_vehicle"];
-	while {!isNil {_vehicle getVariable "WinchRope"}} do {
-		private _rope = _vehicle getVariable "WinchRope";
-		private _dist = _vehicle distance _player;
-		private _optimalDist = _dist + 3;
-		private _maxDist = _dist + 7;
-		if ((ropeLength _rope) < _dist) then {
-			ropeUnwind [_rope, 10, _optimalDist];
-		} else {
-			if ((ropeLength _rope) > _maxDist) then {
-				ropeUnwind [_rope, 10, _optimalDist];
-			};
-		};
-		sleep 0.1;
-	};
+A3A_SR_adjustRope = {
+    params ["_player", "_vehicle"];
+    while {!isNil {_vehicle getVariable "WinchRope"}} do {
+        private _rope = _vehicle getVariable "WinchRope";
+        private _dist = _vehicle distance _player;
+        private _optimalDist = _dist + 3;
+        private _maxDist = _dist + 7;
+        if ((ropeLength _rope) < _dist) then {
+            ropeUnwind [_rope, 10, _optimalDist];
+        } else {
+            if ((ropeLength _rope) > _maxDist) then {
+                ropeUnwind [_rope, 10, _optimalDist];
+            };
+        };
+        sleep 0.1;
+    };
 };
 
 //Stow action
-canStow = { //can stow when the player is not in a vehicle, is within 10m, a rope is deployed, and its attached to the player or no one
-	private _vehicle = cursorTarget;
-	if (isNull _vehicle) exitWith {false};
-	private _ropeExist = if (!isNil {_vehicle getVariable "WinchRope"}) then {true} else {false};
-	private _ropeOwner = if ((_vehicle getVariable "WinchRopeUnit") == player) then {true} else {false};
-	private _attachedPlayer = attachedTo (_vehicle getVariable ["WinchHelper", objNull]);
-	if (isNil {_vehicle getVariable "WinchRope2"} && !(isNull _attachedPlayer)) then {_ropeOwner = true}; //overide if none is on the helper and its not winching salvage obj
-	vehicle player == player && player distance _vehicle < 10 && _ropeExist && _ropeOwner;
+A3A_SR_canStow = { //can stow when the player is not in a vehicle, is within 10m, rope attached to the player or no one, not recovering cargo
+    private _vehicle = cursorTarget;
+    if (isNull _vehicle) exitWith {false};
+    if !(isNil {_vehicle getVariable "WinchRope2"}) exitWith {false};
+    private _attachedPlayer = attachedTo (_vehicle getVariable ["WinchHelper", objNull]);
+    if (isNull _attachedPlayer) exitWith {false}; //winch not deployed
+    vehicle player == player && player distance _vehicle < 10 && (!alive _attachedPlayer || player == _attachedPlayer); //only attached player unless dead
 };
 
-stowRope = {
-	params ["_player"];
-	private _vehicle = cursorTarget;
-	ropeDestroy (_vehicle getVariable "WinchRope");
-	_helper = _vehicle getVariable "WinchHelper";
-	detach _helper;
-	deleteVehicle _helper;
-	_vehicle setVariable ["WinchRope",nil,true];
-	_vehicle setVariable ["WinchHelper",nil,true];
-	player setVariable ["WinchHelperObj", objNull];
-	_vehicle setVariable ["WinchRopeUnit",nil,true];
+A3A_SR_stowRope = {
+    params ["_player"];
+    private _vehicle = cursorTarget;
+    ropeDestroy (_vehicle getVariable "WinchRope");
+    _helper = _vehicle getVariable "WinchHelper";
+    detach _helper;
+    deleteVehicle _helper;
+    _vehicle setVariable ["WinchRope",nil,true];
+    _vehicle setVariable ["WinchHelper",nil,true];
+    player setVariable ["WinchHelperObj", objNull];
 
 };
 
 //Attach action
-canAttach = { //whitelisted objs (SalvageCrate) thats within 13m (finicky with low distance) and thats under water can be attached while the player has a rope
-	_cargo = cursorTarget;
-	if(!isNull _cargo) then {
-		private _helper = player getVariable ["WinchHelperObj", objNull];//get helper from player
-		if !(_helper in attachedObjects player) then {_helper = objNull};//make sure its still attached to the player
-		player != _cargo && _cargo getVariable ["SalvageCrate", false] && player distance _cargo <= 13 && ((ropeAttachedTo _helper) getVariable "WinchRopeUnit") == player && (getPosASLW _cargo#2)<0;
-	} else {
-		false;
-	};
+A3A_SR_canAttach = { //whitelisted objs (SalvageCrate) thats within 13m (finicky with low distance) and thats under water can be attached while the player has a rope
+    _cargo = cursorTarget;
+    if (isNull _cargo) exitWith {false};
+    if !(_cargo getVariable ["SalvageCrate", false]) exitWith {false}; //not whitelisted
+    if ((getPosASLW _cargo#2)>0) exitWith {false}; //above water
+    private _helper = player getVariable ["WinchHelperObj", objNull];//get helper from player
+    player distance _cargo <= 13 && !isNull(ropeAttachedTo _helper); //close enough and has rope
 };
 
-attachRope = {
-	private _cargo = cursorTarget;
-	private ["_vehicle"];
-	private _helper = player getVariable ["WinchHelperObj", objNull];
-	_vehicle = ropeAttachedTo _helper;
-	_vehicle setVariable ["WinchRopeUnit",_vehicle,true]; //to stop stow action from showing while recovering crate
-	[player, false] remoteExec ["setCaptive"];
-	[] spawn A3A_fnc_statistics;
-	private _distance = _vehicle distance _cargo;
-	private _unwind = _distance - 0.5;
-	private _time = 5 + (_unwind*2);
-	ropeDestroy (_vehicle getVariable "WinchRope");
-	_helper = _vehicle getVariable "WinchHelper";
-	detach _helper;
-	deleteVehicle _helper;
-	_vehicle setVariable ["WinchHelper",nil,true];
-	_vehicle setVariable ["WinchRope2", (ropeCreate [_vehicle, [0,-2.8,-0.8], _cargo, [0,0,0], _distance]), true];
-	sleep 1;
-	ropeUnwind [ropes _vehicle select 0, 0.5, -(_unwind), true];
-	_vehicle lockCargo true;
-	sleep _time;
-	ropeDestroy (_vehicle getVariable "WinchRope2");
-	[_vehicle, _cargo] call jn_fnc_logistics_load;
-	_cargo call jn_fnc_logistics_addAction;
-	_vehicle setVariable ["WinchRope2",nil,true];
-	_vehicle setVariable ["WinchRope",nil,true];
-	_vehicle setVariable ["WinchRopeUnit",nil,true];
+A3A_SR_attachRope = {
+    private _cargo = cursorTarget;
+    private ["_vehicle"];
+    private _helper = player getVariable ["WinchHelperObj", objNull];
+    _vehicle = ropeAttachedTo _helper;
+    player setCaptive false;
+    private _distance = _vehicle distance _cargo;
+    private _unwind = _distance - 0.5;
+    private _time = 5 + (_unwind*2);
+    ropeDestroy (_vehicle getVariable "WinchRope");
+    _helper = _vehicle getVariable "WinchHelper";
+    detach _helper;
+    deleteVehicle _helper;
+    _vehicle setVariable ["WinchHelper",nil,true];
+    _vehicle setVariable ["WinchRope2", (ropeCreate [_vehicle, [0,-2.8,-0.8], _cargo, [0,0,0], _distance]), true];
+    sleep 1;
+    ropeUnwind [ropes _vehicle select 0, 0.5, -(_unwind), true];
+    _vehicle lockCargo true;
+    sleep _time;
+    ropeDestroy (_vehicle getVariable "WinchRope2");
+    [_vehicle, _cargo] call jn_fnc_logistics_load;
+    _cargo call jn_fnc_logistics_addAction;
+    _vehicle setVariable ["WinchRope2",nil,true];
+    _vehicle setVariable ["WinchRope",nil,true];
 };
-
 
 //adding of actions
-addplayerWinchActions = {
-	player addAction ["Deploy Winch", {
-		[player] call DeployWinch;
-	}, nil, 0, false, true, "", "[] call canDeployWinch"];
+A3A_SR_addplayerWinchActions = {
+    player addAction ["Deploy Winch", {
+        [player] call A3A_SR_DeployWinch;
+    }, nil, 0, false, true, "", "call A3A_SR_canDeployWinch"];
 
-	player addAction ["Stow Winch", {
-		[player] call stowRope;
-	}, nil, 0, false, true, "", "call canStow"];
+    player addAction ["Stow Winch", {
+        [player] call A3A_SR_stowRope;
+    }, nil, 0, false, true, "", "call A3A_SR_canStow"];
 
-	player addAction ["Attach Rope", {
-		[player] spawn attachRope;
-	}, nil, 0, false, true, "", "call canAttach"];
+    player addAction ["Attach Rope", {
+        [player] spawn A3A_SR_attachRope;
+    }, nil, 0, false, true, "", "call A3A_SR_canAttach"];
 
-	if (isMultiplayer) then {
-		player addEventHandler ["Respawn",{
-			player setVariable ["SalvageRopeAction",false];
-		}];
-	};
+    if (isMultiplayer) then {
+        player addEventHandler ["Respawn",{
+            player setVariable ["SalvageRopeAction",false];
+        }];
+    };
 };
 
 [] spawn {
-	private _missionComplete = false;
-	while {!_missionComplete} do {
-			if (!isNull player && isplayer player) then {
-			if !(player getVariable ["SalvageRopeAction",false]) then {
-				[] call addplayerWinchActions;
-				player setVariable ["SalvageRopeAction",true];
-			};
-		};
-		sleep 2;
-		_missionComplete = "LOG" call BIS_fnc_taskCompleted;
-	};
+    private _missionComplete = false;
+    while {!_missionComplete} do {
+        if (!isNull player && isplayer player) then {
+            if !(player getVariable ["SalvageRopeAction",false]) then {
+                [] call A3A_SR_addplayerWinchActions;
+                player setVariable ["SalvageRopeAction",true];
+            };
+        };
+        sleep 2;
+        _missionComplete = "LOG" call BIS_fnc_taskCompleted;
+    };
 };


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information: last fix for the salvage rope damage problem introduced a disconnect between the player and the vehicle, this made it impossible to recover the cargo in the salvage mission, the other actions was also partially broken as well. i fixed this and improved a oversight of the original design that prevents you from re recovering cargo if say the boat is sunk before you reach shore
    

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [ ] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
