### PR TITLE
Bug-fix #1648 Script error in the function A3A_fnc_createCIV

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_createCIV.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createCIV.sqf
@@ -60,7 +60,7 @@ while {(spawner getVariable _markerX != 2) and (_countParked < _numParked)} do
 			_dirveh = 0;
 			_roadcon = roadsConnectedTo [_road, true];
 
-			if !(_roadcon == [])
+			if (count _roadcon != 0)
 			then
 			{
 				_p2 = getPos (_roadcon # 0);

--- a/A3-Antistasi/functions/CREATE/fn_createCIV.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createCIV.sqf
@@ -57,9 +57,16 @@ while {(spawner getVariable _markerX != 2) and (_countParked < _numParked)} do
 		{
 		if ((count (nearestObjects [_p1, ["Car", "Truck"], 5]) == 0) and !([50,1,_road,teamPlayer] call A3A_fnc_distanceUnits)) then
 			{
-			_roadcon = roadsConnectedto (_road);
-			_p2 = getPos (_roadcon select 0);
-			_dirveh = [_p1,_p2] call BIS_fnc_DirTo;
+			_dirveh = 0;
+			_roadcon = roadsConnectedTo [_road, true];
+
+			if !(_roadcon == [])
+			then
+			{
+				_p2 = getPos (_roadcon # 0);
+				_dirveh = _p1 getDir _p2;
+			};
+
 			_pos = [_p1, 3, _dirveh + 90] call BIS_Fnc_relPos;
 			_typeVehX = selectRandomWeighted civVehiclesWeighted;
 			/*
@@ -189,4 +196,3 @@ waitUntil {sleep 1;(spawner getVariable _markerX == 2)};
 // Chuck all the civ vehicle patrols into the despawners
 { [_x] spawn A3A_fnc_groupDespawner } forEach _groupsPatrol;
 { [_x] spawn A3A_fnc_VEHdespawner } forEach _vehPatrol;
-


### PR DESCRIPTION
that pops up almost every time when civs are create in some maps

## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
when I debugging mission the error in this file pops up on the server almost every time
``` 5:38:21 "Triada/log: ERROR: [BIS_fnc_dirTo] Error: type ARRAY, expected OBJECT, on index 0, in [[10589,4694,0],array]"
 5:38:21 Error in expression <Pos (_roadcon select 0);
_dirveh = [_p1,_p2] call BIS_fnc_DirTo;
_pos = [_p1, 3,>
 5:38:21   Error position: <_p2] call BIS_fnc_DirTo;
_pos = [_p1, 3,>
 5:38:21   Error Undefined variable in expression: _p2
 5:38:21 File functions\CREATE\fn_createCIV.sqf [A3A_fnc_createCIV]..., line 62
 5:38:21 "5521.52: [Antistasi] | INFO | fn_scheduler | Scheduled function: A3A_fnc_createAIcontrols, Function params: [""control_85""]"
 5:38:21 "[Antistasi] Spawning Control Point control_85 (createAIControls.sqf)"
 ```

### Please specify which Issue this PR Resolves.
closes #1648

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in singleplayer?
2. [x] Have you loaded the mission in LAN host?
3. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

1. jump to somewhere in the camera mode
********************************************************
Notes:
