### PR TITLE
Gave default commander medic and engi, updated calls, added header

### DIFF
--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -461,7 +461,7 @@ mapX addAction ["Game Options", {["Game Options", format ["Antistasi - %2<br/><b
 mapX addAction ["Map Info", A3A_fnc_cityinfo,nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull]) and (side (group _this) == teamPlayer)", 4];
 mapX addAction ["Move this asset", A3A_fnc_moveHQObject,nil,0,false,true,"","(_this == theBoss)", 4];
 if (isMultiplayer) then {mapX addAction ["AI Load Info", { [] remoteExec ["A3A_fnc_AILoadInfo",2];},nil,0,false,true,"","((_this == theBoss) || (serverCommandAvailable ""#logout""))"]};
-_nul = [player] execVM "OrgPlayers\unitTraits.sqf";
+[] execVM "OrgPlayers\unitTraits.sqf";
 
 // only add petros actions if he's static
 if (petros == leader group petros) then {

--- a/A3-Antistasi/onPlayerRespawn.sqf
+++ b/A3-Antistasi/onPlayerRespawn.sqf
@@ -235,7 +235,7 @@ if (side group player == teamPlayer) then
 			}
 		];
 	[true] spawn A3A_fnc_reinitY;
-	[player] execVM "OrgPlayers\unitTraits.sqf";
+	[] execVM "OrgPlayers\unitTraits.sqf";
 	[] spawn A3A_fnc_statistics;
 	if (LootToCrateEnabled) then {call A3A_fnc_initLootToCrate};
 	}

--- a/A3-Antistasi/orgPlayers/unitTraits.sqf
+++ b/A3-Antistasi/orgPlayers/unitTraits.sqf
@@ -1,49 +1,82 @@
-private ["_typeX","_textX"];
+/*
+Author: Barbolani
+Maintainer: DoomMetal, MeltedPixel, Bob-Murphy, Wurzel0701
+    Sets the units traits (camouflage, medic, engineer) for the selected role of the player
+    THIS FILE DEPENDS ON ONLY THE DEFAULT COMMANDER HAVING A ROLE DESCRIPTION!
 
-_typeX = typeOf player;
-_textX = "";
-switch (_typeX) do
-	{
-	//case "I_C_Soldier_Para_7_F": {player setUnitTrait ["UAVHacker",true]}; //opted as we use units which automatically have the trait - 8th January 2020, Bob Murphy
-	//case "I_C_Soldier_Para_8_F": {player setUnitTrait ["engineer",true]; player setUnitTrait ["explosiveSpecialist",true]}; //opted as we use units which automatically have the trait - 8th January 2020, Bob Murphy
-	//case "I_C_Soldier_Para_3_F": {player setUnitTrait ["medic",true]}; //opted as we use units which automatically have the trait - 8th January 2020, Bob Murphy
-	case typePetros: {player setUnitTrait ["UAVHacker",true]};
-	//cases for greenfor missions
-	case "I_G_medic_F":  {_textX = "Medic role.<br/><br/>Medics do not have any bonus or penalties, but have the ability to use certain medical items for full health restoration"}; //reintroduced - 8th January 2020, Bob Murphy
-	case "I_G_Soldier_TL_F": {player setUnitTrait ["camouflageCoef",0.8]; player setUnitTrait ["audibleCoef",0.8]; player setUnitTrait ["loadCoef",1.4]; _textX = "Teamleader role.<br/><br/>Teamleader are more lightweight units with increased camouflage capabilities"}; //reintroduced - 8th January 2020, Bob Murphy
-	case "I_G_Soldier_F":  {player setUnitTrait ["audibleCoef",0.8]; player setUnitTrait ["loadCoef",1.2]; player setUnitTrait ["UAVHacker",true]; _textX = "Rifleman role.<br/><br/>Riflemen are more suitable to silent sneak and can hack drones but have less carrying capacity"}; //reintroduced - 8th January 2020, Bob Murphy
-	case "I_G_Soldier_GL_F": {player setUnitTrait ["camouflageCoef",1.2]; player setUnitTrait ["loadCoef",0.8]; _textX = "Grenadier role.<br/><br/>Grenadiers have a slight bonus on carry capacity, but are easy to spot"}; //reintroduced - 8th January 2020, Bob Murphy
-	case "I_G_Soldier_AR_F": {player setUnitTrait ["audibleCoef",1.2]; player setUnitTrait ["loadCoef",0.8]; _textX = "Autorifleman role.<br/><br/>Autoriflemen have a slight bonus on carry capacity, but make too much noise when they move"}; //reintroduced - 8th January 2020, Bob Murphy
-	case "I_G_engineer_F":  {_textX = "Engineer role.<br/><br/>Engineers do not have any bonus or penalties, but have the ability to use Repair Kits for vehicle repair"}; //reintroduced - 8th January 2020, Bob Murphy
-	//cases for blufor missions - added - 8th January 2020, Bob Murphy
-	case "B_G_medic_F":  {_textX = "Medic role.<br/><br/>Medics do not have any bonus or penalties, but have the ability to use certain medical items for full health restoration"}; //added - 8th January 2020, Bob Murphy
-	case "B_G_Soldier_TL_F": {player setUnitTrait ["camouflageCoef",0.8]; player setUnitTrait ["audibleCoef",0.8]; player setUnitTrait ["loadCoef",1.4]; _textX = "Teamleader role.<br/><br/>Teamleader are more lightweight units with increased camouflage capabilities"}; //added - 8th January 2020, Bob Murphy
-	case "B_G_Soldier_F":  {player setUnitTrait ["audibleCoef",0.8]; player setUnitTrait ["loadCoef",1.2]; player setUnitTrait ["UAVHacker",true]; _textX = "Rifleman role.<br/><br/>Riflemen are more suitable to silent sneak and can hack drones but have less carrying capacity"}; //added - 8th January 2020, Bob Murphy
-	case "B_G_Soldier_GL_F": {player setUnitTrait ["camouflageCoef",1.2]; player setUnitTrait ["loadCoef",0.8]; _textX = "Grenadier role.<br/><br/>Grenadiers have a slight bonus on carry capacity, but are easy to spot"}; //added - 8th January 2020, Bob Murphy
-	case "B_G_Soldier_AR_F": {player setUnitTrait ["audibleCoef",1.2]; player setUnitTrait ["loadCoef",0.8]; _textX = "Autorifleman role.<br/><br/>Autoriflemen have a slight bonus on carry capacity, but make too much noise when they move"}; //added - 8th January 2020, Bob Murphy
-	case "B_G_engineer_F":  {_textX = "Engineer role.<br/><br/>Engineers do not have any bonus or penalties, but have the ability to use Repair Kits for vehicle repair"}; //added - 8th January 2020, Bob Murphy
-	//cases for pvp green - added - 9th January 2020, Bob Murphy
-	case "I_medic_F":  {_textX = "Medic role.<br/><br/>Medics do not have any bonus or penalties, but have the ability to use certain medical items for full health restoration"}; //added - 9th January 2020, Bob Murphy
-	case "I_Soldier_TL_F": {player setUnitTrait ["camouflageCoef",0.8]; player setUnitTrait ["audibleCoef",0.8]; player setUnitTrait ["loadCoef",1.4]; _textX = "Teamleader role.<br/><br/>Teamleader are more lightweight units with increased camouflage capabilities"}; //added - 9th January 2020, Bob Murphy
-	case "I_Soldier_M_F": {player setUnitTrait ["camouflageCoef",0.8]; player setUnitTrait ["loadCoef",1.4]; _textX = "Marksman role.<br/><br/>Marksmen are more suitable to silent sneak but have less carrying capacity"}; //added - 9th January 2020, Bob Murphy
-	case "I_Soldier_AR_F": {player setUnitTrait ["audibleCoef",1.2]; player setUnitTrait ["loadCoef",0.8]; _textX = "Autorifleman role.<br/><br/>Autoriflemen have a slight bonus on carry capacity, but make too much noise when they move"}; //added - 9th January 2020, Bob Murphy
-	case "I_Soldier_LAT_F":  {player setUnitTrait ["audibleCoef",1.2]; player setUnitTrait ["loadCoef",0.8]; _textX = "Antitank role.<br/><br/>Antitanks have a slight bonus on carry capacity, but make too much noise when they move"}; //added - 9th January 2020, Bob Murphy
-	//cases for pvp blue - added - 9th January 2020, Bob Murphy
-	case "B_recon_medic_F":  {_textX = "Medic role.<br/><br/>Medics do not have any bonus or penalties, but have the ability to use certain medical items for full health restoration"}; //added - 9th January 2020, Bob Murphy
-	case "B_recon_TL_F": {player setUnitTrait ["camouflageCoef",0.8]; player setUnitTrait ["audibleCoef",0.8]; player setUnitTrait ["loadCoef",1.4]; _textX = "Teamleader role.<br/><br/>Teamleader are more lightweight units with increased camouflage capabilities"}; //added - 9th January 2020, Bob Murphy
-	case "B_recon_M_F": {player setUnitTrait ["camouflageCoef",0.8]; player setUnitTrait ["loadCoef",1.4]; _textX = "Marksman role.<br/><br/>Marksmen are more suitable to silent sneak but have less carrying capacity"}; //added - 9th January 2020, Bob Murphy
-	case "B_Patrol_Soldier_MG_F": {player setUnitTrait ["audibleCoef",1.2]; player setUnitTrait ["loadCoef",0.8]; _textX = "Autorifleman role.<br/><br/>Autoriflemen have a slight bonus on carry capacity, but make too much noise when they move"}; //added - 9th January 2020, Bob Murphy
-	case "B_recon_LAT_F":  {player setUnitTrait ["audibleCoef",1.2]; player setUnitTrait ["loadCoef",0.8]; _textX = "Antitank role.<br/><br/>Antitanks have a slight bonus on carry capacity, but make too much noise when they move"}; //added - 9th January 2020, Bob Murphy
-	//cases for pvp red - added - 9th January 2020, Bob Murphy
-	case "O_T_Recon_Medic_F":  {_textX = "Medic role.<br/><br/>Medics do not have any bonus or penalties, but have the ability to use certain medical items for full health restoration"}; //added - 9th January 2020, Bob Murphy
-	case "O_T_Recon_TL_F": {player setUnitTrait ["camouflageCoef",0.8]; player setUnitTrait ["audibleCoef",0.8]; player setUnitTrait ["loadCoef",1.4]; _textX = "Teamleader role.<br/><br/>Teamleader are more lightweight units with increased camouflage capabilities"}; //added - 9th January 2020, Bob Murphy
-	case "O_T_Recon_M_F": {player setUnitTrait ["camouflageCoef",0.8]; player setUnitTrait ["loadCoef",1.4]; _textX = "Marksman role.<br/><br/>Marksmen are more suitable to silent sneak but have less carrying capacity"}; //added - 9th January 2020, Bob Murphy
-	case "O_Soldier_AR_F": {player setUnitTrait ["audibleCoef",1.2]; player setUnitTrait ["loadCoef",0.8]; _textX = "Autorifleman role.<br/><br/>Autoriflemen have a slight bonus on carry capacity, but make too much noise when they move"}; //added - 9th January 2020, Bob Murphy
-	case "O_T_Recon_LAT_F":  {player setUnitTrait ["audibleCoef",1.2]; player setUnitTrait ["loadCoef",0.8]; _textX = "Antitank role.<br/><br/>Antitanks have a slight bonus on carry capacity, but make too much noise when they move"}; //added - 9th January 2020, Bob Murphy
-	};
+Arguments:
+    <NULL>
+
+Return Value:
+    <NULL>
+
+Scope: Local
+Environment: Any
+Public: No
+Dependencies:
+    <NULL>
+
+Example:
+    [] execVM "OrgPlayers\unitTraits.sqf";
+*/
+
+private _type = typeOf player;
+private _text = "";
+if(roleDescription player != "") then
+{
+    //Same values as teamleader
+    player setUnitTrait ["camouflageCoef",0.8];
+    player setUnitTrait ["audibleCoef",0.8];
+    player setUnitTrait ["loadCoef",1.4];
+    player setUnitTrait ["medic", true];
+	player setUnitTrait ["engineer", true];
+    _text = "Commander role.<br/><br/>The commander is a lightweight unit with increased camouflage, medical and engineering capabilities";
+}
+else
+{
+    switch (_type) do
+    {
+    	//case "I_C_Soldier_Para_7_F": {player setUnitTrait ["UAVHacker",true]}; //opted as we use units which automatically have the trait - 8th January 2020, Bob Murphy
+    	//case "I_C_Soldier_Para_8_F": {player setUnitTrait ["engineer",true]; player setUnitTrait ["explosiveSpecialist",true]}; //opted as we use units which automatically have the trait - 8th January 2020, Bob Murphy
+    	//case "I_C_Soldier_Para_3_F": {player setUnitTrait ["medic",true]}; //opted as we use units which automatically have the trait - 8th January 2020, Bob Murphy
+    	case typePetros: {player setUnitTrait ["UAVHacker",true]};
+    	//cases for greenfor missions
+    	case "I_G_medic_F":  {_text = "Medic role.<br/><br/>Medics do not have any bonus or penalties, but have the ability to use certain medical items for full health restoration"}; //reintroduced - 8th January 2020, Bob Murphy
+    	case "I_G_Soldier_TL_F": {player setUnitTrait ["camouflageCoef",0.8]; player setUnitTrait ["audibleCoef",0.8]; player setUnitTrait ["loadCoef",1.4]; _text = "Teamleader role.<br/><br/>Teamleader are more lightweight units with increased camouflage capabilities"}; //reintroduced - 8th January 2020, Bob Murphy
+    	case "I_G_Soldier_F":  {player setUnitTrait ["audibleCoef",0.8]; player setUnitTrait ["loadCoef",1.2]; player setUnitTrait ["UAVHacker",true]; _text = "Rifleman role.<br/><br/>Riflemen are more suitable to silent sneak and can hack drones but have less carrying capacity"}; //reintroduced - 8th January 2020, Bob Murphy
+    	case "I_G_Soldier_GL_F": {player setUnitTrait ["camouflageCoef",1.2]; player setUnitTrait ["loadCoef",0.8]; _text = "Grenadier role.<br/><br/>Grenadiers have a slight bonus on carry capacity, but are easy to spot"}; //reintroduced - 8th January 2020, Bob Murphy
+    	case "I_G_Soldier_AR_F": {player setUnitTrait ["audibleCoef",1.2]; player setUnitTrait ["loadCoef",0.8]; _text = "Autorifleman role.<br/><br/>Autoriflemen have a slight bonus on carry capacity, but make too much noise when they move"}; //reintroduced - 8th January 2020, Bob Murphy
+    	case "I_G_engineer_F":  {_text = "Engineer role.<br/><br/>Engineers do not have any bonus or penalties, but have the ability to use Repair Kits for vehicle repair"}; //reintroduced - 8th January 2020, Bob Murphy
+    	//cases for blufor missions - added - 8th January 2020, Bob Murphy
+    	case "B_G_medic_F":  {_text = "Medic role.<br/><br/>Medics do not have any bonus or penalties, but have the ability to use certain medical items for full health restoration"}; //added - 8th January 2020, Bob Murphy
+    	case "B_G_Soldier_TL_F": {player setUnitTrait ["camouflageCoef",0.8]; player setUnitTrait ["audibleCoef",0.8]; player setUnitTrait ["loadCoef",1.4]; _text = "Teamleader role.<br/><br/>Teamleader are more lightweight units with increased camouflage capabilities"}; //added - 8th January 2020, Bob Murphy
+    	case "B_G_Soldier_F":  {player setUnitTrait ["audibleCoef",0.8]; player setUnitTrait ["loadCoef",1.2]; player setUnitTrait ["UAVHacker",true]; _text = "Rifleman role.<br/><br/>Riflemen are more suitable to silent sneak and can hack drones but have less carrying capacity"}; //added - 8th January 2020, Bob Murphy
+    	case "B_G_Soldier_GL_F": {player setUnitTrait ["camouflageCoef",1.2]; player setUnitTrait ["loadCoef",0.8]; _text = "Grenadier role.<br/><br/>Grenadiers have a slight bonus on carry capacity, but are easy to spot"}; //added - 8th January 2020, Bob Murphy
+    	case "B_G_Soldier_AR_F": {player setUnitTrait ["audibleCoef",1.2]; player setUnitTrait ["loadCoef",0.8]; _text = "Autorifleman role.<br/><br/>Autoriflemen have a slight bonus on carry capacity, but make too much noise when they move"}; //added - 8th January 2020, Bob Murphy
+    	case "B_G_engineer_F":  {_text = "Engineer role.<br/><br/>Engineers do not have any bonus or penalties, but have the ability to use Repair Kits for vehicle repair"}; //added - 8th January 2020, Bob Murphy
+    	//cases for pvp green - added - 9th January 2020, Bob Murphy
+    	case "I_medic_F":  {_text = "Medic role.<br/><br/>Medics do not have any bonus or penalties, but have the ability to use certain medical items for full health restoration"}; //added - 9th January 2020, Bob Murphy
+    	case "I_Soldier_TL_F": {player setUnitTrait ["camouflageCoef",0.8]; player setUnitTrait ["audibleCoef",0.8]; player setUnitTrait ["loadCoef",1.4]; _text = "Teamleader role.<br/><br/>Teamleader are more lightweight units with increased camouflage capabilities"}; //added - 9th January 2020, Bob Murphy
+    	case "I_Soldier_M_F": {player setUnitTrait ["camouflageCoef",0.8]; player setUnitTrait ["loadCoef",1.4]; _text = "Marksman role.<br/><br/>Marksmen are more suitable to silent sneak but have less carrying capacity"}; //added - 9th January 2020, Bob Murphy
+    	case "I_Soldier_AR_F": {player setUnitTrait ["audibleCoef",1.2]; player setUnitTrait ["loadCoef",0.8]; _text = "Autorifleman role.<br/><br/>Autoriflemen have a slight bonus on carry capacity, but make too much noise when they move"}; //added - 9th January 2020, Bob Murphy
+    	case "I_Soldier_LAT_F":  {player setUnitTrait ["audibleCoef",1.2]; player setUnitTrait ["loadCoef",0.8]; _text = "Antitank role.<br/><br/>Antitanks have a slight bonus on carry capacity, but make too much noise when they move"}; //added - 9th January 2020, Bob Murphy
+    	//cases for pvp blue - added - 9th January 2020, Bob Murphy
+    	case "B_recon_medic_F":  {_text = "Medic role.<br/><br/>Medics do not have any bonus or penalties, but have the ability to use certain medical items for full health restoration"}; //added - 9th January 2020, Bob Murphy
+    	case "B_recon_TL_F": {player setUnitTrait ["camouflageCoef",0.8]; player setUnitTrait ["audibleCoef",0.8]; player setUnitTrait ["loadCoef",1.4]; _text = "Teamleader role.<br/><br/>Teamleader are more lightweight units with increased camouflage capabilities"}; //added - 9th January 2020, Bob Murphy
+    	case "B_recon_M_F": {player setUnitTrait ["camouflageCoef",0.8]; player setUnitTrait ["loadCoef",1.4]; _text = "Marksman role.<br/><br/>Marksmen are more suitable to silent sneak but have less carrying capacity"}; //added - 9th January 2020, Bob Murphy
+    	case "B_Patrol_Soldier_MG_F": {player setUnitTrait ["audibleCoef",1.2]; player setUnitTrait ["loadCoef",0.8]; _text = "Autorifleman role.<br/><br/>Autoriflemen have a slight bonus on carry capacity, but make too much noise when they move"}; //added - 9th January 2020, Bob Murphy
+    	case "B_recon_LAT_F":  {player setUnitTrait ["audibleCoef",1.2]; player setUnitTrait ["loadCoef",0.8]; _text = "Antitank role.<br/><br/>Antitanks have a slight bonus on carry capacity, but make too much noise when they move"}; //added - 9th January 2020, Bob Murphy
+    	//cases for pvp red - added - 9th January 2020, Bob Murphy
+    	case "O_T_Recon_Medic_F":  {_text = "Medic role.<br/><br/>Medics do not have any bonus or penalties, but have the ability to use certain medical items for full health restoration"}; //added - 9th January 2020, Bob Murphy
+    	case "O_T_Recon_TL_F": {player setUnitTrait ["camouflageCoef",0.8]; player setUnitTrait ["audibleCoef",0.8]; player setUnitTrait ["loadCoef",1.4]; _text = "Teamleader role.<br/><br/>Teamleader are more lightweight units with increased camouflage capabilities"}; //added - 9th January 2020, Bob Murphy
+    	case "O_T_Recon_M_F": {player setUnitTrait ["camouflageCoef",0.8]; player setUnitTrait ["loadCoef",1.4]; _text = "Marksman role.<br/><br/>Marksmen are more suitable to silent sneak but have less carrying capacity"}; //added - 9th January 2020, Bob Murphy
+    	case "O_Soldier_AR_F": {player setUnitTrait ["audibleCoef",1.2]; player setUnitTrait ["loadCoef",0.8]; _text = "Autorifleman role.<br/><br/>Autoriflemen have a slight bonus on carry capacity, but make too much noise when they move"}; //added - 9th January 2020, Bob Murphy
+    	case "O_T_Recon_LAT_F":  {player setUnitTrait ["audibleCoef",1.2]; player setUnitTrait ["loadCoef",0.8]; _text = "Antitank role.<br/><br/>Antitanks have a slight bonus on carry capacity, but make too much noise when they move"}; //added - 9th January 2020, Bob Murphy
+    };
+};
 
 if (isMultiPlayer) then
-	{
+{
 	sleep 5;
-	["Unit Traits", format ["You have selected %1",_textX]] call A3A_fnc_customHint;
-	};
+	["Unit Traits", format ["You have selected %1",_text]] call A3A_fnc_customHint;
+};

--- a/A3-Antistasi/orgPlayers/unitTraits.sqf
+++ b/A3-Antistasi/orgPlayers/unitTraits.sqf
@@ -22,7 +22,7 @@ Example:
 
 private _type = typeOf player;
 private _text = "";
-if(roleDescription player != "") then
+if(roleDescription player != "Default Commander") then
 {
     //Same values as teamleader
     player setUnitTrait ["camouflageCoef",0.8];


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Information:
The default commander is now given the medic and engineering trait for people who play solo on local host. Default commander is identified by being the only class to have a role description, so thats a new requirement for porting.
 
Added the new standard header to the file

Cleaned the calls to the file by removing unnecessary parameters

### Please specify which Issue this PR Resolves.
None opened for it

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer? -> Functionality is MP only
2. [X] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Select Default Commander on role selection screen and join in, after 5 seconds you should see the text saying you choose commander role.

Try the same steps without choosing Default Commander and get a different class specific text
********************************************************
Notes:
