### PR TITLE
Enable Airstrike conversion for Airfields / Update a few Hints

### DIFF
--- a/A3-Antistasi/functions/Base/fn_sellVehicle.sqf
+++ b/A3-Antistasi/functions/Base/fn_sellVehicle.sqf
@@ -3,7 +3,7 @@ _veh = cursortarget;
 
 if (isNull _veh) exitWith {["Sell Vehicle", "You are not looking to any vehicle"] call A3A_fnc_customHint;};
 
-if (_veh distance getMarkerPos respawnTeamPlayer > 50) exitWith {["Sell Vehicle", "Vehicle must be closer than 50 meters to the flag"] call A3A_fnc_customHint;};
+if (_veh distance getMarkerPos respawnTeamPlayer > 50) exitWith {["Sell Vehicle", "The Vehicle must be within 50 meters of HQ to be sold."] call A3A_fnc_customHint;};
 
 if ({isPlayer _x} count crew _veh > 0) exitWith {["Sell Vehicle", "In order to sell, vehicle must be empty."] call A3A_fnc_customHint;};
 
@@ -17,7 +17,7 @@ if (!isNil "_owner") then
 		};
 	};
 
-if (_exit) exitWith {["Sell Vehicle", "You are not owner of this vehicle and you cannot sell it"] call A3A_fnc_customHint;};
+if (_exit) exitWith {["Sell Vehicle", "You are not owner of this vehicle and you can't sell it"] call A3A_fnc_customHint;};
 
 _typeX = typeOf _veh;
 _costs = call {

--- a/A3-Antistasi/functions/Base/fn_sellVehicle.sqf
+++ b/A3-Antistasi/functions/Base/fn_sellVehicle.sqf
@@ -3,7 +3,7 @@ _veh = cursortarget;
 
 if (isNull _veh) exitWith {["Sell Vehicle", "You are not looking to any vehicle"] call A3A_fnc_customHint;};
 
-if (_veh distance getMarkerPos respawnTeamPlayer > 50) exitWith {["Sell Vehicle", "The Vehicle must be within 50 meters of HQ to be sold."] call A3A_fnc_customHint;};
+if (_veh distance getMarkerPos respawnTeamPlayer > 50) exitWith {["Sell Vehicle", "Vehicle must be closer than 50 meters to the flag"] call A3A_fnc_customHint;};
 
 if ({isPlayer _x} count crew _veh > 0) exitWith {["Sell Vehicle", "In order to sell, vehicle must be empty."] call A3A_fnc_customHint;};
 
@@ -17,7 +17,7 @@ if (!isNil "_owner") then
 		};
 	};
 
-if (_exit) exitWith {["Sell Vehicle", "You are not owner of this vehicle and you can't sell it"] call A3A_fnc_customHint;};
+if (_exit) exitWith {["Sell Vehicle", "You are not owner of this vehicle and you cannot sell it"] call A3A_fnc_customHint;};
 
 _typeX = typeOf _veh;
 _costs = call {

--- a/A3-Antistasi/functions/Garage/fn_garageVehicle.sqf
+++ b/A3-Antistasi/functions/Garage/fn_garageVehicle.sqf
@@ -11,7 +11,7 @@ _veh = cursorTarget;
 
 if (isNull _veh) exitWith {["Garage", "You are not looking at a vehicle"] call A3A_fnc_customHint;};
 
-if (!alive _veh) exitWith {["Garage", "You cannot add destroyed vehicles to your garage"] call A3A_fnc_customHint;};
+if (!alive _veh) exitWith {["Garage", "You can't add destroyed vehicles to your garage"] call A3A_fnc_customHint;};
 _closeX = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
 _closeX = _closeX select {(player inArea _x) and (_veh inArea _x)};
 
@@ -23,22 +23,23 @@ if ({alive _x} count (crew vehicle _veh) > 0) exitWith {["Garage", "In order to 
 
 _typeVehX = typeOf _veh;
 
-if (_veh isKindOf "Man") exitWith {["Garage", "Are you kidding?"] call A3A_fnc_customHint;};
+if (_veh isKindOf "CAManBase") exitWith {["Garage", format ["Sorry you can't Garage %1.",name _veh]] call A3A_fnc_customHint;};
+
 if ((typeOf _veh) isEqualTo "Box_IND_Wps_F") exitWith {
 	_veh addMagazineCargoGlobal [unlockedMagazines#0,1];// so fnc_empty will delete the crate
 	_transferLoot = [_veh] spawn A3A_fnc_empty;
 	[10] call A3A_fnc_resourcesPlayer;
 	["Garage", "Loot crate stored"] call A3A_fnc_customHint;
 };
-if !(_veh isKindOf "AllVehicles") exitWith {["Garage", "The vehicle you are looking cannot be stored in our Garage"] call A3A_fnc_customHint;};
+if !(_veh isKindOf "AllVehicles") exitWith {["Garage", "The vehicle you are looking can't be stored in our Garage"] call A3A_fnc_customHint;};
 
-_units = (player nearEntities ["Man",300]) select {([_x] call A3A_fnc_CanFight) && (side _x isEqualTo Occupants || side _x isEqualTo Invaders)};
+_units = (player nearEntities ["CAManBase",300]) select {([_x] call A3A_fnc_CanFight) && (side _x isEqualTo Occupants || side _x isEqualTo Invaders)};
 if (_units findIf {_unit = _x; _players = allPlayers select {(side _x isEqualTo teamPlayer) && (player distance _x < 300)}; _players findIf {_x in (_unit targets [true, 300])} != -1} != -1) exitWith {["Garage", "You can't garage vehicles while enemies are engaging you"] call A3A_fnc_customHint};
 if (_units findIf{player distance _x < 100} != -1) exitWith {["Garage", "You can't garage vehicles while enemies are near you"] call A3A_fnc_customHint};
 
 if (player distance _veh > 25) exitWith {["Garage", "You can't garage vehicles that are more than 25m away from you"] call A3A_fnc_customHint};
 
-if (_pool and (count vehInGarage >= (tierWar *5))) exitWith {["Garage", "You cannot garage more vehicles at your current War Level"] call A3A_fnc_customHint;};
+if (_pool and (count vehInGarage >= (tierWar *5))) exitWith {["Garage", "You can't garage more vehicles at your current War Level"] call A3A_fnc_customHint;};
 private _personalGarage = player getVariable ["personalGarage", []];
 if (!((count _personalGarage < personalGarageMax) or (personalGarageMax isEqualTo 0)) and !_pool) exitWith {["Garage", "Personal garage is full, you can't add more vehicles to it"] call A3A_fnc_customHint};
 
@@ -56,7 +57,7 @@ if (!_pool) then
 		};
 	};
 
-if (_exit) exitWith {["Garage", "You are not owner of this vehicle therefore you cannot garage it"] call A3A_fnc_customHint;};
+if (_exit) exitWith {["Garage", "You are not owner of this vehicle therefore you can't garage it"] call A3A_fnc_customHint;};
 
 if (_typeVehX isKindOf "Plane") then
 	{
@@ -64,7 +65,7 @@ if (_typeVehX isKindOf "Plane") then
 	if (count _airportsX == 0) then {_exit = true};
 	};
 
-if (_exit) exitWith {["Garage", format ["You cannot garage an air vehicle while you are not near an Aiport which belongs to %1. Place your HQ near an airbase flag in order to be able to garage it",nameTeamPlayer]] call A3A_fnc_customHint;};
+if (_exit) exitWith {["Garage", format ["You can't garage a Plane while you are not near an Aiport which belongs to %1. Please move your Plane to an Airport to garage it",nameTeamPlayer]] call A3A_fnc_customHint;};
 
 if (_veh in staticsToSave) then {staticsToSave = staticsToSave - [_veh]; publicVariable "staticsToSave"};
 

--- a/A3-Antistasi/functions/Garage/fn_garageVehicle.sqf
+++ b/A3-Antistasi/functions/Garage/fn_garageVehicle.sqf
@@ -23,7 +23,7 @@ if ({alive _x} count (crew vehicle _veh) > 0) exitWith {["Garage", "In order to 
 
 _typeVehX = typeOf _veh;
 
-if (_veh isKindOf "CAManBase") exitWith {["Garage", format ["Sorry you can't Garage %1.",name _veh]] call A3A_fnc_customHint;};
+if (_veh isKindOf "Man") exitWith {["Garage", format ["Sorry you can't Garage %1.",name _veh]] call A3A_fnc_customHint;};
 
 if ((typeOf _veh) isEqualTo "Box_IND_Wps_F") exitWith {
 	_veh addMagazineCargoGlobal [unlockedMagazines#0,1];// so fnc_empty will delete the crate
@@ -33,7 +33,7 @@ if ((typeOf _veh) isEqualTo "Box_IND_Wps_F") exitWith {
 };
 if !(_veh isKindOf "AllVehicles") exitWith {["Garage", "The vehicle you are looking can't be stored in our Garage"] call A3A_fnc_customHint;};
 
-_units = (player nearEntities ["CAManBase",300]) select {([_x] call A3A_fnc_CanFight) && (side _x isEqualTo Occupants || side _x isEqualTo Invaders)};
+_units = (player nearEntities ["Man",300]) select {([_x] call A3A_fnc_CanFight) && (side _x isEqualTo Occupants || side _x isEqualTo Invaders)};
 if (_units findIf {_unit = _x; _players = allPlayers select {(side _x isEqualTo teamPlayer) && (player distance _x < 300)}; _players findIf {_x in (_unit targets [true, 300])} != -1} != -1) exitWith {["Garage", "You can't garage vehicles while enemies are engaging you"] call A3A_fnc_customHint};
 if (_units findIf{player distance _x < 100} != -1) exitWith {["Garage", "You can't garage vehicles while enemies are near you"] call A3A_fnc_customHint};
 
@@ -57,7 +57,7 @@ if (!_pool) then
 		};
 	};
 
-if (_exit) exitWith {["Garage", "You are not owner of this vehicle therefore you can't garage it"] call A3A_fnc_customHint;};
+if (_exit) exitWith {["Garage", "You are not the owner of this vehicle. Therefore, you can't garage it."] call A3A_fnc_customHint;};
 
 if (_typeVehX isKindOf "Plane") then
 	{

--- a/A3-Antistasi/functions/REINF/fn_addBombRun.sqf
+++ b/A3-Antistasi/functions/REINF/fn_addBombRun.sqf
@@ -1,10 +1,10 @@
 _veh = cursortarget;
 
-if (isNull _veh) exitWith {["Airstrike", "You are not looking to any vehicle."] call A3A_fnc_customHint;};
+if (isNull _veh) exitWith {["Airstrike", "You are not looking at a vehicle."] call A3A_fnc_customHint;};
 
 if (!alive _veh) exitWith {["Airstrike", "You can't convert destroyed Air vehicle to Airstrikes."] call A3A_fnc_customHint;};
 
-_units = (player nearEntities ["CAManBase",300]) select {([_x] call A3A_fnc_CanFight) && (side _x isEqualTo Occupants || side _x isEqualTo Invaders)};
+_units = (player nearEntities ["Man",300]) select {([_x] call A3A_fnc_CanFight) && (side _x isEqualTo Occupants || side _x isEqualTo Invaders)};
 if (_units findIf {_unit = _x; _players = allPlayers select {(side _x isEqualTo teamPlayer) && (player distance _x < 300)}; _players findIf {_x in (_unit targets [true, 300])} != -1} != -1) exitWith {["Airstrike", "You can't convert Airstrikes while enemies are near you"] call A3A_fnc_customHint};
 if (_units findIf{player distance _x < 100} != -1) exitWith {["Airstrike", "You can't convert Airstrikes while enemies are near you."] call A3A_fnc_customHint};
 
@@ -25,7 +25,7 @@ if (!isNil "_owner") then
 		};
 	};
 
-if (_exit) exitWith {["Airstrike", "You are not owner of this vehicle and you can't convert it"] call A3A_fnc_customHint;};
+if (_exit) exitWith {["Airstrike", "You are not the owner of this vehicle. Therefore, you can't convert it."] call A3A_fnc_customHint;};
 
 if (not(_veh isKindOf "Air")) exitWith {["Airstrike", "Only Air Vehicles can be used to increase Airstrike points"] call A3A_fnc_customHint;};
 

--- a/A3-Antistasi/functions/REINF/fn_addBombRun.sqf
+++ b/A3-Antistasi/functions/REINF/fn_addBombRun.sqf
@@ -1,10 +1,19 @@
 _veh = cursortarget;
 
-if (isNull _veh) exitWith {["Airstrike", "You are not looking to any vehicle"] call A3A_fnc_customHint;};
+if (isNull _veh) exitWith {["Airstrike", "You are not looking to any vehicle."] call A3A_fnc_customHint;};
 
-if (_veh distance getMarkerPos respawnTeamPlayer > 50) exitWith {["Airstrike", "Vehicle must be closer than 50 meters to the flag"] call A3A_fnc_customHint;};
+if (!alive _veh) exitWith {["Airstrike", "You can't convert destroyed Air vehicle to Airstrikes."] call A3A_fnc_customHint;};
 
-if ({isPlayer _x} count crew _veh > 0) exitWith {["Airstrike", "In order to sell, vehicle must be empty."] call A3A_fnc_customHint;};
+_units = (player nearEntities ["CAManBase",300]) select {([_x] call A3A_fnc_CanFight) && (side _x isEqualTo Occupants || side _x isEqualTo Invaders)};
+if (_units findIf {_unit = _x; _players = allPlayers select {(side _x isEqualTo teamPlayer) && (player distance _x < 300)}; _players findIf {_x in (_unit targets [true, 300])} != -1} != -1) exitWith {["Airstrike", "You can't convert Airstrikes while enemies are near you"] call A3A_fnc_customHint};
+if (_units findIf{player distance _x < 100} != -1) exitWith {["Airstrike", "You can't convert Airstrikes while enemies are near you."] call A3A_fnc_customHint};
+
+_near = (["Synd_HQ"] + airportsX) select {sidesX getVariable [_x,sideUnknown] isEqualTo teamplayer};
+_near = _near select {(player inArea _x) && (_veh inArea _x)};
+
+if (_near isEqualTo []) exitWith {["Airstrike", format ["You and the Air vehicle need to be in the Area of an %1 Airport or HQ in order to convert it to Airstrikes",nameTeamPlayer]] call A3A_fnc_customHint;};
+
+if ({isPlayer _x} count crew _veh > 0) exitWith {["Airstrike", "In order to convert, Vehicle must be empty."] call A3A_fnc_customHint;};
 
 _owner = _veh getVariable "ownerX";
 _exit = false;
@@ -16,7 +25,7 @@ if (!isNil "_owner") then
 		};
 	};
 
-if (_exit) exitWith {["Airstrike", "You are not owner of this vehicle and you cannot sell it"] call A3A_fnc_customHint;};
+if (_exit) exitWith {["Airstrike", "You are not owner of this vehicle and you can't convert it"] call A3A_fnc_customHint;};
 
 if (not(_veh isKindOf "Air")) exitWith {["Airstrike", "Only Air Vehicles can be used to increase Airstrike points"] call A3A_fnc_customHint;};
 
@@ -27,7 +36,7 @@ if (isClass (configfile >> "CfgVehicles" >> _typeX >> "assembleInfo")) then {
 		_exit = true;
 	};
 };
