### PR TITLE
All hints are customHint, navGrid can run without customHint.

### DIFF
--- a/A3-Antistasi/NavGridTools/createNavGrid.sqf
+++ b/A3-Antistasi/NavGridTools/createNavGrid.sqf
@@ -4,6 +4,18 @@
 #define MID_SEGMENT         3
 #define LINK_POINTS         4
 
+if (isNil {A3A_fnc_customHint}) then {
+  A3A_fnc_customHint = {  // Scope will be global, so this nesting and further spawns will not be a problem.
+    params ["_title","_body",["_silent",false]];
+    private _message = parseText (_title+"<br/>"+_body);
+    if (_silent) then {
+      hintSilent _message;
+    } else {
+      hint _message;
+    };
+  };
+};
+
 _showText = true;
 _showText = param [0, true];
 if(isNil "_showText") then

--- a/A3-Antistasi/NavGridTools/extractRoadTypeData.sqf
+++ b/A3-Antistasi/NavGridTools/extractRoadTypeData.sqf
@@ -3,6 +3,18 @@
 #define TRACK 3;
 #define CITY 4;
 
+if (isNil {A3A_fnc_customHint}) then {
+  A3A_fnc_customHint = {  // Scope will be global, so this nesting and further spawns will not be a problem.
+    params ["_title","_body",["_silent",false]];
+    private _message = parseText (_title+"<br/>"+_body);
+    if (_silent) then {
+      hintSilent _message;
+    } else {
+      hint _message;
+    };
+  };
+};
+
 _lowerWorldName = toLower worldName;
 _path = "";
 

--- a/A3-Antistasi/NavGridTools/findOffset.sqf
+++ b/A3-Antistasi/NavGridTools/findOffset.sqf
@@ -1,4 +1,17 @@
 [] call compile preprocessFileLineNumbers "NavGridTools\MapRoadHash\stratisMapRoadHash.sqf";
+
+if (isNil {A3A_fnc_customHint}) then {
+  A3A_fnc_customHint = {  // Scope will be global, so this nesting and further spawns will not be a problem.
+    params ["_title","_body",["_silent",false]];
+    private _message = parseText (_title+"<br/>"+_body);
+    if (_silent) then {
+      hintSilent _message;
+    } else {
+      hint _message;
+    };
+  };
+};
+
 _allRoads = [];
 _allRoads = (getPos player) nearRoads 100000;
 

--- a/A3-Antistasi/functions/Base/fn_createOutpostsFIA.sqf
+++ b/A3-Antistasi/functions/Base/fn_createOutpostsFIA.sqf
@@ -56,7 +56,6 @@ if ({(alive _x) and (_x distance _positionTel < 10)} count units _groupX > 0) th
 		(leader _groupX) setVariable ["owner",_owner,true];
 		{[_x] joinsilent group _owner} forEach units group _owner;
 		[group _owner, _owner] remoteExec ["selectLeader", _owner];
-		"" remoteExec ["hint",_owner];
 		waitUntil {!(isPlayer leader _groupX)};
 		};
 	outpostsFIA = outpostsFIA + [_mrk]; publicVariable "outpostsFIA";

--- a/A3-Antistasi/functions/Garage/fn_attemptPlaceVehicle.sqf
+++ b/A3-Antistasi/functions/Garage/fn_attemptPlaceVehicle.sqf
@@ -15,7 +15,7 @@ if (isNil "_isValidLocationArray") then {
 //EachFrame handler should have exited if we're in here.
 //If that ever changes, change below.
 if (!(_isValidLocationArray select 0))	exitWith {
-		hint (_isValidLocationArray select 1);
+		["Attempt Place Vehicle",_isValidLocationArray select 1] call A3A_fnc_customHint;
 		[] call A3A_fnc_handleVehPlacementCancelled;
 };
 
@@ -28,7 +28,7 @@ if (isNil "_canPlaceArray") then {
 //EachFrame handler should have exited if we're in here.
 //If that ever changes, change below.
 if (!(_canPlaceArray select 0))	exitWith {
-		hint (_canPlaceArray select 1);
+		["Attempt Place Vehicle",_canPlaceArray select 1] call A3A_fnc_customHint;
 		[] call A3A_fnc_handleVehPlacementCancelled;
 };
 


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement/Refactor

### What have you changed and why?
Information:
* All empty silentHints remain as they cover up closing hintC (hint context).
* All hints have been made into customHint (outside UPSMON, commsMP is fine.)
* A3A_fnc_customHint is defined if not defined in 3 navGrid files.

### Please specify which Issue this PR Resolves.
closes #1608 https://github.com/official-antistasi-community/A3-Antistasi/issues/1608

### Please verify the following and ensure all checks are completed.

2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Needs quick test

### How can the changes be tested?
Steps: Copy past hints into the console, to try to trigger them naturally.
