### PR TITLE
Add Small Tree to ClearForest

### DIFF
--- a/A3-Antistasi/functions/Dialogs/fn_clearForest.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_clearForest.sqf
@@ -1,4 +1,4 @@
 if (player != theBoss) exitWith {["Clean Forest", "Only Commanders can order to clean the forest"] call A3A_fnc_customHint;};
-{ _x hideObjectGlobal true } foreach (nearestTerrainObjects [getMarkerPos respawnTeamPlayer,["tree","bush","small tree"],70]);
+{ [_x, true] remoteExec ["hideObjectGlobal",2] } forEach (nearestTerrainObjects [getMarkerPos respawnTeamPlayer,["tree","bush","small tree"],70]);
 ["Clean Forest", "You've cleared the surroundings of trees and bushes"] call A3A_fnc_customHint;
 chopForest = true; publicVariable "chopForest";

--- a/A3-Antistasi/functions/Dialogs/fn_clearForest.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_clearForest.sqf
@@ -1,4 +1,4 @@
 if (player != theBoss) exitWith {["Clean Forest", "Only Commanders can order to clean the forest"] call A3A_fnc_customHint;};
-if (!isMultiplayer) then {{ _x hideObject true } foreach (nearestTerrainObjects [getMarkerPos respawnTeamPlayer,["tree","bush"],70])} else {{[_x,true] remoteExec ["hideObjectGlobal",2]} foreach (nearestTerrainObjects [getMarkerPos respawnTeamPlayer,["tree","bush"],70])};
+{ _x hideObjectGlobal true } foreach (nearestTerrainObjects [getMarkerPos respawnTeamPlayer,["tree","bush","small tree"],70]);
 ["Clean Forest", "You've cleared the surroundings of trees and bushes"] call A3A_fnc_customHint;
 chopForest = true; publicVariable "chopForest";


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Added Small Tree to Clear Forest and made it shorter cause aparently the rest was not needed.
    

### Please specify which Issue this PR Resolves.
closes #1586

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in singleplayer?
2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Try to clear Forests, on Cherno Winter infront of Default HQ,
The Small Tree at [6745.78,5688.3,0] was never Cleared.
![20201115212750_1](https://user-images.githubusercontent.com/57111907/99195959-744ae400-2789-11eb-82ab-f6c147a4a9de.jpg)

********************************************************
Notes:
