### PR TITLE
Improve "Explosive Experts"/ Improve Minesweep

### DIFF
--- a/A3-Antistasi/functions/AI/fn_mineSweep.sqf
+++ b/A3-Antistasi/functions/AI/fn_mineSweep.sqf
@@ -19,14 +19,9 @@ _truckX = vehSDKRepair createVehicle _pos;
 
 [_truckX, teamPlayer] call A3A_fnc_AIVEHinit;
 [_unit] spawn A3A_fnc_FIAinit;
-clearMagazineCargo unitBackpack _unit;
-_unit addItemToBackpack "MineDetector";
 
 _groupX addVehicle _truckX;
 [_unit] orderGetIn true;
-// Add Mine Detector to detect invisible APERS
-clearMagazineCargo (unitBackpack _unit);
-_unit addItemToBackpack "MineDetector";
 //_unit setBehaviour "SAFE";
 theBoss hcSetGroup [_groupX];
 

--- a/A3-Antistasi/functions/AI/fn_mineSweep.sqf
+++ b/A3-Antistasi/functions/AI/fn_mineSweep.sqf
@@ -9,7 +9,7 @@ _costs = (server getVariable (SDKExp select 0)) + ([vehSDKRepair] call A3A_fnc_v
 _groupX = createGroup teamPlayer;
 
 _unit = [_groupX, (SDKExp select 0), getMarkerPos respawnTeamPlayer, [], 0, "NONE"] call A3A_fnc_createUnit;
-_groupX setGroupId ["MineSw"];
+_groupX setGroupIdGlobal [format ["MineSw%1",{side (leader _x) == teamPlayer} count allGroups]];
 _minesX = [];
 sleep 1;
 _road = [getMarkerPos respawnTeamPlayer] call A3A_fnc_findNearestGoodRoad;
@@ -38,7 +38,7 @@ while {alive _unit} do
 				sleep 30;
 				};
 			};
-		_minesX = (detectedMines teamPlayer) select {(_x distance _unit) < 100};
+		_minesX = allmines select {(_x distance _unit) < 100};
 		if (count _minesX == 0) then
 			{
 			waitUntil {sleep 1;(!alive _unit) or (!unitReady _unit)};
@@ -55,7 +55,7 @@ while {alive _unit} do
 				_mineX = _minesX select _countX;
 				[_unit] orderGetin false;
 				_unit doMove position _mineX;
-				_timeOut = time + 120;
+				_timeOut = time + 15;
 				waitUntil {sleep 0.5; (_unit distance _mineX < 8) or (!alive _unit) or (time > _timeOut)};
 				if (alive _unit) then
 					{

--- a/A3-Antistasi/functions/REINF/fn_equipRebel.sqf
+++ b/A3-Antistasi/functions/REINF/fn_equipRebel.sqf
@@ -81,6 +81,8 @@ switch (true) do {
 		[_unit,unlockedRifles] call A3A_fnc_randomRifle;
 		_unit setUnitTrait ["explosiveSpecialist",true];
 		_unit addItemToBackpack "Toolkit";
+		_unit addItemToBackpack "MineDetector";
+		_unit enableAIFeature ["MINEDETECTION", true]; //This should prevent them from Stepping on the Mines as an "Expert" (It helps, they still step on them)
 		if (count unlockedAA > 0) then {
 			[_unit, selectRandom unlockedAA, 1] call _addWeaponAndMags;
 		};


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information:
Removed not working lines in Fn_Minesweep,
Added Minedetectors to SDKexp, 
-------> It would cost a lot to try to farm Minedetectors by Ordering Minefield Placement and Removal.
Also they don't drop of their Equipment when disbanding, only way to farm is to kill them/let them die.
(500€ for one)
enabled Minedetection on SDKexp to try to prevent them from stepping on Mines.
 It does improve their Performance at trying to clear Minefields and makes them sort of Usable again.

Changed Detected Mines to allMines, so they will always look for Mines when within the Radius.

Updated Group Format to fit like all other HC Squads.

Lowered Timeout time.

### Please specify which Issue this PR Resolves.
closes parts of #1593 not everything

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
You need a Minefield to clear first: Zeus Calling fire missions that leave behind UXOs works pretty well, or place Minefields via Zeus.
Getting the MineSweaper: HQ Management/Manage Garisons/Minefield Options/Remove Minefields.
There are 2 ways to use them right now: (3 With Orange DLC or Contact DLC)

Most importantly they need a Point to start, they only Defuse Detected Mines.

1: You go to the Minefield yourself and Mark a Mine with T, if its marked it should Mark it on Map or on your Hud Depending on Difficulty settings (mapContentMines).
Then you order him to a Point within 100 Meters of that Mine, when he stops he SHOULD Dismount and Clear than one mine, if he finds more he will clear those if they are within the 100 meters where the Truck parked.
(The Explosive Specialist can detect mines within a 15 Meter Radius).

2: You can order 2 Explosives specialist, send in one without the Truck to look and Mark mines.
Then send in the One with the Truck and he should start defusing the Mines that were marked within 100 meters of the Position where he parked the Truck.

(3): Use a EOD Drone to Mark Mines (They have a 50 Meter Radius)
Then send in the Minesweepers.

Method 1 in Pictures:
![20201128143855_1](https://user-images.githubusercontent.com/57111907/100517682-b9f5ac80-318c-11eb-9914-9ea61a414ac8.jpg)


![20201128143949_1](https://user-images.githubusercontent.com/57111907/100517688-ca0d8c00-318c-11eb-8bee-ec42f09ad1ec.jpg)

![20201128144110_1](https://user-images.githubusercontent.com/57111907/100517693-d265c700-318c-11eb-8b14-1603b1645932.jpg)

********************************************************
Notes: As said it doesent close #1593 But it will Improve Minesweep a bit more.
