### PR TITLE
Disable ability to select and play from SP scenario menu

### DIFF
--- a/A3-Antistasi/MissionDescription/master.hpp
+++ b/A3-Antistasi/MissionDescription/master.hpp
@@ -7,6 +7,8 @@
 author = $STR_antistasi_credits_generic_author_text;
 loadScreen = "Pictures\Mission\pic.jpg"; // NB, this will resolve from root
 overviewPicture = "Pictures\Mission\pic.jpg"; // NB, this will resolve from root
+Keys[] = {"A3-Antistasi-is-not-availible-in-single-player"};
+KeysLimit = 2;  // Even if player tampers with his unlocked keys, this will never become true.
 
 #include "debug.hpp"
 #include "gameSettings.hpp"


### PR DESCRIPTION
## What type of PR is this.
* Bug
2. [x] Change
* Enhancement

### What have you changed and why?
* Lists only 1unobtainable key.
* Requires 2 unobtainable keys to be played.

### Please specify which Issue this PR Resolves.
closes https://github.com/official-antistasi-community/A3-Antistasi/issues/1667

### Please verify the following and ensure all checks are completed.

* Have you loaded the mission in singleplayer?  // You'll get a prize for this one
* [x] Have you loaded the mission in LAN host?
* [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
* Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
1. Try load from Scenario menu -> Greyed out and no play button
2. Try localhost or dedicated server -> Works
![A3-Antistasi Greyed out](https://user-images.githubusercontent.com/31820984/105752216-a9c13a00-5f4f-11eb-8c79-1fa7cb9e3ff1.PNG)
