### PR TITLE
Common Description.ext contents moved to MissionDescription

### DIFF
--- a/A3-Antistasi/MissionDescription/CfgDebriefingContents.hpp
+++ b/A3-Antistasi/MissionDescription/CfgDebriefingContents.hpp
@@ -1,0 +1,4 @@
+// In map template description.ext use:
+// #include "MissionDescription\CfgDebriefingContents.hpp"
+
+#include "endMission.hpp"

--- a/A3-Antistasi/MissionDescription/CfgFunctionsContents.hpp
+++ b/A3-Antistasi/MissionDescription/CfgFunctionsContents.hpp
@@ -1,0 +1,6 @@
+// In map template description.ext use:
+// #include "MissionDescription\CfgFunctionsContents.hpp"
+
+#include "..\functions.hpp"
+#include "..\JeroenArsenal\functions.hpp"
+//#include "..\Collections\functions.hpp"

--- a/A3-Antistasi/MissionDescription/CfgSoundsContents.hpp
+++ b/A3-Antistasi/MissionDescription/CfgSoundsContents.hpp
@@ -1,0 +1,8 @@
+// In map template description.ext use:
+// #include "MissionDescription\CfgSoundsContents.hpp"
+class fire
+{
+	name="fire";
+	sound[]={"Music\fire.ogg",db+12,1.0}; // NB, this will resolve from root
+	titles[]={};
+};

--- a/A3-Antistasi/MissionDescription/master.hpp
+++ b/A3-Antistasi/MissionDescription/master.hpp
@@ -1,0 +1,14 @@
+// In map template description.ext use:
+// #include "MissionDescription\master.hpp"
+// Whether order should be maintained is unknown.
+#include "..\defines.hpp"
+#include "..\dialogs.hpp"
+
+author = $STR_antistasi_credits_generic_author_text;
+loadScreen = "Pictures\Mission\pic.jpg"; // NB, this will resolve from root
+overviewPicture = "Pictures\Mission\pic.jpg"; // NB, this will resolve from root
+
+#include "debug.hpp"
+#include "gameSettings.hpp"
+#include "params.hpp"
+#include "CfgIdentities.hpp"

--- a/Map-Templates/Antistasi-Altis-BLUFOR.Altis/description.ext
+++ b/Map-Templates/Antistasi-Altis-BLUFOR.Altis/description.ext
@@ -1,41 +1,20 @@
-#include "defines.hpp"
-#include "dialogs.hpp"
+#include "MissionDescription\master.hpp"
 
-author = $STR_antistasi_credits_generic_author_text;
 OnLoadName = $STR_antistasi_mission_info_altisB_mapname_short_text;
 OnLoadMission = $STR_antistasi_mission_info_altis_blurb_text;
-loadScreen = "Pictures\Mission\pic.jpg";
 briefingName = $STR_antistasi_mission_info_altisB_mapname_text;
 overviewText = $STR_antistasi_mission_info_altis_description_text;
-overviewPicture = "Pictures\Mission\pic.jpg";
-
-#include "MissionDescription\debug.hpp"
-
-#include "MissionDescription\gameSettings.hpp"
 
 class CfgFunctions {
-    #include "functions.hpp"
-    #include "JeroenArsenal\functions.hpp"
+    #include "MissionDescription\CfgFunctionsContents.hpp"
 };
 
-class CfgSounds
-{
-    class fire
-    {
-        name="fire";
-        sound[]={"Music\fire.ogg",db+12,1.0};
-        titles[]={};
-    };
+class CfgSounds {
+    #include "MissionDescription\CfgSoundsContents.hpp"
 };
 
-#include "MissionDescription\params.hpp"
-
-#include "MissionDescription\CfgIdentities.hpp"
-
-class CfgDebriefing
-{
-	#include "MissionDescription\endMission.hpp"
-
+class CfgDebriefing {
+    #include "MissionDescription\CfgDebriefingContents.hpp"
 	class End1
 	{
 		title = "V I C T O R Y";

--- a/Map-Templates/Antistasi-Altis.Altis/description.ext
+++ b/Map-Templates/Antistasi-Altis.Altis/description.ext
@@ -1,41 +1,20 @@
-#include "defines.hpp"
-#include "dialogs.hpp"
+#include "MissionDescription\master.hpp"
 
-author = $STR_antistasi_credits_generic_author_text;
 OnLoadName = $STR_antistasi_mission_info_altis_mapname_short_text;
 OnLoadMission = $STR_antistasi_mission_info_altis_blurb_text;
-loadScreen = "Pictures\Mission\pic.jpg";
 briefingName = $STR_antistasi_mission_info_altis_mapname_text;
 overviewText = $STR_antistasi_mission_info_altis_description_text;
-overviewPicture = "Pictures\Mission\pic.jpg";
-
-#include "MissionDescription\debug.hpp"
-
-#include "MissionDescription\gameSettings.hpp"
 
 class CfgFunctions {
-    #include "functions.hpp"
-    #include "JeroenArsenal\functions.hpp"
+    #include "MissionDescription\CfgFunctionsContents.hpp"
 };
 
-class CfgSounds
-{
-    class fire
-    {
-        name="fire";
-        sound[]={"Music\fire.ogg",db+12,1.0};
-        titles[]={};
-    };
+class CfgSounds {
+    #include "MissionDescription\CfgSoundsContents.hpp"
 };
 
-#include "MissionDescription\params.hpp"
-
-#include "MissionDescription\CfgIdentities.hpp"
-
-class CfgDebriefing
-{
-	#include "MissionDescription\endMission.hpp"
-
+class CfgDebriefing {
+    #include "MissionDescription\CfgDebriefingContents.hpp"
 	class End1
 	{
 		title = "V I C T O R Y";

--- a/Map-Templates/Antistasi-Anizay.tem_anizay/description.ext
+++ b/Map-Templates/Antistasi-Anizay.tem_anizay/description.ext
@@ -1,41 +1,20 @@
-#include "defines.hpp"
-#include "dialogs.hpp"
+#include "MissionDescription\master.hpp"
 
-author = $STR_antistasi_credits_generic_author_text;
 OnLoadName = $STR_antistasi_mission_info_anizay_mapname_short_text;
 OnLoadMission = $STR_antistasi_mission_info_anizay_blurb_text;
-loadScreen = "Pictures\Mission\pic.jpg";
 briefingName = $STR_antistasi_mission_info_anizay_mapname_text;
 overviewText = $STR_antistasi_mission_info_anizay_description_text;
-overviewPicture = "Pictures\Mission\pic.jpg";
-
-#include "MissionDescription\debug.hpp"
-
-#include "MissionDescription\gameSettings.hpp"
 
 class CfgFunctions {
-    #include "functions.hpp"
-    #include "JeroenArsenal\functions.hpp"
+    #include "MissionDescription\CfgFunctionsContents.hpp"
 };
 
-class CfgSounds
-{
-    class fire
-    {
-        name="fire";
-        sound[]={"Music\fire.ogg",db+12,1.0};
-        titles[]={};
-    };
+class CfgSounds {
+    #include "MissionDescription\CfgSoundsContents.hpp"
 };
 
-#include "MissionDescription\params.hpp"
-
-#include "MissionDescription\CfgIdentities.hpp"
-
-class CfgDebriefing
-{
-	#include "MissionDescription\endMission.hpp"
-
+class CfgDebriefing {
+    #include "MissionDescription\CfgDebriefingContents.hpp"
 	class End1
 	{
 		title = "V I C T O R Y";

--- a/Map-Templates/Antistasi-Chernarus.chernarus_summer/description.ext
+++ b/Map-Templates/Antistasi-Chernarus.chernarus_summer/description.ext
@@ -1,41 +1,20 @@
-#include "defines.hpp"
-#include "dialogs.hpp"
+#include "MissionDescription\master.hpp"
 
-author = $STR_antistasi_credits_generic_author_text;
 OnLoadName = $STR_antistasi_mission_info_cherna_mapname_short_text;
 OnLoadMission = $STR_antistasi_mission_info_cherna_blurb_text;
-loadScreen = "Pictures\Mission\pic.jpg";
 briefingName = $STR_antistasi_mission_info_cherna_mapname_text;
 overviewText = $STR_antistasi_mission_info_cherna_description_text;
-overviewPicture = "Pictures\Mission\pic.jpg";
-
-#include "MissionDescription\debug.hpp"
-
-#include "MissionDescription\gameSettings.hpp"
 
 class CfgFunctions {
-    #include "functions.hpp"
-    #include "JeroenArsenal\functions.hpp"
+    #include "MissionDescription\CfgFunctionsContents.hpp"
 };
 
-class CfgSounds
-{
-    class fire
-    {
-        name="fire";
-        sound[]={"Music\fire.ogg",db+12,1.0};
-        titles[]={};
-    };
+class CfgSounds {
+    #include "MissionDescription\CfgSoundsContents.hpp"
 };
 
-#include "MissionDescription\params.hpp"
-
-#include "MissionDescription\CfgIdentities.hpp"
-
-class CfgDebriefing
-{
-	#include "MissionDescription\endMission.hpp"
-
+class CfgDebriefing {
+    #include "MissionDescription\CfgDebriefingContents.hpp"
 	class End1
 	{
 		title = "V I C T O R Y";

--- a/Map-Templates/Antistasi-ChernarusWinter.chernarus_winter/description.ext
+++ b/Map-Templates/Antistasi-ChernarusWinter.chernarus_winter/description.ext
@@ -1,31 +1,17 @@
-#include "defines.hpp"
-#include "dialogs.hpp"
+#include "MissionDescription\master.hpp"
 
-author = $STR_antistasi_credits_generic_author_text;
 OnLoadName = $STR_antistasi_mission_info_chernawinter_mapname_short_text;
 OnLoadMission = $STR_antistasi_mission_info_chernawinter_blurb_text;
-loadScreen = "Pictures\Mission\pic.jpg";
 briefingName = $STR_antistasi_mission_info_chernawinter_mapname_text;
 overviewText = $STR_antistasi_mission_info_chernawinter_description_text;
-overviewPicture = "Pictures\Mission\pic.jpg";
-
-#include "MissionDescription\debug.hpp"
-
-#include "MissionDescription\gameSettings.hpp"
 
 class CfgFunctions {
-    #include "functions.hpp"
-    #include "JeroenArsenal\functions.hpp"
+    #include "MissionDescription\CfgFunctionsContents.hpp"
 };
 
 class CfgSounds
 {
-    class fire
-    {
-        name="fire";
-        sound[]={"Music\fire.ogg",db+12,1.0};
-        titles[]={};
-    };
+    #include "MissionDescription\CfgSoundsContents.hpp"
 	// Start Snow Script sounds
     class bcg_wind
 	{
@@ -222,14 +208,8 @@ class CfgSounds
   // End Snow Script Sounds
 };
 
-#include "MissionDescription\params.hpp"
-
-#include "MissionDescription\CfgIdentities.hpp"
-
-class CfgDebriefing
-{
-	#include "MissionDescription\endMission.hpp"
-
+class CfgDebriefing {
+    #include "MissionDescription\CfgDebriefingContents.hpp"
 	class End1
 	{
 		title = "V I C T O R Y";

--- a/Map-Templates/Antistasi-Kunduz.Kunduz/description.ext
+++ b/Map-Templates/Antistasi-Kunduz.Kunduz/description.ext
@@ -1,41 +1,20 @@
-#include "defines.hpp"
-#include "dialogs.hpp"
+#include "MissionDescription\master.hpp"
 
-author = $STR_antistasi_credits_generic_author_text;
 OnLoadName = $STR_antistasi_mission_info_kunduz_mapname_short_text;
 OnLoadMission = $STR_antistasi_mission_info_kunduz_blurb_text;
-loadScreen = "Pictures\Mission\pic.jpg";
 briefingName = $STR_antistasi_mission_info_kunduz_mapname_text;
 overviewText = $STR_antistasi_mission_info_kunduz_description_text;
-overviewPicture = "Pictures\Mission\pic.jpg";
-
-#include "MissionDescription\debug.hpp"
-
-#include "MissionDescription\gameSettings.hpp"
 
 class CfgFunctions {
-    #include "functions.hpp"
-    #include "JeroenArsenal\functions.hpp"
+    #include "MissionDescription\CfgFunctionsContents.hpp"
 };
 
-class CfgSounds
-{
-    class fire
-    {
-        name="fire";
-        sound[]={"Music\fire.ogg",db+12,1.0};
-        titles[]={};
-    };
+class CfgSounds {
+    #include "MissionDescription\CfgSoundsContents.hpp"
 };
 
-#include "MissionDescription\params.hpp"
-
-#include "MissionDescription\CfgIdentities.hpp"
-
-class CfgDebriefing
-{
-	#include "MissionDescription\endMission.hpp"
-
+class CfgDebriefing {
+    #include "MissionDescription\CfgDebriefingContents.hpp"
 	class End1
 	{
 		title = "V I C T O R Y";

--- a/Map-Templates/Antistasi-Livonia.Enoch/description.ext
+++ b/Map-Templates/Antistasi-Livonia.Enoch/description.ext
@@ -1,41 +1,20 @@
-#include "defines.hpp"
-#include "dialogs.hpp"
+#include "MissionDescription\master.hpp"
 
-author = $STR_antistasi_credits_generic_author_text;
 OnLoadName = $STR_antistasi_mission_info_livonia_mapname_short_text;
 OnLoadMission = $STR_antistasi_mission_info_livonia_blurb_text;
-loadScreen = "Pictures\Mission\pic.jpg";
 briefingName = $STR_antistasi_mission_info_livonia_mapname_text;
 overviewText = $STR_antistasi_mission_info_livonia_description_text;
-overviewPicture = "Pictures\Mission\pic.jpg";
-
-#include "MissionDescription\debug.hpp"
-
-#include "MissionDescription\gameSettings.hpp"
 
 class CfgFunctions {
-    #include "functions.hpp"
-    #include "JeroenArsenal\functions.hpp"
+    #include "MissionDescription\CfgFunctionsContents.hpp"
 };
 
-class CfgSounds
-{
-    class fire
-    {
-        name="fire";
-        sound[]={"Music\fire.ogg",db+12,1.0};
-        titles[]={};
-    };
+class CfgSounds {
+    #include "MissionDescription\CfgSoundsContents.hpp"
 };
 
-#include "MissionDescription\params.hpp"
-
-#include "MissionDescription\CfgIdentities.hpp"
-
-class CfgDebriefing
-{
-	#include "MissionDescription\endMission.hpp"
-
+class CfgDebriefing {
+    #include "MissionDescription\CfgDebriefingContents.hpp"
 	class End1
 	{
 		title = "V I C T O R Y";

--- a/Map-Templates/Antistasi-Malden.Malden/description.ext
+++ b/Map-Templates/Antistasi-Malden.Malden/description.ext
@@ -1,41 +1,20 @@
-#include "defines.hpp"
-#include "dialogs.hpp"
+#include "MissionDescription\master.hpp"
 
-author = $STR_antistasi_credits_generic_author_text;
 OnLoadName = $STR_antistasi_mission_info_malden_mapname_short_text;
 OnLoadMission = $STR_antistasi_mission_info_malden_blurb_text;
-loadScreen = "Pictures\Mission\pic.jpg";
 briefingName = $STR_antistasi_mission_info_malden_mapname_text;
 overviewText = $STR_antistasi_mission_info_malden_description_text;
-overviewPicture = "Pictures\Mission\pic.jpg";
-
-#include "MissionDescription\debug.hpp"
-
-#include "MissionDescription\gameSettings.hpp"
 
 class CfgFunctions {
-    #include "functions.hpp"
-    #include "JeroenArsenal\functions.hpp"
+    #include "MissionDescription\CfgFunctionsContents.hpp"
 };
 
-class CfgSounds
-{
-    class fire
-    {
-        name="fire";
-        sound[]={"Music\fire.ogg",db+12,1.0};
-        titles[]={};
-    };
+class CfgSounds {
+    #include "MissionDescription\CfgSoundsContents.hpp"
 };
 
-#include "MissionDescription\params.hpp"
-
-#include "MissionDescription\CfgIdentities.hpp"
-
-class CfgDebriefing
-{
-	#include "MissionDescription\endMission.hpp"
-
+class CfgDebriefing {
+    #include "MissionDescription\CfgDebriefingContents.hpp"
 	class End1
 	{
 		title = "V I C T O R Y";

--- a/Map-Templates/Antistasi-Stratis.Stratis/description.ext
+++ b/Map-Templates/Antistasi-Stratis.Stratis/description.ext
@@ -1,41 +1,20 @@
-#include "defines.hpp"
-#include "dialogs.hpp"
+#include "MissionDescription\master.hpp"
 
-author = $STR_antistasi_credits_generic_author_text;
 OnLoadName = $STR_antistasi_mission_info_stratis_mapname_short_text;
 OnLoadMission = $STR_antistasi_mission_info_stratis_blurb_text;
-loadScreen = "Pictures\Mission\pic.jpg";
 briefingName = $STR_antistasi_mission_info_stratis_mapname_text;
 overviewText = $STR_antistasi_mission_info_stratis_description_text;
-overviewPicture = "Pictures\Mission\pic.jpg";
-
-#include "MissionDescription\debug.hpp"
-
-#include "MissionDescription\gameSettings.hpp"
 
 class CfgFunctions {
-    #include "functions.hpp"
-    #include "JeroenArsenal\functions.hpp"
+    #include "MissionDescription\CfgFunctionsContents.hpp"
 };
 
-class CfgSounds
-{
-    class fire
-    {
-        name="fire";
-        sound[]={"Music\fire.ogg",db+12,1.0};
-        titles[]={};
-    };
+class CfgSounds {
+    #include "MissionDescription\CfgSoundsContents.hpp"
 };
 
-#include "MissionDescription\params.hpp"
-
-#include "MissionDescription\CfgIdentities.hpp"
-
-class CfgDebriefing
-{
-	#include "MissionDescription\endMission.hpp"
-
+class CfgDebriefing {
+    #include "MissionDescription\CfgDebriefingContents.hpp"
 	class End1
 	{
 		title = "V I C T O R Y";

--- a/Map-Templates/Antistasi-Takistan.takistan/description.ext
+++ b/Map-Templates/Antistasi-Takistan.takistan/description.ext
@@ -1,41 +1,20 @@
-#include "defines.hpp"
-#include "dialogs.hpp"
+#include "MissionDescription\master.hpp"
 
-author = $STR_antistasi_credits_generic_author_text;
 OnLoadName = $STR_antistasi_mission_info_takistan_mapname_short_text;
 OnLoadMission = $STR_antistasi_mission_info_takistan_blurb_text;
-loadScreen = "Pictures\Mission\pic.jpg";
 briefingName = $STR_antistasi_mission_info_takistan_mapname_text;
 overviewText = $STR_antistasi_mission_info_takistan_description_text;
-overviewPicture = "Pictures\Mission\pic.jpg";
-
-#include "MissionDescription\debug.hpp"
-
-#include "MissionDescription\gameSettings.hpp"
 
 class CfgFunctions {
-    #include "functions.hpp"
-    #include "JeroenArsenal\functions.hpp"
+    #include "MissionDescription\CfgFunctionsContents.hpp"
 };
 
-class CfgSounds
-{
-    class fire
-    {
-        name="fire";
-        sound[]={"Music\fire.ogg",db+12,1.0};
-        titles[]={};
-    };
+class CfgSounds {
+    #include "MissionDescription\CfgSoundsContents.hpp"
 };
 
-#include "MissionDescription\params.hpp"
-
-#include "MissionDescription\CfgIdentities.hpp"
-
-class CfgDebriefing
-{
-	#include "MissionDescription\endMission.hpp"
-
+class CfgDebriefing {
+    #include "MissionDescription\CfgDebriefingContents.hpp"
 	class End1
 	{
 		title = "V I C T O R Y";

--- a/Map-Templates/Antistasi-Tembelan-Island.Tembelan/description.ext
+++ b/Map-Templates/Antistasi-Tembelan-Island.Tembelan/description.ext
@@ -1,41 +1,20 @@
-#include "defines.hpp"
-#include "dialogs.hpp"
+#include "MissionDescription\master.hpp"
 
-author = $STR_antistasi_credits_generic_author_text;
 OnLoadName = $STR_antistasi_mission_info_tembelan_mapname_short_text;
 OnLoadMission = $STR_antistasi_mission_info_tembelan_blurb_text;
-loadScreen = "Pictures\Mission\pic.jpg";
 briefingName = $STR_antistasi_mission_info_tembelan_mapname_text;
 overviewText = $STR_antistasi_mission_info_tembelan_description_text;
-overviewPicture = "Pictures\Mission\pic.jpg";
-
-#include "MissionDescription\debug.hpp"
-
-#include "MissionDescription\gameSettings.hpp"
 
 class CfgFunctions {
-    #include "functions.hpp"
-    #include "JeroenArsenal\functions.hpp"
+    #include "MissionDescription\CfgFunctionsContents.hpp"
 };
 
-class CfgSounds
-{
-    class fire
-    {
-        name="fire";
-        sound[]={"Music\fire.ogg",db+12,1.0};
-        titles[]={};
-    };
+class CfgSounds {
+    #include "MissionDescription\CfgSoundsContents.hpp"
 };
 
-#include "MissionDescription\params.hpp"
-
-#include "MissionDescription\CfgIdentities.hpp"
-
-class CfgDebriefing
-{
-	#include "MissionDescription\endMission.hpp"
-
+class CfgDebriefing {
+    #include "MissionDescription\CfgDebriefingContents.hpp"
 	class End1
 	{
 		title = "V I C T O R Y";

--- a/Map-Templates/Antistasi-Virolahti.vt7/description.ext
+++ b/Map-Templates/Antistasi-Virolahti.vt7/description.ext
@@ -1,41 +1,20 @@
-#include "defines.hpp"
-#include "dialogs.hpp"
+#include "MissionDescription\master.hpp"
 
-author = $STR_antistasi_credits_generic_author_text;
 OnLoadName = $STR_antistasi_mission_info_virolahti_mapname_short_text;
 OnLoadMission = $STR_antistasi_mission_info_virolahti_blurb_text;
-loadScreen = "Pictures\Mission\pic.jpg";
 briefingName = $STR_antistasi_mission_info_virolahti_mapname_text;
 overviewText = $STR_antistasi_mission_info_virolahti_description_text;
-overviewPicture = "Pictures\Mission\pic.jpg";
-
-#include "MissionDescription\debug.hpp"
-
-#include "MissionDescription\gameSettings.hpp"
 
 class CfgFunctions {
-    #include "functions.hpp"
-    #include "JeroenArsenal\functions.hpp"
+    #include "MissionDescription\CfgFunctionsContents.hpp"
 };
 
-class CfgSounds
-{
-    class fire
-    {
-        name="fire";
-        sound[]={"Music\fire.ogg",db+12,1.0};
-        titles[]={};
-    };
+class CfgSounds {
+    #include "MissionDescription\CfgSoundsContents.hpp"
 };
 
-#include "MissionDescription\params.hpp"
-
-#include "MissionDescription\CfgIdentities.hpp"
-
-class CfgDebriefing
-{
-	#include "MissionDescription\endMission.hpp"
-
+class CfgDebriefing {
+    #include "MissionDescription\CfgDebriefingContents.hpp"
 	class End1
 	{
 		title = "V I C T O R Y";

--- a/Map-Templates/Antistasi-WotP.Tanoa/description.ext
+++ b/Map-Templates/Antistasi-WotP.Tanoa/description.ext
@@ -1,41 +1,20 @@
-#include "defines.hpp"
-#include "dialogs.hpp"
+#include "MissionDescription\master.hpp"
 
-author = $STR_antistasi_credits_generic_author_text;
 OnLoadName = $STR_antistasi_mission_info_tanoa_mapname_short_text;
 OnLoadMission = $STR_antistasi_mission_info_tanoa_blurb_text;
-loadScreen = "Pictures\Mission\pic.jpg";
 briefingName = $STR_antistasi_mission_info_tanoa_mapname_text;
 overviewText = $STR_antistasi_mission_info_tanoa_description_text;
-overviewPicture = "Pictures\Mission\pic.jpg";
-
-#include "MissionDescription\debug.hpp"
-
-#include "MissionDescription\gameSettings.hpp"
 
 class CfgFunctions {
-    #include "functions.hpp"
-    #include "JeroenArsenal\functions.hpp"
+    #include "MissionDescription\CfgFunctionsContents.hpp"
 };
 
-class CfgSounds
-{
-    class fire
-    {
-        name="fire";
-        sound[]={"Music\fire.ogg",db+12,1.0};
-        titles[]={};
-    };
+class CfgSounds {
+    #include "MissionDescription\CfgSoundsContents.hpp"
 };
 
-#include "MissionDescription\params.hpp"
-
-#include "MissionDescription\CfgIdentities.hpp"
-
-class CfgDebriefing
-{
-	#include "MissionDescription\endMission.hpp"
-
+class CfgDebriefing {
+    #include "MissionDescription\CfgDebriefingContents.hpp"
 	class End1
 	{
 		title = "V I C T O R Y";


### PR DESCRIPTION
## What type of PR is this.
* Bug
* Change
3. [x] Enhancement

### What have you changed and why?
* Common Description.ext contents moved files to MissionDescription.
* Due to instances where a map template has some custom scripts, CfgXX class is still defined there and includess contents from MissionDescription\CfgXXXContents.
* Idea: 0060 Move the All the non specific information from description.ext into the MissionDescription Folder, would make adding sub functions and defines easier.
* 0060 - Yes will be done. Everything besides the strings, as well as the picture references and class CfgDebriefing will be put in one file so we only have one include in the description.ext

### Please specify which Issue this PR Resolves.
closes https://github.com/official-antistasi-community/A3-Antistasi/issues/1619

### Please verify the following and ensure all checks are completed.

2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
* Yes

NB: All `description.ext`s were changed by mass find and replace. All of them except `Antistasi-ChernarusWinter.chernarus_winter` are formatted exactly same.
Test Altis, Statis and ChernarusWinter.
All missions in the test were Built with ADD.

### How can the changes be tested?
Steps: 
Build and load missions.
