### PR TITLE
Fix spam sell vehicle exploit

### DIFF
--- a/A3-Antistasi/dialogs.hpp
+++ b/A3-Antistasi/dialogs.hpp
@@ -1855,7 +1855,7 @@ class commander_comm 		{
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			tooltip = "Look at a vehicle and sell it for money";
-			action = "if (player == theBoss) then {closeDialog 0; nul = [] call A3A_fnc_sellVehicle} else {[""Sell Vehicle"", ""Only the Commander can sell vehicles""] call A3A_fnc_customHint;};";
+			action = "if (player == theBoss) then {closeDialog 0; nul = [player,cursorObject] remoteExecCall [""A3A_fnc_sellVehicle"",2]} else {[""Sell Vehicle"", ""Only the Commander can sell vehicles""] call A3A_fnc_customHint;};";
 		};
 	};
 };
@@ -2384,7 +2384,7 @@ class garage_sell 			{
 			y = 0.317959 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
-			action = "closeDialog 0; if (player == theBoss) then {nul = [] call A3A_fnc_sellVehicle} else {[""Sell Vehicle"", ""Only the Commander can sell vehicles""] call A3A_fnc_customHint;};";
+			action = "closeDialog 0; if (player == theBoss) then {nul = [player,cursorObject] remoteExecCall [""A3A_fnc_sellVehicle"",2]} else {[""Sell Vehicle"", ""Only the Commander can sell vehicles""] call A3A_fnc_customHint;};";
 		};
 		/*
 		class HQ_button_Gremove: RscButton

--- a/A3-Antistasi/functions/Base/fn_sellVehicle.sqf
+++ b/A3-Antistasi/functions/Base/fn_sellVehicle.sqf
@@ -18,12 +18,18 @@ Dependencies:
 <ARRAY> Template vehicle arrays, see costs = call {}.
 
 Example:
-["something", player] call A3A_fnc_someExsampleFnc;
+// From a button control:
+action = "if (player == theBoss) then {closeDialog 0; nul = [player,cursorObject] remoteExecCall [""A3A_fnc_sellVehicle"",2]} else {[""Sell Vehicle"", ""Only the Commander can sell vehicles""] call A3A_fnc_customHint;};";
+
+// Testing spam:
+for "_i" from 1 to 1000 do {
+    [player,cursorObject] remoteExecCall ["A3A_fnc_sellVehicle",2];
+};
 
 */
 params [
-	["_player",objNull,[objNull]],
-	["_veh",objNull,[objNull]]
+    ["_player",objNull,[objNull]],
+    ["_veh",objNull,[objNull]]
 ];
 
 if (isNull _veh) exitWith {["Sell Vehicle", "You are not looking to any vehicle"] remoteExecCall ["A3A_fnc_customHint",remoteExecutedOwner];};
