### PR TITLE
Use Icon space to display previous hint titles.

### DIFF
--- a/A3-Antistasi/functions/UI/fn_customHint.sqf
+++ b/A3-Antistasi/functions/UI/fn_customHint.sqf
@@ -45,7 +45,7 @@ params [
     ["_headerText", "headermissingno", [""]],
     ["_bodyText", "bodymissingno", ["",parseText""]],
     ["_isSilent", false, [false]],
-    ["_iconData", ["functions\UI\images\logo.paa",4], [ [] ], 2]
+    ["_iconData", ["",1], [ [] ], 2]
 ];
 private _filename = "fn_customHint.sqf";
 
@@ -58,7 +58,7 @@ if (_bodyText isEqualType parseText"") then {
 } else {
     _structuredText = parseText ([
         "<t size='1' color='#ffffff' font='RobotoCondensed' align='center' valign='middle' underline='0' shadow='1' shadowColor='#000000' shadowOffset='0.0625' colorLink='#0099ff' >",
-        "<img size='",8/_iconData#1,"' shadowOffset='",0.015625*_iconData#1,"' image='",_iconData#0,"' /><br/><br/>",
+        [["<img size='",8/(_iconData#1),"' shadowOffset='",0.015625*(_iconData#1),"' image='",_iconData#0,"' /><br/>"] joinString "",""] select ((_iconData#0) isEqualTo ""),
         "<t size='1.2' color='#e5b348' >",
         _headerText,
         "</t><br/><img size='0.60' color='#e6b24a' image='functions\UI\images\img_line_ca.paa' /><br/><br/><t >",
@@ -76,7 +76,7 @@ if (A3A_customHintEnable) then {
     };
     private _lastMSGIndex = count A3A_customHint_MSGs - 1;
     if (A3A_customHint_MSGs #(_lastMSGIndex)#0 isEqualTo _headerText) then {
-        A3A_customHint_LastMSG = serverTime;
+        A3A_customHint_UpdateTime = serverTime;
     };
 } else {
     if (_isSilent) then {

--- a/A3-Antistasi/functions/UI/fn_customHint.sqf
+++ b/A3-Antistasi/functions/UI/fn_customHint.sqf
@@ -77,7 +77,7 @@ if (A3A_customHintEnable) then {
         A3A_customHint_UpdateTime = serverTime;
     };
 } else {
-    _structuredText = composeText ["<img size='",2.1,"' color='#ffffffff' shadowOffset='",0.06,"' image='functions\UI\images\logo.paa' /><br/>",_structuredText];
+    _structuredText = composeText [parseText "<img size='2.1' color='#ffffffff' shadowOffset='0.06' image='functions\UI\images\logo.paa' /><br/>",_structuredText];
     if (_isSilent) then {
         hintSilent _structuredText;
     } else {

--- a/A3-Antistasi/functions/UI/fn_customHint.sqf
+++ b/A3-Antistasi/functions/UI/fn_customHint.sqf
@@ -4,7 +4,7 @@ Function:
 
 Description:
     Adds item to notification queue.
-    Pre-parse body text to take control of the whole notification (except footer).
+    Pre-parse body text to take control of the space in-between the top A3 icon and footer.
     Note: you don't need pre-parse for custom heading/body XML, just insert where plain text would go.
     Set A3A_customHintEnable=false to use original custom hint.
 
@@ -30,7 +30,7 @@ Examples:
         ["Restart Notification", "Please make your way to HQ as a restart will occure soon™<br/><br/>Please make sure you save your stats at the Map.", true] remoteExec ["A3A_fnc_customHint", 0, false];
     ["Vaya...", "Parece que sus notificaciones importantes se cifraron.<br/><br/>Nadie espera el cifrado español.", false, ["Pictures\Intel\laptop_error.paa",1]] remoteExec ["A3A_fnc_customHint", 0, false];
 
-    // Pre-parse FooBar(Hello World) NoMacro
+    // Pre-parse FooBar
         private _iconXML = parseText "<img color='#ffffff' image='functions\UI\images\logo.paa' align='center' size='2' shadow='1' shadowColor='#000000' />";
         private _separator  = parseText "<br/><img color='#e6b24a' image='functions\UI\images\img_line_ca.paa' align='center' size='0.60' />";
         private _header = parseText "<br/><br/><t size='1.2' color='#e5b348' shadow='1' shadowColor='#000000'>FooBar</t>";
@@ -45,7 +45,7 @@ params [
     ["_headerText", "headermissingno", [""]],
     ["_bodyText", "bodymissingno", ["",parseText""]],
     ["_isSilent", false, [false]],
-    ["_iconData", ["",1], [ [] ], 2]
+    ["_iconData", ["",1], [ [] ], 2]  // Will be used for GUI control version of customHints. Images can be baked into the message via XML or parseText so that the default header is not present. (See example `Pre-parse FooBar`)
 ];
 private _filename = "fn_customHint.sqf";
 
@@ -57,9 +57,7 @@ if (_bodyText isEqualType parseText"") then {
     _structuredText = _bodyText;
 } else {
     _structuredText = parseText ([
-        "<t size='1' color='#ffffff' font='RobotoCondensed' align='center' valign='middle' underline='0' shadow='1' shadowColor='#000000' shadowOffset='0.0625' colorLink='#0099ff' >",
-        [["<img size='",8/(_iconData#1),"' shadowOffset='",0.015625*(_iconData#1),"' image='",_iconData#0,"' /><br/>"] joinString "",""] select ((_iconData#0) isEqualTo ""),
-        "<t size='1.2' color='#e5b348' >",
+        "<t size='1' color='#ffffff' font='RobotoCondensed' align='center' valign='middle' underline='0' shadow='1' shadowColor='#000000' shadowOffset='0.0625' colorLink='#0099ff' ><t size='1.2' color='#e5b348' >",
         _headerText,
         "</t><br/><img size='0.60' color='#e6b24a' image='functions\UI\images\img_line_ca.paa' /><br/><br/><t >",
         _bodyText,
@@ -79,6 +77,7 @@ if (A3A_customHintEnable) then {
         A3A_customHint_UpdateTime = serverTime;
     };
 } else {
+    _structuredText = composeText ["<img size='",2.1,"' color='#ffffffff' shadowOffset='",0.06,"' image='functions\UI\images\logo.paa' /><br/>",_structuredText];
     if (_isSilent) then {
         hintSilent _structuredText;
     } else {
@@ -86,5 +85,3 @@ if (A3A_customHintEnable) then {
     };
 };
 true;
-
-// TODO: remove all `hintSilent ""` used in boot processes.

--- a/A3-Antistasi/functions/UI/fn_customHintDismiss.sqf
+++ b/A3-Antistasi/functions/UI/fn_customHintDismiss.sqf
@@ -37,6 +37,6 @@ if (_dismissAll) then {
         A3A_customHint_MSGs deleteAt _lastMSGIndex;
     };
 };
-A3A_customHint_LastMSG = serverTime;
+A3A_customHint_UpdateTime = serverTime;
 [] call A3A_fnc_customHintRender;  // Instant update will be preffered when user is dismissing notifications.
 true;

--- a/A3-Antistasi/functions/UI/fn_customHintInit.sqf
+++ b/A3-Antistasi/functions/UI/fn_customHintInit.sqf
@@ -32,7 +32,6 @@ if !(isNil {A3A_customHint_InitComplete}) exitWith {false;};
 A3A_customHint_MSGs = [];  // Operates as a upside-down stack (new messages pushed-Back are displayed.)
 A3A_customHint_DismissKeyDown = false;
 A3A_customHint_UpdateTime = 0;
-A3A_customHint_UpdateTimePrev = 0;
 A3A_customHint_RenderFrameCount = 1;
 if (isNil {A3A_customHintEnable}) then {A3A_customHintEnable = true}; // isNil check in case value was set before this initialises.
 
@@ -43,7 +42,7 @@ addMissionEventHandler ["EachFrame", {
         A3A_customHint_DismissKeyDown = !A3A_customHint_DismissKeyDown;                     // user action slot Will be selectable when client-side preferences, Soon™.
         if (A3A_customHint_DismissKeyDown) then { [] call A3A_fnc_customHintDismiss; };
     };
-    if (A3A_customHint_RenderFrameCount >= 15) then {  // Render loop does not need to run every frame.
+    if (A3A_customHint_RenderFrameCount >= 15) then {  // Render loop does not need to run every frame. 4Hz should be enough.
         A3A_customHint_RenderFrameCount = 1;
         [] call A3A_fnc_customHintRender;
     } else {
@@ -65,7 +64,7 @@ All public created variables:
 | A3A_customHint_MSGs               | ARRAY<CUSTOM> | Client    | missionNamespace  | Stack of hint notifications. <_headerText,_structuredText,_isSilent>  |
 | A3A_customHint_DismissKeyDown     | BOOLEAN       | Client    | missionNamespace  | Whether dismiss key is depressed.                                     |
 | A3A_customHintEnable              | BOOLEAN       | Local     | missionNamespace  | Whether queuing and dismissing is enabled. Defined on all, not synced.|
-| A3A_customHint_LastMSG            | SCALAR        | Client    | missionNamespace  | ServerTime of last update to the focused message.                     |
+| A3A_customHint_UpdateTime         | SCALAR        | Client    | missionNamespace  | ServerTime of last update to the visible message.                     |
 | A3A_customHint_RenderFrameCount   | SCALAR        | Client    | missionNamespace  | Determines intensity of hint footer fading.                           |
 
 Worker processes:

--- a/A3-Antistasi/functions/UI/fn_customHintInit.sqf
+++ b/A3-Antistasi/functions/UI/fn_customHintInit.sqf
@@ -31,7 +31,8 @@ if !(isNil {A3A_customHint_InitComplete}) exitWith {false;};
 // These var names don't need to be limited to 16chars for performance as they are not public.
 A3A_customHint_MSGs = [];  // Operates as a upside-down stack (new messages pushed-Back are displayed.)
 A3A_customHint_DismissKeyDown = false;
-A3A_customHint_LastMSG = 0;
+A3A_customHint_UpdateTime = 0;
+A3A_customHint_UpdateTimePrev = 0;
 A3A_customHint_RenderFrameCount = 1;
 if (isNil {A3A_customHintEnable}) then {A3A_customHintEnable = true}; // isNil check in case value was set before this initialises.
 

--- a/A3-Antistasi/functions/UI/fn_customHintRender.sqf
+++ b/A3-Antistasi/functions/UI/fn_customHintRender.sqf
@@ -29,22 +29,30 @@ if (!hasInterface || !A3A_customHintEnable) exitWith {false;}; // Disabled for s
 if (A3A_customHint_MSGs isEqualTo []) then {
     hintSilent "";
 } else{
-    private _autoDismiss = 15;  // Number of seconds for message lifetime  // Constant Value
-    if (serverTime - A3A_customHint_LastMSG > _autoDismiss) exitWith {
+    private _autoDismiss = 3600;  // Number of seconds for message lifetime  // Constant Value
+    if (serverTime - A3A_customHint_UpdateTime > _autoDismiss) exitWith {
         [true] call A3A_fnc_customHintDismiss;
     };
-    private _alphaHex = [(((_autoDismiss + A3A_customHint_LastMSG - serverTime) min (_autoDismiss-5)) / (_autoDismiss-5)) ] call A3A_fnc_shader_ratioToHex;
+    private _alphaHex = [(((_autoDismiss + A3A_customHint_UpdateTime - serverTime) min (_autoDismiss-5)) / (_autoDismiss-5)) ] call A3A_fnc_shader_ratioToHex;
     private _dismissKey = actionKeysNames ["User12",1];
-    _dismissKey = [_dismissKey,"""Use Action 12"""] select (_dismissKey isEqualTo "");
-    private _footer = parseText (["<br/><t size='0.8' color='#",_alphaHex,"e5b348' shadow='1' shadowColor='#",_alphaHex,"000000' valign='top' >Press <t color='#",_alphaHex,"f0d498' >",_dismissKey,"</t> to dismiss notification. +",str((count A3A_customHint_MSGs) -1),"</t>"] joinString ""); // Needs to be added to string table.
+    private _topMSGIndex = count A3A_customHint_MSGs - 1;
+    private _keyBind = (["<br/><t size='0.8' color='#",_alphaHex,"e5b348' shadow='1' shadowColor='#",_alphaHex,"000000' valign='top' >Press <t color='#",_alphaHex,"f0d498' >",[_dismissKey,"Use Action 12"] select (_dismissKey isEqualTo ""),"</t> to dismiss notification. +",str _topMSGIndex,"</t>"] joinString ""); // Needs to be added to string table.
+    private _previousNotifications = ["<t color='#",_alphaHex,"e5b348' font='RobotoCondensed' align='center' valign='middle' underline='0' shadow='1' shadowColor='#",_alphaHex,"000000' shadowOffset='0.0625'>"];
+    if (_topMSGIndex < 4) then {
+        _previousNotifications append ["<img size='",(-20/(8-_topMSGIndex) +4.6),"' color='#",_alphaHex,"ffffff' shadowOffset='",0.015625*(4),"' image='functions\UI\images\logo.paa' /><br/>"];  // ["functions\UI\images\logo.paa",4]
+    };
+    for "_i" from 0 max (4-_topMSGIndex) to 3 do {
+        _previousNotifications append ["<t size='",-10/(_i+5) +2.3,"'>",A3A_customHint_MSGs#(_topMSGIndex-4+_i)#0,"</t><br/>"];
+    };
+    _previousNotifications pushBack "</t>";
+    _previousNotifications = _previousNotifications joinString "";
 
-    private _lastMSGIndex = count A3A_customHint_MSGs - 1;
-    _structuredText = composeText [A3A_customHint_MSGs #(_lastMSGIndex)#1, _footer];
-    if (A3A_customHint_MSGs #(_lastMSGIndex)#2) then {
+    _structuredText = composeText [parseText _previousNotifications,A3A_customHint_MSGs#(_topMSGIndex)#1, parseText _keyBind];
+    if (A3A_customHint_MSGs#(_topMSGIndex)#2) then {
         hintSilent _structuredText;
     } else {
         hint _structuredText;
-        A3A_customHint_MSGs #(_lastMSGIndex) set [2,true]; // so it does not ping more than once.
+        A3A_customHint_MSGs#(_topMSGIndex) set [2,true]; // so it does not ping more than once.
     };
 };
 true;

--- a/A3-Antistasi/functions/UI/fn_customHintRender.sqf
+++ b/A3-Antistasi/functions/UI/fn_customHintRender.sqf
@@ -4,6 +4,7 @@ Function:
 
 Description:
     Renders top item on customHint queue.
+    Adds the Icon and footer around the message.
     This should not be called outside of the render loop in A3A_fnc_customHintInit.
 
 Scope:
@@ -29,7 +30,7 @@ if (!hasInterface || !A3A_customHintEnable) exitWith {false;}; // Disabled for s
 if (A3A_customHint_MSGs isEqualTo []) then {
     hintSilent "";
 } else{
-    private _autoDismiss = 3600;  // Number of seconds for message lifetime  // Constant Value
+    private _autoDismiss = 15;  // Number of seconds for message lifetime  // Constant Value
     if (serverTime - A3A_customHint_UpdateTime > _autoDismiss) exitWith {
         [true] call A3A_fnc_customHintDismiss;
     };
@@ -39,7 +40,8 @@ if (A3A_customHint_MSGs isEqualTo []) then {
     private _keyBind = (["<br/><t size='0.8' color='#",_alphaHex,"e5b348' shadow='1' shadowColor='#",_alphaHex,"000000' valign='top' >Press <t color='#",_alphaHex,"f0d498' >",[_dismissKey,"Use Action 12"] select (_dismissKey isEqualTo ""),"</t> to dismiss notification. +",str _topMSGIndex,"</t>"] joinString ""); // Needs to be added to string table.
     private _previousNotifications = ["<t color='#",_alphaHex,"e5b348' font='RobotoCondensed' align='center' valign='middle' underline='0' shadow='1' shadowColor='#",_alphaHex,"000000' shadowOffset='0.0625'>"];
     if (_topMSGIndex < 4) then {
-        _previousNotifications append ["<img size='",(-20/(8-_topMSGIndex) +4.6),"' color='#",_alphaHex,"ffffff' shadowOffset='",0.015625*(4),"' image='functions\UI\images\logo.paa' /><br/>"];  // ["functions\UI\images\logo.paa",4]
+        private _size = (-20/(8-_topMSGIndex) +4.6);
+        _previousNotifications append ["<img size='",_size,"' color='#",_alphaHex,"ffffff' shadowOffset='",_size*0.03,"' image='functions\UI\images\logo.paa' /><br/>"];
     };
     for "_i" from 0 max (4-_topMSGIndex) to 3 do {
         _previousNotifications append ["<t size='",-10/(_i+5) +2.3,"'>",A3A_customHint_MSGs#(_topMSGIndex-4+_i)#0,"</t><br/>"];


### PR DESCRIPTION
## What type of PR is this.
* Bug
* Change
3. [x] Enhancement

### What have you changed and why?
The icon space of hints is used to display the headings of previous hints.
See picture at the footer for a visual comparison.
    

### Please specify which Issue this PR Resolves.
closes 1611 https://github.com/official-antistasi-community/A3-Antistasi/issues/1611

### Please verify the following and ensure all checks are completed.

2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
* Yes (Needs independent testing.)
Also, please voice any opinions or suggestions about colour size etc.

### How can the changes be tested?
Steps: 
Create many hints, see if it is visually acceptable.
See documentation in fn_customHint to create from debug console.

***
![Hint Title Scaling2](https://user-images.githubusercontent.com/31820984/101776485-a980f280-3af9-11eb-840a-d6b9e6ceba92.png)
