### PR TITLE
Fixed duplication of single mags

### DIFF
--- a/A3-Antistasi/functions/LTC/fn_carryCrate.sqf
+++ b/A3-Antistasi/functions/LTC/fn_carryCrate.sqf
@@ -8,7 +8,7 @@ if (_pickUp) then {
 	player forceWalk true;
 	[player ,_crate] spawn {
 		params ["_player", "_crate"];
-		waitUntil { !alive _crate or !(_player getVariable ["carryingCrate", false]) or !(vehicle _player isEqualTo _player) or ( !([_player] call A3A_fnc_canFight) && !captive _player) };
+		waitUntil { !alive _crate or !(_player getVariable ["carryingCrate", false]) or !(vehicle _player isEqualTo _player) or _player getVariable ["incapacitated",false] or !alive _player };
 		[objNull, false] call A3A_fnc_carryCrate;
 	};
 } else {

--- a/A3-Antistasi/functions/LTC/fn_carryCrate.sqf
+++ b/A3-Antistasi/functions/LTC/fn_carryCrate.sqf
@@ -1,24 +1,26 @@
-params ["_crate", "_pickUp"];
+params [["_crate", objNull], "_pickUp", ["_player", player]];
 
 if (_pickUp) then {
-	_attachedObj = (attachedObjects player)select {!(_x isEqualTo objNull)};
+	private _attachedObj = (attachedObjects _player)select {!(_x isEqualTo objNull)};
 	if !(count _attachedObj == 0) exitWith {systemChat "you are already carrying something."};
-	_crate attachTo [player, [0, 1.5, 0], "Pelvis"];
-	player setVariable ["carryingCrate", true];
-	player forceWalk true;
-	[player ,_crate] spawn {
+	_crate attachTo [_player, [0, 1.5, 0], "Pelvis"];
+	_player setVariable ["carryingCrate", true];
+	_player forceWalk true;
+	[_player ,_crate] spawn {
 		params ["_player", "_crate"];
-		waitUntil { !alive _crate or !(_player getVariable ["carryingCrate", false]) or !(vehicle _player isEqualTo _player) or _player getVariable ["incapacitated",false] or !alive _player };
-		[objNull, false] call A3A_fnc_carryCrate;
+		waitUntil { !alive _crate or !(_player getVariable ["carryingCrate", false]) or !(vehicle _player isEqualTo _player) or _player getVariable ["incapacitated",false] or !alive _player or !(isPlayer attachedTo _crate) };
+		[_crate, false, _player] call A3A_fnc_carryCrate;
 	};
 } else {
-	_attached = (attachedObjects player)select {(typeOf _x) isEqualTo "Box_IND_Wps_F"};
-	_crate = _attached#0;
+    if (isNull _crate) then {
+        private _attached = (attachedObjects _player)select {(typeOf _x) isEqualTo "Box_IND_Wps_F"};
+        _crate = _attached#0;
+    };
 	if !(isNil "_crate") then {
-		player setVelocity [0,0,0];
+		_player setVelocity [0,0,0];
 		detach _crate;
 		_crate setVelocity [0,0,0.3];
 	};
-	player setVariable ["carryingCrate", nil];
-	player forceWalk false;
+	_player setVariable ["carryingCrate", nil];
+	_player forceWalk false;
 };

--- a/A3-Antistasi/functions/LTC/fn_carryCrate.sqf
+++ b/A3-Antistasi/functions/LTC/fn_carryCrate.sqf
@@ -6,9 +6,9 @@ if (_pickUp) then {
 	_crate attachTo [player, [0, 1.5, 0], "Pelvis"];
 	player setVariable ["carryingCrate", true];
 	player forceWalk true;
-	[player ,_crate] spawn { 
+	[player ,_crate] spawn {
 		params ["_player", "_crate"];
-		waitUntil {(!alive _crate) or !(_player getVariable ["carryingCrate", false]) or !((vehicle _player) isEqualTo _player) or !([_player] call A3A_fnc_canFight)};
+		waitUntil { !alive _crate or !(_player getVariable ["carryingCrate", false]) or !(vehicle _player isEqualTo _player) or ( !([_player] call A3A_fnc_canFight) && !captive _player) };
 		[objNull, false] call A3A_fnc_carryCrate;
 	};
 } else {

--- a/A3-Antistasi/functions/LTC/fn_carryCrate.sqf
+++ b/A3-Antistasi/functions/LTC/fn_carryCrate.sqf
@@ -14,6 +14,7 @@ if (_pickUp) then {
 } else {
     if (isNull _crate) then {
         private _attached = (attachedObjects _player)select {(typeOf _x) isEqualTo "Box_IND_Wps_F"};
+        if (_attached isEqualTo []) exitWith {};
         _crate = _attached#0;
     };
 	if !(isNull _crate) then {

--- a/A3-Antistasi/functions/LTC/fn_carryCrate.sqf
+++ b/A3-Antistasi/functions/LTC/fn_carryCrate.sqf
@@ -16,7 +16,7 @@ if (_pickUp) then {
         private _attached = (attachedObjects _player)select {(typeOf _x) isEqualTo "Box_IND_Wps_F"};
         _crate = _attached#0;
     };
-	if !(isNull "_crate") then {
+	if !(isNull _crate) then {
 		_player setVelocity [0,0,0];
 		detach _crate;
 		_crate setVelocity [0,0,0.3];

--- a/A3-Antistasi/functions/LTC/fn_carryCrate.sqf
+++ b/A3-Antistasi/functions/LTC/fn_carryCrate.sqf
@@ -16,7 +16,7 @@ if (_pickUp) then {
         private _attached = (attachedObjects _player)select {(typeOf _x) isEqualTo "Box_IND_Wps_F"};
         _crate = _attached#0;
     };
-	if !(isNil "_crate") then {
+	if !(isNull "_crate") then {
 		_player setVelocity [0,0,0];
 		detach _crate;
 		_crate setVelocity [0,0,0.3];

--- a/A3-Antistasi/functions/LTC/fn_lootFromContainer.sqf
+++ b/A3-Antistasi/functions/LTC/fn_lootFromContainer.sqf
@@ -16,7 +16,6 @@ if (isNil "_container") exitWith {
 
 //break undercover
 player setCaptive false;
-[] spawn A3A_fnc_statistics;
 
 private "_unlocked";
 if (LTCLootUnlocked) then {

--- a/A3-Antistasi/functions/LTC/fn_lootFromContainer.sqf
+++ b/A3-Antistasi/functions/LTC/fn_lootFromContainer.sqf
@@ -104,6 +104,7 @@ _transferCargo = {
 
 		if (_container canAdd [_type, _count] and !(_type in _unlocked)) then {
 			_container addMagazineAmmoCargo [_type, _count, _max];
+			if (_remainder isEqualTo 0) exitWith {};
 			_container addMagazineAmmoCargo [_type, 1, _remainder];
 		} else {
 			(_leftover#1) pushBack [_type, _count, _max, _remainder];

--- a/A3-Antistasi/functions/LTC/fn_lootFromContainer.sqf
+++ b/A3-Antistasi/functions/LTC/fn_lootFromContainer.sqf
@@ -14,6 +14,10 @@ if (isNil "_container") exitWith {
 	[_target, clientOwner, true] remoteExecCall ["A3A_fnc_canTransfer", 2];
 };
 
+//break undercover
+player setCaptive false;
+[] spawn A3A_fnc_statistics;
+
 private "_unlocked";
 if (LTCLootUnlocked) then {
 	_unlocked = [];

--- a/A3-Antistasi/functions/LTC/fn_lootToCrate.sqf
+++ b/A3-Antistasi/functions/LTC/fn_lootToCrate.sqf
@@ -3,6 +3,10 @@ scopeName "Main";
 
 ["Loot crate", "Looting..."] call A3A_fnc_customHint;
 
+//break undercover
+player setCaptive false;
+[] spawn A3A_fnc_statistics;
+
 private "_unlocked";
 if (LTCLootUnlocked) then {
 	_unlocked = [];

--- a/A3-Antistasi/functions/LTC/fn_lootToCrate.sqf
+++ b/A3-Antistasi/functions/LTC/fn_lootToCrate.sqf
@@ -5,7 +5,6 @@ scopeName "Main";
 
 //break undercover
 player setCaptive false;
-[] spawn A3A_fnc_statistics;
 
 private "_unlocked";
 if (LTCLootUnlocked) then {


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information: single mags looted from containers (not bodie) could duplicate mags due to addMagazineAmmoCargo now adding a magazine regardless if ammo count are 0. (this does not happen when magazine count is 0)

it now exits out if theres no remainder to be added (only full magazines)
    

### Please specify which Issue this PR Resolves.
closes #1582

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: drop a backpack with a single count magazine (example: m112 explosive charge), then use a LTC crate to loot the backpack from the ground. you should have exactly what you dropped and no duplicated items

********************************************************
Notes:
