### PR TITLE
Fix #1593 fn_mineSweep doesen't work Properly

### DIFF
--- a/A3-Antistasi/functions/AI/fn_mineSweep.sqf
+++ b/A3-Antistasi/functions/AI/fn_mineSweep.sqf
@@ -19,14 +19,9 @@ _truckX = vehSDKRepair createVehicle _pos;
 
 [_truckX, teamPlayer] call A3A_fnc_AIVEHinit;
 [_unit] spawn A3A_fnc_FIAinit;
-clearMagazineCargo unitBackpack _unit;
-_unit addItemToBackpack "MineDetector";
 
 _groupX addVehicle _truckX;
 [_unit] orderGetIn true;
-// Add Mine Detector to detect invisible APERS
-clearMagazineCargo (unitBackpack _unit);
-_unit addItemToBackpack "MineDetector";
 //_unit setBehaviour "SAFE";
 theBoss hcSetGroup [_groupX];
 

--- a/A3-Antistasi/functions/REINF/fn_equipRebel.sqf
+++ b/A3-Antistasi/functions/REINF/fn_equipRebel.sqf
@@ -80,6 +80,7 @@ switch (true) do {
 	case (_unitClass in SDKExp): {
 		[_unit,unlockedRifles] call A3A_fnc_randomRifle;
 		_unit setUnitTrait ["explosiveSpecialist",true];
+		_unit addItemToBackpack "MineDetector";
 		_unit addItemToBackpack "Toolkit";
 		if (count unlockedAA > 0) then {
 			[_unit, selectRandom unlockedAA, 1] call _addWeaponAndMags;


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Explosive specialists were not being equipped with a Mine Detector. 
    

### Please specify which Issue this PR Resolves.
closes #1593

### Please verify the following and ensure all checks are completed.
**Irrelevant**
1. [ ] Have you loaded the mission in singleplayer?
2. [ ] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
