### PR TITLE
3CB TPGM fix staticCrewTeamPlayer. 👀

### DIFF
--- a/A3-Antistasi/Templates/3CB_Reb_TPGM_Arid.sqf
+++ b/A3-Antistasi/Templates/3CB_Reb_TPGM_Arid.sqf
@@ -12,7 +12,7 @@ typePetros = "UK3CB_TKM_B_WAR";
 //             UNITS             ///
 ////////////////////////////////////
 //First Entry is Guerilla, Second Entry is Para/Military
-staticCrewTeamPlayer = "UK3CB_TKM_B_RIF_1";
+staticCrewTeamPlayer = "UK3CB_TKM_B_STATIC_GUN_NSV";
 SDKUnarmed = "UK3CB_TKC_B_SPOT";
 SDKSniper = ["UK3CB_TKM_B_SPOT","UK3CB_TKM_B_SNI"];
 SDKATman = ["UK3CB_TKM_B_LAT","UK3CB_TKM_B_AT"];


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information: Having the same Classname in SDKMil and staticCrewTeamPlayer leads to multiple Issues:
You can't add Squads "Rifleman" that are Rifleman and Crewman to Garisons (Normal Units that are Part of your Squad and High Command Squads).
If you add Rifleman via Manage Garisons you will get a Free Mortar per Rifleman.
   

### Please specify which Issue this PR Resolves.
closes #1547 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [X] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
3CB BAF Modset on Altis Bluefor
Steps: Recruit Rifleman and try to add them to a Garison, there should not be a Hint telling you that you can't add Crewman.
Adding Rifleman via Manage Garisons shouldn't give you a Free Mortar anymore.

********************************************************
Notes:
