### PR TITLE
Optimised mission root path parsing 

### DIFF
--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -12,7 +12,6 @@ class A3A
         class initACEUnconsciousHandler {};
         class initFuncs {};
         class initGarrisons {};
-        class initGetMissionPath {};
         class initSpawnPlaces {};
 
         class initVar {};

--- a/A3-Antistasi/functions/AI/fn_guardDog.sqf
+++ b/A3-Antistasi/functions/AI/fn_guardDog.sqf
@@ -26,7 +26,7 @@ while {alive _dog} do
 
 		if ((random 10 < 1) and (isNull _spotted)) then
 			{
-			playSound3D [missionPath + (selectRandom ladridos),_dog, false, getPosASL _dog, 1, 1, 100];
+			playSound3D [A3A_missionRootPath + (selectRandom ladridos),_dog, false, getPosASL _dog, 1, 1, 100];
 			};
 		if (_dog distance (leader _groupX) > 50) then {_dog setPos position (leader _groupX)};
 		}
@@ -34,7 +34,7 @@ while {alive _dog} do
 		{
 		_dog doWatch _spotted;
 		(leader _groupX) reveal [_spotted,4];
-		playSound3D [missionPath + (ladridos select (floor random 5)),_dog, false, getPosASL _dog, 1, 1, 100];
+		playSound3D [A3A_missionRootPath + (ladridos select (floor random 5)),_dog, false, getPosASL _dog, 1, 1, 100];
 		_dog moveTo getPosATL _spotted;
 		if (_spotted distance _dog > 100) then {_spotted = objNull};
 		sleep 3;

--- a/A3-Antistasi/functions/AI/fn_guardDog.sqf
+++ b/A3-Antistasi/functions/AI/fn_guardDog.sqf
@@ -26,7 +26,7 @@ while {alive _dog} do
 
 		if ((random 10 < 1) and (isNull _spotted)) then
 			{
-			playSound3D [A3A_missionRootPath + (selectRandom A3A_sounds_dogBark),_dog, false, getPosASL _dog, 1, 1, 100];
+			playSound3D [selectRandom A3A_sounds_dogBark,_dog, false, getPosASL _dog, 1, 1, 100];
 			};
 		if (_dog distance (leader _groupX) > 50) then {_dog setPos position (leader _groupX)};
 		}
@@ -34,7 +34,7 @@ while {alive _dog} do
 		{
 		_dog doWatch _spotted;
 		(leader _groupX) reveal [_spotted,4];
-		playSound3D [A3A_missionRootPath + (A3A_sounds_dogBark select (floor random 5)),_dog, false, getPosASL _dog, 1, 1, 100];
+		playSound3D [A3A_sounds_dogBark select (floor random 5),_dog, false, getPosASL _dog, 1, 1, 100];
 		_dog moveTo getPosATL _spotted;
 		if (_spotted distance _dog > 100) then {_spotted = objNull};
 		sleep 3;

--- a/A3-Antistasi/functions/AI/fn_guardDog.sqf
+++ b/A3-Antistasi/functions/AI/fn_guardDog.sqf
@@ -26,7 +26,7 @@ while {alive _dog} do
 
 		if ((random 10 < 1) and (isNull _spotted)) then
 			{
-			playSound3D [A3A_missionRootPath + (selectRandom ladridos),_dog, false, getPosASL _dog, 1, 1, 100];
+			playSound3D [A3A_missionRootPath + (selectRandom A3A_sounds_dogBark),_dog, false, getPosASL _dog, 1, 1, 100];
 			};
 		if (_dog distance (leader _groupX) > 50) then {_dog setPos position (leader _groupX)};
 		}
@@ -34,7 +34,7 @@ while {alive _dog} do
 		{
 		_dog doWatch _spotted;
 		(leader _groupX) reveal [_spotted,4];
-		playSound3D [A3A_missionRootPath + (ladridos select (floor random 5)),_dog, false, getPosASL _dog, 1, 1, 100];
+		playSound3D [A3A_missionRootPath + (A3A_sounds_dogBark select (floor random 5)),_dog, false, getPosASL _dog, 1, 1, 100];
 		_dog moveTo getPosATL _spotted;
 		if (_spotted distance _dog > 100) then {_spotted = objNull};
 		sleep 3;

--- a/A3-Antistasi/functions/init/fn_initGetMissionPath.sqf
+++ b/A3-Antistasi/functions/init/fn_initGetMissionPath.sqf
@@ -1,6 +1,0 @@
-private _fileName = "fn_initGetMissionPath.sqf";
-scriptName "fn_initGetMissionPath.sqf";
-[2,"Compiling mission path",_fileName] call A3A_fnc_log;
-missionPath = [(str missionConfigFile), 0, -15] call BIS_fnc_trimString;
-publicVariable "missionPath";
-[2,"Mission path is valid",_fileName] call A3A_fnc_log;

--- a/A3-Antistasi/functions/init/fn_initVarCommon.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarCommon.sqf
@@ -112,11 +112,12 @@ lamptypes = ["Lamps_Base_F", "PowerLines_base_F","Land_LampDecor_F","Land_LampHa
 ////////////////////////////////////
 //     SOUNDS AND ANIMATIONS     ///
 ////////////////////////////////////
+[2,"Compiling sounds and animations",_fileName] call A3A_fnc_log;
+
 private _missionRootPath_nodes = str missionConfigFile splitString "\";
 A3A_missionRootPath = (_missionRootPath_nodes select [0,count _missionRootPath_nodes -1] joinString "\") + "\";
 
-[2,"Compiling sounds and animations",_fileName] call A3A_fnc_log;
-A3A_sounds_dogBark = ["Music\dog_bark01.wss", "Music\dog_bark02.wss", "Music\dog_bark04.wss", "Music\dog_bark05.wss", "Music\dog_maul01.wss", "Music\dog_yelp02.wss"];
+A3A_sounds_dogBark = ["Music\dog_bark01.wss", "Music\dog_bark02.wss", "Music\dog_bark04.wss", "Music\dog_bark05.wss", "Music\dog_maul01.wss", "Music\dog_yelp02.wss"] apply {A3A_missionRootPath + _x};
 injuredSounds =  // Todo: migrate functions to A3A_sounds_callMedic
 [
 	"a3\sounds_f\characters\human-sfx\Person0\P0_moan_13_words.wss","a3\sounds_f\characters\human-sfx\Person0\P0_moan_14_words.wss","a3\sounds_f\characters\human-sfx\Person0\P0_moan_15_words.wss","a3\sounds_f\characters\human-sfx\Person0\P0_moan_16_words.wss","a3\sounds_f\characters\human-sfx\Person0\P0_moan_17_words.wss","a3\sounds_f\characters\human-sfx\Person0\P0_moan_18_words.wss","a3\sounds_f\characters\human-sfx\Person0\P0_moan_19_words.wss","a3\sounds_f\characters\human-sfx\Person0\P0_moan_20_words.wss",

--- a/A3-Antistasi/functions/init/fn_initVarCommon.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarCommon.sqf
@@ -116,7 +116,7 @@ private _missionRootPath_nodes = str missionConfigFile splitString "\";
 A3A_missionRootPath = (_missionRootPath_nodes select [0,count _missionRootPath_nodes -1] joinString "\") + "\";
 
 [2,"Compiling sounds and animations",_fileName] call A3A_fnc_log;
-ladridos = ["Music\dog_bark01.wss", "Music\dog_bark02.wss", "Music\dog_bark04.wss", "Music\dog_bark05.wss", "Music\dog_maul01.wss", "Music\dog_yelp02.wss"];
+A3A_sounds_dogBark = ["Music\dog_bark01.wss", "Music\dog_bark02.wss", "Music\dog_bark04.wss", "Music\dog_bark05.wss", "Music\dog_maul01.wss", "Music\dog_yelp02.wss"];
 injuredSounds =  // Todo: migrate functions to A3A_sounds_callMedic
 [
 	"a3\sounds_f\characters\human-sfx\Person0\P0_moan_13_words.wss","a3\sounds_f\characters\human-sfx\Person0\P0_moan_14_words.wss","a3\sounds_f\characters\human-sfx\Person0\P0_moan_15_words.wss","a3\sounds_f\characters\human-sfx\Person0\P0_moan_16_words.wss","a3\sounds_f\characters\human-sfx\Person0\P0_moan_17_words.wss","a3\sounds_f\characters\human-sfx\Person0\P0_moan_18_words.wss","a3\sounds_f\characters\human-sfx\Person0\P0_moan_19_words.wss","a3\sounds_f\characters\human-sfx\Person0\P0_moan_20_words.wss",

--- a/A3-Antistasi/functions/init/fn_initVarCommon.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarCommon.sqf
@@ -112,6 +112,9 @@ lamptypes = ["Lamps_Base_F", "PowerLines_base_F","Land_LampDecor_F","Land_LampHa
 ////////////////////////////////////
 //     SOUNDS AND ANIMATIONS     ///
 ////////////////////////////////////
+private _missionRootPath_nodes = str missionConfigFile splitString "\";
+A3A_missionRootPath = (_missionRootPath_nodes select [0,count _missionRootPath_nodes -1] joinString "\") + "\";
+
 [2,"Compiling sounds and animations",_fileName] call A3A_fnc_log;
 ladridos = ["Music\dog_bark01.wss", "Music\dog_bark02.wss", "Music\dog_bark04.wss", "Music\dog_bark05.wss", "Music\dog_maul01.wss", "Music\dog_yelp02.wss"];
 injuredSounds =  // Todo: migrate functions to A3A_sounds_callMedic
@@ -150,27 +153,6 @@ if !(A3A_hasIFA) then {
 	arrayids = ["Anthis","Costa","Dimitirou","Elias","Gekas","Kouris","Leventis","Markos","Nikas","Nicolo","Panas","Rosi","Samaras","Thanos","Vega"];
 	if (isMultiplayer) then {arrayids = arrayids + ["protagonista"]};
 };
-
-////////////////////////////////////
-//     MISSION PATH WARNING      ///
-////////////////////////////////////
-[2,"Checking mission path",_fileName] call A3A_fnc_log;
-private _getMissionPath = [] spawn A3A_fnc_initGetMissionPath;
-waitUntil
-{
-	if (scriptDone _getMissionPath) exitWith {true};
-	if (hasInterface) then {
-		["ERROR", "Stuck on compiling missionPath, re-launch the mission."] call A3A_fnc_customHint;
-	};
-	[1,"Stuck on compiling missionPath, re-launch the mission.",_fileName] call A3A_fnc_log;
-	false;
-};
-
-if (hasInterface) then {
-	["Server Information", "Done compiling missionPath"] call A3A_fnc_customHint;
-};
-[2,"Done compiling missionPath",_fileName] call A3A_fnc_log;
-
 
 ////////////////////////////////////
 //   MAP SETTINGS AND MARKERS    ///

--- a/A3-Antistasi/functions/init/fn_initVarCommon.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarCommon.sqf
@@ -114,8 +114,8 @@ lamptypes = ["Lamps_Base_F", "PowerLines_base_F","Land_LampDecor_F","Land_LampHa
 ////////////////////////////////////
 [2,"Compiling sounds and animations",_fileName] call A3A_fnc_log;
 
-private _missionRootPath_nodes = str missionConfigFile splitString "\";
-A3A_missionRootPath = (_missionRootPath_nodes select [0,count _missionRootPath_nodes -1] joinString "\") + "\";
+private _missionRootPathNodes = str missionConfigFile splitString "\";
+A3A_missionRootPath = (_missionRootPathNodes select [0,count _missionRootPathNodes -1] joinString "\") + "\";
 
 A3A_sounds_dogBark = ["Music\dog_bark01.wss", "Music\dog_bark02.wss", "Music\dog_bark04.wss", "Music\dog_bark05.wss", "Music\dog_maul01.wss", "Music\dog_yelp02.wss"] apply {A3A_missionRootPath + _x};
 injuredSounds =  // Todo: migrate functions to A3A_sounds_callMedic


### PR DESCRIPTION
## What type of PR is this.
* Bug
* Change
3. [x] Performance

### What have you changed and why?
* Mission path parsing is now done correctly and does not log non-sense.
* Renamed `ladridos` to `A3A_sounds_dogBark`
* A3A_sounds_dogBark now has full path baked in.

### Please specify which Issue this PR Resolves.
closes https://github.com/official-antistasi-community/A3-Antistasi/issues/1672

### Please verify the following and ensure all checks are completed.

2. [x] Have you loaded the mission in LAN host?
3. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
* Yes (Please provide further detail below.)

### How can the changes be tested?
exec this from debug console. You should hear a dog bark and nothing should appear in the RPT.
```sqf
playSound3D [selectRandom A3A_sounds_dogBark,player, false, getPosASL player, 1, 1, 100];
```
