### PR TITLE
github tab size

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,3 @@
 [*.{sqf,hpp,ext,inc}]
 charset = utf-8
-indent_style = tab
 indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*.{sqf,hpp,ext,inc}]
+charset = utf-8
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
this change tab size in github veiw and editor in all branches that have this file
default tab size 8 is very ugly