@@ -37,26 +43,26 @@ if ({isPlayer _x} count crew _veh > 0) exitWith {["Sell Vehicle", "In order to s
 
 _owner = _veh getVariable ["ownerX",""];
 if !(_owner isEqualTo "" || {getPlayerUID _player isEqualTo _owner}) exitWith {  // Vehicle cannot be sold if owned by another player.
-	_veh setVariable ["A3A_sellVehicle_inProgress",false,false];
-	["Sell Vehicle", "You are not the rebel commander or owner of this vehicle. Therefore, you cannot sell it"] remoteExecCall ["A3A_fnc_customHint",remoteExecutedOwner];
+    _veh setVariable ["A3A_sellVehicle_inProgress",false,false];
+    ["Sell Vehicle", "You are not the rebel commander or owner of this vehicle. Therefore, you cannot sell it"] remoteExecCall ["A3A_fnc_customHint",remoteExecutedOwner];
 };
 
 private _typeX = typeOf _veh;
 private _costs = call {
-	if (_veh isKindOf "StaticWeapon") exitWith {100};			// in case rebel static is same as enemy statics
-	if (_typeX in vehFIA) exitWith { ([_typeX] call A3A_fnc_vehiclePrice) / 2 };
-	if ((_typeX in arrayCivVeh) or (_typeX in civBoats) or (_typeX in [civBoat,civCar,civTruck])) exitWith {25};
-	if ((_typeX in vehNormal) or (_typeX in vehBoats) or (_typeX in vehAmmoTrucks)) exitWith {100};
-	if (_typeX in [vehCSATPatrolHeli, vehNATOPatrolHeli, civHeli]) exitWith {500};
-	if ((_typeX in vehAPCs) || (_typeX in vehTransportAir) || (_typeX in vehUAVs)) exitWith {1000};
-	if ((_typeX in vehAttackHelis) or (_typeX in vehTanks) or (_typeX in vehAA) or (_typeX in vehMRLS)) exitWith {3000};
-	if (_typeX in [vehNATOPlane,vehNATOPlaneAA,vehCSATPlane,vehCSATPlaneAA]) exitWith {4000};
-	0;
+    if (_veh isKindOf "StaticWeapon") exitWith {100};			// in case rebel static is same as enemy statics
+    if (_typeX in vehFIA) exitWith { ([_typeX] call A3A_fnc_vehiclePrice) / 2 };
+    if ((_typeX in arrayCivVeh) or (_typeX in civBoats) or (_typeX in [civBoat,civCar,civTruck])) exitWith {25};
+    if ((_typeX in vehNormal) or (_typeX in vehBoats) or (_typeX in vehAmmoTrucks)) exitWith {100};
+    if (_typeX in [vehCSATPatrolHeli, vehNATOPatrolHeli, civHeli]) exitWith {500};
+    if ((_typeX in vehAPCs) || (_typeX in vehTransportAir) || (_typeX in vehUAVs)) exitWith {1000};
+    if ((_typeX in vehAttackHelis) or (_typeX in vehTanks) or (_typeX in vehAA) or (_typeX in vehMRLS)) exitWith {3000};
+    if (_typeX in [vehNATOPlane,vehNATOPlaneAA,vehCSATPlane,vehCSATPlaneAA]) exitWith {4000};
+    0;
 };
 
 if (_costs == 0) exitWith {
-	_veh setVariable ["A3A_sellVehicle_inProgress",false,false];
-	["Sell Vehicle", "The vehicle you are looking is not suitable in our marketplace"] remoteExecCall ["A3A_fnc_customHint",remoteExecutedOwner];
+    _veh setVariable ["A3A_sellVehicle_inProgress",false,false];
+    ["Sell Vehicle", "The vehicle you are looking is not suitable in our marketplace"] remoteExecCall ["A3A_fnc_customHint",remoteExecutedOwner];
 };
 
 _costs = round (_costs * (1-damage _veh));

--- a/A3-Antistasi/functions/Base/fn_sellVehicle.sqf
+++ b/A3-Antistasi/functions/Base/fn_sellVehicle.sqf
@@ -31,20 +31,22 @@ params [
     ["_player",objNull,[objNull]],
     ["_veh",objNull,[objNull]]
 ];
+private _filename = "fn_sellVehicle";
 
-if (isNull _veh) exitWith {["Sell Vehicle", "You are not looking to any vehicle"] remoteExecCall ["A3A_fnc_customHint",remoteExecutedOwner];};
+if (isNull _player) exitWith {[1,"_player is null.",_filename] call A3A_fnc_log;};
+if (isNull _veh) exitWith {["Sell Vehicle", "You are not looking at a vehicle."] remoteExecCall ["A3A_fnc_customHint",_player];};
 
-if (_veh getVariable ["A3A_sellVehicle_inProgress",false]) exitWith {["Sell Vehicle", "Vehicle sale already in progress."] remoteExecCall ["A3A_fnc_customHint",remoteExecutedOwner];};
+if (_veh getVariable ["A3A_sellVehicle_inProgress",false]) exitWith {["Sell Vehicle", "Vehicle sale already in progress."] remoteExecCall ["A3A_fnc_customHint",_player];};
 _veh setVariable ["A3A_sellVehicle_inProgress",true,false];  // Only processed on the server. It is absolutely pointless trying to network this due to race conditions.
 
-if (_veh distance getMarkerPos respawnTeamPlayer > 50) exitWith {["Sell Vehicle", "Vehicle must be closer than 50 meters to the flag"] remoteExecCall ["A3A_fnc_customHint",remoteExecutedOwner];};
+if (_veh distance getMarkerPos respawnTeamPlayer > 50) exitWith {["Sell Vehicle", "Vehicle must be closer than 50 meters to the flag marker."] remoteExecCall ["A3A_fnc_customHint",_player];};
 
-if ({isPlayer _x} count crew _veh > 0) exitWith {["Sell Vehicle", "In order to sell, vehicle must be empty."] remoteExecCall ["A3A_fnc_customHint",remoteExecutedOwner];};
+if ({isPlayer _x} count crew _veh > 0) exitWith {["Sell Vehicle", "In order to sell the vehicle, it must be empty."] remoteExecCall ["A3A_fnc_customHint",_player];};
 
 _owner = _veh getVariable ["ownerX",""];
 if !(_owner isEqualTo "" || {getPlayerUID _player isEqualTo _owner}) exitWith {  // Vehicle cannot be sold if owned by another player.
     _veh setVariable ["A3A_sellVehicle_inProgress",false,false];
-    ["Sell Vehicle", "You are not the rebel commander or owner of this vehicle. Therefore, you cannot sell it"] remoteExecCall ["A3A_fnc_customHint",remoteExecutedOwner];
+    ["Sell Vehicle", "You are not the owner of this vehicle. Therefore, you cannot sell it."] remoteExecCall ["A3A_fnc_customHint",_player];
 };
 
 private _typeX = typeOf _veh;
@@ -62,7 +64,7 @@ private _costs = call {
 
 if (_costs == 0) exitWith {
     _veh setVariable ["A3A_sellVehicle_inProgress",false,false];
-    ["Sell Vehicle", "The vehicle you are looking is not suitable in our marketplace"] remoteExecCall ["A3A_fnc_customHint",remoteExecutedOwner];
+    ["Sell Vehicle", "The vehicle you are looking is not suitable in our marketplace."] remoteExecCall ["A3A_fnc_customHint",_player];
 };
 
 _costs = round (_costs * (1-damage _veh));
@@ -76,5 +78,5 @@ if (_veh in reportedVehs) then {reportedVehs = reportedVehs - [_veh]; publicVari
 
 if (_veh isKindOf "StaticWeapon") then {deleteVehicle _veh};
 
-["Sell Vehicle", "Vehicle Sold"] remoteExecCall ["A3A_fnc_customHint",remoteExecutedOwner];
+["Sell Vehicle", "Vehicle Sold."] remoteExecCall ["A3A_fnc_customHint",_player];
 nil;

--- a/A3-Antistasi/functions/Base/fn_sellVehicle.sqf
+++ b/A3-Antistasi/functions/Base/fn_sellVehicle.sqf
@@ -1,26 +1,48 @@
-private ["_veh", "_costs","_typeX"];
-_veh = cursortarget;
+/*
+Author: Barbolani, Wurzel, Jaj22, Michael Phillips, Caleb Serafin
+Attempts to sell the vehicle the player is looking at.
+Vehicle cannot be sold if owned by another player.
 
-if (isNull _veh) exitWith {["Sell Vehicle", "You are not looking to any vehicle"] call A3A_fnc_customHint;};
+Arguments:
+    <OBJECT> Player who is trying to sell a vehicle.
+    <OBJECT> cursorObject of the player.
 
-if (_veh distance getMarkerPos respawnTeamPlayer > 50) exitWith {["Sell Vehicle", "Vehicle must be closer than 50 meters to the flag"] call A3A_fnc_customHint;};
+Return Value:
+<NIL> nil
 
-if ({isPlayer _x} count crew _veh > 0) exitWith {["Sell Vehicle", "In order to sell, vehicle must be empty."] call A3A_fnc_customHint;};
+Scope: Server/HC, All calls need to be executed on one machine, using an HC is also possible.
+Environment: Unscheduled, is used to sell vehicles, execution cannot be stacked and exploited.
+Public: No
+Dependencies:
+<STRING> ownerX found on vehicles, contains UID of player who bought it.
+<ARRAY> Template vehicle arrays, see costs = call {}.
 
-_owner = _veh getVariable "ownerX";
-_exit = false;
-if (!isNil "_owner") then
-	{
-	if (_owner isEqualType "") then
-		{
-		if (getPlayerUID player != _owner) then {_exit = true};
-		};
-	};
+Example:
+["something", player] call A3A_fnc_someExsampleFnc;
 
-if (_exit) exitWith {["Sell Vehicle", "You are not owner of this vehicle and you cannot sell it"] call A3A_fnc_customHint;};
+*/
+params [
+	["_player",objNull,[objNull]],
+	["_veh",objNull,[objNull]]
+];
 
-_typeX = typeOf _veh;
-_costs = call {
+if (isNull _veh) exitWith {["Sell Vehicle", "You are not looking to any vehicle"] remoteExecCall ["A3A_fnc_customHint",remoteExecutedOwner];};
+
+if (_veh getVariable ["A3A_sellVehicle_inProgress",false]) exitWith {["Sell Vehicle", "Vehicle sale already in progress."] remoteExecCall ["A3A_fnc_customHint",remoteExecutedOwner];};
+_veh setVariable ["A3A_sellVehicle_inProgress",true,false];  // Only processed on the server. It is absolutely pointless trying to network this due to race conditions.
+
+if (_veh distance getMarkerPos respawnTeamPlayer > 50) exitWith {["Sell Vehicle", "Vehicle must be closer than 50 meters to the flag"] remoteExecCall ["A3A_fnc_customHint",remoteExecutedOwner];};
+
+if ({isPlayer _x} count crew _veh > 0) exitWith {["Sell Vehicle", "In order to sell, vehicle must be empty."] remoteExecCall ["A3A_fnc_customHint",remoteExecutedOwner];};
+
+_owner = _veh getVariable ["ownerX",""];
+if !(_owner isEqualTo "" || {getPlayerUID _player isEqualTo _owner}) exitWith {  // Vehicle cannot be sold if owned by another player.
+	_veh setVariable ["A3A_sellVehicle_inProgress",false,false];
+	["Sell Vehicle", "You are not the rebel commander or owner of this vehicle. Therefore, you cannot sell it"] remoteExecCall ["A3A_fnc_customHint",remoteExecutedOwner];
+};
+
+private _typeX = typeOf _veh;
+private _costs = call {
 	if (_veh isKindOf "StaticWeapon") exitWith {100};			// in case rebel static is same as enemy statics
 	if (_typeX in vehFIA) exitWith { ([_typeX] call A3A_fnc_vehiclePrice) / 2 };
 	if ((_typeX in arrayCivVeh) or (_typeX in civBoats) or (_typeX in [civBoat,civCar,civTruck])) exitWith {25};
@@ -32,7 +54,10 @@ _costs = call {
 	0;
 };
 
-if (_costs == 0) exitWith {["Sell Vehicle", "The vehicle you are looking is not suitable in our marketplace"] call A3A_fnc_customHint;};
+if (_costs == 0) exitWith {
+	_veh setVariable ["A3A_sellVehicle_inProgress",false,false];
+	["Sell Vehicle", "The vehicle you are looking is not suitable in our marketplace"] remoteExecCall ["A3A_fnc_customHint",remoteExecutedOwner];
+};
 
 _costs = round (_costs * (1-damage _veh));
 
@@ -45,4 +70,5 @@ if (_veh in reportedVehs) then {reportedVehs = reportedVehs - [_veh]; publicVari
 
 if (_veh isKindOf "StaticWeapon") then {deleteVehicle _veh};
 
-["Sell Vehicle", "Vehicle Sold"] call A3A_fnc_customHint;
+["Sell Vehicle", "Vehicle Sold"] remoteExecCall ["A3A_fnc_customHint",remoteExecutedOwner];
+nil;


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
* Change
* Enhancement

### What have I changed and why?
* Vehicle Sales are not processed on the server.
* "A3A_sellVehicle_inProgress" is made true on vehicles being sold. (This is only checked on the server)
* This change fixes the sell-vehicle exploit abused to gain infinite money.

Please check [2e2d20e](https://github.com/official-antistasi-community/A3-Antistasi/pull/1615/commits/2e2d20ecbf427190c788298eb6689503bc0d5454) for functional changes.

### Please specify which Issue this PR Resolves.
closes #1613 https://github.com/official-antistasi-community/A3-Antistasi/issues/1613

### Please verify the following and ensure all checks are completed.

2. [x] Have you loaded the mission in LAN host?
3. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
* Yes (Give it to an expert exploiter)

### Testing steps
On dedicated server: look at a sellable vehicle and run the code below
```sqf
for "_i" from 1 to 1000 do {
    [player,cursorObject] remoteExecCall ["A3A_fnc_sellVehicle",2];
};
```