-if (_exit) exitWith {["Airstrike", "Backpack drones cannot be used to increase Airstrike points"] call A3A_fnc_customHint;};
+if (_exit) exitWith {["Airstrike", "Backpack drones can't be used to increase Airstrike points"] call A3A_fnc_customHint;};
 
 
 //if (_typeX == vehSDKHeli) exitWith {hint "Syndikat Helicopters cannot be used to increase Airstrike points"};


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [X] Enhancement

### What have you changed and why?
Information: 
Changed Cannot to Can't, both were used in Hints but for the sake of Consistency i changed it to "can't".


Updated "You can't Garage Plane" Hint in fn_garageVehicle.sqf,

Applied the !Alive check from Garage to fn_addBombRun.sqf,

Applied the "Enemies Near" check from fn_garageVehicle.sqf to fn_addBombRun.sqf,

Added the "In Area" check from fn_garageVehicle.sqf to fn_addBombRun.sqf,
For only HQ and AirportsX, i keept HQ in there for the Poor people that Land a Plane near HQ and Helicopters are fine to Garage at HQ, you can't Pull them out so Airstrike conversion seems alright.

If you have ideas to improve wording, just tell me.

### Please specify which Issue this PR Resolves.
closes #1289 
### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [X] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: Convert Airstrikes at HQ, AirportsX,
Try Converting Destroyed Vehicles to Airstrikes,
Try Garaging Vehicles or Converting Airstrikes while enemies are near (It should work as Garage's Enemies near check, but i didnt get it working in Local host)

********************************************************
Notes:
