### PR TITLE
Removed Start-up Shenanigans

### DIFF
--- a/A3-Antistasi/dialogs.hpp
+++ b/A3-Antistasi/dialogs.hpp
@@ -47,54 +47,6 @@ class set_params {
 	};
 };
 
-class should_load_personal_save {
-	idd=-1;
-	movingenable=false;
-
-	class controls {
-		class HQ_box: BOX
-		{
-			idc = -1;
-			text = $STR_antistasi_dialogs_generic_box_text;
-			x = 0.244979 * safezoneW + safezoneX;
-			y = 0.223941 * safezoneH + safezoneY;
-			w = 0.445038 * safezoneW;
-			h = 0.20 * safezoneH;//30
-		};
-		class HQ_frame: RscFrame
-		{
-			idc = -1;
-			text = $STR_antistasi_dialogs_lps_frame_text;
-			x = 0.254979 * safezoneW + safezoneX;
-			y = 0.233941 * safezoneH + safezoneY;
-			w = 0.425038 * safezoneW;
-			h = 0.18 * safezoneH;//28
-		};
-		class HQ_button_Gsquad: RscButton
-		{
-			idc = -1;
-			text = $STR_antistasi_dialogs_generic_button_yes_text;
-			tooltip = $STR_antistasi_dialogs_generic_button_yes_tooltip;
-			x = 0.272481 * safezoneW + safezoneX;
-			y = 0.317959 * safezoneH + safezoneY;
-			w = 0.175015 * safezoneW;
-			h = 0.0560125 * safezoneH;
-			action = "[true] call A3A_fnc_loadPreviousSession; closeDialog 0;";
-		};
-		class HQ_button_Gstatic: RscButton
-		{
-			idc = -1;
-			text = $STR_antistasi_dialogs_generic_button_no_text;
-			tooltip = $STR_antistasi_dialogs_generic_button_no_tooltip;
-			x = 0.482498 * safezoneW + safezoneX;
-			y = 0.317959 * safezoneH + safezoneY;
-			w = 0.175015 * safezoneW;
-			h = 0.0560125 * safezoneH;
-			action = "[false] call A3A_fnc_loadPreviousSession; closeDialog 0;";
-		};
-	};
-};
-
 //FLAG
 class HQ_menu 			{
 	idd=100;

--- a/A3-Antistasi/functions/Dialogs/fn_createDialog_shouldLoadPersonalSave.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_createDialog_shouldLoadPersonalSave.sqf
@@ -1,6 +1,3 @@
-_nul=createDialog "should_load_personal_save";
-
-waitUntil {dialog};
 private _autoSaveInterval = "autoSaveInterval" call BIS_fnc_getParamValue;
 [
 	"W A R N I N G ",
@@ -8,11 +5,7 @@ private _autoSaveInterval = "autoSaveInterval" call BIS_fnc_getParamValue;
 	"To Save: Your commander needs to go to the <t color='#f0d498'>Map Board</t>, scroll-select <t color='#f0d498'>""Game Options""</t> and click on the <t color='#f0d498'>""Persistent Save""</t> button.<br/><br/>",
 	"Current parameters are configured to auto-save every <t color='#f0d498'>",(_autoSaveInterval/60) toFixed 0," minutes</t>."] joinString ""
 ] call A3A_fnc_customHint;
-waitUntil {!dialog};
 
-if (isNil "previousSessionLoaded") then {
-	// Dialog closed without selecting a button. Default to loading previous save.
-	[true] call A3A_fnc_loadPreviousSession;
-};
+[true] call A3A_fnc_loadPreviousSession;
 
 [] spawn A3A_fnc_credits;

--- a/A3-Antistasi/functions/UI/fn_customHintRender.sqf
+++ b/A3-Antistasi/functions/UI/fn_customHintRender.sqf
@@ -62,3 +62,4 @@ true;
 // Arma 3 Apex #218a36 // BIS Website Differs incorrectly from in-game
 // Arma 3 #c48214
 // Custom Orange #e5b348
+// Custom Peach #f0d498

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -399,41 +399,29 @@ else
 //Move this
 //HC_commanderX synchronizeObjectsAdd [player];
 //player synchronizeObjectsAdd [HC_commanderX];
+A3A_customHintEnable = true; // Was false in initVarCommon to allow debug progress  hints to flow in and overwrite each other.
 
-_textX = [];
+if (isServer || player isEqualTo theBoss || (call BIS_fnc_admin) > 0) then {  // Local Host || Commander || Dedicated Admin
+	private _modsAndLoadText = [
+		[hasTFAR,"TFAR","Players will use TFAR radios. Unconscious players' radios will be muted."],
+		[hasACRE,"ACRE","Players will use ACRE radios. Unconscious players' radios will be muted."],
+		[hasACE,"ACE 3","ACE items added to arsenal and ammo-boxes. Default AI control is disabled"],
+		[hasACEHearing,"ACE 3 Hearing","Default earplugs will be disabled."],
+		[hasACEMedical,"ACE 3 Medical","Default revive system will be disabled"],
+		[A3A_hasRHS,"RHS","All factions will be replaced by RHS (AFRF & USAF & GREF)."],
+		[A3A_has3CB,"3CB","All factions will be replaced by 3CB and RHS."],
+		[A3A_hasFFAA,"FFAA","Occupant faction will be replaced by Spanish Armed Forces"],
+		[A3A_hasIvory,"Ivory Cars","Mod cars will be added to civilian car spawns."]
+	] select {_x#0};
 
-if ((hasTFAR) or (hasACRE)) then {
-	_textX = ["TFAR or ACRE Detected\n\nAntistasi detects TFAR or ACRE in the server config.\nAll players will start with addon default radios.\nDefault revive system will shut down radios while players are unconscious.\n\n"];
-};
-if (hasACE) then {
-	_textX = _textX + ["ACE 3 Detected\n\nAntistasi detects ACE modules in the server config.\nACE items added to arsenal and ammoboxes. Default AI control is disabled\nIf ACE Medical is used, default revive system will be disabled.\nIf ACE Hearing is used, default earplugs will be disabled."];
-};
-if (A3A_hasRHS) then {
-	_textX = _textX + ["RHS Detected\n\nAntistasi detects RHS in the server config.\nAll factions will be replaced by factions from the mod."];
-};
-if (A3A_has3CB) then {
-	_textX = _textX + ["3CB Detected\n\nAntistasi detects 3CB in the server config.\nAll factions will be replaced by factions from the mod."];
-};
-if (A3A_hasFFAA) then {
-	_textX = _textX + ["FFAA Detected\n\nAntistasi detects FFAA in the server config.\nOccupant faction will be replaced by Spanish Armed Forces"];
-};
-if (A3A_hasIvory) then {
-	_textX = _textX + ["Ivory Cars Detected\n\nAntistasi detects Ivory Cars in the server config.\nMod cars will be added to civilian car spawns."];
+	private _loadedTemplateInfo = A3A_loadedTemplateInfo apply {[true,_x#0,_x#1]};	// Remove and simplify when the list above is empty and can be deleted.
+	_modsAndLoadText append _loadedTemplateInfo;
+
+	if (count _modsAndLoadText isEqualTo 0) exitWith {};
+	private _textXML = (_modsAndLoadText apply { "<t color='#f0d498'>" + _x#1 + ":</t>" + _x#2 }) joinString "<br/>";
+	["Loaded Mods",_textXML] call A3A_fnc_customHint;
 };
 
-if (hasTFAR or hasACE or A3A_hasRHS or hasACRE or A3A_hasFFAA or A3A_has3CB or A3A_hasIvory) then {
-	[_textX] spawn {
-		sleep 0.5;
-		_textX = _this select 0;
-		"Integrated Mods Detected" hintC _textX;
-		hintC_arr_EH = findDisplay 72 displayAddEventHandler ["unload", {
-			0 = _this spawn {
-				_this select 0 displayRemoveEventHandler ["unload", hintC_arr_EH];
-				hintSilent "";
-			};
-		}];
-	};
-};
 waituntil {!isnull (finddisplay 46)};
 gameMenu = (findDisplay 46) displayAddEventHandler ["KeyDown",A3A_fnc_keys];
 //removeAllActions boxX;
@@ -547,7 +535,6 @@ player setPos (getMarkerPos respawnTeamPlayer);
 enableEnvironment [false, true];
 
 [2,"initClient completed",_fileName] call A3A_fnc_log;
-A3A_customHintEnable = true; // Was false in initVarCommon to allow hints to flow in and overwrite each other.
 
 if(!isMultiplayer) then
 {

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -381,20 +381,19 @@ if (isServer || player isEqualTo theBoss || (call BIS_fnc_admin) > 0) then {  //
 	private _modsAndLoadText = [
 		[hasTFAR,"TFAR","Players will use TFAR radios. Unconscious players' radios will be muted."],
 		[hasACRE,"ACRE","Players will use ACRE radios. Unconscious players' radios will be muted."],
-		[hasACE,"ACE 3","ACE items added to arsenal and ammo-boxes. Default AI control is disabled"],
-		[hasACEHearing,"ACE 3 Hearing","Default earplugs will be disabled."],
+		[hasACE,"ACE 3","ACE items added to arsenal and ammo-boxes."],
 		[hasACEMedical,"ACE 3 Medical","Default revive system will be disabled"],
-		[A3A_hasRHS,"RHS","All factions will be replaced by RHS (AFRF & USAF & GREF)."],
+		[A3A_hasRHS,"RHS","All factions will be replaced by RHS (AFRF &amp; USAF &amp; GREF)."],
 		[A3A_has3CB,"3CB","All factions will be replaced by 3CB and RHS."],
 		[A3A_hasFFAA,"FFAA","Occupant faction will be replaced by Spanish Armed Forces"],
 		[A3A_hasIvory,"Ivory Cars","Mod cars will be added to civilian car spawns."]
 	] select {_x#0};
 
-	private _loadedTemplateInfo = A3A_loadedTemplateInfo apply {[true,_x#0,_x#1]};	// Remove and simplify when the list above is empty and can be deleted.
-	_modsAndLoadText append _loadedTemplateInfo;
+	private _loadedTemplateInfoXML = A3A_loadedTemplateInfoXML apply {[true,_x#0,_x#1]};	// Remove and simplify when the list above is empty and can be deleted.
+	_modsAndLoadText append _loadedTemplateInfoXML;
 
 	if (count _modsAndLoadText isEqualTo 0) exitWith {};
-	private _textXML = (_modsAndLoadText apply { "<t color='#f0d498'>" + _x#1 + ":</t>" + _x#2 }) joinString "<br/>";
+	private _textXML = "<t align='left'>" + ((_modsAndLoadText apply { "<t color='#f0d498'>" + _x#1 + ":</t>" + _x#2 }) joinString "<br/>") + "</t>";
 	["Loaded Mods",_textXML] call A3A_fnc_customHint;
 };
 

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -494,11 +494,9 @@ if (isMultiplayer) then {
 }
 else
 {
-	if (loadLastSave) then {
-		// just do this directly, because playerHasSave doesn't work without moneyX
-		private _loadout = [getPlayerUID player, "loadoutPlayer"] call A3A_fnc_retrievePlayerStat;
-		if (!isNil "_loadout") then { player setUnitLoadout _loadout };
-	};
+	// just do this directly, because playerHasSave doesn't work without moneyX
+	private _loadout = [getPlayerUID player, "loadoutPlayer"] call A3A_fnc_retrievePlayerStat;
+	if (!isNil "_loadout") then { player setUnitLoadout _loadout };
 	player setVariable ["canSave", true];
 };
 

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -53,7 +53,6 @@ if (isMultiplayer) then {
 		player setVariable ["eligible",true,true];
 	};
 	musicON = false;
-	//waitUntil {scriptdone _introshot};
 	disableUserInput true;
 	cutText ["Waiting for Players and Server Init","BLACK",0];
 	[2,"Waiting for server...",_fileName] call A3A_fnc_log;
@@ -77,31 +76,10 @@ else {
 	player hcSetGroup [group player];		// why?
 	player setUnitTrait ["medic", true];
 	player setUnitTrait ["engineer", true];
-	waitUntil {/*(scriptdone _introshot) and */(!isNil "serverInitDone")};
+	waitUntil {!isNil "serverInitDone"};
 };
 
 [] spawn A3A_fnc_ambientCivs;
-private ["_colourTeamPlayer", "_colorInvaders"];
-_colourTeamPlayer = teamPlayer call BIS_fnc_sideColor;
-_colorInvaders = Invaders call BIS_fnc_sideColor;
-_positionX = if (side player isEqualTo teamPlayer) then {position petros} else {getMarkerPos "respawn_west"};
-
-{
-	_x set [3, 0.33]
-} forEach [_colourTeamPlayer, _colorInvaders];
-
-_introShot = [
-	_positionX, // Target position
-	format ["%1",worldName], // SITREP text
-	50, //  altitude
-	50, //  radius
-	90, //  degrees viewing angle
-	0, // clockwise movement
-	[
-		["\a3\ui_f\data\map\markers\Nato\o_inf.paa", _colourTeamPlayer, markerPos "insertMrk", 1, 1, 0, "Insertion Point", 0],
-		["\a3\ui_f\data\map\markers\Nato\o_inf.paa", _colorInvaders, markerPos "towerBaseMrk", 1, 1, 0, "Radio Towers", 0]
-	]
-] spawn BIS_fnc_establishingShot;
 
 //Initialise membershipEnabled so we can do isMember checks.
 membershipEnabled = if (isMultiplayer && "membership" call BIS_fnc_getParamValue == 1) then {true} else {false};
@@ -366,8 +344,6 @@ if !(isPlayer leader group player) then {
 };
 
 [] remoteExec ["A3A_fnc_assignBossIfNone", 2];
-
-waitUntil { scriptDone _introshot };
 
 if (_isJip) then {
 	[2,"Joining In Progress (JIP)",_filename] call A3A_fnc_log;

--- a/A3-Antistasi/functions/init/fn_initVarCommon.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarCommon.sqf
@@ -78,6 +78,9 @@ allCategories = allCategoriesExceptSpecial + specialCategories;
 [2,"Starting mod detection",_fileName] call A3A_fnc_log;
 allDLCMods = ["kart", "mark", "heli", "expansion", "jets", "orange", "tank", "globmob", "enoch", "officialmod", "tacops", "argo", "warlords"];
 
+// Short Info of loaded mods needs to be added to this array. eg: `A3A_loadedTemplateInfo pushBack ["RHS","All factions will be replaced by RHS (AFRF & USAF & GREF)."];`
+A3A_loadedTemplateInfo = [];
+
 //Mod detection is done locally to each client, in case some clients have different modsets for some reason.
 //Systems Mods
 hasACE = false;

--- a/A3-Antistasi/functions/init/fn_initVarCommon.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarCommon.sqf
@@ -78,8 +78,8 @@ allCategories = allCategoriesExceptSpecial + specialCategories;
 [2,"Starting mod detection",_fileName] call A3A_fnc_log;
 allDLCMods = ["kart", "mark", "heli", "expansion", "jets", "orange", "tank", "globmob", "enoch", "officialmod", "tacops", "argo", "warlords"];
 
-// Short Info of loaded mods needs to be added to this array. eg: `A3A_loadedTemplateInfo pushBack ["RHS","All factions will be replaced by RHS (AFRF & USAF & GREF)."];`
-A3A_loadedTemplateInfo = [];
+// Short Info of loaded mods needs to be added to this array. eg: `A3A_loadedTemplateInfoXML pushBack ["RHS","All factions will be replaced by RHS (AFRF &amp; USAF &amp; GREF)."];`
+A3A_loadedTemplateInfoXML = [];
 
 //Mod detection is done locally to each client, in case some clients have different modsets for some reason.
 //Systems Mods


### PR DESCRIPTION
## What type of PR is this.
* Bug
2. [x] Change
3. [x] Enhancement

### What have you changed and why?
* Mod load info reduced and is hint message.
* Removed intro shot orbit camera.
* Removed load previous session dialogue, always true.

### Please specify which Issue this PR Resolves.
closes https://github.com/official-antistasi-community/A3-Antistasi/issues/1670

### Please verify the following and ensure all checks are completed.

2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
* Yes (Please provide further detail below.)

### How can the changes be tested?
Speedrun Load mission, see if you beat the world champ.
Last personal save should be loaded (gear, cash, garage)