### PR TITLE
block attempt to transfer to loot to destroyed vehicle

### DIFF
--- a/A3-Antistasi/functions/LTC/fn_lootFromContainer.sqf
+++ b/A3-Antistasi/functions/LTC/fn_lootFromContainer.sqf
@@ -26,7 +26,7 @@ scopeName "Main";
 
 private "_container";
 if (isNil "_override") then {
-    private _containers = nearestObjects [_target, ["Car", "Motorcycle", "Tank", "Air"], 10];
+    private _containers = (nearestObjects [_target, ["Car", "Motorcycle", "Tank", "Air"], 10]) select {alive _x};
     _container = _containers#0;
 } else {
     _container = _override;


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information: blocks LTC crates from transfering to destroyed vehicle, causing the loss of the loot
    

### Please specify which Issue this PR Resolves.
closes #1675 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: try loading loot into a destroyed vehicle

********************************************************
Notes:
