### PR TITLE
Fixed Malden outpost_12 (Bad mission spawner)

### DIFF
--- a/Map-Templates/Antistasi-Malden.Malden/mission.sqm
+++ b/Map-Templates/Antistasi-Malden.Malden/mission.sqm
@@ -2,28 +2,28 @@ version=53;
 class EditorData
 {
 	moveGridStep=0.125;
-	angleGridStep=0.2617994;
+	angleGridStep=0.017453292;
 	scaleGridStep=1;
 	autoGroupingDist=10;
 	toggles=1025;
 	class ItemIDProvider
 	{
-		nextID=9059;
+		nextID=9352;
 	};
 	class MarkerIDProvider
 	{
-		nextID=39;
+		nextID=40;
 	};
 	class LayerIndexProvider
 	{
-		nextID=1670;
+		nextID=1844;
 	};
 	class Camera
 	{
-		pos[]={6054.959,235.19136,10397.772};
-		dir[]={-0.55186653,-0.58789772,-0.59158599};
-		up[]={-0.40105355,0.80890119,-0.42991617};
-		aside[]={-0.73128223,1.4557736e-006,0.68218994};
+		pos[]={6067.1865,218.81451,10357.297};
+		dir[]={-0.84627956,-0.41712481,0.33140767};
+		up[]={-0.38841161,0.90884686,0.1521045};
+		aside[]={0.36464566,5.2968971e-008,0.9311561};
 	};
 };
 binarizationWanted=0;
@@ -49,8 +49,8 @@ addons[]=
 	"A3_Structures_F_Ind_Shed",
 	"A3_Structures_F_Wrecks",
 	"A3_Structures_F_Mil_Barracks",
-	"A3_Structures_F_Civ_Garbage",
 	"A3_Structures_F_EPA_Mil_Scrapyard",
+	"A3_Structures_F_Civ_Garbage",
 	"A3_Structures_F_Mil_BagFence",
 	"A3_Structures_F_Mil_Helipads",
 	"A3_Structures_F_EPA_Civ_Constructions",
@@ -71,7 +71,10 @@ addons[]=
 	"A3_Characters_F_Exp",
 	"A3_Structures_F_Exp_Military_Flags",
 	"A3_Props_F_Exp_Civilian_Garbage",
-	"A3_Structures_F_Tank_Military_RepairDepot"
+	"A3_Structures_F_Tank_Military_RepairDepot",
+	"A3_Structures_F_Ind_Tank",
+	"A3_Structures_F_Civ_Accessories",
+	"A3_Structures_F_Ind_WindPowerPlant"
 };
 class AddonsMetaData
 {
@@ -227,7 +230,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=881;
+		items=890;
 		class Item0
 		{
 			dataType="Marker";
@@ -5601,22 +5604,6 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={9686.5098,43.794998,3912.8296};
-				angles[]={0,1.6034911,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-			};
-			id=1419;
-			type="Land_Cargo_Patrol_V1_F";
-		};
-		class Item332
-		{
-			dataType="Object";
-			class PositionInfo
-			{
 				position[]={9754.7529,43.789967,3951.5425};
 				angles[]={0,4.6890874,0};
 			};
@@ -5628,7 +5615,7 @@ class Mission
 			id=1420;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item333
+		class Item332
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5644,7 +5631,7 @@ class Mission
 			id=1421;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item334
+		class Item333
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5660,7 +5647,7 @@ class Mission
 			id=1422;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item335
+		class Item334
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5676,28 +5663,28 @@ class Mission
 			id=1423;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item336
+		class Item335
 		{
 			dataType="Layer";
 			name="Open Ammo Dump";
 			id=1424;
 			atlOffset=96.5;
 		};
-		class Item337
+		class Item336
 		{
 			dataType="Layer";
 			name="Vehicle Repair";
 			id=1449;
 			atlOffset=96.5;
 		};
-		class Item338
+		class Item337
 		{
 			dataType="Layer";
 			name="Camp Audacity";
 			id=1883;
 			atlOffset=96.5;
 		};
-		class Item339
+		class Item338
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5752,7 +5739,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item340
+		class Item339
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5768,7 +5755,7 @@ class Mission
 			id=1886;
 			type="Land_Wall_IndCnc_4_F";
 		};
-		class Item341
+		class Item340
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5823,7 +5810,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item342
+		class Item341
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5839,7 +5826,7 @@ class Mission
 			id=1889;
 			type="Land_ConcreteWall_01_l_8m_F";
 		};
-		class Item343
+		class Item342
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -5894,7 +5881,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item344
+		class Item343
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5910,7 +5897,7 @@ class Mission
 			id=1891;
 			type="Land_ConcreteWall_01_l_8m_F";
 		};
-		class Item345
+		class Item344
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5926,35 +5913,35 @@ class Mission
 			id=1892;
 			type="Land_ConcreteWall_01_l_4m_F";
 		};
-		class Item346
+		class Item345
 		{
 			dataType="Layer";
 			name="Open Ammo Dump_1";
 			id=1955;
 			atlOffset=96.5;
 		};
-		class Item347
+		class Item346
 		{
 			dataType="Layer";
 			name="Vehicle Repair_1";
 			id=1980;
 			atlOffset=96.5;
 		};
-		class Item348
+		class Item347
 		{
 			dataType="Layer";
 			name="Open Ammo Dump_2";
 			id=2357;
 			atlOffset=96.5;
 		};
-		class Item349
+		class Item348
 		{
 			dataType="Layer";
 			name="Vehicle Repair_2";
 			id=2382;
 			atlOffset=96.5;
 		};
-		class Item350
+		class Item349
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5971,7 +5958,7 @@ class Mission
 			id=2848;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item351
+		class Item350
 		{
 			dataType="Object";
 			class PositionInfo
@@ -5989,7 +5976,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item352
+		class Item351
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6006,7 +5993,7 @@ class Mission
 			id=2850;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item353
+		class Item352
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6024,7 +6011,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item354
+		class Item353
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6042,7 +6029,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item355
+		class Item354
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6060,7 +6047,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-3.8146973e-006;
 		};
-		class Item356
+		class Item355
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6078,7 +6065,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item357
+		class Item356
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6096,7 +6083,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item358
+		class Item357
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6114,7 +6101,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item359
+		class Item358
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6131,7 +6118,7 @@ class Mission
 			id=2857;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item360
+		class Item359
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6148,7 +6135,7 @@ class Mission
 			id=2858;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item361
+		class Item360
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6165,7 +6152,7 @@ class Mission
 			id=2859;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item362
+		class Item361
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6182,7 +6169,7 @@ class Mission
 			id=2860;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item363
+		class Item362
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6200,7 +6187,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item364
+		class Item363
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6217,7 +6204,7 @@ class Mission
 			id=2862;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item365
+		class Item364
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6234,7 +6221,7 @@ class Mission
 			id=2863;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item366
+		class Item365
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6251,7 +6238,7 @@ class Mission
 			id=2864;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item367
+		class Item366
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6268,7 +6255,7 @@ class Mission
 			id=2865;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item368
+		class Item367
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6285,7 +6272,7 @@ class Mission
 			id=2866;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item369
+		class Item368
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6302,7 +6289,7 @@ class Mission
 			id=2867;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item370
+		class Item369
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6319,7 +6306,7 @@ class Mission
 			id=2868;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item371
+		class Item370
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6336,7 +6323,7 @@ class Mission
 			id=2869;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item372
+		class Item371
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6353,7 +6340,7 @@ class Mission
 			id=2870;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item373
+		class Item372
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6371,7 +6358,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-3.8146973e-006;
 		};
-		class Item374
+		class Item373
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6388,7 +6375,7 @@ class Mission
 			id=2872;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item375
+		class Item374
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6405,7 +6392,7 @@ class Mission
 			id=2873;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item376
+		class Item375
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6423,7 +6410,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-3.8146973e-006;
 		};
-		class Item377
+		class Item376
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6439,7 +6426,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.25;
 		};
-		class Item378
+		class Item377
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6456,7 +6443,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item379
+		class Item378
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6473,7 +6460,7 @@ class Mission
 			id=2877;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item380
+		class Item379
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6491,7 +6478,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item381
+		class Item380
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6508,7 +6495,7 @@ class Mission
 			id=2879;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item382
+		class Item381
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6525,7 +6512,7 @@ class Mission
 			id=2880;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item383
+		class Item382
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6542,7 +6529,7 @@ class Mission
 			id=2881;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item384
+		class Item383
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6559,7 +6546,7 @@ class Mission
 			id=2882;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item385
+		class Item384
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6576,7 +6563,7 @@ class Mission
 			id=2883;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item386
+		class Item385
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6593,7 +6580,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.24999619;
 		};
-		class Item387
+		class Item386
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6610,7 +6597,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item388
+		class Item387
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6627,7 +6614,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item389
+		class Item388
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6643,7 +6630,7 @@ class Mission
 			id=2887;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item390
+		class Item389
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6659,7 +6646,7 @@ class Mission
 			id=2888;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item391
+		class Item390
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6675,7 +6662,7 @@ class Mission
 			id=2889;
 			type="Land_TTowerSmall_1_F";
 		};
-		class Item392
+		class Item391
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6692,7 +6679,7 @@ class Mission
 			type="Land_TTowerSmall_2_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item393
+		class Item392
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6709,7 +6696,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=3.8146973e-006;
 		};
-		class Item394
+		class Item393
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6727,7 +6714,7 @@ class Mission
 			id=2892;
 			type="Land_Cargo40_military_green_F";
 		};
-		class Item395
+		class Item394
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6746,7 +6733,7 @@ class Mission
 			type="Land_Cargo40_military_green_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item396
+		class Item395
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6764,7 +6751,7 @@ class Mission
 			id=2894;
 			type="Land_Cargo40_military_green_F";
 		};
-		class Item397
+		class Item396
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6780,7 +6767,7 @@ class Mission
 			id=2895;
 			type="Land_Medevac_house_V1_F";
 		};
-		class Item398
+		class Item397
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6797,7 +6784,7 @@ class Mission
 			id=2896;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item399
+		class Item398
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6814,7 +6801,7 @@ class Mission
 			id=2897;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item400
+		class Item399
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6831,7 +6818,7 @@ class Mission
 			id=2898;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item401
+		class Item400
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6849,7 +6836,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item402
+		class Item401
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6867,7 +6854,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item403
+		class Item402
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6884,7 +6871,7 @@ class Mission
 			id=2901;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item404
+		class Item403
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6901,7 +6888,7 @@ class Mission
 			id=2902;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item405
+		class Item404
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6918,7 +6905,7 @@ class Mission
 			id=2903;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item406
+		class Item405
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6935,7 +6922,7 @@ class Mission
 			id=2904;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item407
+		class Item406
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6952,7 +6939,7 @@ class Mission
 			id=2905;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item408
+		class Item407
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6969,7 +6956,7 @@ class Mission
 			id=2906;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item409
+		class Item408
 		{
 			dataType="Object";
 			class PositionInfo
@@ -6987,7 +6974,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item410
+		class Item409
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7004,7 +6991,7 @@ class Mission
 			id=2908;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item411
+		class Item410
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7021,7 +7008,7 @@ class Mission
 			id=2909;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item412
+		class Item411
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7039,7 +7026,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item413
+		class Item412
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7056,7 +7043,7 @@ class Mission
 			id=2911;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item414
+		class Item413
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7074,7 +7061,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item415
+		class Item414
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7092,7 +7079,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item416
+		class Item415
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7110,7 +7097,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item417
+		class Item416
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7127,7 +7114,7 @@ class Mission
 			id=2915;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item418
+		class Item417
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7145,7 +7132,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=6.1035156e-005;
 		};
-		class Item419
+		class Item418
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7162,7 +7149,7 @@ class Mission
 			id=2917;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item420
+		class Item419
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7179,7 +7166,7 @@ class Mission
 			id=2918;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item421
+		class Item420
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7197,7 +7184,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item422
+		class Item421
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7215,7 +7202,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item423
+		class Item422
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7233,7 +7220,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item424
+		class Item423
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7251,7 +7238,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item425
+		class Item424
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7267,7 +7254,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.25006104;
 		};
-		class Item426
+		class Item425
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7283,7 +7270,7 @@ class Mission
 			id=2924;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item427
+		class Item426
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7301,7 +7288,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item428
+		class Item427
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7319,7 +7306,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item429
+		class Item428
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7336,7 +7323,7 @@ class Mission
 			id=2927;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item430
+		class Item429
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7354,7 +7341,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item431
+		class Item430
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7371,7 +7358,7 @@ class Mission
 			id=2929;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item432
+		class Item431
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7388,7 +7375,7 @@ class Mission
 			id=2930;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item433
+		class Item432
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7405,7 +7392,7 @@ class Mission
 			id=2931;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item434
+		class Item433
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7421,7 +7408,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.25003052;
 		};
-		class Item435
+		class Item434
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7437,7 +7424,7 @@ class Mission
 			id=2933;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item436
+		class Item435
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7453,7 +7440,7 @@ class Mission
 			id=2934;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item437
+		class Item436
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7469,7 +7456,7 @@ class Mission
 			id=2935;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item438
+		class Item437
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7485,7 +7472,7 @@ class Mission
 			id=2936;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item439
+		class Item438
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7502,7 +7489,7 @@ class Mission
 			type="Land_TTowerSmall_1_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item440
+		class Item439
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7519,7 +7506,7 @@ class Mission
 			type="Land_TTowerSmall_2_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item441
+		class Item440
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7536,7 +7523,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item442
+		class Item441
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7555,7 +7542,7 @@ class Mission
 			type="Land_Cargo40_military_green_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item443
+		class Item442
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7574,7 +7561,7 @@ class Mission
 			type="Land_Cargo40_military_green_F";
 			atlOffset=3.0517578e-005;
 		};
-		class Item444
+		class Item443
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7592,7 +7579,7 @@ class Mission
 			type="Land_Cargo40_military_green_F";
 			atlOffset=2.6217957;
 		};
-		class Item445
+		class Item444
 		{
 			dataType="Object";
 			class PositionInfo
@@ -7608,62 +7595,62 @@ class Mission
 			id=2943;
 			type="Land_Medevac_house_V1_F";
 		};
-		class Item446
+		class Item445
 		{
 			dataType="Layer";
 			name="Open Ammo Dump_3";
 			id=2945;
 			atlOffset=96.5;
 		};
-		class Item447
+		class Item446
 		{
 			dataType="Layer";
 			name="Vehicle Repair_3";
 			id=2970;
 			atlOffset=96.5;
 		};
-		class Item448
+		class Item447
 		{
 			dataType="Layer";
 			name="Abandoned AA Gun Emplacement";
 			id=3316;
 			atlOffset=96.5;
 		};
-		class Item449
+		class Item448
 		{
 			dataType="Layer";
 			name="Abandoned Field Hospital";
 			id=3423;
 			atlOffset=96.5;
 		};
-		class Item450
+		class Item449
 		{
 			dataType="Layer";
 			name="Hasty Landing Zone";
 			id=3470;
 			atlOffset=96.5;
 		};
-		class Item451
+		class Item450
 		{
 			dataType="Layer";
 			name="Landing Zone";
 			id=3571;
 			atlOffset=96.5;
 		};
-		class Item452
+		class Item451
 		{
 			dataType="Layer";
 			name="Roadblock";
 			id=3599;
 			atlOffset=96.5;
 		};
-		class Item453
+		class Item452
 		{
 			dataType="Layer";
 			name="Landing Zone";
 			class Entities
 			{
-				items=52;
+				items=55;
 				class Item0
 				{
 					dataType="Object";
@@ -8634,255 +8621,308 @@ class Mission
 					id=9011;
 					type="Land_Cargo_Patrol_V1_F";
 				};
+				class Item52
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5653.0684,359.76456,5597.6406};
+						angles[]={0,1.5802717,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9188;
+					type="Land_Cargo_Patrol_V1_F";
+					atlOffset=0.00012207031;
+				};
+				class Item53
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5706.8735,362.04651,5637.3403};
+						angles[]={0,3.3417304,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9189;
+					type="Land_Cargo_Patrol_V1_F";
+				};
+				class Item54
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5746.4966,355.32169,5582.4697};
+						angles[]={0,4.9194012,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9190;
+					type="Land_Cargo_Patrol_V1_F";
+					atlOffset=9.1552734e-005;
+				};
 			};
 			id=3700;
-			atlOffset=34.57901;
+			atlOffset=-82.44043;
 		};
-		class Item454
+		class Item453
 		{
 			dataType="Layer";
 			name="Industrial Compound (Large)";
 			id=3996;
 			atlOffset=96.5;
 		};
-		class Item455
+		class Item454
 		{
 			dataType="Layer";
 			name="Storage Facility and Warehouse";
 			id=4280;
 			atlOffset=96.5;
 		};
-		class Item456
+		class Item455
 		{
 			dataType="Layer";
 			name="IDAP Refugee Camp Large";
 			id=4597;
 			atlOffset=96.5;
 		};
-		class Item457
+		class Item456
 		{
 			dataType="Layer";
 			name="Basketball Court";
 			id=4615;
 			atlOffset=96.5;
 		};
-		class Item458
+		class Item457
 		{
 			dataType="Layer";
 			name="Gas Station";
 			id=4676;
 			atlOffset=96.5;
 		};
-		class Item459
+		class Item458
 		{
 			dataType="Layer";
 			name="Cargo Post";
 			id=4692;
 			atlOffset=96.5;
 		};
-		class Item460
+		class Item459
 		{
 			dataType="Layer";
 			name="Bunker (Small) #1";
 			id=4710;
 			atlOffset=96.5;
 		};
-		class Item461
+		class Item460
 		{
 			dataType="Layer";
 			name="Shoot House";
 			id=5060;
 			atlOffset=96.5;
 		};
-		class Item462
+		class Item461
 		{
 			dataType="Layer";
 			name="Depot [BLU]";
 			id=5115;
 			atlOffset=96.5;
 		};
-		class Item463
+		class Item462
 		{
 			dataType="Layer";
 			name="Hangar";
 			id=5227;
 			atlOffset=96.5;
 		};
-		class Item464
+		class Item463
 		{
 			dataType="Layer";
 			name="Hangar";
 			id=5339;
 			atlOffset=96.5;
 		};
-		class Item465
+		class Item464
 		{
 			dataType="Layer";
 			name="Factory Headquarters";
 			id=5415;
 			atlOffset=96.5;
 		};
-		class Item466
+		class Item465
 		{
 			dataType="Layer";
 			name="Main Headquarters";
 			id=5477;
 			atlOffset=96.5;
 		};
-		class Item467
+		class Item466
 		{
 			dataType="Layer";
 			name="Radar Dome";
 			id=5539;
 			atlOffset=96.5;
 		};
-		class Item468
+		class Item467
 		{
 			dataType="Layer";
 			name="Fortified Comms Tower";
 			id=5612;
 			atlOffset=96.5;
 		};
-		class Item469
+		class Item468
 		{
 			dataType="Layer";
 			name="Communications Post";
 			id=5672;
 			atlOffset=96.5;
 		};
-		class Item470
+		class Item469
 		{
 			dataType="Layer";
 			name="Comms Post [BLU]";
 			id=5708;
 			atlOffset=96.5;
 		};
-		class Item471
+		class Item470
 		{
 			dataType="Layer";
 			name="Comms Post [OPF]";
 			id=5760;
 			atlOffset=96.5;
 		};
-		class Item472
+		class Item471
 		{
 			dataType="Layer";
 			name="Cargo HQ [BLU] #1";
 			id=5851;
 			atlOffset=96.5;
 		};
-		class Item473
+		class Item472
 		{
 			dataType="Layer";
 			name="Cargo Tower [BLU]";
 			id=5981;
 			atlOffset=96.5;
 		};
-		class Item474
+		class Item473
 		{
 			dataType="Layer";
 			name="Field Depot [BLU]";
 			id=6077;
 			atlOffset=96.5;
 		};
-		class Item475
+		class Item474
 		{
 			dataType="Layer";
 			name="Field HQ [BLU]";
 			id=6205;
 			atlOffset=96.5;
 		};
-		class Item476
+		class Item475
 		{
 			dataType="Layer";
 			name="Concrete Wall LZ";
 			id=6319;
 			atlOffset=96.5;
 		};
-		class Item477
+		class Item476
 		{
 			dataType="Layer";
 			name="Heliport - Fortified [BLU]";
 			id=6393;
 			atlOffset=96.5;
 		};
-		class Item478
+		class Item477
 		{
 			dataType="Layer";
 			name="Heliport [BLU]";
 			id=6439;
 			atlOffset=96.5;
 		};
-		class Item479
+		class Item478
 		{
 			dataType="Layer";
 			name="Command Centre";
 			id=6566;
 			atlOffset=96.5;
 		};
-		class Item480
+		class Item479
 		{
 			dataType="Layer";
 			name="Main Headquarters [BLU]";
 			id=6757;
 			atlOffset=96.5;
 		};
-		class Item481
+		class Item480
 		{
 			dataType="Layer";
 			name="Headquarters";
 			id=6794;
 			atlOffset=96.5;
 		};
-		class Item482
+		class Item481
 		{
 			dataType="Layer";
 			name="Headquarters (Fortified)";
 			id=6858;
 			atlOffset=96.5;
 		};
-		class Item483
+		class Item482
 		{
 			dataType="Layer";
 			name="Military Compound";
 			id=7018;
 			atlOffset=96.5;
 		};
-		class Item484
+		class Item483
 		{
 			dataType="Layer";
 			name="VIP Compound";
 			id=7156;
 			atlOffset=96.5;
 		};
-		class Item485
+		class Item484
 		{
 			dataType="Layer";
 			name="Main Headquarters [OPF]";
 			id=7410;
 			atlOffset=96.5;
 		};
-		class Item486
+		class Item485
 		{
 			dataType="Layer";
 			name="Main Headquarters [BLU]";
 			id=7601;
 			atlOffset=96.5;
 		};
-		class Item487
+		class Item486
 		{
 			dataType="Layer";
 			name="Military Compound";
 			id=7761;
 			atlOffset=96.5;
 		};
-		class Item488
+		class Item487
 		{
 			dataType="Layer";
 			name="Command Centre";
 			class Entities
 			{
-				items=113;
+				items=218;
 				class Item0
 				{
 					dataType="Object";
@@ -9359,23 +9399,6 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={6006.3789,195.51183,10374.604};
-						angles[]={6.232029,0.64228714,6.2328267};
-					};
-					side="Empty";
-					flags=4;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=8919;
-					type="Land_GarbageBags_F";
-				};
-				class Item28
-				{
-					dataType="Object";
-					class PositionInfo
-					{
 						position[]={6004.0396,196.12912,10390.324};
 						angles[]={6.2543926,0.63394618,6.2503963};
 					};
@@ -9389,7 +9412,7 @@ class Mission
 					type="Land_PaperBox_closed_F";
 					atlOffset=0.047088623;
 				};
-				class Item29
+				class Item28
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9406,7 +9429,7 @@ class Mission
 					id=8921;
 					type="Land_JunkPile_F";
 				};
-				class Item30
+				class Item29
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9424,7 +9447,7 @@ class Mission
 					type="Land_PaperBox_open_empty_F";
 					atlOffset=0.047088623;
 				};
-				class Item31
+				class Item30
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9442,7 +9465,7 @@ class Mission
 					type="Land_Wall_IndCnc_4_F";
 					atlOffset=0.12200928;
 				};
-				class Item32
+				class Item31
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9460,7 +9483,7 @@ class Mission
 					type="Land_Wall_IndCnc_4_F";
 					atlOffset=0.35804749;
 				};
-				class Item33
+				class Item32
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9477,7 +9500,7 @@ class Mission
 					id=8926;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item34
+				class Item33
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9495,7 +9518,7 @@ class Mission
 					type="Land_Wall_IndCnc_4_F";
 					atlOffset=0.77624512;
 				};
-				class Item35
+				class Item34
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9512,7 +9535,7 @@ class Mission
 					id=8928;
 					type="Land_Wall_IndCnc_4_D_F";
 				};
-				class Item36
+				class Item35
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9530,7 +9553,7 @@ class Mission
 					type="Land_Wall_IndCnc_4_F";
 					atlOffset=1.5258789e-005;
 				};
-				class Item37
+				class Item36
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9548,7 +9571,7 @@ class Mission
 					type="Land_BagFence_Round_F";
 					atlOffset=1.5258789e-005;
 				};
-				class Item38
+				class Item37
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9565,7 +9588,7 @@ class Mission
 					id=8931;
 					type="Land_BagFence_Round_F";
 				};
-				class Item39
+				class Item38
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9582,7 +9605,7 @@ class Mission
 					id=8932;
 					type="Land_BagFence_Long_F";
 				};
-				class Item40
+				class Item39
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9599,7 +9622,7 @@ class Mission
 					id=8933;
 					type="Land_BagFence_Long_F";
 				};
-				class Item41
+				class Item40
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9616,7 +9639,7 @@ class Mission
 					id=8934;
 					type="Land_BagFence_Long_F";
 				};
-				class Item42
+				class Item41
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9633,7 +9656,7 @@ class Mission
 					id=8935;
 					type="Land_BagFence_Long_F";
 				};
-				class Item43
+				class Item42
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9650,7 +9673,7 @@ class Mission
 					id=8936;
 					type="Land_BagFence_Long_F";
 				};
-				class Item44
+				class Item43
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9668,7 +9691,7 @@ class Mission
 					type="Land_BagFence_Long_F";
 					atlOffset=1.5258789e-005;
 				};
-				class Item45
+				class Item44
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9685,7 +9708,7 @@ class Mission
 					id=8938;
 					type="Land_BagFence_Long_F";
 				};
-				class Item46
+				class Item45
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9704,7 +9727,7 @@ class Mission
 					type="Land_HelipadSquare_F";
 					atlOffset=-1.5258789e-005;
 				};
-				class Item47
+				class Item46
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9722,7 +9745,7 @@ class Mission
 					type="Land_Wall_IndCnc_4_F";
 					atlOffset=1.5258789e-005;
 				};
-				class Item48
+				class Item47
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9740,7 +9763,7 @@ class Mission
 					type="Land_Wall_IndCnc_4_F";
 					atlOffset=1.5258789e-005;
 				};
-				class Item49
+				class Item48
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9758,7 +9781,7 @@ class Mission
 					type="Land_Wall_IndCnc_4_F";
 					atlOffset=-1.5258789e-005;
 				};
-				class Item50
+				class Item49
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9775,7 +9798,7 @@ class Mission
 					id=8943;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item51
+				class Item50
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9793,7 +9816,7 @@ class Mission
 					type="Land_Wall_IndCnc_4_F";
 					atlOffset=-1.5258789e-005;
 				};
-				class Item52
+				class Item51
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9810,7 +9833,7 @@ class Mission
 					id=8945;
 					type="Land_Wall_IndCnc_4_D_F";
 				};
-				class Item53
+				class Item52
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9828,7 +9851,7 @@ class Mission
 					type="Land_FieldToilet_F";
 					atlOffset=-0.00440979;
 				};
-				class Item54
+				class Item53
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9846,7 +9869,7 @@ class Mission
 					type="Land_FieldToilet_F";
 					atlOffset=-0.0044250488;
 				};
-				class Item55
+				class Item54
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9863,7 +9886,7 @@ class Mission
 					id=8948;
 					type="Land_LampHalogen_F";
 				};
-				class Item56
+				class Item55
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9881,7 +9904,7 @@ class Mission
 					type="Land_GarbagePallet_F";
 					atlOffset=-1.5258789e-005;
 				};
-				class Item57
+				class Item56
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9901,7 +9924,7 @@ class Mission
 					type="Land_Cargo20_cyan_F";
 					atlOffset=-1.5258789e-005;
 				};
-				class Item58
+				class Item57
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9919,7 +9942,7 @@ class Mission
 					type="Land_Wall_IndCnc_4_F";
 					atlOffset=1.5258789e-005;
 				};
-				class Item59
+				class Item58
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9937,7 +9960,7 @@ class Mission
 					type="Land_Wall_IndCnc_4_F";
 					atlOffset=1.5258789e-005;
 				};
-				class Item60
+				class Item59
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9955,7 +9978,7 @@ class Mission
 					type="Land_Wall_IndCnc_4_F";
 					atlOffset=1.5258789e-005;
 				};
-				class Item61
+				class Item60
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9972,7 +9995,7 @@ class Mission
 					id=8954;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item62
+				class Item61
 				{
 					dataType="Object";
 					class PositionInfo
@@ -9989,7 +10012,7 @@ class Mission
 					id=8955;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item63
+				class Item62
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10006,7 +10029,7 @@ class Mission
 					id=8956;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item64
+				class Item63
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10024,7 +10047,7 @@ class Mission
 					type="Land_Wall_IndCnc_4_F";
 					atlOffset=1.5258789e-005;
 				};
-				class Item65
+				class Item64
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10041,7 +10064,7 @@ class Mission
 					id=8958;
 					type="Land_PortableLight_double_F";
 				};
-				class Item66
+				class Item65
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10058,7 +10081,7 @@ class Mission
 					id=8959;
 					type="Land_LampHalogen_F";
 				};
-				class Item67
+				class Item66
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10076,7 +10099,7 @@ class Mission
 					type="Land_Wall_IndCnc_4_F";
 					atlOffset=0.40290833;
 				};
-				class Item68
+				class Item67
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10094,7 +10117,7 @@ class Mission
 					type="Land_Wall_IndCnc_4_F";
 					atlOffset=0.41383362;
 				};
-				class Item69
+				class Item68
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10111,7 +10134,7 @@ class Mission
 					id=8962;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item70
+				class Item69
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10129,7 +10152,7 @@ class Mission
 					type="Land_Wall_IndCnc_4_F";
 					atlOffset=0.37948608;
 				};
-				class Item71
+				class Item70
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10146,7 +10169,7 @@ class Mission
 					id=8964;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item72
+				class Item71
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10164,24 +10187,7 @@ class Mission
 					type="Land_Wall_IndCnc_4_F";
 					atlOffset=0.071640015;
 				};
-				class Item73
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5938.2061,215.66074,10375.776};
-						angles[]={0,0.64228714,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=8968;
-					type="Land_TTowerBig_1_F";
-				};
-				class Item74
+				class Item72
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10201,7 +10207,7 @@ class Mission
 					type="Land_Cargo20_light_green_F";
 					atlOffset=-0.00091552734;
 				};
-				class Item75
+				class Item73
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10219,7 +10225,7 @@ class Mission
 					type="Land_BagFence_Round_F";
 					atlOffset=-1.5258789e-005;
 				};
-				class Item76
+				class Item74
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10236,7 +10242,7 @@ class Mission
 					id=8972;
 					type="Land_BagFence_Long_F";
 				};
-				class Item77
+				class Item75
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10254,7 +10260,7 @@ class Mission
 					type="Land_BagFence_Long_F";
 					atlOffset=-1.5258789e-005;
 				};
-				class Item78
+				class Item76
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10272,7 +10278,7 @@ class Mission
 					type="Land_BagFence_Long_F";
 					atlOffset=1.5258789e-005;
 				};
-				class Item79
+				class Item77
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10289,7 +10295,7 @@ class Mission
 					id=8975;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item80
+				class Item78
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10306,7 +10312,7 @@ class Mission
 					id=8976;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item81
+				class Item79
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10324,7 +10330,7 @@ class Mission
 					type="Land_Wall_IndCnc_4_F";
 					atlOffset=-1.5258789e-005;
 				};
-				class Item82
+				class Item80
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10341,7 +10347,7 @@ class Mission
 					id=8978;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item83
+				class Item81
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10358,7 +10364,7 @@ class Mission
 					id=8979;
 					type="Land_LampHalogen_F";
 				};
-				class Item84
+				class Item82
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10375,7 +10381,7 @@ class Mission
 					id=8980;
 					type="Land_LampHalogen_F";
 				};
-				class Item85
+				class Item83
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10393,7 +10399,7 @@ class Mission
 					type="Land_BagFence_Round_F";
 					atlOffset=1.5258789e-005;
 				};
-				class Item86
+				class Item84
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10411,7 +10417,7 @@ class Mission
 					type="Land_BagFence_Round_F";
 					atlOffset=1.5258789e-005;
 				};
-				class Item87
+				class Item85
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10429,7 +10435,7 @@ class Mission
 					type="Land_BagFence_Long_F";
 					atlOffset=1.5258789e-005;
 				};
-				class Item88
+				class Item86
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10446,7 +10452,7 @@ class Mission
 					id=8984;
 					type="Land_BagFence_Long_F";
 				};
-				class Item89
+				class Item87
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10463,7 +10469,7 @@ class Mission
 					id=8985;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item90
+				class Item88
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10480,7 +10486,7 @@ class Mission
 					id=8986;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item91
+				class Item89
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10497,7 +10503,7 @@ class Mission
 					id=8987;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item92
+				class Item90
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10514,7 +10520,7 @@ class Mission
 					id=8988;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item93
+				class Item91
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10531,7 +10537,7 @@ class Mission
 					id=8989;
 					type="Land_Wall_IndCnc_4_D_F";
 				};
-				class Item94
+				class Item92
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10548,7 +10554,7 @@ class Mission
 					id=8990;
 					type="Land_Wall_IndCnc_Pole_F";
 				};
-				class Item95
+				class Item93
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10565,7 +10571,7 @@ class Mission
 					id=8991;
 					type="Land_LampHalogen_F";
 				};
-				class Item96
+				class Item94
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10582,7 +10588,7 @@ class Mission
 					id=8992;
 					type="Land_BarGate_F";
 				};
-				class Item97
+				class Item95
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10599,7 +10605,7 @@ class Mission
 					id=8993;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item98
+				class Item96
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10616,7 +10622,7 @@ class Mission
 					id=8994;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item99
+				class Item97
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10634,7 +10640,7 @@ class Mission
 					type="Land_Wall_IndCnc_4_F";
 					atlOffset=0.095581055;
 				};
-				class Item100
+				class Item98
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10652,7 +10658,7 @@ class Mission
 					type="Land_Wall_IndCnc_4_F";
 					atlOffset=0.62687683;
 				};
-				class Item101
+				class Item99
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10669,7 +10675,7 @@ class Mission
 					id=8997;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item102
+				class Item100
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10686,7 +10692,7 @@ class Mission
 					id=9002;
 					type="Land_BagFence_Round_F";
 				};
-				class Item103
+				class Item101
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10703,7 +10709,7 @@ class Mission
 					id=9003;
 					type="Land_BagFence_Long_F";
 				};
-				class Item104
+				class Item102
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10720,7 +10726,7 @@ class Mission
 					id=9004;
 					type="Land_BagFence_Long_F";
 				};
-				class Item105
+				class Item103
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10737,7 +10743,7 @@ class Mission
 					id=9005;
 					type="Land_BagFence_Round_F";
 				};
-				class Item106
+				class Item104
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10754,7 +10760,7 @@ class Mission
 					id=9006;
 					type="Land_BagFence_Long_F";
 				};
-				class Item107
+				class Item105
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10771,7 +10777,7 @@ class Mission
 					id=9007;
 					type="Land_BagFence_Long_F";
 				};
-				class Item108
+				class Item106
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10789,7 +10795,7 @@ class Mission
 					id=9008;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item109
+				class Item107
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10806,7 +10812,7 @@ class Mission
 					id=9009;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item110
+				class Item108
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10846,7 +10852,7 @@ class Mission
 						nAttributes=1;
 					};
 				};
-				class Item111
+				class Item109
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10863,7 +10869,7 @@ class Mission
 					id=9047;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item112
+				class Item110
 				{
 					dataType="Object";
 					class PositionInfo
@@ -10880,11 +10886,1953 @@ class Mission
 					id=9048;
 					type="Land_Wall_IndCnc_4_F";
 				};
+				class Item111
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5685.7881,356.80099,5542.9116};
+						angles[]={0,4.0776172,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9191;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item112
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5689.3467,357.24994,5538.0801};
+						angles[]={0,4.0776172,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9192;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item113
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5682.231,356.38757,5547.7422};
+						angles[]={0,4.0776172,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9193;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item114
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5693.5669,357.14688,5537.6191};
+						angles[]={0,2.5068207,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9194;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item115
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5671.5566,355.52982,5562.2363};
+						angles[]={0,4.0776172,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9195;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item116
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5664.4414,355.37497,5571.8989};
+						angles[]={0,4.0776172,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9196;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item117
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5678.6724,356.0853,5552.5737};
+						angles[]={0,4.0776172,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9197;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item118
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5660.8828,355.33191,5576.7295};
+						angles[]={0,4.0776172,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9198;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=6.1035156e-005;
+				};
+				class Item119
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5667.9985,355.44458,5567.0674};
+						angles[]={0,4.0776172,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9199;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item120
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5674.7568,355.89127,5557.1523};
+						angles[]={0,4.0776172,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9200;
+					type="Land_Wall_IndCnc_4_D_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item121
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5653.7666,355.76016,5586.3926};
+						angles[]={0,4.0776172,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9201;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.36682129;
+				};
+				class Item122
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5646.7529,356.37628,5596.0908};
+						angles[]={0,4.0776172,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9202;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.89221191;
+				};
+				class Item123
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5650.3027,356.23837,5591.2124};
+						angles[]={0,4.0776172,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9203;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.80145264;
+				};
+				class Item124
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5657.3242,355.37653,5581.561};
+						angles[]={0,4.0776172,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9204;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.013916016;
+				};
+				class Item125
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5661.5459,355.40631,5581.1001};
+						angles[]={0,2.5068207,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9205;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=6.1035156e-005;
+				};
+				class Item126
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5647.2075,356.41809,5600.2563};
+						angles[]={0,5.6484141,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9206;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.85232544;
+				};
+				class Item127
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5653.7778,360.70895,5589.7476};
+						angles[]={0,2.5907927,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9207;
+					type="Land_LampHalogen_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item128
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5666.2344,355.97495,5581.4561};
+						angles[]={6.2679858,5.614418,6.269588};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+						createAsSimpleObject=1;
+						disableSimulation=1;
+					};
+					id=9208;
+					type="Land_Cargo40_yellow_F";
+					atlOffset=-0.0009765625;
+				};
+				class Item129
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5703.229,356.12473,5544.7349};
+						angles[]={0,2.5068207,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9209;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.27072144;
+				};
+				class Item130
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5717.7236,354.01294,5555.4092};
+						angles[]={0,2.5068207,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9210;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item131
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5698.3984,356.84387,5541.1772};
+						angles[]={0,2.5068207,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9211;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.33969116;
+				};
+				class Item132
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5708.061,355.61179,5548.2925};
+						angles[]={0,2.5068207,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9212;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.41439819;
+				};
+				class Item133
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5712.8916,354.63351,5551.8516};
+						angles[]={0,2.5068207,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9213;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item134
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5661.5259,359.56964,5587.356};
+						angles[]={0,5.5995631,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9214;
+					type="Land_dp_smallTank_F";
+					atlOffset=6.1035156e-005;
+				};
+				class Item135
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5705.5508,357.0708,5615.9653};
+						angles[]={6.2535558,5.647532,6.2782345};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9215;
+					type="Land_i_Shed_Ind_F";
+					atlOffset=0.93017578;
+				};
+				class Item136
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5718.5166,354.17432,5597.3389};
+						angles[]={6.2432065,0.73962384,6.2288389};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9216;
+					type="Land_Wreck_HMMWV_F";
+				};
+				class Item137
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5721.478,352.33359,5574.8149};
+						angles[]={6.2828059,2.5001392,6.2253485};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9217;
+					type="Land_i_Barracks_V1_F";
+				};
+				class Item138
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5702.7715,354.99631,5610.105};
+						angles[]={6.253592,5.6400728,6.259192};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9219;
+					type="Land_PaperBox_closed_F";
+					atlOffset=0.050506592;
+				};
+				class Item139
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5667.5381,354.8562,5572.9165};
+						angles[]={0.02399601,0.10750943,6.269588};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9220;
+					type="Land_JunkPile_F";
+				};
+				class Item140
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5704.0645,354.91003,5611.0879};
+						angles[]={6.253592,5.6400728,6.259192};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9221;
+					type="Land_PaperBox_open_empty_F";
+					atlOffset=0.0023498535;
+				};
+				class Item141
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5666.4375,356.11111,5614.5078};
+						angles[]={0,5.6484141,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9222;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.12188721;
+				};
+				class Item142
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5661.6055,356.1929,5610.9502};
+						angles[]={0,5.6484141,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9223;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.35791016;
+				};
+				class Item143
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5671.2681,356.23227,5618.0659};
+						angles[]={0,5.6484141,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9224;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.00012207031;
+				};
+				class Item144
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5651.9819,356.43799,5603.7646};
+						angles[]={0,5.6484141,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9225;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.77612305;
+				};
+				class Item145
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5690.3096,357.60461,5632.6118};
+						angles[]={0,5.6484132,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9226;
+					type="Land_Wall_IndCnc_4_D_F";
+					atlOffset=0.10574341;
+				};
+				class Item146
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5666.3765,355.42078,5584.6577};
+						angles[]={0,2.5068207,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9227;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=6.1035156e-005;
+				};
+				class Item147
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5697.1382,354.72845,5604.085};
+						angles[]={6.2583904,0.033662617,6.2559919};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9228;
+					type="Land_BagFence_Round_F";
+				};
+				class Item148
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5689.7793,354.91528,5602.8281};
+						angles[]={6.2607903,4.8857665,6.2535939};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9229;
+					type="Land_BagFence_Round_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item149
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5678.3066,355.06024,5594.1582};
+						angles[]={6.2647886,5.6878352,6.2463999};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9230;
+					type="Land_BagFence_Long_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item150
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5703.9038,354.83911,5608.3486};
+						angles[]={6.2583904,2.5062289,6.2543926};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9231;
+					type="Land_BagFence_Long_F";
+					atlOffset=0.19519043;
+				};
+				class Item151
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5701.6914,354.75391,5606.7173};
+						angles[]={6.2583904,2.5062289,6.2543926};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9232;
+					type="Land_BagFence_Long_F";
+					atlOffset=0.086700439;
+				};
+				class Item152
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5688.8691,354.99564,5605.2124};
+						angles[]={6.2607903,4.1003685,6.2535939};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9233;
+					type="Land_BagFence_Long_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item153
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5699.4775,354.6897,5605.0859};
+						angles[]={6.2583904,2.5062289,6.2559919};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9234;
+					type="Land_BagFence_Long_F";
+					atlOffset=3.0517578e-005;
+				};
+				class Item154
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5695.0654,354.82236,5605.5962};
+						angles[]={6.2583904,0.94389802,6.2559919};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9235;
+					type="Land_BagFence_Long_F";
+					atlOffset=3.0517578e-005;
+				};
+				class Item155
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5688.0928,354.92151,5600.8779};
+						angles[]={6.2607903,2.529572,6.2535939};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9236;
+					type="Land_BagFence_Long_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item156
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5678.0728,354.84076,5604.2788};
+						angles[]={6.2687874,4.1198125,6.2535939};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+						disableSimulation=1;
+					};
+					id=9237;
+					type="Land_HelipadSquare_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item157
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5737.0479,351.6839,5569.6401};
+						angles[]={0,2.5068207,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9238;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.00012207031;
+				};
+				class Item158
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5741.8794,351.19183,5573.1987};
+						angles[]={0,2.5068207,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9239;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.00012207031;
+				};
+				class Item159
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5727.3862,352.74274,5562.5244};
+						angles[]={0,2.5068207,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9240;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item160
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5732.188,352.18192,5566.0605};
+						angles[]={0,2.5068207,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9241;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item161
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5722.5542,353.41339,5558.9668};
+						angles[]={0,2.5068207,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9242;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item162
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5746.9473,350.75626,5576.4414};
+						angles[]={0,2.5068207,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9243;
+					type="Land_Wall_IndCnc_4_D_F";
+				};
+				class Item163
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5681.019,363.7865,5638.5972};
+						angles[]={0,4.9849229,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9246;
+					type="Land_LampHalogen_F";
+				};
+				class Item164
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5739.8179,352.96469,5594.8345};
+						angles[]={6.2352223,2.4599545,6.1954131};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+						createAsSimpleObject=1;
+						disableSimulation=1;
+					};
+					id=9248;
+					type="Land_Cargo20_cyan_F";
+					atlOffset=-0.0043640137;
+				};
+				class Item165
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5728.9258,353.55338,5601.4253};
+						angles[]={0,5.6484141,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9250;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item166
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5724.1128,353.77563,5597.8101};
+						angles[]={0,5.6484141,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9251;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item167
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5715.2021,354.15948,5594.9043};
+						angles[]={0,4.0776172,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9252;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item168
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5675.855,355.76068,5591.2085};
+						angles[]={0,3.5540185,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9256;
+					type="Land_PortableLight_double_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item169
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5712.5269,359.97101,5592.5771};
+						angles[]={0,2.5242741,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9257;
+					type="Land_LampHalogen_F";
+					atlOffset=0.46984863;
+				};
+				class Item170
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5656.9507,356.15051,5607.4189};
+						angles[]={0,5.6484141,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9258;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.40274048;
+				};
+				class Item171
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5695.4243,358.181,5635.8555};
+						angles[]={0,5.6484141,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9259;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.31137085;
+				};
+				class Item172
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5685.7617,357.06796,5628.7397};
+						angles[]={0,5.6484141,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9260;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item173
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5700.3516,358.62698,5639.4058};
+						angles[]={0,5.6484141,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9261;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.37936401;
+				};
+				class Item174
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5676.1001,356.4812,5621.624};
+						angles[]={0,5.6484141,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9262;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item175
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5680.9307,356.74362,5625.1816};
+						angles[]={0,5.6484141,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9263;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.071502686;
+				};
+				class Item176
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5692.8667,375.32489,5552.8901};
+						angles[]={0,5.6484141,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9264;
+					type="Land_TTowerBig_1_F";
+					atlOffset=1.3768921;
+				};
+				class Item177
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5666.6636,355.89578,5577.1646};
+						angles[]={6.2679858,2.4872561,6.269588};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+						createAsSimpleObject=1;
+						disableSimulation=1;
+					};
+					id=9265;
+					type="Land_Cargo20_light_green_F";
+					atlOffset=-0.005065918;
+				};
+				class Item178
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5741.4355,352.57443,5607.8481};
+						angles[]={6.2344222,4.8630152,6.2025604};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9266;
+					type="Land_BagFence_Round_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item179
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5740.4546,352.77676,5610.2256};
+						angles[]={6.2240524,4.0776172,6.2129011};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9267;
+					type="Land_BagFence_Long_F";
+					atlOffset=0.00012207031;
+				};
+				class Item180
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5739.7783,352.61081,5605.8501};
+						angles[]={6.2344222,2.5068207,6.2025604};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9268;
+					type="Land_BagFence_Long_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item181
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5673.9448,355.20325,5594.9502};
+						angles[]={6.2647886,4.1170392,6.2767816};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9269;
+					type="Land_BagFence_Long_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item182
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5720.0786,356.12787,5628.1538};
+						angles[]={0,0.93602449,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9270;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item183
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5751.5425,351.24283,5580.3145};
+						angles[]={0,2.5068207,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9271;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.67953491;
+				};
+				class Item184
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5752.0039,351.30664,5584.5352};
+						angles[]={0,0.93602449,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9272;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.55163574;
+				};
+				class Item185
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5748.4453,352.03705,5589.3662};
+						angles[]={0,0.93602449,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9273;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.69342041;
+				};
+				class Item186
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5746.8511,356.75739,5589.75};
+						angles[]={0,5.6697078,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9274;
+					type="Land_LampHalogen_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item187
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5717.8604,361.66217,5629.4253};
+						angles[]={0,2.5068207,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9275;
+					type="Land_LampHalogen_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item188
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5675.8726,355.13339,5593.2651};
+						angles[]={6.2647886,0.19004804,6.2463999};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9276;
+					type="Land_BagFence_Round_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item189
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5732.7544,354.13571,5619.6079};
+						angles[]={6.1811414,3.2922187,6.2224622};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9277;
+					type="Land_BagFence_Round_F";
+				};
+				class Item190
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5734.7266,353.84921,5617.981};
+						angles[]={6.1811414,0.93602449,6.2224622};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9278;
+					type="Land_BagFence_Long_F";
+				};
+				class Item191
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5726.0713,355.06091,5624.6743};
+						angles[]={6.1811414,2.5068207,6.2224622};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9279;
+					type="Land_BagFence_Long_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item192
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5712.812,357.8338,5637.8564};
+						angles[]={0,0.93602449,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9280;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item193
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5709.3979,358.52682,5642.5454};
+						angles[]={0,0.93602449,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9281;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=6.1035156e-005;
+				};
+				class Item194
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5716.4648,356.99261,5633.0947};
+						angles[]={0,0.93602449,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9282;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item195
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5733.6895,353.30975,5604.8301};
+						angles[]={0,5.6484141,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9283;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item196
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5723.8569,355.34506,5623.4512};
+						angles[]={0,0.93602449,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9284;
+					type="Land_Wall_IndCnc_4_D_F";
+					atlOffset=6.1035156e-005;
+				};
+				class Item197
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5711.2573,358.17459,5640.1313};
+						angles[]={0,0.93602449,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9285;
+					type="Land_Wall_IndCnc_Pole_F";
+					atlOffset=6.1035156e-005;
+				};
+				class Item198
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5723.3228,360.48288,5621.7388};
+						angles[]={0,0.41242582,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9286;
+					type="Land_LampHalogen_F";
+					atlOffset=6.1035156e-005;
+				};
+				class Item199
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5732.7998,357.30884,5610.9409};
+						angles[]={6.1784506,0.93419999,0.017357673};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9287;
+					type="Land_BarGate_F";
+					atlOffset=0.31500244;
+				};
+				class Item200
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5741.3677,353.28098,5598.9888};
+						angles[]={0,0.93602449,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9288;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.83432007;
+				};
+				class Item201
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5737.751,353.53113,5603.8696};
+						angles[]={0,0.93602449,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9289;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.54760742;
+				};
+				class Item202
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5744.8667,352.73428,5594.2075};
+						angles[]={0,0.93602449,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9290;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.83425903;
+				};
+				class Item203
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5705.1128,359.2706,5643.0581};
+						angles[]={0,5.6484141,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9291;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.62677002;
+				};
+				class Item204
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5680.8188,355.65393,5616.3779};
+						angles[]={6.2033553,3.3376794,6.26159};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9293;
+					type="Land_BagFence_Round_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item205
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5678.4136,355.63745,5615.5225};
+						angles[]={6.2033553,2.5522814,6.26159};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9294;
+					type="Land_BagFence_Long_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item206
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5682.7295,355.47418,5614.647};
+						angles[]={6.2033553,0.98148471,6.26159};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9295;
+					type="Land_BagFence_Long_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item207
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5666.8013,355.45084,5607.167};
+						angles[]={6.2679896,1.7672505,6.2767911};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9296;
+					type="Land_BagFence_Round_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item208
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5667.6563,355.40878,5604.7617};
+						angles[]={6.2679896,0.98185235,6.2767911};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9297;
+					type="Land_BagFence_Long_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item209
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5668.5322,355.46667,5609.0767};
+						angles[]={6.2687874,5.694241,6.2759843};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9298;
+					type="Land_BagFence_Long_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item210
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5679.4507,355.67157,5556.9243};
+						angles[]={0,5.7042584,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+						dynamicSimulation=1;
+					};
+					id=9299;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=9.1552734e-005;
+				};
+				class Item211
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5684.4985,355.22202,5560.229};
+						angles[]={0,5.7042584,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9300;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.00012207031;
+				};
+				class Item212
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5689.5469,354.83182,5563.5342};
+						angles[]={0,5.7042584,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9301;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=9.1552734e-005;
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="allowDamage";
+							expression="_this allowdamage _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"BOOL"
+										};
+									};
+									value=0;
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item213
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5726.5215,354.71426,5614.2192};
+						angles[]={0,5.6542802,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9302;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.37908936;
+				};
+				class Item214
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5721.6699,355.11005,5610.6904};
+						angles[]={0,5.6542802,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9303;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.74447632;
+				};
+				class Item215
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5719.3174,353.89145,5594.1836};
+						angles[]={0,5.6484141,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9320;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item216
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5727.2422,354.67221,5618.2739};
+						angles[]={0,4.0776172,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9321;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item217
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5730.5815,354.17157,5618.6113};
+						angles[]={6.188272,5.5611472,6.2152915};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9324;
+					type="Land_BagFence_Long_F";
+				};
 			};
 			id=7888;
-			atlOffset=-0.83552551;
+			atlOffset=0.25784302;
 		};
-		class Item489
+		class Item488
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10902,7 +12850,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item490
+		class Item489
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10920,7 +12868,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item491
+		class Item490
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10937,7 +12885,7 @@ class Mission
 			id=7895;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item492
+		class Item491
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10954,7 +12902,7 @@ class Mission
 			id=7896;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item493
+		class Item492
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10972,7 +12920,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item494
+		class Item493
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10989,7 +12937,7 @@ class Mission
 			id=7898;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item495
+		class Item494
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11007,7 +12955,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item496
+		class Item495
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11025,7 +12973,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item497
+		class Item496
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11042,7 +12990,7 @@ class Mission
 			id=7901;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item498
+		class Item497
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11060,7 +13008,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item499
+		class Item498
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11077,7 +13025,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=0.4550705;
 		};
-		class Item500
+		class Item499
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11095,7 +13043,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item501
+		class Item500
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11112,7 +13060,7 @@ class Mission
 			id=7905;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item502
+		class Item501
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11129,7 +13077,7 @@ class Mission
 			id=7906;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item503
+		class Item502
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11146,7 +13094,7 @@ class Mission
 			id=7907;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item504
+		class Item503
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11163,7 +13111,7 @@ class Mission
 			id=7908;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item505
+		class Item504
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11180,7 +13128,7 @@ class Mission
 			id=7909;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item506
+		class Item505
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11197,7 +13145,7 @@ class Mission
 			id=7910;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item507
+		class Item506
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11214,7 +13162,7 @@ class Mission
 			id=7911;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item508
+		class Item507
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11231,7 +13179,7 @@ class Mission
 			id=7912;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item509
+		class Item508
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11248,7 +13196,7 @@ class Mission
 			id=7913;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item510
+		class Item509
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11265,7 +13213,7 @@ class Mission
 			id=7914;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item511
+		class Item510
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11282,7 +13230,7 @@ class Mission
 			id=7915;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item512
+		class Item511
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11299,7 +13247,7 @@ class Mission
 			id=7916;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item513
+		class Item512
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11317,7 +13265,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item514
+		class Item513
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11334,7 +13282,7 @@ class Mission
 			id=7918;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item515
+		class Item514
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11351,7 +13299,7 @@ class Mission
 			id=7919;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item516
+		class Item515
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11367,7 +13315,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.25;
 		};
-		class Item517
+		class Item516
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11384,7 +13332,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item518
+		class Item517
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11401,7 +13349,7 @@ class Mission
 			id=7922;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item519
+		class Item518
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11418,7 +13366,7 @@ class Mission
 			id=7923;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item520
+		class Item519
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11435,7 +13383,7 @@ class Mission
 			id=7924;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item521
+		class Item520
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11453,7 +13401,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item522
+		class Item521
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11471,7 +13419,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item523
+		class Item522
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11489,7 +13437,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item524
+		class Item523
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11506,7 +13454,7 @@ class Mission
 			id=7928;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item525
+		class Item524
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11523,7 +13471,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.24999237;
 		};
-		class Item526
+		class Item525
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11539,7 +13487,7 @@ class Mission
 			id=7930;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item527
+		class Item526
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11555,7 +13503,7 @@ class Mission
 			id=7931;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item528
+		class Item527
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11571,7 +13519,7 @@ class Mission
 			id=7932;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item529
+		class Item528
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11588,7 +13536,7 @@ class Mission
 			type="Land_Cargo_House_V1_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item530
+		class Item529
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11605,7 +13553,7 @@ class Mission
 			type="Land_TTowerSmall_1_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item531
+		class Item530
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11622,7 +13570,7 @@ class Mission
 			type="Land_TTowerSmall_2_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item532
+		class Item531
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11638,7 +13586,7 @@ class Mission
 			id=7936;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item533
+		class Item532
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11656,7 +13604,7 @@ class Mission
 			type="Land_Cargo40_military_green_F";
 			atlOffset=0.41942596;
 		};
-		class Item534
+		class Item533
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11674,7 +13622,7 @@ class Mission
 			type="Land_Cargo40_military_green_F";
 			atlOffset=0.34242249;
 		};
-		class Item535
+		class Item534
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11691,7 +13639,7 @@ class Mission
 			type="Land_Medevac_house_V1_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item536
+		class Item535
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -11748,7 +13696,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item537
+		class Item536
 		{
 			dataType="Marker";
 			position[]={5411.4707,451.25,5968.7446};
@@ -11763,7 +13711,7 @@ class Mission
 			id=7946;
 			atlOffset=80.688202;
 		};
-		class Item538
+		class Item537
 		{
 			dataType="Marker";
 			position[]={10685.275,38.889198,3810.7349};
@@ -11778,7 +13726,7 @@ class Mission
 			id=7947;
 			atlOffset=15.959801;
 		};
-		class Item539
+		class Item538
 		{
 			dataType="Marker";
 			position[]={1119.0909,16.625,11948.07};
@@ -11793,7 +13741,7 @@ class Mission
 			id=7948;
 			atlOffset=-13.964973;
 		};
-		class Item540
+		class Item539
 		{
 			dataType="Marker";
 			position[]={9662.0869,33.314789,3789.7827};
@@ -11802,7 +13750,7 @@ class Mission
 			id=7950;
 			atlOffset=-1.9511871;
 		};
-		class Item541
+		class Item540
 		{
 			dataType="Marker";
 			position[]={9430.9902,15.582298,3615.3931};
@@ -11811,7 +13759,7 @@ class Mission
 			id=7951;
 			atlOffset=-1.9511871;
 		};
-		class Item542
+		class Item541
 		{
 			dataType="Marker";
 			position[]={9767.667,36.92873,3990.6501};
@@ -11820,7 +13768,7 @@ class Mission
 			id=7952;
 			atlOffset=-1.9511871;
 		};
-		class Item543
+		class Item542
 		{
 			dataType="Marker";
 			position[]={10066.299,26.17466,4027.6467};
@@ -11829,7 +13777,7 @@ class Mission
 			id=7953;
 			atlOffset=-1.9511871;
 		};
-		class Item544
+		class Item543
 		{
 			dataType="Marker";
 			position[]={10486.761,15.848598,4196.1509};
@@ -11838,7 +13786,7 @@ class Mission
 			id=7954;
 			atlOffset=-1.9511881;
 		};
-		class Item545
+		class Item544
 		{
 			dataType="Marker";
 			position[]={11058.517,22.712757,4197.6699};
@@ -11847,7 +13795,7 @@ class Mission
 			id=7955;
 			atlOffset=-1.9511871;
 		};
-		class Item546
+		class Item545
 		{
 			dataType="Marker";
 			position[]={11261.775,15.748955,4268.458};
@@ -11856,7 +13804,7 @@ class Mission
 			id=7956;
 			atlOffset=-1.9511871;
 		};
-		class Item547
+		class Item546
 		{
 			dataType="Marker";
 			position[]={833.31549,14.35758,11943.996};
@@ -11865,7 +13813,7 @@ class Mission
 			id=7958;
 			atlOffset=-1.9511871;
 		};
-		class Item548
+		class Item547
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -11922,7 +13870,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item549
+		class Item548
 		{
 			dataType="Layer";
 			name="Open Ammo Dump_4";
@@ -12359,7 +14307,7 @@ class Mission
 			id=7962;
 			atlOffset=1.3211975;
 		};
-		class Item550
+		class Item549
 		{
 			dataType="Layer";
 			name="Vehicle Repair_4";
@@ -12639,7 +14587,7 @@ class Mission
 			id=7987;
 			atlOffset=-0.01071167;
 		};
-		class Item551
+		class Item550
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12656,7 +14604,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=2.3841858e-007;
 		};
-		class Item552
+		class Item551
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12673,7 +14621,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item553
+		class Item552
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12690,7 +14638,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=-2.3841858e-007;
 		};
-		class Item554
+		class Item553
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12707,7 +14655,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item555
+		class Item554
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12724,7 +14672,7 @@ class Mission
 			type="Land_Cargo_Tower_V2_F";
 			atlOffset=-1.9073486e-006;
 		};
-		class Item556
+		class Item555
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12740,7 +14688,7 @@ class Mission
 			type="Land_Cargo_Tower_V2_F";
 			atlOffset=-1.9073486e-006;
 		};
-		class Item557
+		class Item556
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12756,7 +14704,7 @@ class Mission
 			id=8386;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item558
+		class Item557
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -12767,7 +14715,7 @@ class Mission
 			id=8387;
 			type="Logic";
 		};
-		class Item559
+		class Item558
 		{
 			dataType="Marker";
 			position[]={8515.5879,-1.2098112,3849.7024};
@@ -12776,7 +14724,7 @@ class Mission
 			id=8388;
 			atlOffset=6.3372011;
 		};
-		class Item560
+		class Item559
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12794,7 +14742,7 @@ class Mission
 			type="Land_HelipadCircle_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item561
+		class Item560
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12811,7 +14759,7 @@ class Mission
 			id=8391;
 			type="Land_HelipadCircle_F";
 		};
-		class Item562
+		class Item561
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12829,7 +14777,7 @@ class Mission
 			type="Land_HelipadCircle_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item563
+		class Item562
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12845,7 +14793,7 @@ class Mission
 			id=8393;
 			type="Land_Hangar_F";
 		};
-		class Item564
+		class Item563
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12861,7 +14809,7 @@ class Mission
 			id=8394;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item565
+		class Item564
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12877,7 +14825,7 @@ class Mission
 			id=8395;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item566
+		class Item565
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12893,7 +14841,7 @@ class Mission
 			id=8396;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item567
+		class Item566
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12911,7 +14859,7 @@ class Mission
 			type="Land_HelipadCircle_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item568
+		class Item567
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12929,7 +14877,7 @@ class Mission
 			type="Land_HelipadCircle_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item569
+		class Item568
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12945,7 +14893,7 @@ class Mission
 			id=8402;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item570
+		class Item569
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12962,7 +14910,7 @@ class Mission
 			type="Land_TentHangar_V1_F";
 			atlOffset=-1.9073486e-006;
 		};
-		class Item571
+		class Item570
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12978,7 +14926,7 @@ class Mission
 			id=8404;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item572
+		class Item571
 		{
 			dataType="Layer";
 			name="Airports";
@@ -13137,7 +15085,7 @@ class Mission
 			id=8407;
 			atlOffset=-188.44035;
 		};
-		class Item573
+		class Item572
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13154,7 +15102,7 @@ class Mission
 			id=8410;
 			type="Land_HelipadCircle_F";
 		};
-		class Item574
+		class Item573
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13171,7 +15119,7 @@ class Mission
 			id=8413;
 			type="Land_HelipadCircle_F";
 		};
-		class Item575
+		class Item574
 		{
 			dataType="Layer";
 			name="Factories";
@@ -13275,7 +15223,7 @@ class Mission
 			id=8415;
 			atlOffset=-70.030045;
 		};
-		class Item576
+		class Item575
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13292,7 +15240,7 @@ class Mission
 			id=8418;
 			type="Land_HelipadCircle_F";
 		};
-		class Item577
+		class Item576
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13310,7 +15258,7 @@ class Mission
 			type="Land_HelipadCircle_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item578
+		class Item577
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13327,7 +15275,7 @@ class Mission
 			id=8420;
 			type="Land_HelipadCircle_F";
 		};
-		class Item579
+		class Item578
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13344,7 +15292,7 @@ class Mission
 			id=8428;
 			type="Land_HelipadSquare_F";
 		};
-		class Item580
+		class Item579
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13361,7 +15309,7 @@ class Mission
 			id=8430;
 			type="Land_HelipadSquare_F";
 		};
-		class Item581
+		class Item580
 		{
 			dataType="Layer";
 			name="Resources";
@@ -13562,7 +15510,7 @@ class Mission
 			id=8431;
 			atlOffset=12.317825;
 		};
-		class Item582
+		class Item581
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13580,7 +15528,7 @@ class Mission
 			type="Land_HelipadSquare_F";
 			atlOffset=-3.3378601e-006;
 		};
-		class Item583
+		class Item582
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13598,7 +15546,7 @@ class Mission
 			type="Land_HelipadSquare_F";
 			atlOffset=3.3378601e-006;
 		};
-		class Item584
+		class Item583
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13615,7 +15563,7 @@ class Mission
 			id=8442;
 			type="Land_HelipadSquare_F";
 		};
-		class Item585
+		class Item584
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13632,7 +15580,7 @@ class Mission
 			type="Land_HelipadSquare_F";
 			atlOffset=1.4099998;
 		};
-		class Item586
+		class Item585
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13649,7 +15597,7 @@ class Mission
 			id=8448;
 			type="Land_HelipadSquare_F";
 		};
-		class Item587
+		class Item586
 		{
 			dataType="Layer";
 			name="Seaports";
@@ -13873,7 +15821,7 @@ class Mission
 			id=8452;
 			atlOffset=14.549579;
 		};
-		class Item588
+		class Item587
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13891,7 +15839,7 @@ class Mission
 			type="Land_HelipadCircle_F";
 			atlOffset=-9.5367432e-006;
 		};
-		class Item589
+		class Item588
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13908,7 +15856,7 @@ class Mission
 			id=8476;
 			type="Land_HelipadSquare_F";
 		};
-		class Item590
+		class Item589
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13925,7 +15873,7 @@ class Mission
 			type="Land_HelipadSquare_F";
 			atlOffset=2.9406738;
 		};
-		class Item591
+		class Item590
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13942,13 +15890,13 @@ class Mission
 			id=8483;
 			type="Land_HelipadSquare_F";
 		};
-		class Item592
+		class Item591
 		{
 			dataType="Layer";
 			name="Outposts";
 			class Entities
 			{
-				items=27;
+				items=28;
 				class Item0
 				{
 					dataType="Marker";
@@ -14186,16 +16134,16 @@ class Mission
 				class Item17
 				{
 					dataType="Marker";
-					position[]={5975.5117,10681.125,10385.423};
+					position[]={5700.9043,10682.237,5586.4438};
 					name="outpost_12";
 					markerType="RECTANGLE";
 					type="rectangle";
 					colorName="ColorGreen";
-					a=58.343082;
-					b=46.417057;
-					angle=216.99579;
+					a=62.826801;
+					b=55.433304;
+					angle=232.00449;
 					id=183;
-					atlOffset=10484.82;
+					atlOffset=10328.511;
 				};
 				class Item18
 				{
@@ -14319,11 +16267,25 @@ class Mission
 					id=30;
 					atlOffset=-7.1350021;
 				};
+				class Item27
+				{
+					dataType="Marker";
+					position[]={5974.5957,10748.66,10383.418};
+					name="outpost_14";
+					markerType="RECTANGLE";
+					type="rectangle";
+					colorName="ColorGreen";
+					a=62.826801;
+					b=55.433304;
+					angle=217.26146;
+					id=9351;
+					atlOffset=10552.287;
+				};
 			};
 			id=8484;
-			atlOffset=35.842239;
+			atlOffset=5302.0947;
 		};
-		class Item593
+		class Item592
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14341,7 +16303,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item594
+		class Item593
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14358,7 +16320,7 @@ class Mission
 			id=8525;
 			type="Land_HBarrier_5_F";
 		};
-		class Item595
+		class Item594
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14375,7 +16337,7 @@ class Mission
 			id=8526;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item596
+		class Item595
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14393,7 +16355,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item597
+		class Item596
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14410,7 +16372,7 @@ class Mission
 			id=8528;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item598
+		class Item597
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14427,7 +16389,7 @@ class Mission
 			id=8529;
 			type="Land_HBarrier_5_F";
 		};
-		class Item599
+		class Item598
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14444,7 +16406,7 @@ class Mission
 			id=8530;
 			type="Land_HBarrier_5_F";
 		};
-		class Item600
+		class Item599
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14461,7 +16423,7 @@ class Mission
 			id=8531;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item601
+		class Item600
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14478,7 +16440,7 @@ class Mission
 			id=8532;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item602
+		class Item601
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14496,7 +16458,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item603
+		class Item602
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14513,7 +16475,7 @@ class Mission
 			id=8534;
 			type="Land_HBarrier_3_F";
 		};
-		class Item604
+		class Item603
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14530,7 +16492,7 @@ class Mission
 			id=8535;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item605
+		class Item604
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14547,7 +16509,7 @@ class Mission
 			id=8536;
 			type="Land_HBarrier_5_F";
 		};
-		class Item606
+		class Item605
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14565,7 +16527,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item607
+		class Item606
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14583,7 +16545,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item608
+		class Item607
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14600,7 +16562,7 @@ class Mission
 			id=8539;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item609
+		class Item608
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14618,7 +16580,7 @@ class Mission
 			type="Land_HBarrier_3_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item610
+		class Item609
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14635,7 +16597,7 @@ class Mission
 			id=8541;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item611
+		class Item610
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14653,7 +16615,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-0.19999695;
 		};
-		class Item612
+		class Item611
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14671,7 +16633,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item613
+		class Item612
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14688,7 +16650,7 @@ class Mission
 			id=8544;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item614
+		class Item613
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14705,7 +16667,7 @@ class Mission
 			id=8545;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item615
+		class Item614
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14722,7 +16684,7 @@ class Mission
 			id=8546;
 			type="Land_HBarrier_3_F";
 		};
-		class Item616
+		class Item615
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14739,7 +16701,7 @@ class Mission
 			id=8547;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item617
+		class Item616
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14756,7 +16718,7 @@ class Mission
 			id=8548;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item618
+		class Item617
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14773,7 +16735,7 @@ class Mission
 			id=8549;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item619
+		class Item618
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14790,7 +16752,7 @@ class Mission
 			id=8550;
 			type="Land_HBarrierWall6_F";
 		};
-		class Item620
+		class Item619
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14808,7 +16770,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item621
+		class Item620
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14825,7 +16787,7 @@ class Mission
 			type="Land_Mil_WiredFence_Gate_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item622
+		class Item621
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14843,7 +16805,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item623
+		class Item622
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14861,7 +16823,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item624
+		class Item623
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14878,7 +16840,7 @@ class Mission
 			id=8555;
 			type="Land_HBarrier_5_F";
 		};
-		class Item625
+		class Item624
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14896,7 +16858,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item626
+		class Item625
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14914,7 +16876,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item627
+		class Item626
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14931,7 +16893,7 @@ class Mission
 			id=8558;
 			type="Land_HBarrier_5_F";
 		};
-		class Item628
+		class Item627
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14949,7 +16911,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item629
+		class Item628
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14967,7 +16929,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item630
+		class Item629
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14984,7 +16946,7 @@ class Mission
 			id=8561;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item631
+		class Item630
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15001,7 +16963,7 @@ class Mission
 			id=8562;
 			type="Land_HBarrier_5_F";
 		};
-		class Item632
+		class Item631
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15018,7 +16980,7 @@ class Mission
 			id=8563;
 			type="Land_HBarrier_5_F";
 		};
-		class Item633
+		class Item632
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15035,7 +16997,7 @@ class Mission
 			id=8564;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item634
+		class Item633
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15053,7 +17015,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item635
+		class Item634
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15070,7 +17032,7 @@ class Mission
 			id=8566;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item636
+		class Item635
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15087,7 +17049,7 @@ class Mission
 			id=8567;
 			type="Land_HBarrier_5_F";
 		};
-		class Item637
+		class Item636
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15104,7 +17066,7 @@ class Mission
 			id=8568;
 			type="Land_HBarrier_5_F";
 		};
-		class Item638
+		class Item637
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15121,7 +17083,7 @@ class Mission
 			id=8569;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item639
+		class Item638
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15139,7 +17101,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item640
+		class Item639
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15156,7 +17118,7 @@ class Mission
 			id=8571;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item641
+		class Item640
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15173,7 +17135,7 @@ class Mission
 			id=8572;
 			type="Land_HBarrier_5_F";
 		};
-		class Item642
+		class Item641
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15190,7 +17152,7 @@ class Mission
 			id=8573;
 			type="Land_HBarrier_5_F";
 		};
-		class Item643
+		class Item642
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15207,7 +17169,7 @@ class Mission
 			id=8574;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item644
+		class Item643
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15224,7 +17186,7 @@ class Mission
 			id=8575;
 			type="Land_HBarrier_5_F";
 		};
-		class Item645
+		class Item644
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15241,7 +17203,7 @@ class Mission
 			id=8576;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item646
+		class Item645
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15258,7 +17220,7 @@ class Mission
 			id=8577;
 			type="Land_HBarrier_3_F";
 		};
-		class Item647
+		class Item646
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15274,7 +17236,7 @@ class Mission
 			id=8579;
 			type="Land_Razorwire_F";
 		};
-		class Item648
+		class Item647
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15290,7 +17252,7 @@ class Mission
 			id=8580;
 			type="Land_Razorwire_F";
 		};
-		class Item649
+		class Item648
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15306,7 +17268,7 @@ class Mission
 			id=8581;
 			type="Land_Razorwire_F";
 		};
-		class Item650
+		class Item649
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15322,7 +17284,7 @@ class Mission
 			id=8582;
 			type="Land_Razorwire_F";
 		};
-		class Item651
+		class Item650
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15338,7 +17300,7 @@ class Mission
 			id=8583;
 			type="Land_Razorwire_F";
 		};
-		class Item652
+		class Item651
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15354,7 +17316,7 @@ class Mission
 			id=8584;
 			type="Land_Razorwire_F";
 		};
-		class Item653
+		class Item652
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15371,7 +17333,7 @@ class Mission
 			id=8585;
 			type="Land_HBarrier_3_F";
 		};
-		class Item654
+		class Item653
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15388,7 +17350,7 @@ class Mission
 			type="Land_LampSolar_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item655
+		class Item654
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15405,7 +17367,7 @@ class Mission
 			id=8589;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item656
+		class Item655
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15422,7 +17384,7 @@ class Mission
 			type="Land_PressureWasher_01_F";
 			atlOffset=-0.00012207031;
 		};
-		class Item657
+		class Item656
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15439,7 +17401,7 @@ class Mission
 			id=8594;
 			type="Land_HBarrier_5_F";
 		};
-		class Item658
+		class Item657
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15456,7 +17418,7 @@ class Mission
 			id=8595;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item659
+		class Item658
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15473,7 +17435,7 @@ class Mission
 			id=8596;
 			type="Land_HBarrier_5_F";
 		};
-		class Item660
+		class Item659
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15490,7 +17452,7 @@ class Mission
 			id=8597;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item661
+		class Item660
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15507,7 +17469,7 @@ class Mission
 			id=8598;
 			type="Land_HBarrier_5_F";
 		};
-		class Item662
+		class Item661
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15524,7 +17486,7 @@ class Mission
 			id=8599;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item663
+		class Item662
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15541,7 +17503,7 @@ class Mission
 			id=8600;
 			type="Land_HBarrier_5_F";
 		};
-		class Item664
+		class Item663
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15558,7 +17520,7 @@ class Mission
 			id=8601;
 			type="Land_HBarrier_3_F";
 		};
-		class Item665
+		class Item664
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15576,7 +17538,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item666
+		class Item665
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15594,7 +17556,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item667
+		class Item666
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15611,7 +17573,7 @@ class Mission
 			id=8604;
 			type="Land_HBarrier_3_F";
 		};
-		class Item668
+		class Item667
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15629,7 +17591,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item669
+		class Item668
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15646,7 +17608,7 @@ class Mission
 			id=8606;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item670
+		class Item669
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15664,7 +17626,7 @@ class Mission
 			type="Land_HBarrier_3_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item671
+		class Item670
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15682,7 +17644,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item672
+		class Item671
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15700,7 +17662,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item673
+		class Item672
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15717,7 +17679,7 @@ class Mission
 			id=8610;
 			type="Land_HBarrier_3_F";
 		};
-		class Item674
+		class Item673
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15734,7 +17696,7 @@ class Mission
 			id=8611;
 			type="Land_HBarrier_5_F";
 		};
-		class Item675
+		class Item674
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15751,7 +17713,7 @@ class Mission
 			id=8612;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item676
+		class Item675
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15768,7 +17730,7 @@ class Mission
 			id=8613;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item677
+		class Item676
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15785,7 +17747,7 @@ class Mission
 			id=8614;
 			type="Land_HBarrier_5_F";
 		};
-		class Item678
+		class Item677
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15803,7 +17765,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item679
+		class Item678
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15820,7 +17782,7 @@ class Mission
 			id=8616;
 			type="Land_HBarrier_5_F";
 		};
-		class Item680
+		class Item679
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15837,7 +17799,7 @@ class Mission
 			id=8617;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item681
+		class Item680
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15854,7 +17816,7 @@ class Mission
 			id=8618;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item682
+		class Item681
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15872,7 +17834,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item683
+		class Item682
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15889,7 +17851,7 @@ class Mission
 			id=8620;
 			type="Land_HBarrier_5_F";
 		};
-		class Item684
+		class Item683
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15906,7 +17868,7 @@ class Mission
 			id=8621;
 			type="Land_HBarrier_5_F";
 		};
-		class Item685
+		class Item684
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15923,7 +17885,7 @@ class Mission
 			id=8622;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item686
+		class Item685
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15940,7 +17902,7 @@ class Mission
 			id=8623;
 			type="Land_HBarrier_5_F";
 		};
-		class Item687
+		class Item686
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15957,7 +17919,7 @@ class Mission
 			id=8624;
 			type="Land_HBarrier_5_F";
 		};
-		class Item688
+		class Item687
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15974,7 +17936,7 @@ class Mission
 			id=8625;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item689
+		class Item688
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15991,7 +17953,7 @@ class Mission
 			id=8626;
 			type="Land_HBarrier_5_F";
 		};
-		class Item690
+		class Item689
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16008,7 +17970,7 @@ class Mission
 			id=8627;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item691
+		class Item690
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16025,7 +17987,7 @@ class Mission
 			id=8628;
 			type="Land_HBarrier_5_F";
 		};
-		class Item692
+		class Item691
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16042,7 +18004,7 @@ class Mission
 			id=8629;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item693
+		class Item692
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16059,7 +18021,7 @@ class Mission
 			id=8630;
 			type="Land_HBarrier_5_F";
 		};
-		class Item694
+		class Item693
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16076,7 +18038,7 @@ class Mission
 			id=8631;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item695
+		class Item694
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16093,7 +18055,7 @@ class Mission
 			id=8632;
 			type="Land_HBarrier_5_F";
 		};
-		class Item696
+		class Item695
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16110,7 +18072,7 @@ class Mission
 			id=8633;
 			type="Land_HBarrier_5_F";
 		};
-		class Item697
+		class Item696
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16127,7 +18089,7 @@ class Mission
 			id=8634;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item698
+		class Item697
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16145,7 +18107,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item699
+		class Item698
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16162,7 +18124,7 @@ class Mission
 			id=8636;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item700
+		class Item699
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16179,7 +18141,7 @@ class Mission
 			id=8637;
 			type="Land_HBarrier_5_F";
 		};
-		class Item701
+		class Item700
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16197,7 +18159,7 @@ class Mission
 			type="Land_HBarrier_3_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item702
+		class Item701
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16215,7 +18177,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item703
+		class Item702
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16232,7 +18194,7 @@ class Mission
 			id=8640;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item704
+		class Item703
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16249,7 +18211,7 @@ class Mission
 			id=8641;
 			type="Land_HBarrier_5_F";
 		};
-		class Item705
+		class Item704
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16266,7 +18228,7 @@ class Mission
 			id=8642;
 			type="Land_HBarrier_1_F";
 		};
-		class Item706
+		class Item705
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16283,7 +18245,7 @@ class Mission
 			id=8643;
 			type="Land_HBarrier_1_F";
 		};
-		class Item707
+		class Item706
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16301,7 +18263,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item708
+		class Item707
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16319,7 +18281,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item709
+		class Item708
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16336,7 +18298,7 @@ class Mission
 			id=8646;
 			type="Land_HBarrier_5_F";
 		};
-		class Item710
+		class Item709
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16353,7 +18315,7 @@ class Mission
 			id=8647;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item711
+		class Item710
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16370,7 +18332,7 @@ class Mission
 			id=8648;
 			type="Land_HBarrier_5_F";
 		};
-		class Item712
+		class Item711
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16387,7 +18349,7 @@ class Mission
 			id=8649;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item713
+		class Item712
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16404,7 +18366,7 @@ class Mission
 			id=8650;
 			type="Land_HBarrier_5_F";
 		};
-		class Item714
+		class Item713
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16421,7 +18383,7 @@ class Mission
 			id=8651;
 			type="Land_HBarrier_3_F";
 		};
-		class Item715
+		class Item714
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16438,7 +18400,7 @@ class Mission
 			id=8652;
 			type="Land_HBarrier_5_F";
 		};
-		class Item716
+		class Item715
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16455,7 +18417,7 @@ class Mission
 			id=8653;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item717
+		class Item716
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16472,7 +18434,7 @@ class Mission
 			id=8654;
 			type="Land_HBarrier_5_F";
 		};
-		class Item718
+		class Item717
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16489,7 +18451,7 @@ class Mission
 			id=8655;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item719
+		class Item718
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16506,7 +18468,7 @@ class Mission
 			id=8656;
 			type="Land_HBarrier_5_F";
 		};
-		class Item720
+		class Item719
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16524,7 +18486,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item721
+		class Item720
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16540,7 +18502,7 @@ class Mission
 			id=8658;
 			type="Land_MobileRadar_01_radar_F";
 		};
-		class Item722
+		class Item721
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16557,7 +18519,7 @@ class Mission
 			type="Land_MobileRadar_01_generator_F";
 			atlOffset=0.25138855;
 		};
-		class Item723
+		class Item722
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16573,7 +18535,7 @@ class Mission
 			id=8660;
 			type="Land_Cargo_HQ_V1_F";
 		};
-		class Item724
+		class Item723
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16589,7 +18551,7 @@ class Mission
 			id=8661;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item725
+		class Item724
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16605,7 +18567,7 @@ class Mission
 			id=8662;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item726
+		class Item725
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16621,7 +18583,7 @@ class Mission
 			id=8663;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item727
+		class Item726
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16637,7 +18599,7 @@ class Mission
 			id=8664;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item728
+		class Item727
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16655,7 +18617,7 @@ class Mission
 			type="Land_HelipadSquare_F";
 			atlOffset=0.65576172;
 		};
-		class Item729
+		class Item728
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16673,7 +18635,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item730
+		class Item729
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16691,7 +18653,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item731
+		class Item730
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16709,7 +18671,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item732
+		class Item731
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16727,7 +18689,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item733
+		class Item732
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16744,7 +18706,7 @@ class Mission
 			id=8670;
 			type="Land_HBarrier_5_F";
 		};
-		class Item734
+		class Item733
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16761,7 +18723,7 @@ class Mission
 			id=8671;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item735
+		class Item734
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16778,7 +18740,7 @@ class Mission
 			id=8672;
 			type="Land_HBarrier_5_F";
 		};
-		class Item736
+		class Item735
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16795,7 +18757,7 @@ class Mission
 			id=8673;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item737
+		class Item736
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16812,7 +18774,7 @@ class Mission
 			id=8674;
 			type="Land_HBarrier_5_F";
 		};
-		class Item738
+		class Item737
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16829,7 +18791,7 @@ class Mission
 			id=8675;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item739
+		class Item738
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16846,7 +18808,7 @@ class Mission
 			id=8676;
 			type="Land_HBarrier_5_F";
 		};
-		class Item740
+		class Item739
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16864,7 +18826,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item741
+		class Item740
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16881,7 +18843,7 @@ class Mission
 			id=8678;
 			type="Land_HBarrier_5_F";
 		};
-		class Item742
+		class Item741
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16898,7 +18860,7 @@ class Mission
 			id=8679;
 			type="Land_HBarrier_3_F";
 		};
-		class Item743
+		class Item742
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16916,7 +18878,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item744
+		class Item743
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16933,7 +18895,7 @@ class Mission
 			id=8681;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item745
+		class Item744
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16950,7 +18912,7 @@ class Mission
 			id=8682;
 			type="Land_HBarrier_5_F";
 		};
-		class Item746
+		class Item745
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16967,7 +18929,7 @@ class Mission
 			id=8683;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item747
+		class Item746
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16985,7 +18947,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item748
+		class Item747
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17003,7 +18965,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item749
+		class Item748
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17020,7 +18982,7 @@ class Mission
 			id=8686;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item750
+		class Item749
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17037,7 +18999,7 @@ class Mission
 			id=8687;
 			type="Land_HBarrier_5_F";
 		};
-		class Item751
+		class Item750
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17054,7 +19016,7 @@ class Mission
 			id=8688;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item752
+		class Item751
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17071,7 +19033,7 @@ class Mission
 			id=8689;
 			type="Land_HBarrier_5_F";
 		};
-		class Item753
+		class Item752
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17088,7 +19050,7 @@ class Mission
 			id=8690;
 			type="Land_HBarrier_5_F";
 		};
-		class Item754
+		class Item753
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17105,7 +19067,7 @@ class Mission
 			id=8691;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item755
+		class Item754
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17122,7 +19084,7 @@ class Mission
 			id=8692;
 			type="Land_HBarrier_5_F";
 		};
-		class Item756
+		class Item755
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17140,7 +19102,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item757
+		class Item756
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17157,7 +19119,7 @@ class Mission
 			id=8694;
 			type="Land_HBarrier_3_F";
 		};
-		class Item758
+		class Item757
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17174,7 +19136,7 @@ class Mission
 			id=8695;
 			type="Land_HBarrier_5_F";
 		};
-		class Item759
+		class Item758
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17191,7 +19153,7 @@ class Mission
 			id=8696;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item760
+		class Item759
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17208,7 +19170,7 @@ class Mission
 			id=8697;
 			type="Land_HBarrier_5_F";
 		};
-		class Item761
+		class Item760
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17225,7 +19187,7 @@ class Mission
 			id=8698;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item762
+		class Item761
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17242,7 +19204,7 @@ class Mission
 			id=8699;
 			type="Land_HBarrier_5_F";
 		};
-		class Item763
+		class Item762
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17260,7 +19222,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item764
+		class Item763
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17278,7 +19240,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item765
+		class Item764
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17295,7 +19257,7 @@ class Mission
 			id=8702;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item766
+		class Item765
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17313,7 +19275,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item767
+		class Item766
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17330,7 +19292,7 @@ class Mission
 			id=8704;
 			type="Land_HBarrier_3_F";
 		};
-		class Item768
+		class Item767
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17348,7 +19310,7 @@ class Mission
 			type="Land_HBarrier_3_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item769
+		class Item768
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17366,7 +19328,7 @@ class Mission
 			type="Land_HBarrier_3_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item770
+		class Item769
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17384,7 +19346,7 @@ class Mission
 			type="Land_HBarrier_1_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item771
+		class Item770
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17402,7 +19364,7 @@ class Mission
 			type="Land_HelipadSquare_F";
 			atlOffset=0.64489746;
 		};
-		class Item772
+		class Item771
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17419,7 +19381,7 @@ class Mission
 			id=8709;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item773
+		class Item772
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17436,7 +19398,7 @@ class Mission
 			id=8710;
 			type="Land_HBarrier_5_F";
 		};
-		class Item774
+		class Item773
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17453,7 +19415,7 @@ class Mission
 			id=8711;
 			type="Land_HBarrier_5_F";
 		};
-		class Item775
+		class Item774
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17471,7 +19433,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item776
+		class Item775
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17488,7 +19450,7 @@ class Mission
 			id=8713;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item777
+		class Item776
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17505,7 +19467,7 @@ class Mission
 			id=8714;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item778
+		class Item777
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17523,7 +19485,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item779
+		class Item778
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17541,7 +19503,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item780
+		class Item779
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17558,7 +19520,7 @@ class Mission
 			id=8717;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item781
+		class Item780
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17575,7 +19537,7 @@ class Mission
 			id=8718;
 			type="Land_HBarrier_5_F";
 		};
-		class Item782
+		class Item781
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17592,7 +19554,7 @@ class Mission
 			id=8719;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item783
+		class Item782
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17609,7 +19571,7 @@ class Mission
 			id=8720;
 			type="Land_HBarrier_5_F";
 		};
-		class Item784
+		class Item783
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17626,7 +19588,7 @@ class Mission
 			id=8721;
 			type="Land_HBarrier_5_F";
 		};
-		class Item785
+		class Item784
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17643,7 +19605,7 @@ class Mission
 			id=8722;
 			type="Land_HBarrier_5_F";
 		};
-		class Item786
+		class Item785
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17660,7 +19622,7 @@ class Mission
 			id=8723;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item787
+		class Item786
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17677,7 +19639,7 @@ class Mission
 			id=8724;
 			type="Land_HBarrier_5_F";
 		};
-		class Item788
+		class Item787
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17694,7 +19656,7 @@ class Mission
 			id=8725;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item789
+		class Item788
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17710,7 +19672,7 @@ class Mission
 			id=8726;
 			type="Land_Cargo_Tower_V1_F";
 		};
-		class Item790
+		class Item789
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17727,7 +19689,7 @@ class Mission
 			type="Land_Cargo_Tower_V1_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item791
+		class Item790
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17743,7 +19705,7 @@ class Mission
 			id=8728;
 			type="Land_Cargo_Tower_V1_F";
 		};
-		class Item792
+		class Item791
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17761,7 +19723,7 @@ class Mission
 			type="Land_HelipadSquare_F";
 			atlOffset=0.70658875;
 		};
-		class Item793
+		class Item792
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17779,7 +19741,7 @@ class Mission
 			type="Land_HelipadSquare_F";
 			atlOffset=0.63046265;
 		};
-		class Item794
+		class Item793
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17797,7 +19759,7 @@ class Mission
 			type="Land_HelipadSquare_F";
 			atlOffset=0.66749573;
 		};
-		class Item795
+		class Item794
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17815,7 +19777,7 @@ class Mission
 			type="Land_HelipadSquare_F";
 			atlOffset=0.61737061;
 		};
-		class Item796
+		class Item795
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17831,7 +19793,7 @@ class Mission
 			id=8733;
 			type="Land_LampAirport_F";
 		};
-		class Item797
+		class Item796
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17847,7 +19809,7 @@ class Mission
 			id=8734;
 			type="Land_LampAirport_F";
 		};
-		class Item798
+		class Item797
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17863,7 +19825,7 @@ class Mission
 			id=8740;
 			type="StorageBladder_01_fuel_forest_F";
 		};
-		class Item799
+		class Item798
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17879,7 +19841,7 @@ class Mission
 			id=8741;
 			type="StorageBladder_01_fuel_forest_F";
 		};
-		class Item800
+		class Item799
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17896,7 +19858,7 @@ class Mission
 			id=8742;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item801
+		class Item800
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17913,7 +19875,7 @@ class Mission
 			id=8743;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item802
+		class Item801
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17930,7 +19892,7 @@ class Mission
 			id=8744;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item803
+		class Item802
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17947,7 +19909,7 @@ class Mission
 			id=8745;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item804
+		class Item803
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17964,7 +19926,7 @@ class Mission
 			id=8746;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item805
+		class Item804
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17981,7 +19943,7 @@ class Mission
 			type="Land_LampAirport_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item806
+		class Item805
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17997,7 +19959,7 @@ class Mission
 			id=8748;
 			type="Land_LampAirport_F";
 		};
-		class Item807
+		class Item806
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18014,7 +19976,7 @@ class Mission
 			type="Land_LampSolar_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item808
+		class Item807
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18031,7 +19993,7 @@ class Mission
 			id=8750;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item809
+		class Item808
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18048,7 +20010,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=0.265625;
 		};
-		class Item810
+		class Item809
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18064,7 +20026,7 @@ class Mission
 			id=8752;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item811
+		class Item810
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18081,7 +20043,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item812
+		class Item811
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18098,7 +20060,7 @@ class Mission
 			id=8756;
 			type="Land_HelipadCircle_F";
 		};
-		class Item813
+		class Item812
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18115,7 +20077,7 @@ class Mission
 			type="Land_Cargo_Patrol_V4_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item814
+		class Item813
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -18127,7 +20089,7 @@ class Mission
 			type="HighCommand";
 			atlOffset=0.043842316;
 		};
-		class Item815
+		class Item814
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -18138,7 +20100,7 @@ class Mission
 			type="HighCommandSubordinate";
 			atlOffset=-0.043831825;
 		};
-		class Item816
+		class Item815
 		{
 			dataType="Marker";
 			position[]={737.70398,27.885,12084.651};
@@ -18147,7 +20109,7 @@ class Mission
 			id=8765;
 			atlOffset=0.00016021729;
 		};
-		class Item817
+		class Item816
 		{
 			dataType="Marker";
 			position[]={8157.2852,29.357891,9844.3545};
@@ -18155,7 +20117,7 @@ class Mission
 			type="hd_start";
 			id=8766;
 		};
-		class Item818
+		class Item817
 		{
 			dataType="Marker";
 			position[]={2353.4297,193.33873,3599.1111};
@@ -18163,7 +20125,7 @@ class Mission
 			type="hd_start";
 			id=8767;
 		};
-		class Item819
+		class Item818
 		{
 			dataType="Group";
 			side="Independent";
@@ -19041,7 +21003,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item820
+		class Item819
 		{
 			dataType="Marker";
 			position[]={6275.625,148,4915.625};
@@ -19053,7 +21015,7 @@ class Mission
 			id=8817;
 			atlOffset=-195.57904;
 		};
-		class Item821
+		class Item820
 		{
 			dataType="Marker";
 			position[]={3465.5056,251.49741,7661.5068};
@@ -19064,7 +21026,7 @@ class Mission
 			b=144.91785;
 			id=8818;
 		};
-		class Item822
+		class Item821
 		{
 			dataType="Marker";
 			position[]={6099.8125,248.32848,8058.6289};
@@ -19075,7 +21037,7 @@ class Mission
 			b=144.91785;
 			id=8819;
 		};
-		class Item823
+		class Item822
 		{
 			dataType="Marker";
 			position[]={2815.7451,229.74904,4730.1313};
@@ -19086,7 +21048,7 @@ class Mission
 			b=144.91785;
 			id=8820;
 		};
-		class Item824
+		class Item823
 		{
 			dataType="Marker";
 			position[]={8163.481,156.58452,7220.6636};
@@ -19097,7 +21059,7 @@ class Mission
 			b=144.91785;
 			id=8821;
 		};
-		class Item825
+		class Item824
 		{
 			dataType="Marker";
 			position[]={5702.8481,124.312,10623.949};
@@ -19109,7 +21071,7 @@ class Mission
 			id=8822;
 			atlOffset=-0.00037384033;
 		};
-		class Item826
+		class Item825
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19125,7 +21087,7 @@ class Mission
 			id=8824;
 			type="Land_TTowerBig_1_F";
 		};
-		class Item827
+		class Item826
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19142,7 +21104,7 @@ class Mission
 			id=8825;
 			type="Land_HBarrier_5_F";
 		};
-		class Item828
+		class Item827
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19159,7 +21121,7 @@ class Mission
 			id=8826;
 			type="Land_HBarrier_5_F";
 		};
-		class Item829
+		class Item828
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19176,7 +21138,7 @@ class Mission
 			id=8827;
 			type="Land_HBarrier_5_F";
 		};
-		class Item830
+		class Item829
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19193,7 +21155,7 @@ class Mission
 			id=8828;
 			type="Land_HBarrier_5_F";
 		};
-		class Item831
+		class Item830
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19210,7 +21172,7 @@ class Mission
 			id=8829;
 			type="Land_HBarrier_5_F";
 		};
-		class Item832
+		class Item831
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19227,7 +21189,7 @@ class Mission
 			id=8830;
 			type="Land_HBarrier_5_F";
 		};
-		class Item833
+		class Item832
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19244,7 +21206,7 @@ class Mission
 			id=8831;
 			type="Land_HBarrier_5_F";
 		};
-		class Item834
+		class Item833
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19260,7 +21222,7 @@ class Mission
 			id=8832;
 			type="Land_TTowerBig_1_F";
 		};
-		class Item835
+		class Item834
 		{
 			dataType="Marker";
 			position[]={5206.25,409.125,6234.625};
@@ -19272,7 +21234,7 @@ class Mission
 			id=8840;
 			atlOffset=2.4406433;
 		};
-		class Item836
+		class Item835
 		{
 			dataType="Marker";
 			position[]={4383.6133,264.81461,8853.4551};
@@ -19283,7 +21245,7 @@ class Mission
 			b=144.91785;
 			id=8841;
 		};
-		class Item837
+		class Item836
 		{
 			dataType="Marker";
 			position[]={7368.5747,127.35316,9579.5996};
@@ -19295,7 +21257,7 @@ class Mission
 			id=8842;
 			atlOffset=-7.6293945e-006;
 		};
-		class Item838
+		class Item837
 		{
 			dataType="Marker";
 			position[]={3714.0037,111.85905,5453.6143};
@@ -19307,7 +21269,7 @@ class Mission
 			id=8843;
 			atlOffset=-7.6293945e-006;
 		};
-		class Item839
+		class Item838
 		{
 			dataType="Marker";
 			position[]={4756.8188,34.743,3167.177};
@@ -19319,7 +21281,7 @@ class Mission
 			id=8844;
 			atlOffset=-0.00023269653;
 		};
-		class Item840
+		class Item839
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19336,7 +21298,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item841
+		class Item840
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -19393,7 +21355,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item842
+		class Item841
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19410,7 +21372,7 @@ class Mission
 			type="Land_Cargo_Patrol_V4_F";
 			atlOffset=-3.8146973e-006;
 		};
-		class Item843
+		class Item842
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19427,7 +21389,7 @@ class Mission
 			type="Land_Cargo_Patrol_V4_F";
 			atlOffset=-1.9073486e-006;
 		};
-		class Item844
+		class Item843
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19443,7 +21405,7 @@ class Mission
 			id=8849;
 			type="Land_Cargo_Patrol_V4_F";
 		};
-		class Item845
+		class Item844
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19460,7 +21422,7 @@ class Mission
 			type="Land_Cargo_Patrol_V4_F";
 			atlOffset=-1.9073486e-006;
 		};
-		class Item846
+		class Item845
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -19516,7 +21478,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item847
+		class Item846
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -19571,7 +21533,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item848
+		class Item847
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19587,7 +21549,7 @@ class Mission
 			id=8856;
 			type="Flag_NATO_F";
 		};
-		class Item849
+		class Item848
 		{
 			dataType="Marker";
 			position[]={9722.457,17.32926,5923.7598};
@@ -19595,7 +21557,7 @@ class Mission
 			type="flag_CTRG";
 			id=8857;
 		};
-		class Item850
+		class Item849
 		{
 			dataType="Group";
 			side="West";
@@ -20060,7 +22022,7 @@ class Mission
 			};
 			id=8858;
 		};
-		class Item851
+		class Item850
 		{
 			dataType="Marker";
 			position[]={9999.6533,17.973528,2235.1763};
@@ -20068,7 +22030,7 @@ class Mission
 			type="flag_Viper";
 			id=8865;
 		};
-		class Item852
+		class Item851
 		{
 			dataType="Group";
 			side="East";
@@ -20525,7 +22487,7 @@ class Mission
 			};
 			id=8866;
 		};
-		class Item853
+		class Item852
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20542,7 +22504,7 @@ class Mission
 			id=8873;
 			type="Flag_Viper_F";
 		};
-		class Item854
+		class Item853
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20556,7 +22518,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=0.14967728;
 		};
-		class Item855
+		class Item854
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20570,7 +22532,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=0.13149166;
 		};
-		class Item856
+		class Item855
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20584,7 +22546,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=0.12053108;
 		};
-		class Item857
+		class Item856
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20641,7 +22603,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item858
+		class Item857
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20696,7 +22658,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item859
+		class Item858
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20750,7 +22712,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item860
+		class Item859
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20807,7 +22769,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item861
+		class Item860
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20864,7 +22826,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item862
+		class Item861
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20921,7 +22883,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item863
+		class Item862
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20977,7 +22939,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item864
+		class Item863
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -21034,7 +22996,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item865
+		class Item864
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -21089,7 +23051,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item866
+		class Item865
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -21144,7 +23106,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item867
+		class Item866
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -21201,23 +23163,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item868
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={5951.0664,197.53584,10352.195};
-				angles[]={0.004796607,3.7571216,6.2543945};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=9000;
-			type="Land_GarbageHeap_03_F";
-		};
-		class Item869
+		class Item867
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21233,7 +23179,7 @@ class Mission
 			id=9001;
 			type="Land_GarbageHeap_03_F";
 		};
-		class Item870
+		class Item868
 		{
 			dataType="Marker";
 			position[]={5037.6235,59.503517,3738.2615};
@@ -21241,7 +23187,7 @@ class Mission
 			type="mil_circle";
 			id=9014;
 		};
-		class Item871
+		class Item869
 		{
 			dataType="Marker";
 			position[]={3785.9294,68.754272,4934.2417};
@@ -21249,7 +23195,7 @@ class Mission
 			type="mil_circle";
 			id=9015;
 		};
-		class Item872
+		class Item870
 		{
 			dataType="Marker";
 			position[]={4057.447,369.1442,6326.9438};
@@ -21257,7 +23203,7 @@ class Mission
 			type="mil_circle";
 			id=9016;
 		};
-		class Item873
+		class Item871
 		{
 			dataType="Marker";
 			position[]={7074.5698,96.740334,6751.6738};
@@ -21265,63 +23211,14 @@ class Mission
 			type="mil_circle";
 			id=9017;
 		};
-		class Item874
+		class Item872
 		{
 			dataType="Layer";
 			name="Check Point (Large)";
 			id=9037;
 			atlOffset=96.5;
 		};
-		class Item875
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={6009.2451,195.32214,10373.922};
-				angles[]={6.232029,3.809119,6.2328267};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=9039;
-			type="MetalBarrel_burning_F";
-			atlOffset=-0.00045776367;
-		};
-		class Item876
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={5997.0967,195.00629,10345.985};
-				angles[]={6.2168822,0.53670949,6.2073317};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=9045;
-			type="Land_ScrapHeap_2_F";
-		};
-		class Item877
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={5998.1821,195.75606,10353.575};
-				angles[]={6.2192731,6.1168904,6.2200685};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=9053;
-			type="Land_RepairDepot_01_tan_ruins_F";
-		};
-		class Item878
+		class Item873
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21337,7 +23234,7 @@ class Mission
 			id=9054;
 			type="Land_CargoBox_V1_F";
 		};
-		class Item879
+		class Item874
 		{
 			dataType="Object";
 			class PositionInfo
@@ -21353,21 +23250,289 @@ class Mission
 			id=9055;
 			type="Land_CargoBox_V1_F";
 		};
-		class Item880
+		class Item875
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={5702.4399,353.96194,5590.5493};
+				angles[]={6.2559919,5.6484075,6.2480001};
+			};
+			areaSize[]={66.759079,0,68.79084};
+			areaIsRectangle=1;
+			flags=1;
+			id=9304;
+			type="ModuleHideTerrainObjects_F";
+			atlOffset=0.17486572;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="#filter";
+					expression="_this setVariable [""#filter"",_value]";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"SCALAR"
+								};
+							};
+							value=15;
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="#hideLocally";
+					expression="_this setVariable [""#hideLocally"",_value]";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=2;
+			};
+		};
+		class Item876
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={6008.4395,195.3168,10373.016};
-				angles[]={6.232029,3.809119,6.2328267};
+				position[]={5715.437,354.92816,5618.0518};
+				angles[]={6.1930323,2.5320601,6.2360172};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
 			};
-			id=9058;
+			id=9307;
 			type="MetalBarrel_burning_F";
+		};
+		class Item877
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5672.1104,355.61887,5565.5259};
+				angles[]={0.02399601,2.4181087,6.269588};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=9308;
+			type="Land_ScrapHeap_2_F";
+		};
+		class Item878
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5679.0054,355.87122,5562.1724};
+				angles[]={0.067895547,1.7151043,6.2424073};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=9309;
+			type="Land_RepairDepot_01_tan_ruins_F";
+		};
+		class Item879
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5670.75,355.30945,5571.1279};
+				angles[]={0.02399601,5.7506552,6.269588};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=9310;
+			type="Land_CargoBox_V1_F";
+			atlOffset=-0.0038757324;
+		};
+		class Item880
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5669.1392,355.35379,5570.1929};
+				angles[]={0.02399601,1.057883,6.269588};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=9311;
+			type="Land_CargoBox_V1_F";
+			atlOffset=-0.00390625;
+		};
+		class Item881
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5695.0483,356.74982,5622.4219};
+				angles[]={6.1985884,2.4783676,6.2607903};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=9326;
+			type="Land_Tank_rust_F";
+		};
+		class Item882
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5734.249,355.9512,5602.6611};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+			};
+			id=9333;
+			type="Land_Loudspeakers_F";
+		};
+		class Item883
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5696.0122,358.03336,5611.3789};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+			};
+			id=9334;
+			type="Land_Loudspeakers_F";
+			atlOffset=0.0095214844;
+		};
+		class Item884
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5697.5137,355.23413,5609.6582};
+				angles[]={6.2583904,2.4434609,6.2559919};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=9335;
+			type="Land_PowerGenerator_F";
+			atlOffset=0.0014343262;
+		};
+		class Item885
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5735.5708,352.82101,5597.6392};
+				angles[]={0,0.94247776,0};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=9337;
+			type="Land_Cargo_House_V1_F";
+			atlOffset=-3.0517578e-005;
+		};
+		class Item886
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5936.7939,200.38014,10373.309};
+				angles[]={0,2.2414045,0};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+			};
+			id=9341;
+			type="Land_Cargo_HQ_V1_F";
+		};
+		class Item887
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5996.1572,195.42865,10351.089};
+				angles[]={0,2.2468913,0};
+			};
+			side="Empty";
+			flags=1;
+			class Attributes
+			{
+			};
+			id=9344;
+			type="Land_Cargo_House_V1_F";
+			atlOffset=0.26083374;
+		};
+		class Item888
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={6000.4858,197.90337,10354.816};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+			};
+			id=9345;
+			type="Land_Loudspeakers_F";
+		};
+		class Item889
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5994.8301,195.5358,10344.775};
+				angles[]={6.2168822,0.67172641,6.2073317};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=9350;
+			type="Land_Cargo10_red_F";
 		};
 	};
 	class Connections

--- a/Map-Templates/Antistasi-Malden.Malden/mission.sqm
+++ b/Map-Templates/Antistasi-Malden.Malden/mission.sqm
@@ -16,14 +16,14 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=1844;
+		nextID=1902;
 	};
 	class Camera
 	{
-		pos[]={6067.1865,218.81451,10357.297};
-		dir[]={-0.84627956,-0.41712481,0.33140767};
-		up[]={-0.38841161,0.90884686,0.1521045};
-		aside[]={0.36464566,5.2968971e-008,0.9311561};
+		pos[]={7074.5698,121.74033,6726.6738};
+		dir[]={-0.58197796,-0.052415621,0.81152713};
+		up[]={-0.03055325,0.99862641,0.042605102};
+		aside[]={0.81264609,-1.6175909e-007,0.58277982};
 	};
 };
 binarizationWanted=0;
@@ -217,20 +217,28 @@ class AddonsMetaData
 	};
 };
 randomSeed=13388897;
+class ScenarioData
+{
+	author="Dad";
+};
 class Mission
 {
 	class Intel
 	{
-		briefingName=$STR_antistasi_mission_info_malden_mapname_text;
 		resistanceWest=0;
+		startWind=0.1;
+		forecastWind=0.1;
+		forecastWaves=0.1;
 		year=2035;
 		month=6;
 		hour=10;
 		minute=0;
+		startFogDecay=0.0049333;
+		forecastFogDecay=0.0049333;
 	};
 	class Entities
 	{
-		items=890;
+		items=886;
 		class Item0
 		{
 			dataType="Marker";
@@ -16141,7 +16149,7 @@ class Mission
 					colorName="ColorGreen";
 					a=62.826801;
 					b=55.433304;
-					angle=232.00449;
+					angle=232.00447;
 					id=183;
 					atlOffset=10328.511;
 				};
@@ -16277,7 +16285,7 @@ class Mission
 					colorName="ColorGreen";
 					a=62.826801;
 					b=55.433304;
-					angle=217.26146;
+					angle=217.26143;
 					id=9351;
 					atlOffset=10552.287;
 				};
@@ -23181,44 +23189,12 @@ class Mission
 		};
 		class Item868
 		{
-			dataType="Marker";
-			position[]={5037.6235,59.503517,3738.2615};
-			name="marker_35";
-			type="mil_circle";
-			id=9014;
-		};
-		class Item869
-		{
-			dataType="Marker";
-			position[]={3785.9294,68.754272,4934.2417};
-			name="marker_36";
-			type="mil_circle";
-			id=9015;
-		};
-		class Item870
-		{
-			dataType="Marker";
-			position[]={4057.447,369.1442,6326.9438};
-			name="marker_37";
-			type="mil_circle";
-			id=9016;
-		};
-		class Item871
-		{
-			dataType="Marker";
-			position[]={7074.5698,96.740334,6751.6738};
-			name="marker_38";
-			type="mil_circle";
-			id=9017;
-		};
-		class Item872
-		{
 			dataType="Layer";
 			name="Check Point (Large)";
 			id=9037;
 			atlOffset=96.5;
 		};
-		class Item873
+		class Item869
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23234,7 +23210,7 @@ class Mission
 			id=9054;
 			type="Land_CargoBox_V1_F";
 		};
-		class Item874
+		class Item870
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23250,7 +23226,7 @@ class Mission
 			id=9055;
 			type="Land_CargoBox_V1_F";
 		};
-		class Item875
+		class Item871
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -23307,7 +23283,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item876
+		class Item872
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23323,7 +23299,7 @@ class Mission
 			id=9307;
 			type="MetalBarrel_burning_F";
 		};
-		class Item877
+		class Item873
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23339,7 +23315,7 @@ class Mission
 			id=9308;
 			type="Land_ScrapHeap_2_F";
 		};
-		class Item878
+		class Item874
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23355,7 +23331,7 @@ class Mission
 			id=9309;
 			type="Land_RepairDepot_01_tan_ruins_F";
 		};
-		class Item879
+		class Item875
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23372,7 +23348,7 @@ class Mission
 			type="Land_CargoBox_V1_F";
 			atlOffset=-0.0038757324;
 		};
-		class Item880
+		class Item876
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23389,7 +23365,7 @@ class Mission
 			type="Land_CargoBox_V1_F";
 			atlOffset=-0.00390625;
 		};
-		class Item881
+		class Item877
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23405,7 +23381,7 @@ class Mission
 			id=9326;
 			type="Land_Tank_rust_F";
 		};
-		class Item882
+		class Item878
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23420,7 +23396,7 @@ class Mission
 			id=9333;
 			type="Land_Loudspeakers_F";
 		};
-		class Item883
+		class Item879
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23436,7 +23412,7 @@ class Mission
 			type="Land_Loudspeakers_F";
 			atlOffset=0.0095214844;
 		};
-		class Item884
+		class Item880
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23453,7 +23429,7 @@ class Mission
 			type="Land_PowerGenerator_F";
 			atlOffset=0.0014343262;
 		};
-		class Item885
+		class Item881
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23470,7 +23446,7 @@ class Mission
 			type="Land_Cargo_House_V1_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item886
+		class Item882
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23486,7 +23462,7 @@ class Mission
 			id=9341;
 			type="Land_Cargo_HQ_V1_F";
 		};
-		class Item887
+		class Item883
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23503,7 +23479,7 @@ class Mission
 			type="Land_Cargo_House_V1_F";
 			atlOffset=0.26083374;
 		};
-		class Item888
+		class Item884
 		{
 			dataType="Object";
 			class PositionInfo
@@ -23518,7 +23494,7 @@ class Mission
 			id=9345;
 			type="Land_Loudspeakers_F";
 		};
-		class Item889
+		class Item885
 		{
 			dataType="Object";
 			class PositionInfo

--- a/Map-Templates/Antistasi-Malden.Malden/mission.sqm
+++ b/Map-Templates/Antistasi-Malden.Malden/mission.sqm
@@ -5,10 +5,10 @@ class EditorData
 	angleGridStep=0.2617994;
 	scaleGridStep=1;
 	autoGroupingDist=10;
-	toggles=1030;
+	toggles=1029;
 	class ItemIDProvider
 	{
-		nextID=8889;
+		nextID=9014;
 	};
 	class MarkerIDProvider
 	{
@@ -16,14 +16,14 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=1382;
+		nextID=1439;
 	};
 	class Camera
 	{
-		pos[]={3029.6587,29.031927,8463.7686};
-		dir[]={0.7241295,-0.67149013,-0.15732601};
-		up[]={0.65618867,0.74101174,-0.14256525};
-		aside[]={-0.21231113,-1.9133586e-007,-0.97721249};
+		pos[]={6011.4937,214.68979,10347.634};
+		dir[]={-0.87181216,-0.48838425,-0.040808197};
+		up[]={-0.48793665,0.87247401,-0.022845829};
+		aside[]={-0.046772361,-4.8073889e-007,0.99897295};
 	};
 };
 binarizationWanted=0;
@@ -70,13 +70,14 @@ addons[]=
 	"A3_Weapons_F",
 	"A3_Ui_F_Exp",
 	"A3_Characters_F_Exp",
-	"A3_Structures_F_Exp_Military_Flags"
+	"A3_Structures_F_Exp_Military_Flags",
+	"A3_Props_F_Exp_Civilian_Garbage"
 };
 class AddonsMetaData
 {
 	class List
 	{
-		items=17;
+		items=18;
 		class Item0
 		{
 			className="A3_Ui_F";
@@ -196,6 +197,13 @@ class AddonsMetaData
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
+		class Item17
+		{
+			className="A3_Props_F_Exp";
+			name="Arma 3 Apex - Decorative and Mission Objects";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
 	};
 };
 randomSeed=13388897;
@@ -212,7 +220,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=868;
+		items=871;
 		class Item0
 		{
 			dataType="Marker";
@@ -7648,7 +7656,7 @@ class Mission
 			name="Landing Zone";
 			class Entities
 			{
-				items=51;
+				items=52;
 				class Item0
 				{
 					dataType="Object";
@@ -8573,8 +8581,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5666.7402,360.34012,5616.7847};
-						angles[]={0,2.3030751,0};
+						position[]={5933.0063,198.57759,10405.604};
+						angles[]={0,2.9453621,0};
 					};
 					side="Empty";
 					flags=5;
@@ -8582,17 +8590,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7890;
+					id=8889;
 					type="Land_Cargo_Patrol_V1_F";
-					atlOffset=3.0517578e-005;
 				};
 				class Item50
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5732.6416,357.11926,5550.7334};
-						angles[]={0,5.4741454,0};
+						position[]={5934.75,203.2403,10321.125};
+						angles[]={0,0.63872468,0};
 					};
 					side="Empty";
 					flags=5;
@@ -8600,12 +8607,29 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7891;
+					id=8890;
+					type="Land_Cargo_Patrol_V1_F";
+				};
+				class Item51
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5978.875,200.67189,10350.5};
+						angles[]={0,5.3990045,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9011;
 					type="Land_Cargo_Patrol_V1_F";
 				};
 			};
 			id=3700;
-			atlOffset=-10.067444;
+			atlOffset=38.106186;
 		};
 		class Item454
 		{
@@ -8851,14 +8875,14 @@ class Mission
 			name="Command Centre";
 			class Entities
 			{
-				items=107;
+				items=112;
 				class Item0
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5660.5327,357.87314,5553.7852};
-						angles[]={0,4.712389,0};
+						position[]={5890.2974,197.58372,10359.252};
+						angles[]={0,5.3546762,0};
 					};
 					side="Empty";
 					flags=5;
@@ -8866,447 +8890,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7762;
+					id=8891;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.12460327;
 				};
 				class Item1
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5660.5327,359.29453,5547.7852};
-						angles[]={0,4.712389,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7763;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.12945557;
-				};
-				class Item2
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5660.5327,356.43808,5559.7852};
-						angles[]={0,4.712389,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7764;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.15838623;
-				};
-				class Item3
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5663.6577,359.63678,5544.9106};
-						angles[]={0,3.1415927,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7765;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.050231934;
-				};
-				class Item4
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5663.6577,355.63287,5562.9106};
-						angles[]={0,3.1415927,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7766;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.015991211;
-				};
-				class Item5
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5660.5327,355.34369,5577.7852};
-						angles[]={0,4.712389,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7767;
-					type="Land_Wall_IndCnc_4_F";
-				};
-				class Item6
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5660.5327,355.53168,5589.7852};
-						angles[]={0,4.712389,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7768;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=6.1035156e-005;
-				};
-				class Item7
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5660.5327,355.74692,5565.7852};
-						angles[]={0,4.712389,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7769;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.21279907;
-				};
-				class Item8
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5660.5327,355.60849,5595.7852};
-						angles[]={0,4.712389,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7770;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=6.1035156e-005;
-				};
-				class Item9
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5660.5327,355.43491,5583.7852};
-						angles[]={0,4.712389,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7771;
-					type="Land_Wall_IndCnc_4_F";
-				};
-				class Item10
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5660.0952,355.35336,5571.7939};
-						angles[]={0,4.712389,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7772;
-					type="Land_Wall_IndCnc_4_D_F";
-				};
-				class Item11
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5660.5327,355.77921,5607.7852};
-						angles[]={0,4.712389,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7774;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
-				};
-				class Item12
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5660.5327,356.40292,5619.7852};
-						angles[]={0,4.712389,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7775;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
-				};
-				class Item13
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5660.5327,355.94751,5613.7852};
-						angles[]={0,4.712389,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7776;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
-				};
-				class Item14
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5660.5327,355.68811,5601.7852};
-						angles[]={0,4.712389,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7777;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
-				};
-				class Item15
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5663.6577,355.64755,5598.9106};
-						angles[]={0,3.1415927,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7778;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
-				};
-				class Item16
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5663.4072,356.64963,5622.9102};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7779;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
-				};
-				class Item17
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5661.501,361.8172,5621.75};
-						angles[]={0,4.1887903,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7780;
-					type="Land_LampHalogen_F";
-					atlOffset=3.0517578e-005;
-				};
-				class Item18
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5690.0986,355.51215,5561.4287};
-						angles[]={0.071078755,3.1415927,6.2408099};
-					};
-					side="Empty";
-					flags=4;
-					class Attributes
-					{
-						skill=0.2;
-						createAsSimpleObject=1;
-						disableSimulation=1;
-					};
-					id=7782;
-					type="Land_Cargo40_yellow_F";
-					atlOffset=-0.0068359375;
-				};
-				class Item19
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5675.6577,357.61789,5544.9106};
-						angles[]={0,3.1415927,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7783;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
-				};
-				class Item20
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5693.6577,356.20917,5544.9106};
-						angles[]={0,3.1415927,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7784;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
-				};
-				class Item21
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5669.6577,358.66437,5544.9106};
-						angles[]={0,3.1415927,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7785;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
-				};
-				class Item22
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5681.6577,356.78302,5544.9106};
-						angles[]={0,3.1415927,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7786;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
-				};
-				class Item23
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5687.6577,356.44043,5544.9106};
-						angles[]={0,3.1415927,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7788;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
-				};
-				class Item24
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5668.1255,360.7196,5554.5};
-						angles[]={0,5.497787,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7789;
-					type="Land_dp_smallTank_F";
-					atlOffset=0.033294678;
-				};
-				class Item25
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5692.3755,356.70471,5557.5};
-						angles[]={0,3.1402836,0};
+						position[]={5886.7036,198.76993,10354.447};
+						angles[]={0,5.3546762,0};
 					};
 					side="Empty";
 					flags=1;
@@ -9314,53 +8907,470 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7790;
+					id=8892;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.70245361;
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5893.8916,197.16165,10364.056};
+						angles[]={0,5.3546762,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8893;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5887.4839,199.25839,10350.273};
+						angles[]={0,3.7838798,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8894;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.7232666;
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5904.6743,195.79025,10378.469};
+						angles[]={0,5.3546762,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8896;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5911.8628,195.03987,10388.078};
+						angles[]={0,5.3546762,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8897;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item6
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5897.4858,196.68085,10368.86};
+						angles[]={0,5.3546762,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8898;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item7
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5915.4565,194.64827,10392.882};
+						angles[]={0,5.3546762,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8899;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item8
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5908.2686,195.37106,10383.273};
+						angles[]={0,5.3546762,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8900;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item9
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5900.7349,196.19188,10373.934};
+						angles[]={0,5.3546762,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8901;
+					type="Land_Wall_IndCnc_4_D_F";
+				};
+				class Item10
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5922.645,194.44234,10402.491};
+						angles[]={0,5.3546762,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8902;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.37631226;
+				};
+				class Item11
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5929.8813,194.56424,10412.104};
+						angles[]={0,5.3546762,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8903;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.90168762;
+				};
+				class Item12
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5926.2393,194.67432,10407.295};
+						angles[]={0,5.3546762,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8904;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.8110199;
+				};
+				class Item13
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5919.0508,194.35445,10397.687};
+						angles[]={0,5.3546762,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8905;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.023422241;
+				};
+				class Item14
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5919.8315,194.79082,10393.513};
+						angles[]={0,3.7838798,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8906;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item15
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5934,194.72498,10412.875};
+						angles[]={0,0.64228714,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8907;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.86175537;
+				};
+				class Item16
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5931.7856,200.44884,10413.093};
+						angles[]={0,4.8310776,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8908;
+					type="Land_LampHalogen_F";
+					atlOffset=1.510437;
+				};
+				class Item17
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5914.4375,195.92729,10386.659};
+						angles[]={0.097292177,5.3206806,0.04556872};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+						createAsSimpleObject=1;
+						disableSimulation=1;
+					};
+					id=8909;
+					type="Land_Cargo40_yellow_F";
+					atlOffset=-0.0090789795;
+				};
+				class Item18
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5897.0928,199.24039,10343.086};
+						angles[]={0,3.7838798,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8910;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item19
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5911.5059,199.89816,10332.303};
+						angles[]={0,3.7838798,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8911;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item20
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5892.2886,198.89047,10346.68};
+						angles[]={0,3.7838798,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8912;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item21
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5901.897,199.53871,10339.491};
+						angles[]={0,3.7838798,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8913;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item22
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5906.7017,199.73357,10335.897};
+						angles[]={0,3.7838798,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8914;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item23
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5950.75,200.42528,10391.25};
+						angles[]={0,6.1400743,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8915;
+					type="Land_dp_smallTank_F";
+				};
+				class Item24
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5952.125,199.28996,10330.125};
+						angles[]={0,2.2178783,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8916;
 					type="Land_i_Shed_Ind_F";
-					atlOffset=0.79580688;
+					atlOffset=0.79508972;
+				};
+				class Item25
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5955.5,197.72966,10358.75};
+						angles[]={6.2639894,2.0166829,6.2783766};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8917;
+					type="Land_Wreck_HMMWV_F";
 				};
 				class Item26
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5679.7393,355.19565,5582.6465};
-						angles[]={6.2663875,5.6900353,6.2408113};
+						position[]={5923.625,198.15701,10341.875};
+						angles[]={0,3.7165687,0};
 					};
 					side="Empty";
-					flags=4;
+					flags=5;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7791;
-					type="Land_Wreck_HMMWV_F";
-					atlOffset=3.0517578e-005;
+					id=8918;
+					type="Land_i_Barracks_V1_F";
 				};
 				class Item27
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5670.5005,354.552,5579};
-						angles[]={0,4.712389,0};
+						position[]={5949.75,196.58664,10382};
+						angles[]={0.058334891,0.64228714,0.032787289};
 					};
 					side="Empty";
-					flags=5;
+					flags=4;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7792;
-					type="Land_i_Barracks_V1_F";
-					atlOffset=3.0517578e-005;
+					id=8919;
+					type="Land_GarbageBags_F";
 				};
 				class Item28
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5679.6196,354.86752,5585.8857};
-						angles[]={6.2607903,0,6.2464013};
+						position[]={5952.5894,197.5585,10336.183};
+						angles[]={6.2663875,2.2130835,6.232029};
 					};
 					side="Empty";
 					flags=4;
@@ -9368,17 +9378,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7793;
-					type="Land_GarbageBags_F";
-					atlOffset=6.1035156e-005;
+					id=8920;
+					type="Land_PaperBox_closed_F";
 				};
 				class Item29
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5676.4907,355.18573,5567.7778};
-						angles[]={0.02399601,1.5707964,6.2424073};
+						position[]={5946.125,197.69038,10309.875};
+						angles[]={6.271987,1.3845687,6.186687};
 					};
 					side="Empty";
 					flags=4;
@@ -9386,17 +9395,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7794;
-					type="Land_PaperBox_closed_F";
-					atlOffset=3.0517578e-005;
+					id=8921;
+					type="Land_JunkPile_F";
 				};
 				class Item30
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5677.1211,354.72171,5570.6855};
-						angles[]={0.02399601,0.7422815,6.2424073};
+						position[]={5951.625,197.57216,10334.875};
+						angles[]={0.0055992967,2.2130835,6.2097178};
 					};
 					side="Empty";
 					flags=4;
@@ -9404,34 +9412,34 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7795;
-					type="Land_JunkPile_F";
-					atlOffset=3.0517578e-005;
+					id=8922;
+					type="Land_PaperBox_open_empty_F";
 				};
 				class Item31
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5676.502,355.18808,5566.1538};
-						angles[]={0.02399601,1.5707964,6.2424073};
+						position[]={5965.875,200.41508,10369.625};
+						angles[]={0,0.65157181,0};
 					};
 					side="Empty";
-					flags=4;
+					flags=1;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7797;
-					type="Land_PaperBox_open_empty_F";
-					atlOffset=3.0517578e-005;
+					id=8923;
+					type="Land_MilOffices_V1_F";
+					atlOffset=0.39929199;
 				};
 				class Item32
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5692.501,357.82565,5607};
+						position[]={5953.2246,196.15392,10398.503};
+						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
 					flags=5;
@@ -9439,32 +9447,35 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7798;
-					type="Land_MilOffices_V1_F";
-					atlOffset=0.026794434;
+					id=8924;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.13134766;
 				};
 				class Item33
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5687.4072,356.33978,5622.9102};
+						position[]={5948.4204,195.92281,10402.098};
+						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
-					flags=5;
+					flags=1;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7799;
+					id=8925;
 					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.36738586;
 				};
 				class Item34
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5681.4072,356.46936,5622.9102};
+						position[]={5958.0288,196.41612,10394.909};
+						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
 					flags=5;
@@ -9472,7 +9483,7 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7800;
+					id=8926;
 					type="Land_Wall_IndCnc_4_F";
 				};
 				class Item35
@@ -9480,41 +9491,44 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5693.4072,356.20032,5622.9102};
+						position[]={5938.7563,195.26659,10409.229};
+						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
-					flags=5;
+					flags=1;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7801;
+					id=8927;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.0049133301;
+					atlOffset=0.7855835;
 				};
 				class Item36
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5669.4072,356.62573,5622.9102};
+						position[]={5943.8882,195.68192,10405.989};
+						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
-					flags=5;
+					flags=1;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7802;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=6.1035156e-005;
+					id=8928;
+					type="Land_Wall_IndCnc_4_D_F";
+					atlOffset=0.69999695;
 				};
 				class Item37
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5675.4468,356.60931,5623.312};
+						position[]={5924.6357,195.46445,10389.919};
+						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
 					flags=5;
@@ -9522,35 +9536,34 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7803;
-					type="Land_Wall_IndCnc_4_D_F";
-					atlOffset=3.0517578e-005;
+					id=8929;
+					type="Land_Wall_IndCnc_4_F";
 				};
 				class Item38
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5669.6577,355.60916,5598.9106};
-						angles[]={0,3.1415927,0};
+						position[]={5959.8047,197.0098,10341.484};
+						angles[]={6.2623858,3.0458794,6.2543926};
 					};
 					side="Empty";
-					flags=5;
+					flags=4;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7804;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
+					id=8930;
+					type="Land_BagFence_Round_F";
+					atlOffset=-1.5258789e-005;
 				};
 				class Item39
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5705.3916,353.90317,5562.3062};
-						angles[]={0.071081273,3.9269907,6.2424073};
+						position[]={5935.125,197.63213,10357.875};
+						angles[]={0.027990974,6.1628256,6.277586};
 					};
 					side="Empty";
 					flags=4;
@@ -9558,17 +9571,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7805;
+					id=8931;
 					type="Land_BagFence_Round_F";
-					atlOffset=3.0517578e-005;
 				};
 				class Item40
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5733.6479,351.68253,5573.6523};
-						angles[]={0.0048090173,5.537209,6.1882734};
+						position[]={5923.5049,197.23192,10366.347};
+						angles[]={0.07346756,0.68170887,0.029591488};
 					};
 					side="Empty";
 					flags=4;
@@ -9576,17 +9588,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7806;
-					type="Land_BagFence_Round_F";
-					atlOffset=3.0517578e-005;
+					id=8932;
+					type="Land_BagFence_Long_F";
 				};
 				class Item41
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5716,353.15912,5573.75};
-						angles[]={0.015199739,0.039421737,6.2121043};
+						position[]={5962.1328,196.91966,10340.375};
+						angles[]={6.2623858,0.68968511,6.2543926};
 					};
 					side="Empty";
 					flags=4;
@@ -9594,16 +9605,17 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7807;
+					id=8933;
 					type="Land_BagFence_Long_F";
+					atlOffset=-1.5258789e-005;
 				};
 				class Item42
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5706.0166,354.05588,5559.8032};
-						angles[]={0.071081273,1.5707964,6.2424073};
+						position[]={5964.2534,196.75348,10338.625};
+						angles[]={6.2623887,0.68968511,6.215291};
 					};
 					side="Empty";
 					flags=4;
@@ -9611,17 +9623,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7808;
+					id=8934;
 					type="Land_BagFence_Long_F";
-					atlOffset=3.0517578e-005;
 				};
 				class Item43
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5706.0166,354.25171,5557.0532};
-						angles[]={0.071081273,1.5707964,6.2424073};
+						position[]={5937.144,197.5771,10359.437};
+						angles[]={0.027990974,5.3774276,6.277586};
 					};
 					side="Empty";
 					flags=4;
@@ -9629,17 +9640,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7809;
+					id=8935;
 					type="Land_BagFence_Long_F";
-					atlOffset=3.0517578e-005;
 				};
 				class Item44
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5734.3701,351.65726,5576.1006};
-						angles[]={6.2424059,4.751811,6.1882734};
+						position[]={5966.375,196.56079,10336.875};
+						angles[]={6.2432065,0.68968511,6.215291};
 					};
 					side="Empty";
 					flags=4;
@@ -9647,17 +9657,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7810;
+					id=8936;
 					type="Land_BagFence_Long_F";
-					atlOffset=0.005065918;
 				};
 				class Item45
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5706.0166,354.44751,5554.3032};
-						angles[]={0.071078755,1.5707964,6.2424107};
+						position[]={5957.7388,197.08916,10339.957};
+						angles[]={0.0016194459,2.2604814,6.232029};
 					};
 					side="Empty";
 					flags=4;
@@ -9665,17 +9674,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7811;
+					id=8937;
 					type="Land_BagFence_Long_F";
-					atlOffset=3.0517578e-005;
 				};
 				class Item46
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5702.8994,353.98181,5562.9277};
-						angles[]={0.021595482,3.1415927,6.2424073};
+						position[]={5932.7705,197.61591,10358.925};
+						angles[]={0.027990974,3.8066308,6.277586};
 					};
 					side="Empty";
 					flags=4;
@@ -9683,34 +9691,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7812;
+					id=8938;
 					type="Land_BagFence_Long_F";
-					atlOffset=3.0517578e-005;
 				};
 				class Item47
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5731.125,351.92523,5573.125};
-						angles[]={0.0048090173,3.1810145,6.1882734};
-					};
-					side="Empty";
-					flags=4;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7813;
-					type="Land_BagFence_Long_F";
-				};
-				class Item48
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5723.75,352.53342,5584.25};
-						angles[]={0,4.7326784,0};
+						position[]={5933.125,196.63809,10369.5};
+						angles[]={0.05115639,5.3968663,0.016798066};
 					};
 					side="Empty";
 					flags=4;
@@ -9719,16 +9709,33 @@ class Mission
 						skill=0.2;
 						disableSimulation=1;
 					};
-					id=7814;
+					id=8939;
 					type="Land_HelipadSquare_F";
+				};
+				class Item48
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5930.7231,199.43848,10317.927};
+						angles[]={0,3.7838798,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8940;
+					type="Land_Wall_IndCnc_4_F";
 				};
 				class Item49
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5717.6577,354.73694,5544.9106};
-						angles[]={0,3.1415927,0};
+						position[]={5935.5278,199.12103,10314.332};
+						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
 					flags=5;
@@ -9736,17 +9743,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7815;
+					id=8941;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
 				};
 				class Item50
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5723.6577,354.28091,5544.9106};
-						angles[]={0,3.1415927,0};
+						position[]={5921.1147,199.9173,10325.114};
+						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
 					flags=5;
@@ -9754,17 +9760,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7816;
+					id=8942;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
 				};
 				class Item51
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5705.6577,355.7338,5544.9106};
-						angles[]={0,3.1415927,0};
+						position[]={5940.332,198.71111,10310.738};
+						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
 					flags=5;
@@ -9772,17 +9777,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7817;
+					id=8943;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=6.1035156e-005;
 				};
 				class Item52
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5729.6577,353.61996,5544.9106};
-						angles[]={0,3.1415927,0};
+						position[]={5916.3101,199.92563,10328.709};
+						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
 					flags=5;
@@ -9790,17 +9794,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7818;
+					id=8944;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
 				};
 				class Item53
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5699.6577,355.97397,5544.9106};
-						angles[]={0,3.1415927,0};
+						position[]={5925.6753,199.77193,10321.181};
+						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
 					flags=5;
@@ -9808,35 +9811,34 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7819;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
+					id=8945;
+					type="Land_Wall_IndCnc_4_D_F";
 				};
 				class Item54
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5711.666,355.52176,5544.4932};
-						angles[]={0,3.1415927,0};
+						position[]={5907.2427,200.07396,10337.736};
+						angles[]={0.088568218,3.734885,6.2623887};
 					};
 					side="Empty";
-					flags=5;
+					flags=4;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7820;
-					type="Land_Wall_IndCnc_4_D_F";
-					atlOffset=6.1035156e-005;
+					id=8946;
+					type="Land_FieldToilet_F";
+					atlOffset=-0.0094909668;
 				};
 				class Item55
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5708.5474,355.76755,5547.5825};
-						angles[]={0.12888117,3.1416101,6.2424107};
+						position[]={5906.1177,200.03078,10338.486};
+						angles[]={0.088568218,3.8294125,6.2623887};
 					};
 					side="Empty";
 					flags=4;
@@ -9844,35 +9846,17 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7821;
+					id=8947;
 					type="Land_FieldToilet_F";
-					atlOffset=-0.0083007813;
+					atlOffset=-0.009475708;
 				};
 				class Item56
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5710.4224,355.69104,5547.5825};
-						angles[]={0.12888117,3.4033921,6.2424107};
-					};
-					side="Empty";
-					flags=4;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7822;
-					type="Land_FieldToilet_F";
-					atlOffset=-0.0083312988;
-				};
-				class Item57
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5704.375,360.93454,5545.75};
-						angles[]={0,1.5707964,0};
+						position[]={5992.5,201.49817,10367.5};
+						angles[]={0,6.261982,0};
 					};
 					side="Empty";
 					flags=5;
@@ -9880,17 +9864,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7823;
+					id=8948;
 					type="Land_LampHalogen_F";
-					atlOffset=6.1035156e-005;
 				};
-				class Item58
+				class Item57
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5705.771,354.98596,5547.0293};
-						angles[]={0.12888117,0,6.2424107};
+						position[]={5910.125,199.19531,10335.875};
+						angles[]={0.07346756,0.64228714,6.2623887};
 					};
 					side="Empty";
 					flags=4;
@@ -9898,17 +9881,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7824;
+					id=8949;
 					type="Land_GarbagePallet_F";
-					atlOffset=6.1035156e-005;
 				};
-				class Item59
+				class Item58
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5706.8013,354.92633,5589.3452};
-						angles[]={6.2559919,4.712389,6.2480001};
+						position[]={5947.2148,196.36699,10397.973};
+						angles[]={0.061521512,2.2360301,0.05115639};
 					};
 					side="Empty";
 					flags=4;
@@ -9918,16 +9900,34 @@ class Mission
 						createAsSimpleObject=1;
 						disableSimulation=1;
 					};
-					id=7825;
+					id=8950;
 					type="Land_Cargo20_cyan_F";
-					atlOffset=-9.1552734e-005;
+					atlOffset=-0.013839722;
+				};
+				class Item59
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5956.2681,197.68466,10362.507};
+						angles[]={0,0.64228714,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8951;
+					type="Land_Wall_IndCnc_4_F";
 				};
 				class Item60
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5711.4072,354.39612,5595.9102};
+						position[]={5970.6812,197.02922,10351.725};
+						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
 					flags=5;
@@ -9935,16 +9935,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7827;
+					id=8952;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.0071105957;
 				};
 				class Item61
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5729.4072,353.27722,5595.9102};
+						position[]={5965.877,197.34419,10355.318};
+						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
 					flags=5;
@@ -9952,16 +9952,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7828;
+					id=8953;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.011138916;
 				};
 				class Item62
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5723.4072,353.74918,5595.9102};
+						position[]={5948.5005,197.75134,10356.922};
+						angles[]={0,5.3546762,0};
 					};
 					side="Empty";
 					flags=5;
@@ -9969,17 +9969,17 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7829;
+					id=8954;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.011138916;
+					atlOffset=-1.5258789e-005;
 				};
 				class Item63
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5708.5327,354.19293,5586.7852};
-						angles[]={0,4.712389,0};
+						position[]={5952.0947,197.69006,10361.727};
+						angles[]={0,5.3546762,0};
 					};
 					side="Empty";
 					flags=5;
@@ -9987,17 +9987,17 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7830;
+					id=8955;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
+					atlOffset=-1.5258789e-005;
 				};
 				class Item64
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5708.5327,354.36679,5592.7852};
-						angles[]={0,4.712389,0};
+						position[]={5944.9063,197.86646,10352.118};
+						angles[]={0,5.3546762,0};
 					};
 					side="Empty";
 					flags=5;
@@ -10005,7 +10005,7 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7831;
+					id=8956;
 					type="Land_Wall_IndCnc_4_F";
 				};
 				class Item65
@@ -10013,8 +10013,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5708.5327,354.01184,5580.7852};
-						angles[]={0,4.712389,0};
+						position[]={5961.0728,197.59293,10358.913};
+						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
 					flags=5;
@@ -10022,16 +10022,17 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7832;
+					id=8957;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.0013427734;
+					atlOffset=-1.5258789e-005;
 				};
 				class Item66
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5717.4072,354.07156,5595.9102};
+						position[]={5922.4722,197.38397,10372.895};
+						angles[]={0,4.8310776,0};
 					};
 					side="Empty";
 					flags=5;
@@ -10039,17 +10040,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7833;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.0071411133;
+					id=8958;
+					type="Land_PortableLight_double_F";
 				};
 				class Item67
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5711.2505,354.20041,5578.375};
-						angles[]={0,4.1887903,0};
+						position[]={5954.1709,202.93217,10363.096};
+						angles[]={0,6.1400743,0};
 					};
 					side="Empty";
 					flags=5;
@@ -10057,83 +10057,88 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7842;
-					type="Land_PortableLight_double_F";
-					atlOffset=3.0517578e-005;
+					id=8959;
+					type="Land_LampHalogen_F";
 				};
 				class Item68
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5709.3755,359.67838,5595.125};
-						angles[]={0,5.497787,0};
+						position[]={5977.2466,197.54556,10380.532};
+						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
-					flags=5;
+					flags=1;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7843;
-					type="Land_LampHalogen_F";
+					id=8960;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.48136902;
 				};
 				class Item69
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5717.4072,355.59094,5622.9102};
+						position[]={5982.0508,197.56488,10376.938};
+						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
-					flags=5;
+					flags=1;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7848;
+					id=8961;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.0030212402;
+					atlOffset=0.6363678;
 				};
 				class Item70
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5723.4072,355.33353,5622.9102};
+						position[]={5972.4419,197.40637,10384.127};
+						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
-					flags=5;
+					flags=1;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7849;
+					id=8962;
 					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.3354187;
 				};
 				class Item71
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5711.4072,355.82919,5622.9102};
+						position[]={5986.875,197.34998,10373.25};
+						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
-					flags=5;
+					flags=1;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7850;
+					id=8963;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.0030517578;
+					atlOffset=0.63569641;
 				};
 				class Item72
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5729.4072,354.98303,5622.9102};
+						position[]={5962.8335,196.79402,10391.314};
+						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
 					flags=5;
@@ -10141,16 +10146,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7851;
+					id=8964;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
 				};
 				class Item73
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5699.4072,356.061,5622.9102};
+						position[]={5967.6377,197.04179,10387.721};
+						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
 					flags=5;
@@ -10158,15 +10163,17 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7852;
+					id=8965;
 					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.080978394;
 				};
 				class Item74
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5705.4072,355.93784,5622.9102};
+						position[]={5901.125,216.61215,10356.5};
+						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
 					flags=5;
@@ -10174,70 +10181,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7853;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.0012817383;
+					id=8968;
+					type="Land_TTowerBig_1_F";
 				};
 				class Item75
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5712.1382,354.96362,5616.7402};
-						angles[]={6.1930332,5.7828341,6.2647853};
-					};
-					side="Empty";
-					flags=4;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7854;
-					type="Land_GarbageBags_F";
-					atlOffset=3.0517578e-005;
-				};
-				class Item76
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5711.2695,354.91754,5613.7354};
-						angles[]={6.1930332,1.5707964,6.2647853};
-					};
-					side="Empty";
-					flags=4;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7855;
-					type="Land_PaperBox_closed_F";
-					atlOffset=3.0517578e-005;
-				};
-				class Item77
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5725.5005,372.70749,5610.125};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7856;
-					type="Land_TTowerBig_1_F";
-					atlOffset=3.0517578e-005;
-				};
-				class Item78
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5722.9219,354.42667,5597.46};
-						angles[]={6.2432065,0,6.2288389};
+						position[]={5904.9951,197.34526,10369.95};
+						angles[]={0.11390442,3.8483632,0.021595482};
 					};
 					side="Empty";
 					flags=4;
@@ -10247,17 +10200,70 @@ class Mission
 						createAsSimpleObject=1;
 						disableSimulation=1;
 					};
-					id=7857;
+					id=8969;
 					type="Land_Cargo20_light_green_F";
-					atlOffset=-0.0020446777;
+					atlOffset=-0.023574829;
+				};
+				class Item76
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5972.25,195.87131,10329.625};
+						angles[]={6.2432065,6.1400743,6.215291};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8971;
+					type="Land_BagFence_Round_F";
+				};
+				class Item77
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5974.2417,195.80103,10331.253};
+						angles[]={6.2432065,5.3546762,6.215291};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8972;
+					type="Land_BagFence_Long_F";
+					atlOffset=1.5258789e-005;
+				};
+				class Item78
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5969.8574,196.07433,10330.633};
+						angles[]={6.2432065,3.7838798,6.215291};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8973;
+					type="Land_BagFence_Long_F";
+					atlOffset=1.5258789e-005;
 				};
 				class Item79
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5711.2686,354.76498,5612.1084};
-						angles[]={6.253592,1.5707964,6.259192};
+						position[]={5923,196.89293,10370.75};
+						angles[]={0.07346756,5.3940983,0.029591488};
 					};
 					side="Empty";
 					flags=4;
@@ -10265,88 +10271,84 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7858;
-					type="Land_PaperBox_open_empty_F";
+					id=8974;
+					type="Land_BagFence_Long_F";
 				};
 				class Item80
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5744.6768,350.80942,5559.0283};
-						angles[]={0.050355144,5.497787,6.1811419};
+						position[]={5981.8169,196.28506,10351.11};
+						angles[]={0,2.2130835,0};
 					};
 					side="Empty";
-					flags=4;
+					flags=5;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7859;
-					type="Land_BagFence_Round_F";
-					atlOffset=3.0517578e-005;
+					id=8975;
+					type="Land_Wall_IndCnc_4_F";
 				};
 				class Item81
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5745.2969,350.62015,5561.5239};
-						angles[]={0.050355144,4.712389,6.1811419};
+						position[]={5945.1362,198.2058,10307.144};
+						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
-					flags=4;
+					flags=5;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7860;
-					type="Land_BagFence_Long_F";
-					atlOffset=3.0517578e-005;
+					id=8976;
+					type="Land_Wall_IndCnc_4_F";
 				};
 				class Item82
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5742.1572,351.099,5558.4023};
-						angles[]={0.050355144,3.1415927,6.1811419};
+						position[]={5949.3101,197.81053,10307.924};
+						angles[]={0,2.2130835,0};
 					};
 					side="Empty";
-					flags=4;
+					flags=5;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7861;
-					type="Land_BagFence_Long_F";
-					atlOffset=3.0517578e-005;
+					id=8977;
+					type="Land_Wall_IndCnc_4_F";
 				};
 				class Item83
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5712.958,353.41669,5576.9736};
-						angles[]={6.2527928,4.751811,6.2121053};
+						position[]={5952.9043,197.52908,10312.729};
+						angles[]={0,2.2130835,0};
 					};
 					side="Empty";
-					flags=4;
+					flags=5;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7862;
-					type="Land_BagFence_Long_F";
-					atlOffset=-3.0517578e-005;
+					id=8978;
+					type="Land_Wall_IndCnc_4_F";
 				};
 				class Item84
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5738.5322,351.70953,5560.0356};
-						angles[]={0,1.5707964,0};
+						position[]={5947.189,203.26059,10306.813};
+						angles[]={0,1.6894847,0};
 					};
 					side="Empty";
 					flags=5;
@@ -10354,17 +10356,16 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7864;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
+					id=8979;
+					type="Land_LampHalogen_F";
 				};
 				class Item85
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5735.6577,352.94452,5544.9106};
-						angles[]={0,3.1415927,0};
+						position[]={5982.3921,201.58531,10353.602};
+						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
 					flags=5;
@@ -10372,143 +10373,308 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7865;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
+					id=8980;
+					type="Land_LampHalogen_F";
 				};
 				class Item86
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5738.5322,352.43759,5548.0356};
-						angles[]={0,1.5707964,0};
+						position[]={5921.9453,197.03343,10368.417};
+						angles[]={0.07346756,1.4671068,0.029591488};
 					};
 					side="Empty";
-					flags=5;
+					flags=4;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7866;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
+					id=8981;
+					type="Land_BagFence_Round_F";
 				};
 				class Item87
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5738.5322,352.07913,5554.0356};
-						angles[]={0,1.5707964,0};
+						position[]={5981.8613,195.55629,10342.359};
+						angles[]={6.2456031,4.5692778,6.1922369};
 					};
 					side="Empty";
-					flags=5;
+					flags=4;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7867;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
+					id=8982;
+					type="Land_BagFence_Round_F";
 				};
 				class Item88
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5737.5,357.93982,5545.875};
-						angles[]={0,1.0471976,0};
+						position[]={5980.875,195.5575,10340};
+						angles[]={6.2456031,2.2130835,6.1922369};
 					};
 					side="Empty";
-					flags=5;
+					flags=4;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7868;
-					type="Land_LampHalogen_F";
-					atlOffset=3.0517578e-005;
+					id=8983;
+					type="Land_BagFence_Long_F";
 				};
 				class Item89
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5737.5005,356.93988,5562.3755};
-						angles[]={0,3.1415927,0};
+						position[]={5980.2212,195.78136,10344.367};
+						angles[]={6.2456031,3.7838798,6.1922369};
 					};
 					side="Empty";
-					flags=5;
+					flags=4;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7869;
-					type="Land_LampHalogen_F";
-					atlOffset=3.0517578e-005;
+					id=8984;
+					type="Land_BagFence_Long_F";
 				};
 				class Item90
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5713.5112,353.32529,5574.4741};
-						angles[]={0.015199739,0.82481974,6.2121043};
+						position[]={5989,196.24777,10360.875};
+						angles[]={0,2.2130835,0};
 					};
 					side="Empty";
-					flags=4;
+					flags=5;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7870;
-					type="Land_BagFence_Round_F";
-					atlOffset=-3.0517578e-005;
+					id=8985;
+					type="Land_Wall_IndCnc_4_F";
 				};
 				class Item91
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5744.6709,350.77725,5578.2568};
-						angles[]={6.2352247,3.9269907,6.1874781};
+						position[]={5992.5,196.19618,10365.5};
+						angles[]={0,2.2130835,0};
 					};
 					side="Empty";
-					flags=4;
+					flags=5;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7871;
-					type="Land_BagFence_Round_F";
-					atlOffset=3.0517578e-005;
+					id=8986;
+					type="Land_Wall_IndCnc_4_F";
 				};
 				class Item92
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5745.2949,350.59827,5575.7759};
-						angles[]={6.2352247,1.5707964,6.1874781};
+						position[]={5985.5,196.23537,10356};
+						angles[]={0,2.2130835,0};
 					};
 					side="Empty";
-					flags=4;
+					flags=5;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7872;
-					type="Land_BagFence_Long_F";
-					atlOffset=3.0517578e-005;
+					id=8987;
+					type="Land_Wall_IndCnc_4_F";
 				};
 				class Item93
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5742.1553,351.04874,5578.8813};
-						angles[]={6.2352247,3.1415927,6.1874781};
+						position[]={5975.4858,196.66035,10348.13};
+						angles[]={0,0.64228714,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8988;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item94
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5978.4097,196.29758,10346.132};
+						angles[]={0,2.2130835,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8989;
+					type="Land_Wall_IndCnc_4_D_F";
+				};
+				class Item95
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5990.7275,196.25267,10363.021};
+						angles[]={0,2.2130835,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8990;
+					type="Land_Wall_IndCnc_Pole_F";
+				};
+				class Item96
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5976.6162,201.73994,10346.147};
+						angles[]={0,1.6894847,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8991;
+					type="Land_LampHalogen_F";
+				};
+				class Item97
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5973.25,199.7805,10339};
+						angles[]={0,2.2130835,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8992;
+					type="Land_BarGate_F";
+				};
+				class Item98
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5963.75,196.8667,10327.125};
+						angles[]={0,2.2130835,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8993;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item99
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5967.375,196.618,10332};
+						angles[]={0,2.2130835,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8994;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item100
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5960.187,197.15755,10322.392};
+						angles[]={0,2.2130835,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8995;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.10491943;
+				};
+				class Item101
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5991.75,196.97498,10369.75};
+						angles[]={0,0.64228714,0};
+					};
+					side="Empty";
+					flags=1;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8996;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.63621521;
+				};
+				class Item102
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5956.5928,197.22626,10317.587};
+						angles[]={0,2.2130835,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=8997;
+					type="Land_Wall_IndCnc_4_F";
+					atlOffset=0.0093078613;
+				};
+				class Item103
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5945.5,197.0943,10370.375};
+						angles[]={0.033588443,4.6147385,0.011203959};
 					};
 					side="Empty";
 					flags=4;
@@ -10516,230 +10682,120 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7873;
-					type="Land_BagFence_Long_F";
-					atlOffset=3.0517578e-005;
-				};
-				class Item94
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5738.5322,352.25272,5590.0356};
-						angles[]={0,1.5707964,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7875;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.0068969727;
-				};
-				class Item95
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5738.5322,351.66162,5578.0356};
-						angles[]={0,1.5707964,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7876;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
-				};
-				class Item96
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5738.5322,351.94962,5584.0356};
-						angles[]={0,1.5707964,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7877;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=3.0517578e-005;
-				};
-				class Item97
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5735.4072,352.82755,5595.9102};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7878;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.041473389;
-				};
-				class Item98
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5738.9453,352.52133,5596.062};
-						angles[]={0,1.5707964,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7879;
-					type="Land_Wall_IndCnc_4_D_F";
-					atlOffset=0.043548584;
-				};
-				class Item99
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5738.5327,351.51578,5574.9106};
-						angles[]={0,1.5707964,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7880;
-					type="Land_Wall_IndCnc_Pole_F";
-					atlOffset=6.1035156e-005;
-				};
-				class Item100
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5737.5,357.83215,5595};
-						angles[]={0,1.0471976,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7881;
-					type="Land_LampHalogen_F";
-				};
-				class Item101
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5740.8755,354.83295,5569.0005};
-						angles[]={0,1.5707964,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7882;
-					type="Land_BarGate_F";
-					atlOffset=0.20944214;
-				};
-				class Item102
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5738.5322,353.51553,5614.0356};
-						angles[]={0,1.5707964,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7883;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.0059814453;
-				};
-				class Item103
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5738.5322,354.13724,5620.0356};
-						angles[]={0,1.5707964,0};
-					};
-					side="Empty";
-					flags=5;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=7884;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.013275146;
+					id=9002;
+					type="Land_BagFence_Round_F";
 				};
 				class Item104
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5738.5322,353.14023,5608.0356};
-						angles[]={0,1.5707964,0};
+						position[]={5943.9849,197.00835,10372.429};
+						angles[]={0.033588443,3.8293405,0.011203959};
 					};
 					side="Empty";
-					flags=5;
+					flags=4;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7885;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.01651001;
+					id=9003;
+					type="Land_BagFence_Long_F";
 				};
 				class Item105
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5735.4072,354.64154,5622.9102};
+						position[]={5944.397,197.16127,10368.045};
+						angles[]={0.05115639,2.2585435,6.2767911};
 					};
 					side="Empty";
-					flags=5;
+					flags=4;
 					class Attributes
 					{
 						skill=0.2;
 					};
-					id=7886;
-					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.023345947;
+					id=9004;
+					type="Land_BagFence_Long_F";
+					atlOffset=1.5258789e-005;
 				};
 				class Item106
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5738.5322,352.84094,5602.0356};
-						angles[]={0,1.5707964,0};
+						position[]={5932.625,196.1916,10381.125};
+						angles[]={0.079829417,3.0443094,0.034386542};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9005;
+					type="Land_BagFence_Round_F";
+				};
+				class Item107
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5930.5703,196.28291,10379.61};
+						angles[]={0.097292177,2.2589114,0.016798066};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9006;
+					type="Land_BagFence_Long_F";
+				};
+				class Item108
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5934.9546,196.36012,10380.021};
+						angles[]={0.079829417,0.68811464,0.034386542};
+					};
+					side="Empty";
+					flags=4;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9007;
+					type="Land_BagFence_Long_F";
+				};
+				class Item109
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5901.875,196.75899,10369.375};
+						angles[]={0,0.69813168,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+						dynamicSimulation=1;
+					};
+					id=9008;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item110
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5906.5,197.30219,10365.5};
+						angles[]={0,0.69813168,0};
 					};
 					side="Empty";
 					flags=5;
@@ -10747,72 +10803,54 @@ class Mission
 					{
 						skill=0.2;
 					};
-					id=7887;
+					id=9009;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.010040283;
+				};
+				class Item111
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5911.125,197.80618,10361.625};
+						angles[]={0,0.69813168,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9010;
+					type="Land_Wall_IndCnc_4_F";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="allowDamage";
+							expression="_this allowdamage _value;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"BOOL"
+										};
+									};
+									value=0;
+								};
+							};
+						};
+						nAttributes=1;
+					};
 				};
 			};
 			id=7888;
-			atlOffset=0.17941284;
+			atlOffset=-0.033935547;
 		};
 		class Item489
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={5684.9873,353.69931,5586.7319};
-				angles[]={6.2527928,0,6.2479987};
-			};
-			areaSize[]={59.677002,0,41.096436};
-			areaIsRectangle=1;
-			flags=1;
-			id=7889;
-			type="ModuleHideTerrainObjects_F";
-			atlOffset=-0.55593872;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="#filter";
-					expression="_this setVariable [""#filter"",_value]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=15;
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="#hideLocally";
-					expression="_this setVariable [""#hideLocally"",_value]";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				nAttributes=2;
-			};
-		};
-		class Item490
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10830,7 +10868,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item491
+		class Item490
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10848,7 +10886,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item492
+		class Item491
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10865,7 +10903,7 @@ class Mission
 			id=7895;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item493
+		class Item492
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10882,7 +10920,7 @@ class Mission
 			id=7896;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item494
+		class Item493
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10900,7 +10938,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item495
+		class Item494
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10917,7 +10955,7 @@ class Mission
 			id=7898;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item496
+		class Item495
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10935,7 +10973,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item497
+		class Item496
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10953,7 +10991,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item498
+		class Item497
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10970,7 +11008,7 @@ class Mission
 			id=7901;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item499
+		class Item498
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10988,7 +11026,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item500
+		class Item499
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11005,7 +11043,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=0.4550705;
 		};
-		class Item501
+		class Item500
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11023,7 +11061,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item502
+		class Item501
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11040,7 +11078,7 @@ class Mission
 			id=7905;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item503
+		class Item502
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11057,7 +11095,7 @@ class Mission
 			id=7906;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item504
+		class Item503
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11074,7 +11112,7 @@ class Mission
 			id=7907;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item505
+		class Item504
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11091,7 +11129,7 @@ class Mission
 			id=7908;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item506
+		class Item505
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11108,7 +11146,7 @@ class Mission
 			id=7909;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item507
+		class Item506
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11125,7 +11163,7 @@ class Mission
 			id=7910;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item508
+		class Item507
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11142,7 +11180,7 @@ class Mission
 			id=7911;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item509
+		class Item508
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11159,7 +11197,7 @@ class Mission
 			id=7912;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item510
+		class Item509
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11176,7 +11214,7 @@ class Mission
 			id=7913;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item511
+		class Item510
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11193,7 +11231,7 @@ class Mission
 			id=7914;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item512
+		class Item511
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11210,7 +11248,7 @@ class Mission
 			id=7915;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item513
+		class Item512
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11227,7 +11265,7 @@ class Mission
 			id=7916;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item514
+		class Item513
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11245,7 +11283,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item515
+		class Item514
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11262,7 +11300,7 @@ class Mission
 			id=7918;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item516
+		class Item515
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11279,7 +11317,7 @@ class Mission
 			id=7919;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item517
+		class Item516
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11295,7 +11333,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.25;
 		};
-		class Item518
+		class Item517
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11312,7 +11350,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item519
+		class Item518
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11329,7 +11367,7 @@ class Mission
 			id=7922;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item520
+		class Item519
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11346,7 +11384,7 @@ class Mission
 			id=7923;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item521
+		class Item520
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11363,7 +11401,7 @@ class Mission
 			id=7924;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item522
+		class Item521
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11381,7 +11419,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item523
+		class Item522
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11399,7 +11437,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-7.6293945e-006;
 		};
-		class Item524
+		class Item523
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11417,7 +11455,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item525
+		class Item524
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11434,7 +11472,7 @@ class Mission
 			id=7928;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item526
+		class Item525
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11451,7 +11489,7 @@ class Mission
 			type="Land_BarGate_F";
 			atlOffset=0.24999237;
 		};
-		class Item527
+		class Item526
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11467,7 +11505,7 @@ class Mission
 			id=7930;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item528
+		class Item527
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11483,7 +11521,7 @@ class Mission
 			id=7931;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item529
+		class Item528
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11499,7 +11537,7 @@ class Mission
 			id=7932;
 			type="Land_Cargo_House_V1_F";
 		};
-		class Item530
+		class Item529
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11516,7 +11554,7 @@ class Mission
 			type="Land_Cargo_House_V1_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item531
+		class Item530
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11533,7 +11571,7 @@ class Mission
 			type="Land_TTowerSmall_1_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item532
+		class Item531
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11550,7 +11588,7 @@ class Mission
 			type="Land_TTowerSmall_2_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item533
+		class Item532
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11566,7 +11604,7 @@ class Mission
 			id=7936;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item534
+		class Item533
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11584,7 +11622,7 @@ class Mission
 			type="Land_Cargo40_military_green_F";
 			atlOffset=0.41942596;
 		};
-		class Item535
+		class Item534
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11602,7 +11640,7 @@ class Mission
 			type="Land_Cargo40_military_green_F";
 			atlOffset=0.34242249;
 		};
-		class Item536
+		class Item535
 		{
 			dataType="Object";
 			class PositionInfo
@@ -11619,7 +11657,7 @@ class Mission
 			type="Land_Medevac_house_V1_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item537
+		class Item536
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -11676,7 +11714,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item538
+		class Item537
 		{
 			dataType="Marker";
 			position[]={5411.4707,451.25,5968.7446};
@@ -11691,7 +11729,7 @@ class Mission
 			id=7946;
 			atlOffset=80.688202;
 		};
-		class Item539
+		class Item538
 		{
 			dataType="Marker";
 			position[]={10685.275,38.889198,3810.7349};
@@ -11706,7 +11744,7 @@ class Mission
 			id=7947;
 			atlOffset=15.959801;
 		};
-		class Item540
+		class Item539
 		{
 			dataType="Marker";
 			position[]={1119.0909,16.625,11948.07};
@@ -11721,7 +11759,7 @@ class Mission
 			id=7948;
 			atlOffset=-13.964973;
 		};
-		class Item541
+		class Item540
 		{
 			dataType="Marker";
 			position[]={9662.0869,33.314789,3789.7827};
@@ -11730,7 +11768,7 @@ class Mission
 			id=7950;
 			atlOffset=-1.9511871;
 		};
-		class Item542
+		class Item541
 		{
 			dataType="Marker";
 			position[]={9430.9902,15.582298,3615.3931};
@@ -11739,7 +11777,7 @@ class Mission
 			id=7951;
 			atlOffset=-1.9511871;
 		};
-		class Item543
+		class Item542
 		{
 			dataType="Marker";
 			position[]={9767.667,36.92873,3990.6501};
@@ -11748,7 +11786,7 @@ class Mission
 			id=7952;
 			atlOffset=-1.9511871;
 		};
-		class Item544
+		class Item543
 		{
 			dataType="Marker";
 			position[]={10066.299,26.17466,4027.6467};
@@ -11757,7 +11795,7 @@ class Mission
 			id=7953;
 			atlOffset=-1.9511871;
 		};
-		class Item545
+		class Item544
 		{
 			dataType="Marker";
 			position[]={10486.761,15.848598,4196.1509};
@@ -11766,7 +11804,7 @@ class Mission
 			id=7954;
 			atlOffset=-1.9511881;
 		};
-		class Item546
+		class Item545
 		{
 			dataType="Marker";
 			position[]={11058.517,22.712757,4197.6699};
@@ -11775,7 +11813,7 @@ class Mission
 			id=7955;
 			atlOffset=-1.9511871;
 		};
-		class Item547
+		class Item546
 		{
 			dataType="Marker";
 			position[]={11261.775,15.748955,4268.458};
@@ -11784,7 +11822,7 @@ class Mission
 			id=7956;
 			atlOffset=-1.9511871;
 		};
-		class Item548
+		class Item547
 		{
 			dataType="Marker";
 			position[]={833.31549,14.35758,11943.996};
@@ -11793,7 +11831,7 @@ class Mission
 			id=7958;
 			atlOffset=-1.9511871;
 		};
-		class Item549
+		class Item548
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -11850,7 +11888,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item550
+		class Item549
 		{
 			dataType="Layer";
 			name="Open Ammo Dump_4";
@@ -12287,7 +12325,7 @@ class Mission
 			id=7962;
 			atlOffset=1.3211975;
 		};
-		class Item551
+		class Item550
 		{
 			dataType="Layer";
 			name="Vehicle Repair_4";
@@ -12567,7 +12605,7 @@ class Mission
 			id=7987;
 			atlOffset=-0.01071167;
 		};
-		class Item552
+		class Item551
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12584,7 +12622,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=2.3841858e-007;
 		};
-		class Item553
+		class Item552
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12601,7 +12639,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item554
+		class Item553
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12618,7 +12656,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=-2.3841858e-007;
 		};
-		class Item555
+		class Item554
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12635,7 +12673,7 @@ class Mission
 			type="Land_Cargo_Patrol_V2_F";
 			atlOffset=-4.7683716e-007;
 		};
-		class Item556
+		class Item555
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12652,7 +12690,7 @@ class Mission
 			type="Land_Cargo_Tower_V2_F";
 			atlOffset=-1.9073486e-006;
 		};
-		class Item557
+		class Item556
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12668,7 +12706,7 @@ class Mission
 			type="Land_Cargo_Tower_V2_F";
 			atlOffset=-1.9073486e-006;
 		};
-		class Item558
+		class Item557
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12684,7 +12722,7 @@ class Mission
 			id=8386;
 			type="Land_Cargo_Patrol_V2_F";
 		};
-		class Item559
+		class Item558
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -12695,7 +12733,7 @@ class Mission
 			id=8387;
 			type="Logic";
 		};
-		class Item560
+		class Item559
 		{
 			dataType="Marker";
 			position[]={8515.5879,-1.2098112,3849.7024};
@@ -12704,7 +12742,7 @@ class Mission
 			id=8388;
 			atlOffset=6.3372011;
 		};
-		class Item561
+		class Item560
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12722,7 +12760,7 @@ class Mission
 			type="Land_HelipadCircle_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item562
+		class Item561
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12739,7 +12777,7 @@ class Mission
 			id=8391;
 			type="Land_HelipadCircle_F";
 		};
-		class Item563
+		class Item562
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12757,7 +12795,7 @@ class Mission
 			type="Land_HelipadCircle_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item564
+		class Item563
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12773,7 +12811,7 @@ class Mission
 			id=8393;
 			type="Land_Hangar_F";
 		};
-		class Item565
+		class Item564
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12789,7 +12827,7 @@ class Mission
 			id=8394;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item566
+		class Item565
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12805,7 +12843,7 @@ class Mission
 			id=8395;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item567
+		class Item566
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12821,7 +12859,7 @@ class Mission
 			id=8396;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item568
+		class Item567
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12839,7 +12877,7 @@ class Mission
 			type="Land_HelipadCircle_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item569
+		class Item568
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12857,7 +12895,7 @@ class Mission
 			type="Land_HelipadCircle_F";
 			atlOffset=1.9073486e-006;
 		};
-		class Item570
+		class Item569
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12873,7 +12911,7 @@ class Mission
 			id=8402;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item571
+		class Item570
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12890,7 +12928,7 @@ class Mission
 			type="Land_TentHangar_V1_F";
 			atlOffset=-1.9073486e-006;
 		};
-		class Item572
+		class Item571
 		{
 			dataType="Object";
 			class PositionInfo
@@ -12906,7 +12944,7 @@ class Mission
 			id=8404;
 			type="Land_TentHangar_V1_F";
 		};
-		class Item573
+		class Item572
 		{
 			dataType="Layer";
 			name="Airports";
@@ -12937,7 +12975,7 @@ class Mission
 					colorName="ColorGreen";
 					a=20.458;
 					b=6;
-					angle=343.81635;
+					angle=343.81625;
 					id=8406;
 					atlOffset=5.2016144;
 				};
@@ -13065,7 +13103,7 @@ class Mission
 			id=8407;
 			atlOffset=-188.44035;
 		};
-		class Item574
+		class Item573
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13082,7 +13120,7 @@ class Mission
 			id=8410;
 			type="Land_HelipadCircle_F";
 		};
-		class Item575
+		class Item574
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13099,7 +13137,7 @@ class Mission
 			id=8413;
 			type="Land_HelipadCircle_F";
 		};
-		class Item576
+		class Item575
 		{
 			dataType="Layer";
 			name="Factories";
@@ -13203,7 +13241,7 @@ class Mission
 			id=8415;
 			atlOffset=-70.030045;
 		};
-		class Item577
+		class Item576
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13220,7 +13258,7 @@ class Mission
 			id=8418;
 			type="Land_HelipadCircle_F";
 		};
-		class Item578
+		class Item577
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13238,7 +13276,7 @@ class Mission
 			type="Land_HelipadCircle_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item579
+		class Item578
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13255,7 +13293,7 @@ class Mission
 			id=8420;
 			type="Land_HelipadCircle_F";
 		};
-		class Item580
+		class Item579
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13272,7 +13310,7 @@ class Mission
 			id=8428;
 			type="Land_HelipadSquare_F";
 		};
-		class Item581
+		class Item580
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13289,7 +13327,7 @@ class Mission
 			id=8430;
 			type="Land_HelipadSquare_F";
 		};
-		class Item582
+		class Item581
 		{
 			dataType="Layer";
 			name="Resources";
@@ -13490,7 +13528,7 @@ class Mission
 			id=8431;
 			atlOffset=12.317825;
 		};
-		class Item583
+		class Item582
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13508,7 +13546,7 @@ class Mission
 			type="Land_HelipadSquare_F";
 			atlOffset=-3.3378601e-006;
 		};
-		class Item584
+		class Item583
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13526,7 +13564,7 @@ class Mission
 			type="Land_HelipadSquare_F";
 			atlOffset=3.3378601e-006;
 		};
-		class Item585
+		class Item584
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13543,7 +13581,7 @@ class Mission
 			id=8442;
 			type="Land_HelipadSquare_F";
 		};
-		class Item586
+		class Item585
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13560,7 +13598,7 @@ class Mission
 			type="Land_HelipadSquare_F";
 			atlOffset=1.4099998;
 		};
-		class Item587
+		class Item586
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13577,7 +13615,7 @@ class Mission
 			id=8448;
 			type="Land_HelipadSquare_F";
 		};
-		class Item588
+		class Item587
 		{
 			dataType="Layer";
 			name="Seaports";
@@ -13801,7 +13839,7 @@ class Mission
 			id=8452;
 			atlOffset=14.549579;
 		};
-		class Item589
+		class Item588
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13819,7 +13857,7 @@ class Mission
 			type="Land_HelipadCircle_F";
 			atlOffset=-9.5367432e-006;
 		};
-		class Item590
+		class Item589
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13836,7 +13874,7 @@ class Mission
 			id=8476;
 			type="Land_HelipadSquare_F";
 		};
-		class Item591
+		class Item590
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13853,7 +13891,7 @@ class Mission
 			type="Land_HelipadSquare_F";
 			atlOffset=2.9406738;
 		};
-		class Item592
+		class Item591
 		{
 			dataType="Object";
 			class PositionInfo
@@ -13870,7 +13908,7 @@ class Mission
 			id=8483;
 			type="Land_HelipadSquare_F";
 		};
-		class Item593
+		class Item592
 		{
 			dataType="Layer";
 			name="Outposts";
@@ -13970,7 +14008,7 @@ class Mission
 					colorName="ColorGreen";
 					a=10;
 					b=6;
-					angle=79.407036;
+					angle=79.407021;
 					id=8468;
 					atlOffset=-0.73122406;
 				};
@@ -14114,16 +14152,16 @@ class Mission
 				class Item17
 				{
 					dataType="Marker";
-					position[]={6493.38,10681,0.00149536};
+					position[]={5945.1201,10681.125,10357.63};
 					name="outpost_12";
 					markerType="RECTANGLE";
 					type="rectangle";
 					colorName="ColorGreen";
-					a=62.875336;
-					b=48.203556;
-					angle=180.13968;
+					a=58.343082;
+					b=46.417057;
+					angle=216.99591;
 					id=183;
-					atlOffset=-4.4351501;
+					atlOffset=10484.08;
 				};
 				class Item18
 				{
@@ -14249,9 +14287,9 @@ class Mission
 				};
 			};
 			id=8484;
-			atlOffset=25.19136;
+			atlOffset=35.85553;
 		};
-		class Item594
+		class Item593
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14269,7 +14307,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item595
+		class Item594
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14286,7 +14324,7 @@ class Mission
 			id=8525;
 			type="Land_HBarrier_5_F";
 		};
-		class Item596
+		class Item595
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14303,7 +14341,7 @@ class Mission
 			id=8526;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item597
+		class Item596
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14321,7 +14359,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item598
+		class Item597
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14338,7 +14376,7 @@ class Mission
 			id=8528;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item599
+		class Item598
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14355,7 +14393,7 @@ class Mission
 			id=8529;
 			type="Land_HBarrier_5_F";
 		};
-		class Item600
+		class Item599
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14372,7 +14410,7 @@ class Mission
 			id=8530;
 			type="Land_HBarrier_5_F";
 		};
-		class Item601
+		class Item600
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14389,7 +14427,7 @@ class Mission
 			id=8531;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item602
+		class Item601
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14406,7 +14444,7 @@ class Mission
 			id=8532;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item603
+		class Item602
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14424,7 +14462,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item604
+		class Item603
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14441,7 +14479,7 @@ class Mission
 			id=8534;
 			type="Land_HBarrier_3_F";
 		};
-		class Item605
+		class Item604
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14458,7 +14496,7 @@ class Mission
 			id=8535;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item606
+		class Item605
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14475,7 +14513,7 @@ class Mission
 			id=8536;
 			type="Land_HBarrier_5_F";
 		};
-		class Item607
+		class Item606
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14493,7 +14531,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item608
+		class Item607
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14511,7 +14549,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item609
+		class Item608
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14528,7 +14566,7 @@ class Mission
 			id=8539;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item610
+		class Item609
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14546,7 +14584,7 @@ class Mission
 			type="Land_HBarrier_3_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item611
+		class Item610
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14563,7 +14601,7 @@ class Mission
 			id=8541;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item612
+		class Item611
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14581,7 +14619,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-0.19999695;
 		};
-		class Item613
+		class Item612
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14599,7 +14637,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item614
+		class Item613
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14616,7 +14654,7 @@ class Mission
 			id=8544;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item615
+		class Item614
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14633,7 +14671,7 @@ class Mission
 			id=8545;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item616
+		class Item615
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14650,7 +14688,7 @@ class Mission
 			id=8546;
 			type="Land_HBarrier_3_F";
 		};
-		class Item617
+		class Item616
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14667,7 +14705,7 @@ class Mission
 			id=8547;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item618
+		class Item617
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14684,7 +14722,7 @@ class Mission
 			id=8548;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item619
+		class Item618
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14701,7 +14739,7 @@ class Mission
 			id=8549;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item620
+		class Item619
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14718,7 +14756,7 @@ class Mission
 			id=8550;
 			type="Land_HBarrierWall6_F";
 		};
-		class Item621
+		class Item620
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14736,7 +14774,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item622
+		class Item621
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14753,7 +14791,7 @@ class Mission
 			type="Land_Mil_WiredFence_Gate_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item623
+		class Item622
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14771,7 +14809,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item624
+		class Item623
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14789,7 +14827,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item625
+		class Item624
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14806,7 +14844,7 @@ class Mission
 			id=8555;
 			type="Land_HBarrier_5_F";
 		};
-		class Item626
+		class Item625
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14824,7 +14862,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item627
+		class Item626
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14842,7 +14880,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item628
+		class Item627
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14859,7 +14897,7 @@ class Mission
 			id=8558;
 			type="Land_HBarrier_5_F";
 		};
-		class Item629
+		class Item628
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14877,7 +14915,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item630
+		class Item629
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14895,7 +14933,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item631
+		class Item630
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14912,7 +14950,7 @@ class Mission
 			id=8561;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item632
+		class Item631
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14929,7 +14967,7 @@ class Mission
 			id=8562;
 			type="Land_HBarrier_5_F";
 		};
-		class Item633
+		class Item632
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14946,7 +14984,7 @@ class Mission
 			id=8563;
 			type="Land_HBarrier_5_F";
 		};
-		class Item634
+		class Item633
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14963,7 +15001,7 @@ class Mission
 			id=8564;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item635
+		class Item634
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14981,7 +15019,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item636
+		class Item635
 		{
 			dataType="Object";
 			class PositionInfo
@@ -14998,7 +15036,7 @@ class Mission
 			id=8566;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item637
+		class Item636
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15015,7 +15053,7 @@ class Mission
 			id=8567;
 			type="Land_HBarrier_5_F";
 		};
-		class Item638
+		class Item637
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15032,7 +15070,7 @@ class Mission
 			id=8568;
 			type="Land_HBarrier_5_F";
 		};
-		class Item639
+		class Item638
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15049,7 +15087,7 @@ class Mission
 			id=8569;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item640
+		class Item639
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15067,7 +15105,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item641
+		class Item640
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15084,7 +15122,7 @@ class Mission
 			id=8571;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item642
+		class Item641
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15101,7 +15139,7 @@ class Mission
 			id=8572;
 			type="Land_HBarrier_5_F";
 		};
-		class Item643
+		class Item642
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15118,7 +15156,7 @@ class Mission
 			id=8573;
 			type="Land_HBarrier_5_F";
 		};
-		class Item644
+		class Item643
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15135,7 +15173,7 @@ class Mission
 			id=8574;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item645
+		class Item644
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15152,7 +15190,7 @@ class Mission
 			id=8575;
 			type="Land_HBarrier_5_F";
 		};
-		class Item646
+		class Item645
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15169,7 +15207,7 @@ class Mission
 			id=8576;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item647
+		class Item646
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15186,7 +15224,7 @@ class Mission
 			id=8577;
 			type="Land_HBarrier_3_F";
 		};
-		class Item648
+		class Item647
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15202,7 +15240,7 @@ class Mission
 			id=8579;
 			type="Land_Razorwire_F";
 		};
-		class Item649
+		class Item648
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15218,7 +15256,7 @@ class Mission
 			id=8580;
 			type="Land_Razorwire_F";
 		};
-		class Item650
+		class Item649
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15234,7 +15272,7 @@ class Mission
 			id=8581;
 			type="Land_Razorwire_F";
 		};
-		class Item651
+		class Item650
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15250,7 +15288,7 @@ class Mission
 			id=8582;
 			type="Land_Razorwire_F";
 		};
-		class Item652
+		class Item651
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15266,7 +15304,7 @@ class Mission
 			id=8583;
 			type="Land_Razorwire_F";
 		};
-		class Item653
+		class Item652
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15282,7 +15320,7 @@ class Mission
 			id=8584;
 			type="Land_Razorwire_F";
 		};
-		class Item654
+		class Item653
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15299,7 +15337,7 @@ class Mission
 			id=8585;
 			type="Land_HBarrier_3_F";
 		};
-		class Item655
+		class Item654
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15316,7 +15354,7 @@ class Mission
 			type="Land_LampSolar_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item656
+		class Item655
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15333,7 +15371,7 @@ class Mission
 			id=8589;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item657
+		class Item656
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15350,7 +15388,7 @@ class Mission
 			type="Land_PressureWasher_01_F";
 			atlOffset=-0.00012207031;
 		};
-		class Item658
+		class Item657
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15367,7 +15405,7 @@ class Mission
 			id=8594;
 			type="Land_HBarrier_5_F";
 		};
-		class Item659
+		class Item658
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15384,7 +15422,7 @@ class Mission
 			id=8595;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item660
+		class Item659
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15401,7 +15439,7 @@ class Mission
 			id=8596;
 			type="Land_HBarrier_5_F";
 		};
-		class Item661
+		class Item660
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15418,7 +15456,7 @@ class Mission
 			id=8597;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item662
+		class Item661
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15435,7 +15473,7 @@ class Mission
 			id=8598;
 			type="Land_HBarrier_5_F";
 		};
-		class Item663
+		class Item662
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15452,7 +15490,7 @@ class Mission
 			id=8599;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item664
+		class Item663
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15469,7 +15507,7 @@ class Mission
 			id=8600;
 			type="Land_HBarrier_5_F";
 		};
-		class Item665
+		class Item664
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15486,7 +15524,7 @@ class Mission
 			id=8601;
 			type="Land_HBarrier_3_F";
 		};
-		class Item666
+		class Item665
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15504,7 +15542,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item667
+		class Item666
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15522,7 +15560,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item668
+		class Item667
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15539,7 +15577,7 @@ class Mission
 			id=8604;
 			type="Land_HBarrier_3_F";
 		};
-		class Item669
+		class Item668
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15557,7 +15595,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item670
+		class Item669
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15574,7 +15612,7 @@ class Mission
 			id=8606;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item671
+		class Item670
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15592,7 +15630,7 @@ class Mission
 			type="Land_HBarrier_3_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item672
+		class Item671
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15610,7 +15648,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item673
+		class Item672
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15628,7 +15666,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item674
+		class Item673
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15645,7 +15683,7 @@ class Mission
 			id=8610;
 			type="Land_HBarrier_3_F";
 		};
-		class Item675
+		class Item674
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15662,7 +15700,7 @@ class Mission
 			id=8611;
 			type="Land_HBarrier_5_F";
 		};
-		class Item676
+		class Item675
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15679,7 +15717,7 @@ class Mission
 			id=8612;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item677
+		class Item676
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15696,7 +15734,7 @@ class Mission
 			id=8613;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item678
+		class Item677
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15713,7 +15751,7 @@ class Mission
 			id=8614;
 			type="Land_HBarrier_5_F";
 		};
-		class Item679
+		class Item678
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15731,7 +15769,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-3.0517578e-005;
 		};
-		class Item680
+		class Item679
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15748,7 +15786,7 @@ class Mission
 			id=8616;
 			type="Land_HBarrier_5_F";
 		};
-		class Item681
+		class Item680
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15765,7 +15803,7 @@ class Mission
 			id=8617;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item682
+		class Item681
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15782,7 +15820,7 @@ class Mission
 			id=8618;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item683
+		class Item682
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15800,7 +15838,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item684
+		class Item683
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15817,7 +15855,7 @@ class Mission
 			id=8620;
 			type="Land_HBarrier_5_F";
 		};
-		class Item685
+		class Item684
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15834,7 +15872,7 @@ class Mission
 			id=8621;
 			type="Land_HBarrier_5_F";
 		};
-		class Item686
+		class Item685
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15851,7 +15889,7 @@ class Mission
 			id=8622;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item687
+		class Item686
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15868,7 +15906,7 @@ class Mission
 			id=8623;
 			type="Land_HBarrier_5_F";
 		};
-		class Item688
+		class Item687
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15885,7 +15923,7 @@ class Mission
 			id=8624;
 			type="Land_HBarrier_5_F";
 		};
-		class Item689
+		class Item688
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15902,7 +15940,7 @@ class Mission
 			id=8625;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item690
+		class Item689
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15919,7 +15957,7 @@ class Mission
 			id=8626;
 			type="Land_HBarrier_5_F";
 		};
-		class Item691
+		class Item690
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15936,7 +15974,7 @@ class Mission
 			id=8627;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item692
+		class Item691
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15953,7 +15991,7 @@ class Mission
 			id=8628;
 			type="Land_HBarrier_5_F";
 		};
-		class Item693
+		class Item692
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15970,7 +16008,7 @@ class Mission
 			id=8629;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item694
+		class Item693
 		{
 			dataType="Object";
 			class PositionInfo
@@ -15987,7 +16025,7 @@ class Mission
 			id=8630;
 			type="Land_HBarrier_5_F";
 		};
-		class Item695
+		class Item694
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16004,7 +16042,7 @@ class Mission
 			id=8631;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item696
+		class Item695
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16021,7 +16059,7 @@ class Mission
 			id=8632;
 			type="Land_HBarrier_5_F";
 		};
-		class Item697
+		class Item696
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16038,7 +16076,7 @@ class Mission
 			id=8633;
 			type="Land_HBarrier_5_F";
 		};
-		class Item698
+		class Item697
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16055,7 +16093,7 @@ class Mission
 			id=8634;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item699
+		class Item698
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16073,7 +16111,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item700
+		class Item699
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16090,7 +16128,7 @@ class Mission
 			id=8636;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item701
+		class Item700
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16107,7 +16145,7 @@ class Mission
 			id=8637;
 			type="Land_HBarrier_5_F";
 		};
-		class Item702
+		class Item701
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16125,7 +16163,7 @@ class Mission
 			type="Land_HBarrier_3_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item703
+		class Item702
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16143,7 +16181,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item704
+		class Item703
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16160,7 +16198,7 @@ class Mission
 			id=8640;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item705
+		class Item704
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16177,7 +16215,7 @@ class Mission
 			id=8641;
 			type="Land_HBarrier_5_F";
 		};
-		class Item706
+		class Item705
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16194,7 +16232,7 @@ class Mission
 			id=8642;
 			type="Land_HBarrier_1_F";
 		};
-		class Item707
+		class Item706
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16211,7 +16249,7 @@ class Mission
 			id=8643;
 			type="Land_HBarrier_1_F";
 		};
-		class Item708
+		class Item707
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16229,7 +16267,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item709
+		class Item708
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16247,7 +16285,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item710
+		class Item709
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16264,7 +16302,7 @@ class Mission
 			id=8646;
 			type="Land_HBarrier_5_F";
 		};
-		class Item711
+		class Item710
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16281,7 +16319,7 @@ class Mission
 			id=8647;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item712
+		class Item711
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16298,7 +16336,7 @@ class Mission
 			id=8648;
 			type="Land_HBarrier_5_F";
 		};
-		class Item713
+		class Item712
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16315,7 +16353,7 @@ class Mission
 			id=8649;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item714
+		class Item713
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16332,7 +16370,7 @@ class Mission
 			id=8650;
 			type="Land_HBarrier_5_F";
 		};
-		class Item715
+		class Item714
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16349,7 +16387,7 @@ class Mission
 			id=8651;
 			type="Land_HBarrier_3_F";
 		};
-		class Item716
+		class Item715
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16366,7 +16404,7 @@ class Mission
 			id=8652;
 			type="Land_HBarrier_5_F";
 		};
-		class Item717
+		class Item716
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16383,7 +16421,7 @@ class Mission
 			id=8653;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item718
+		class Item717
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16400,7 +16438,7 @@ class Mission
 			id=8654;
 			type="Land_HBarrier_5_F";
 		};
-		class Item719
+		class Item718
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16417,7 +16455,7 @@ class Mission
 			id=8655;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item720
+		class Item719
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16434,7 +16472,7 @@ class Mission
 			id=8656;
 			type="Land_HBarrier_5_F";
 		};
-		class Item721
+		class Item720
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16452,7 +16490,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item722
+		class Item721
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16468,7 +16506,7 @@ class Mission
 			id=8658;
 			type="Land_MobileRadar_01_radar_F";
 		};
-		class Item723
+		class Item722
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16485,7 +16523,7 @@ class Mission
 			type="Land_MobileRadar_01_generator_F";
 			atlOffset=0.25138855;
 		};
-		class Item724
+		class Item723
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16501,7 +16539,7 @@ class Mission
 			id=8660;
 			type="Land_Cargo_HQ_V1_F";
 		};
-		class Item725
+		class Item724
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16517,7 +16555,7 @@ class Mission
 			id=8661;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item726
+		class Item725
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16533,7 +16571,7 @@ class Mission
 			id=8662;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item727
+		class Item726
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16549,7 +16587,7 @@ class Mission
 			id=8663;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item728
+		class Item727
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16565,7 +16603,7 @@ class Mission
 			id=8664;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item729
+		class Item728
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16583,7 +16621,7 @@ class Mission
 			type="Land_HelipadSquare_F";
 			atlOffset=0.65576172;
 		};
-		class Item730
+		class Item729
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16601,7 +16639,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item731
+		class Item730
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16619,7 +16657,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item732
+		class Item731
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16637,7 +16675,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item733
+		class Item732
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16655,7 +16693,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item734
+		class Item733
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16672,7 +16710,7 @@ class Mission
 			id=8670;
 			type="Land_HBarrier_5_F";
 		};
-		class Item735
+		class Item734
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16689,7 +16727,7 @@ class Mission
 			id=8671;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item736
+		class Item735
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16706,7 +16744,7 @@ class Mission
 			id=8672;
 			type="Land_HBarrier_5_F";
 		};
-		class Item737
+		class Item736
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16723,7 +16761,7 @@ class Mission
 			id=8673;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item738
+		class Item737
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16740,7 +16778,7 @@ class Mission
 			id=8674;
 			type="Land_HBarrier_5_F";
 		};
-		class Item739
+		class Item738
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16757,7 +16795,7 @@ class Mission
 			id=8675;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item740
+		class Item739
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16774,7 +16812,7 @@ class Mission
 			id=8676;
 			type="Land_HBarrier_5_F";
 		};
-		class Item741
+		class Item740
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16792,7 +16830,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item742
+		class Item741
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16809,7 +16847,7 @@ class Mission
 			id=8678;
 			type="Land_HBarrier_5_F";
 		};
-		class Item743
+		class Item742
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16826,7 +16864,7 @@ class Mission
 			id=8679;
 			type="Land_HBarrier_3_F";
 		};
-		class Item744
+		class Item743
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16844,7 +16882,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item745
+		class Item744
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16861,7 +16899,7 @@ class Mission
 			id=8681;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item746
+		class Item745
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16878,7 +16916,7 @@ class Mission
 			id=8682;
 			type="Land_HBarrier_5_F";
 		};
-		class Item747
+		class Item746
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16895,7 +16933,7 @@ class Mission
 			id=8683;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item748
+		class Item747
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16913,7 +16951,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item749
+		class Item748
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16931,7 +16969,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item750
+		class Item749
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16948,7 +16986,7 @@ class Mission
 			id=8686;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item751
+		class Item750
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16965,7 +17003,7 @@ class Mission
 			id=8687;
 			type="Land_HBarrier_5_F";
 		};
-		class Item752
+		class Item751
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16982,7 +17020,7 @@ class Mission
 			id=8688;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item753
+		class Item752
 		{
 			dataType="Object";
 			class PositionInfo
@@ -16999,7 +17037,7 @@ class Mission
 			id=8689;
 			type="Land_HBarrier_5_F";
 		};
-		class Item754
+		class Item753
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17016,7 +17054,7 @@ class Mission
 			id=8690;
 			type="Land_HBarrier_5_F";
 		};
-		class Item755
+		class Item754
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17033,7 +17071,7 @@ class Mission
 			id=8691;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item756
+		class Item755
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17050,7 +17088,7 @@ class Mission
 			id=8692;
 			type="Land_HBarrier_5_F";
 		};
-		class Item757
+		class Item756
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17068,7 +17106,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item758
+		class Item757
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17085,7 +17123,7 @@ class Mission
 			id=8694;
 			type="Land_HBarrier_3_F";
 		};
-		class Item759
+		class Item758
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17102,7 +17140,7 @@ class Mission
 			id=8695;
 			type="Land_HBarrier_5_F";
 		};
-		class Item760
+		class Item759
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17119,7 +17157,7 @@ class Mission
 			id=8696;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item761
+		class Item760
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17136,7 +17174,7 @@ class Mission
 			id=8697;
 			type="Land_HBarrier_5_F";
 		};
-		class Item762
+		class Item761
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17153,7 +17191,7 @@ class Mission
 			id=8698;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item763
+		class Item762
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17170,7 +17208,7 @@ class Mission
 			id=8699;
 			type="Land_HBarrier_5_F";
 		};
-		class Item764
+		class Item763
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17188,7 +17226,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item765
+		class Item764
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17206,7 +17244,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item766
+		class Item765
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17223,7 +17261,7 @@ class Mission
 			id=8702;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item767
+		class Item766
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17241,7 +17279,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item768
+		class Item767
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17258,7 +17296,7 @@ class Mission
 			id=8704;
 			type="Land_HBarrier_3_F";
 		};
-		class Item769
+		class Item768
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17276,7 +17314,7 @@ class Mission
 			type="Land_HBarrier_3_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item770
+		class Item769
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17294,7 +17332,7 @@ class Mission
 			type="Land_HBarrier_3_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item771
+		class Item770
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17312,7 +17350,7 @@ class Mission
 			type="Land_HBarrier_1_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item772
+		class Item771
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17330,7 +17368,7 @@ class Mission
 			type="Land_HelipadSquare_F";
 			atlOffset=0.64489746;
 		};
-		class Item773
+		class Item772
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17347,7 +17385,7 @@ class Mission
 			id=8709;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item774
+		class Item773
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17364,7 +17402,7 @@ class Mission
 			id=8710;
 			type="Land_HBarrier_5_F";
 		};
-		class Item775
+		class Item774
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17381,7 +17419,7 @@ class Mission
 			id=8711;
 			type="Land_HBarrier_5_F";
 		};
-		class Item776
+		class Item775
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17399,7 +17437,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item777
+		class Item776
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17416,7 +17454,7 @@ class Mission
 			id=8713;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item778
+		class Item777
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17433,7 +17471,7 @@ class Mission
 			id=8714;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item779
+		class Item778
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17451,7 +17489,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item780
+		class Item779
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17469,7 +17507,7 @@ class Mission
 			type="Land_HBarrier_5_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item781
+		class Item780
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17486,7 +17524,7 @@ class Mission
 			id=8717;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item782
+		class Item781
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17503,7 +17541,7 @@ class Mission
 			id=8718;
 			type="Land_HBarrier_5_F";
 		};
-		class Item783
+		class Item782
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17520,7 +17558,7 @@ class Mission
 			id=8719;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item784
+		class Item783
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17537,7 +17575,7 @@ class Mission
 			id=8720;
 			type="Land_HBarrier_5_F";
 		};
-		class Item785
+		class Item784
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17554,7 +17592,7 @@ class Mission
 			id=8721;
 			type="Land_HBarrier_5_F";
 		};
-		class Item786
+		class Item785
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17571,7 +17609,7 @@ class Mission
 			id=8722;
 			type="Land_HBarrier_5_F";
 		};
-		class Item787
+		class Item786
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17588,7 +17626,7 @@ class Mission
 			id=8723;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item788
+		class Item787
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17605,7 +17643,7 @@ class Mission
 			id=8724;
 			type="Land_HBarrier_5_F";
 		};
-		class Item789
+		class Item788
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17622,7 +17660,7 @@ class Mission
 			id=8725;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item790
+		class Item789
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17638,7 +17676,7 @@ class Mission
 			id=8726;
 			type="Land_Cargo_Tower_V1_F";
 		};
-		class Item791
+		class Item790
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17655,7 +17693,7 @@ class Mission
 			type="Land_Cargo_Tower_V1_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item792
+		class Item791
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17671,7 +17709,7 @@ class Mission
 			id=8728;
 			type="Land_Cargo_Tower_V1_F";
 		};
-		class Item793
+		class Item792
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17689,7 +17727,7 @@ class Mission
 			type="Land_HelipadSquare_F";
 			atlOffset=0.70658875;
 		};
-		class Item794
+		class Item793
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17707,7 +17745,7 @@ class Mission
 			type="Land_HelipadSquare_F";
 			atlOffset=0.63046265;
 		};
-		class Item795
+		class Item794
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17725,7 +17763,7 @@ class Mission
 			type="Land_HelipadSquare_F";
 			atlOffset=0.66749573;
 		};
-		class Item796
+		class Item795
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17743,7 +17781,7 @@ class Mission
 			type="Land_HelipadSquare_F";
 			atlOffset=0.61737061;
 		};
-		class Item797
+		class Item796
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17759,7 +17797,7 @@ class Mission
 			id=8733;
 			type="Land_LampAirport_F";
 		};
-		class Item798
+		class Item797
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17775,7 +17813,7 @@ class Mission
 			id=8734;
 			type="Land_LampAirport_F";
 		};
-		class Item799
+		class Item798
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17791,7 +17829,7 @@ class Mission
 			id=8740;
 			type="StorageBladder_01_fuel_forest_F";
 		};
-		class Item800
+		class Item799
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17807,7 +17845,7 @@ class Mission
 			id=8741;
 			type="StorageBladder_01_fuel_forest_F";
 		};
-		class Item801
+		class Item800
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17824,7 +17862,7 @@ class Mission
 			id=8742;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item802
+		class Item801
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17841,7 +17879,7 @@ class Mission
 			id=8743;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item803
+		class Item802
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17858,7 +17896,7 @@ class Mission
 			id=8744;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item804
+		class Item803
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17875,7 +17913,7 @@ class Mission
 			id=8745;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item805
+		class Item804
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17892,7 +17930,7 @@ class Mission
 			id=8746;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item806
+		class Item805
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17909,7 +17947,7 @@ class Mission
 			type="Land_LampAirport_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item807
+		class Item806
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17925,7 +17963,7 @@ class Mission
 			id=8748;
 			type="Land_LampAirport_F";
 		};
-		class Item808
+		class Item807
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17942,7 +17980,7 @@ class Mission
 			type="Land_LampSolar_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item809
+		class Item808
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17959,7 +17997,7 @@ class Mission
 			id=8750;
 			type="Land_HBarrier_Big_F";
 		};
-		class Item810
+		class Item809
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17976,7 +18014,7 @@ class Mission
 			type="Land_HBarrier_Big_F";
 			atlOffset=0.265625;
 		};
-		class Item811
+		class Item810
 		{
 			dataType="Object";
 			class PositionInfo
@@ -17992,7 +18030,7 @@ class Mission
 			id=8752;
 			type="Land_Cargo_Patrol_V1_F";
 		};
-		class Item812
+		class Item811
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18009,7 +18047,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=1.5258789e-005;
 		};
-		class Item813
+		class Item812
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18026,7 +18064,7 @@ class Mission
 			id=8756;
 			type="Land_HelipadCircle_F";
 		};
-		class Item814
+		class Item813
 		{
 			dataType="Object";
 			class PositionInfo
@@ -18043,7 +18081,7 @@ class Mission
 			type="Land_Cargo_Patrol_V4_F";
 			atlOffset=7.6293945e-006;
 		};
-		class Item815
+		class Item814
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -18055,7 +18093,7 @@ class Mission
 			type="HighCommand";
 			atlOffset=0.043842316;
 		};
-		class Item816
+		class Item815
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -18066,7 +18104,7 @@ class Mission
 			type="HighCommandSubordinate";
 			atlOffset=-0.043831825;
 		};
-		class Item817
+		class Item816
 		{
 			dataType="Marker";
 			position[]={737.70398,27.885,12084.651};
@@ -18075,7 +18113,7 @@ class Mission
 			id=8765;
 			atlOffset=0.00016021729;
 		};
-		class Item818
+		class Item817
 		{
 			dataType="Marker";
 			position[]={8157.2852,29.357891,9844.3545};
@@ -18083,7 +18121,7 @@ class Mission
 			type="hd_start";
 			id=8766;
 		};
-		class Item819
+		class Item818
 		{
 			dataType="Marker";
 			position[]={2353.4297,193.33873,3599.1111};
@@ -18091,7 +18129,7 @@ class Mission
 			type="hd_start";
 			id=8767;
 		};
-		class Item820
+		class Item819
 		{
 			dataType="Group";
 			side="Independent";
@@ -18969,7 +19007,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item821
+		class Item820
 		{
 			dataType="Marker";
 			position[]={6275.625,148,4915.625};
@@ -18981,7 +19019,7 @@ class Mission
 			id=8817;
 			atlOffset=-195.57904;
 		};
-		class Item822
+		class Item821
 		{
 			dataType="Marker";
 			position[]={3465.5056,251.49741,7661.5068};
@@ -18992,7 +19030,7 @@ class Mission
 			b=144.91785;
 			id=8818;
 		};
-		class Item823
+		class Item822
 		{
 			dataType="Marker";
 			position[]={6099.8125,248.32848,8058.6289};
@@ -19003,7 +19041,7 @@ class Mission
 			b=144.91785;
 			id=8819;
 		};
-		class Item824
+		class Item823
 		{
 			dataType="Marker";
 			position[]={2815.7451,229.74904,4730.1313};
@@ -19014,7 +19052,7 @@ class Mission
 			b=144.91785;
 			id=8820;
 		};
-		class Item825
+		class Item824
 		{
 			dataType="Marker";
 			position[]={8163.481,156.58452,7220.6636};
@@ -19025,7 +19063,7 @@ class Mission
 			b=144.91785;
 			id=8821;
 		};
-		class Item826
+		class Item825
 		{
 			dataType="Marker";
 			position[]={5702.8481,124.312,10623.949};
@@ -19037,7 +19075,7 @@ class Mission
 			id=8822;
 			atlOffset=-0.00037384033;
 		};
-		class Item827
+		class Item826
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19053,7 +19091,7 @@ class Mission
 			id=8824;
 			type="Land_TTowerBig_1_F";
 		};
-		class Item828
+		class Item827
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19070,7 +19108,7 @@ class Mission
 			id=8825;
 			type="Land_HBarrier_5_F";
 		};
-		class Item829
+		class Item828
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19087,7 +19125,7 @@ class Mission
 			id=8826;
 			type="Land_HBarrier_5_F";
 		};
-		class Item830
+		class Item829
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19104,7 +19142,7 @@ class Mission
 			id=8827;
 			type="Land_HBarrier_5_F";
 		};
-		class Item831
+		class Item830
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19121,7 +19159,7 @@ class Mission
 			id=8828;
 			type="Land_HBarrier_5_F";
 		};
-		class Item832
+		class Item831
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19138,7 +19176,7 @@ class Mission
 			id=8829;
 			type="Land_HBarrier_5_F";
 		};
-		class Item833
+		class Item832
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19155,7 +19193,7 @@ class Mission
 			id=8830;
 			type="Land_HBarrier_5_F";
 		};
-		class Item834
+		class Item833
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19172,7 +19210,7 @@ class Mission
 			id=8831;
 			type="Land_HBarrier_5_F";
 		};
-		class Item835
+		class Item834
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19188,7 +19226,7 @@ class Mission
 			id=8832;
 			type="Land_TTowerBig_1_F";
 		};
-		class Item836
+		class Item835
 		{
 			dataType="Marker";
 			position[]={5206.25,409.125,6234.625};
@@ -19200,7 +19238,7 @@ class Mission
 			id=8840;
 			atlOffset=2.4406433;
 		};
-		class Item837
+		class Item836
 		{
 			dataType="Marker";
 			position[]={4383.6133,264.81461,8853.4551};
@@ -19211,7 +19249,7 @@ class Mission
 			b=144.91785;
 			id=8841;
 		};
-		class Item838
+		class Item837
 		{
 			dataType="Marker";
 			position[]={7368.5747,127.35316,9579.5996};
@@ -19223,7 +19261,7 @@ class Mission
 			id=8842;
 			atlOffset=-7.6293945e-006;
 		};
-		class Item839
+		class Item838
 		{
 			dataType="Marker";
 			position[]={3714.0037,111.85905,5453.6143};
@@ -19235,7 +19273,7 @@ class Mission
 			id=8843;
 			atlOffset=-7.6293945e-006;
 		};
-		class Item840
+		class Item839
 		{
 			dataType="Marker";
 			position[]={4756.8188,34.743,3167.177};
@@ -19247,7 +19285,7 @@ class Mission
 			id=8844;
 			atlOffset=-0.00023269653;
 		};
-		class Item841
+		class Item840
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19264,7 +19302,7 @@ class Mission
 			type="Land_Cargo_Patrol_V1_F";
 			atlOffset=-1.5258789e-005;
 		};
-		class Item842
+		class Item841
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -19321,7 +19359,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item843
+		class Item842
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19338,7 +19376,7 @@ class Mission
 			type="Land_Cargo_Patrol_V4_F";
 			atlOffset=-3.8146973e-006;
 		};
-		class Item844
+		class Item843
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19355,7 +19393,7 @@ class Mission
 			type="Land_Cargo_Patrol_V4_F";
 			atlOffset=-1.9073486e-006;
 		};
-		class Item845
+		class Item844
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19371,7 +19409,7 @@ class Mission
 			id=8849;
 			type="Land_Cargo_Patrol_V4_F";
 		};
-		class Item846
+		class Item845
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19388,7 +19426,7 @@ class Mission
 			type="Land_Cargo_Patrol_V4_F";
 			atlOffset=-1.9073486e-006;
 		};
-		class Item847
+		class Item846
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -19444,7 +19482,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item848
+		class Item847
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -19499,7 +19537,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item849
+		class Item848
 		{
 			dataType="Object";
 			class PositionInfo
@@ -19515,7 +19553,7 @@ class Mission
 			id=8856;
 			type="Flag_NATO_F";
 		};
-		class Item850
+		class Item849
 		{
 			dataType="Marker";
 			position[]={9722.457,17.32926,5923.7598};
@@ -19523,7 +19561,7 @@ class Mission
 			type="flag_CTRG";
 			id=8857;
 		};
-		class Item851
+		class Item850
 		{
 			dataType="Group";
 			side="West";
@@ -19988,7 +20026,7 @@ class Mission
 			};
 			id=8858;
 		};
-		class Item852
+		class Item851
 		{
 			dataType="Marker";
 			position[]={9999.6533,17.973528,2235.1763};
@@ -19996,7 +20034,7 @@ class Mission
 			type="flag_Viper";
 			id=8865;
 		};
-		class Item853
+		class Item852
 		{
 			dataType="Group";
 			side="East";
@@ -20453,7 +20491,7 @@ class Mission
 			};
 			id=8866;
 		};
-		class Item854
+		class Item853
 		{
 			dataType="Object";
 			class PositionInfo
@@ -20470,7 +20508,7 @@ class Mission
 			id=8873;
 			type="Flag_Viper_F";
 		};
-		class Item855
+		class Item854
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20484,7 +20522,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=0.14967728;
 		};
-		class Item856
+		class Item855
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20498,7 +20536,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=0.13149166;
 		};
-		class Item857
+		class Item856
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20512,7 +20550,7 @@ class Mission
 			type="HeadlessClient_F";
 			atlOffset=0.12053108;
 		};
-		class Item858
+		class Item857
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20569,7 +20607,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item859
+		class Item858
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20624,7 +20662,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item860
+		class Item859
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20678,7 +20716,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item861
+		class Item860
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20735,7 +20773,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item862
+		class Item861
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20792,7 +20830,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item863
+		class Item862
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20849,7 +20887,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item864
+		class Item863
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20905,7 +20943,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item865
+		class Item864
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -20962,7 +21000,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item866
+		class Item865
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -21017,7 +21055,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item867
+		class Item866
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -21071,6 +21109,112 @@ class Mission
 				};
 				nAttributes=2;
 			};
+		};
+		class Item867
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={5945.1533,196.90634,10356.715};
+				angles[]={0.07346756,0.64228117,6.277586};
+			};
+			areaSize[]={56.117241,0,43.735672};
+			areaIsRectangle=1;
+			flags=1;
+			id=8998;
+			type="ModuleHideTerrainObjects_F";
+			atlOffset=-0.14245605;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="#filter";
+					expression="_this setVariable [""#filter"",_value]";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"SCALAR"
+								};
+							};
+							value=15;
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="#hideLocally";
+					expression="_this setVariable [""#hideLocally"",_value]";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=2;
+			};
+		};
+		class Item868
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5913.5981,199.51453,10333.729};
+				angles[]={0.073466748,0,6.2264457};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=9000;
+			type="Land_GarbageHeap_03_F";
+			atlOffset=0.0023040771;
+		};
+		class Item869
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5889.375,198.28455,10350.875};
+				angles[]={0.10758245,0.54572666,0.0064037596};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=9001;
+			type="Land_GarbageHeap_03_F";
+		};
+		class Item870
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5933.875,193.45494,10414.25};
+				angles[]={0.13517158,3.6839166,0.068690397};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=9013;
+			type="Land_GarbageHeap_04_F";
 		};
 	};
 	class Connections

--- a/Map-Templates/Antistasi-Malden.Malden/mission.sqm
+++ b/Map-Templates/Antistasi-Malden.Malden/mission.sqm
@@ -14114,7 +14114,7 @@ class Mission
 				class Item17
 				{
 					dataType="Marker";
-					position[]={5687.5581,349.78223,5589.0303};
+					position[]={6493.38,10681,0.00149536};
 					name="outpost_12";
 					markerType="RECTANGLE";
 					type="rectangle";

--- a/Map-Templates/Antistasi-Malden.Malden/mission.sqm
+++ b/Map-Templates/Antistasi-Malden.Malden/mission.sqm
@@ -5,25 +5,25 @@ class EditorData
 	angleGridStep=0.2617994;
 	scaleGridStep=1;
 	autoGroupingDist=10;
-	toggles=1029;
+	toggles=1025;
 	class ItemIDProvider
 	{
-		nextID=9014;
+		nextID=9059;
 	};
 	class MarkerIDProvider
 	{
-		nextID=35;
+		nextID=39;
 	};
 	class LayerIndexProvider
 	{
-		nextID=1439;
+		nextID=1670;
 	};
 	class Camera
 	{
-		pos[]={6011.4937,214.68979,10347.634};
-		dir[]={-0.87181216,-0.48838425,-0.040808197};
-		up[]={-0.48793665,0.87247401,-0.022845829};
-		aside[]={-0.046772361,-4.8073889e-007,0.99897295};
+		pos[]={6054.959,235.19136,10397.772};
+		dir[]={-0.55186653,-0.58789772,-0.59158599};
+		up[]={-0.40105355,0.80890119,-0.42991617};
+		aside[]={-0.73128223,1.4557736e-006,0.68218994};
 	};
 };
 binarizationWanted=0;
@@ -51,7 +51,6 @@ addons[]=
 	"A3_Structures_F_Mil_Barracks",
 	"A3_Structures_F_Civ_Garbage",
 	"A3_Structures_F_EPA_Mil_Scrapyard",
-	"A3_Structures_F_Mil_Offices",
 	"A3_Structures_F_Mil_BagFence",
 	"A3_Structures_F_Mil_Helipads",
 	"A3_Structures_F_EPA_Civ_Constructions",
@@ -71,13 +70,14 @@ addons[]=
 	"A3_Ui_F_Exp",
 	"A3_Characters_F_Exp",
 	"A3_Structures_F_Exp_Military_Flags",
-	"A3_Props_F_Exp_Civilian_Garbage"
+	"A3_Props_F_Exp_Civilian_Garbage",
+	"A3_Structures_F_Tank_Military_RepairDepot"
 };
 class AddonsMetaData
 {
 	class List
 	{
-		items=18;
+		items=19;
 		class Item0
 		{
 			className="A3_Ui_F";
@@ -204,6 +204,13 @@ class AddonsMetaData
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
+		class Item18
+		{
+			className="A3_Structures_F_Tank";
+			name="Arma 3 Tank - Buildings and Structures";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
 	};
 };
 randomSeed=13388897;
@@ -220,7 +227,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=871;
+		items=881;
 		class Item0
 		{
 			dataType="Marker";
@@ -8581,8 +8588,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5933.0063,198.57759,10405.604};
-						angles[]={0,2.9453621,0};
+						position[]={5970.2905,199.08662,10425.692};
+						angles[]={0,2.8573301,0};
 					};
 					side="Empty";
 					flags=5;
@@ -8598,8 +8605,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5934.75,203.2403,10321.125};
-						angles[]={0,0.63872468,0};
+						position[]={5944.1025,199.82034,10397.609};
+						angles[]={0,2.2625949,0};
 					};
 					side="Empty";
 					flags=5;
@@ -8615,8 +8622,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5978.875,200.67189,10350.5};
-						angles[]={0,5.3990045,0};
+						position[]={5982.8198,199.4747,10331.873};
+						angles[]={0,6.1964602,0};
 					};
 					side="Empty";
 					flags=5;
@@ -8629,7 +8636,7 @@ class Mission
 				};
 			};
 			id=3700;
-			atlOffset=38.106186;
+			atlOffset=34.57901;
 		};
 		class Item454
 		{
@@ -8875,13 +8882,13 @@ class Mission
 			name="Command Centre";
 			class Entities
 			{
-				items=112;
+				items=113;
 				class Item0
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5890.2974,197.58372,10359.252};
+						position[]={5927.3784,196.64063,10378.528};
 						angles[]={0,5.3546762,0};
 					};
 					side="Empty";
@@ -8898,25 +8905,24 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5886.7036,198.76993,10354.447};
+						position[]={5923.7847,197.00294,10373.724};
 						angles[]={0,5.3546762,0};
 					};
 					side="Empty";
-					flags=1;
+					flags=5;
 					class Attributes
 					{
 						skill=0.2;
 					};
 					id=8892;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.70245361;
 				};
 				class Item2
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5893.8916,197.16165,10364.056};
+						position[]={5930.9727,196.26387,10383.332};
 						angles[]={0,5.3546762,0};
 					};
 					side="Empty";
@@ -8933,25 +8939,24 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5887.4839,199.25839,10350.273};
+						position[]={5924.5649,197.33325,10369.55};
 						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
-					flags=1;
+					flags=5;
 					class Attributes
 					{
 						skill=0.2;
 					};
 					id=8894;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.7232666;
 				};
 				class Item4
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5904.6743,195.79025,10378.469};
+						position[]={5941.7554,195.51176,10397.745};
 						angles[]={0,5.3546762,0};
 					};
 					side="Empty";
@@ -8968,7 +8973,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5911.8628,195.03987,10388.078};
+						position[]={5948.9438,195.26341,10407.354};
 						angles[]={0,5.3546762,0};
 					};
 					side="Empty";
@@ -8979,13 +8984,14 @@ class Mission
 					};
 					id=8897;
 					type="Land_Wall_IndCnc_4_F";
+					atlOffset=-4.5776367e-005;
 				};
 				class Item6
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5897.4858,196.68085,10368.86};
+						position[]={5934.5669,195.99197,10388.137};
 						angles[]={0,5.3546762,0};
 					};
 					side="Empty";
@@ -9002,7 +9008,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5915.4565,194.64827,10392.882};
+						position[]={5952.5376,195.21394,10412.158};
 						angles[]={0,5.3546762,0};
 					};
 					side="Empty";
@@ -9013,13 +9019,14 @@ class Mission
 					};
 					id=8899;
 					type="Land_Wall_IndCnc_4_F";
+					atlOffset=1.5258789e-005;
 				};
 				class Item8
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5908.2686,195.37106,10383.273};
+						position[]={5945.3496,195.35289,10402.55};
 						angles[]={0,5.3546762,0};
 					};
 					side="Empty";
@@ -9036,7 +9043,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5900.7349,196.19188,10373.934};
+						position[]={5937.8159,195.68755,10393.21};
 						angles[]={0,5.3546762,0};
 					};
 					side="Empty";
@@ -9053,7 +9060,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5922.645,194.44234,10402.491};
+						position[]={5959.7261,195.13144,10421.768};
 						angles[]={0,5.3546762,0};
 					};
 					side="Empty";
@@ -9064,14 +9071,14 @@ class Mission
 					};
 					id=8902;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.37631226;
+					atlOffset=0.36698914;
 				};
 				class Item11
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5929.8813,194.56424,10412.104};
+						position[]={5966.9785,194.78207,10431.288};
 						angles[]={0,5.3546762,0};
 					};
 					side="Empty";
@@ -9082,14 +9089,14 @@ class Mission
 					};
 					id=8903;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.90168762;
+					atlOffset=0.89237976;
 				};
 				class Item12
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5926.2393,194.67432,10407.295};
+						position[]={5963.3364,195.27455,10426.479};
 						angles[]={0,5.3546762,0};
 					};
 					side="Empty";
@@ -9100,14 +9107,14 @@ class Mission
 					};
 					id=8904;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.8110199;
+					atlOffset=0.80158997;
 				};
 				class Item13
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5919.0508,194.35445,10397.687};
+						position[]={5956.1318,194.98637,10416.963};
 						angles[]={0,5.3546762,0};
 					};
 					side="Empty";
@@ -9118,14 +9125,14 @@ class Mission
 					};
 					id=8905;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.023422241;
+					atlOffset=0.014083862;
 				};
 				class Item14
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5919.8315,194.79082,10393.513};
+						position[]={5956.9126,195.48651,10412.789};
 						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
@@ -9142,7 +9149,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5934,194.72498,10412.875};
+						position[]={5971.0972,194.82968,10432.06};
 						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
@@ -9153,33 +9160,32 @@ class Mission
 					};
 					id=8907;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.86175537;
+					atlOffset=0.85244751;
 				};
 				class Item16
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5931.7856,200.44884,10413.093};
-						angles[]={0,4.8310776,0};
+						position[]={5962.9404,200.16678,10422.728};
+						angles[]={0,3.8678515,0};
 					};
 					side="Empty";
-					flags=1;
+					flags=5;
 					class Attributes
 					{
 						skill=0.2;
 					};
 					id=8908;
 					type="Land_LampHalogen_F";
-					atlOffset=1.510437;
 				};
 				class Item17
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5914.4375,195.92729,10386.659};
-						angles[]={0.097292177,5.3206806,0.04556872};
+						position[]={5951.5186,196.1104,10405.936};
+						angles[]={0.06232097,5.3206806,0.051953323};
 					};
 					side="Empty";
 					flags=4;
@@ -9191,14 +9197,14 @@ class Mission
 					};
 					id=8909;
 					type="Land_Cargo40_yellow_F";
-					atlOffset=-0.0090789795;
+					atlOffset=-0.00088500977;
 				};
 				class Item18
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5897.0928,199.24039,10343.086};
+						position[]={5934.1738,197.81747,10362.362};
 						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
@@ -9215,7 +9221,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5911.5059,199.89816,10332.303};
+						position[]={5948.5869,197.77643,10351.579};
 						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
@@ -9226,13 +9232,14 @@ class Mission
 					};
 					id=8911;
 					type="Land_Wall_IndCnc_4_F";
+					atlOffset=-1.5258789e-005;
 				};
 				class Item20
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5892.2886,198.89047,10346.68};
+						position[]={5929.3696,197.58615,10365.956};
 						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
@@ -9249,7 +9256,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5901.897,199.53871,10339.491};
+						position[]={5938.978,197.85574,10358.768};
 						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
@@ -9266,7 +9273,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5906.7017,199.73357,10335.897};
+						position[]={5943.7827,197.81416,10355.174};
 						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
@@ -9283,8 +9290,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5950.75,200.42528,10391.25};
-						angles[]={0,6.1400743,0};
+						position[]={5962.8945,199.79379,10414.619};
+						angles[]={0,0.5934366,0};
 					};
 					side="Empty";
 					flags=5;
@@ -9300,8 +9307,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5952.125,199.28996,10330.125};
-						angles[]={0,2.2178783,0};
+						position[]={6009.7544,197.22957,10389.636};
+						angles[]={0,0.63873816,6.2657323};
 					};
 					side="Empty";
 					flags=1;
@@ -9311,15 +9318,15 @@ class Mission
 					};
 					id=8916;
 					type="Land_i_Shed_Ind_F";
-					atlOffset=0.79508972;
+					atlOffset=0.45803833;
 				};
 				class Item25
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5955.5,197.72966,10358.75};
-						angles[]={6.2639894,2.0166829,6.2783766};
+						position[]={5992.5811,196.56601,10378.026};
+						angles[]={0.011995304,2.0166829,6.2368193};
 					};
 					side="Empty";
 					flags=4;
@@ -9335,8 +9342,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5923.625,198.15701,10341.875};
-						angles[]={0,3.7165687,0};
+						position[]={5959.8677,196.84569,10357.451};
+						angles[]={0,3.7714009,0};
 					};
 					side="Empty";
 					flags=5;
@@ -9352,8 +9359,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5949.75,196.58664,10382};
-						angles[]={0.058334891,0.64228714,0.032787289};
+						position[]={6006.3789,195.51183,10374.604};
+						angles[]={6.232029,0.64228714,6.2328267};
 					};
 					side="Empty";
 					flags=4;
@@ -9369,8 +9376,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5952.5894,197.5585,10336.183};
-						angles[]={6.2663875,2.2130835,6.232029};
+						position[]={6004.0396,196.12912,10390.324};
+						angles[]={6.2543926,0.63394618,6.2503963};
 					};
 					side="Empty";
 					flags=4;
@@ -9380,14 +9387,15 @@ class Mission
 					};
 					id=8920;
 					type="Land_PaperBox_closed_F";
+					atlOffset=0.047088623;
 				};
 				class Item29
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5946.125,197.69038,10309.875};
-						angles[]={6.271987,1.3845687,6.186687};
+						position[]={5974.2051,196.37241,10350.365};
+						angles[]={6.2639894,1.3845687,6.2320304};
 					};
 					side="Empty";
 					flags=4;
@@ -9403,8 +9411,8 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5951.625,197.57216,10334.875};
-						angles[]={0.0055992967,2.2130835,6.2097178};
+						position[]={6005.3555,196.02235,10389.371};
+						angles[]={6.2543926,0.63394618,6.2503963};
 					};
 					side="Empty";
 					flags=4;
@@ -9414,31 +9422,14 @@ class Mission
 					};
 					id=8922;
 					type="Land_PaperBox_open_empty_F";
+					atlOffset=0.047088623;
 				};
 				class Item31
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5965.875,200.41508,10369.625};
-						angles[]={0,0.65157181,0};
-					};
-					side="Empty";
-					flags=1;
-					class Attributes
-					{
-						skill=0.2;
-					};
-					id=8923;
-					type="Land_MilOffices_V1_F";
-					atlOffset=0.39929199;
-				};
-				class Item32
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={5953.2246,196.15392,10398.503};
+						position[]={5990.3057,196.11121,10417.779};
 						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
@@ -9449,14 +9440,14 @@ class Mission
 					};
 					id=8924;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.13134766;
+					atlOffset=0.12200928;
 				};
-				class Item33
+				class Item32
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5948.4204,195.92281,10402.098};
+						position[]={5985.5015,195.99043,10421.374};
 						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
@@ -9467,14 +9458,14 @@ class Mission
 					};
 					id=8925;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.36738586;
+					atlOffset=0.35804749;
 				};
-				class Item34
+				class Item33
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5958.0288,196.41612,10394.909};
+						position[]={5995.1099,196.36029,10414.186};
 						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
@@ -9486,12 +9477,12 @@ class Mission
 					id=8926;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item35
+				class Item34
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5938.7563,195.26659,10409.229};
+						position[]={5975.8374,195.49252,10428.505};
 						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
@@ -9502,32 +9493,31 @@ class Mission
 					};
 					id=8927;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.7855835;
+					atlOffset=0.77624512;
 				};
-				class Item36
+				class Item35
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5943.8882,195.68192,10405.989};
-						angles[]={0,0.64228714,0};
+						position[]={6014.5459,195.96379,10400.172};
+						angles[]={0,0.6422869,0};
 					};
 					side="Empty";
-					flags=1;
+					flags=5;
 					class Attributes
 					{
 						skill=0.2;
 					};
 					id=8928;
 					type="Land_Wall_IndCnc_4_D_F";
-					atlOffset=0.69999695;
 				};
-				class Item37
+				class Item36
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5924.6357,195.46445,10389.919};
+						position[]={5961.7168,196.00548,10409.195};
 						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
@@ -9538,14 +9528,15 @@ class Mission
 					};
 					id=8929;
 					type="Land_Wall_IndCnc_4_F";
+					atlOffset=1.5258789e-005;
 				};
-				class Item38
+				class Item37
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5959.8047,197.0098,10341.484};
-						angles[]={6.2623858,3.0458794,6.2543926};
+						position[]={5997.8418,195.98003,10390.734};
+						angles[]={6.2543945,1.3107218,0.010398259};
 					};
 					side="Empty";
 					flags=4;
@@ -9555,15 +9546,15 @@ class Mission
 					};
 					id=8930;
 					type="Land_BagFence_Round_F";
-					atlOffset=-1.5258789e-005;
+					atlOffset=1.5258789e-005;
 				};
-				class Item39
+				class Item38
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5935.125,197.63213,10357.875};
-						angles[]={0.027990974,6.1628256,6.277586};
+						position[]={5985.8843,196.24908,10392.056};
+						angles[]={0.010398259,6.1628256,6.2663875};
 					};
 					side="Empty";
 					flags=4;
@@ -9574,13 +9565,13 @@ class Mission
 					id=8931;
 					type="Land_BagFence_Round_F";
 				};
-				class Item40
+				class Item39
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5923.5049,197.23192,10366.347};
-						angles[]={0.07346756,0.68170887,0.029591488};
+						position[]={5974.2642,196.31502,10400.527};
+						angles[]={0.041575778,0.68170887,0.016798066};
 					};
 					side="Empty";
 					flags=4;
@@ -9591,13 +9582,13 @@ class Mission
 					id=8932;
 					type="Land_BagFence_Long_F";
 				};
-				class Item41
+				class Item40
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5962.1328,196.91966,10340.375};
-						angles[]={6.2623858,0.68968511,6.2543926};
+						position[]={6003.8818,195.73543,10385.493};
+						angles[]={6.2599902,3.7832878,6.2503982};
 					};
 					side="Empty";
 					flags=4;
@@ -9607,15 +9598,14 @@ class Mission
 					};
 					id=8933;
 					type="Land_BagFence_Long_F";
-					atlOffset=-1.5258789e-005;
 				};
-				class Item42
+				class Item41
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5964.2534,196.75348,10338.625};
-						angles[]={6.2623887,0.68968511,6.215291};
+						position[]={6001.6797,195.84584,10387.139};
+						angles[]={6.2599902,3.7832878,6.2503982};
 					};
 					side="Empty";
 					flags=4;
@@ -9626,13 +9616,13 @@ class Mission
 					id=8934;
 					type="Land_BagFence_Long_F";
 				};
-				class Item43
+				class Item42
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5937.144,197.5771,10359.437};
-						angles[]={0.027990974,5.3774276,6.277586};
+						position[]={5987.9033,196.19408,10393.617};
+						angles[]={0.010398259,5.3774276,6.2543945};
 					};
 					side="Empty";
 					flags=4;
@@ -9643,13 +9633,13 @@ class Mission
 					id=8935;
 					type="Land_BagFence_Long_F";
 				};
-				class Item44
+				class Item43
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5966.375,196.56079,10336.875};
-						angles[]={6.2432065,0.68968511,6.215291};
+						position[]={5999.4771,195.94089,10388.785};
+						angles[]={6.2543945,3.7832878,0.010398259};
 					};
 					side="Empty";
 					flags=4;
@@ -9660,13 +9650,13 @@ class Mission
 					id=8936;
 					type="Land_BagFence_Long_F";
 				};
-				class Item45
+				class Item44
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5957.7388,197.08916,10339.957};
-						angles[]={0.0016194459,2.2604814,6.232029};
+						position[]={5998.688,196.05858,10393.156};
+						angles[]={6.2543945,2.220957,0.010398259};
 					};
 					side="Empty";
 					flags=4;
@@ -9676,14 +9666,15 @@ class Mission
 					};
 					id=8937;
 					type="Land_BagFence_Long_F";
+					atlOffset=1.5258789e-005;
 				};
-				class Item46
+				class Item45
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5932.7705,197.61591,10358.925};
-						angles[]={0.027990974,3.8066308,6.277586};
+						position[]={5983.5298,196.27771,10393.105};
+						angles[]={0.010398259,3.8066308,6.2663875};
 					};
 					side="Empty";
 					flags=4;
@@ -9694,13 +9685,13 @@ class Mission
 					id=8938;
 					type="Land_BagFence_Long_F";
 				};
-				class Item47
+				class Item46
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5933.125,196.63809,10369.5};
-						angles[]={0.05115639,5.3968663,0.016798066};
+						position[]={5983.8838,195.69632,10403.681};
+						angles[]={0.0078539811,5.396872,0};
 					};
 					side="Empty";
 					flags=4;
@@ -9711,13 +9702,14 @@ class Mission
 					};
 					id=8939;
 					type="Land_HelipadSquare_F";
+					atlOffset=-1.5258789e-005;
 				};
-				class Item48
+				class Item47
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5930.7231,199.43848,10317.927};
+						position[]={5967.8042,196.78244,10337.203};
 						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
@@ -9728,13 +9720,14 @@ class Mission
 					};
 					id=8940;
 					type="Land_Wall_IndCnc_4_F";
+					atlOffset=1.5258789e-005;
 				};
-				class Item49
+				class Item48
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5935.5278,199.12103,10314.332};
+						position[]={5972.6089,196.31194,10333.608};
 						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
@@ -9745,13 +9738,14 @@ class Mission
 					};
 					id=8941;
 					type="Land_Wall_IndCnc_4_F";
+					atlOffset=1.5258789e-005;
 				};
-				class Item50
+				class Item49
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5921.1147,199.9173,10325.114};
+						position[]={5958.1958,197.42224,10344.391};
 						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
@@ -9762,13 +9756,14 @@ class Mission
 					};
 					id=8942;
 					type="Land_Wall_IndCnc_4_F";
+					atlOffset=-1.5258789e-005;
 				};
-				class Item51
+				class Item50
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5940.332,198.71111,10310.738};
+						position[]={5977.4131,195.75461,10330.015};
 						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
@@ -9780,12 +9775,12 @@ class Mission
 					id=8943;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item52
+				class Item51
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5916.3101,199.92563,10328.709};
+						position[]={5953.3911,197.63539,10347.985};
 						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
@@ -9796,13 +9791,14 @@ class Mission
 					};
 					id=8944;
 					type="Land_Wall_IndCnc_4_F";
+					atlOffset=-1.5258789e-005;
 				};
-				class Item53
+				class Item52
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5925.6753,199.77193,10321.181};
+						position[]={5962.7563,197.17805,10340.457};
 						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
@@ -9814,13 +9810,13 @@ class Mission
 					id=8945;
 					type="Land_Wall_IndCnc_4_D_F";
 				};
-				class Item54
+				class Item53
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5907.2427,200.07396,10337.736};
-						angles[]={0.088568218,3.734885,6.2623887};
+						position[]={5944.3237,198.26836,10357.013};
+						angles[]={0.004796607,3.734885,6.2767911};
 					};
 					side="Empty";
 					flags=4;
@@ -9830,15 +9826,15 @@ class Mission
 					};
 					id=8946;
 					type="Land_FieldToilet_F";
-					atlOffset=-0.0094909668;
+					atlOffset=-0.00440979;
 				};
-				class Item55
+				class Item54
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5906.1177,200.03078,10338.486};
-						angles[]={0.088568218,3.8294125,6.2623887};
+						position[]={5943.1987,198.27194,10357.763};
+						angles[]={0.004796607,3.8294125,6.2767911};
 					};
 					side="Empty";
 					flags=4;
@@ -9848,14 +9844,14 @@ class Mission
 					};
 					id=8947;
 					type="Land_FieldToilet_F";
-					atlOffset=-0.009475708;
+					atlOffset=-0.0044250488;
 				};
-				class Item56
+				class Item55
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5992.5,201.49817,10367.5};
+						position[]={6029.5811,199.12964,10386.776};
 						angles[]={0,6.261982,0};
 					};
 					side="Empty";
@@ -9867,13 +9863,13 @@ class Mission
 					id=8948;
 					type="Land_LampHalogen_F";
 				};
-				class Item57
+				class Item56
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5910.125,199.19531,10335.875};
-						angles[]={0.07346756,0.64228714,6.2623887};
+						position[]={5947.2061,197.29947,10355.151};
+						angles[]={0.004796607,0.64228714,6.2767911};
 					};
 					side="Empty";
 					flags=4;
@@ -9883,14 +9879,15 @@ class Mission
 					};
 					id=8949;
 					type="Land_GarbagePallet_F";
+					atlOffset=-1.5258789e-005;
 				};
-				class Item58
+				class Item57
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5947.2148,196.36699,10397.973};
-						angles[]={0.061521512,2.2360301,0.05115639};
+						position[]={5955.5347,196.34113,10405.534};
+						angles[]={0.06232097,2.2360301,0.051953323};
 					};
 					side="Empty";
 					flags=4;
@@ -9902,14 +9899,14 @@ class Mission
 					};
 					id=8950;
 					type="Land_Cargo20_cyan_F";
-					atlOffset=-0.013839722;
+					atlOffset=-1.5258789e-005;
 				};
-				class Item59
+				class Item58
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5956.2681,197.68466,10362.507};
+						position[]={5993.3491,196.37453,10381.783};
 						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
@@ -9920,13 +9917,14 @@ class Mission
 					};
 					id=8951;
 					type="Land_Wall_IndCnc_4_F";
+					atlOffset=1.5258789e-005;
 				};
-				class Item60
+				class Item59
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5970.6812,197.02922,10351.725};
+						position[]={6007.7622,195.549,10371.001};
 						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
@@ -9937,13 +9935,14 @@ class Mission
 					};
 					id=8952;
 					type="Land_Wall_IndCnc_4_F";
+					atlOffset=1.5258789e-005;
 				};
-				class Item61
+				class Item60
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5965.877,197.34419,10355.318};
+						position[]={6002.958,195.97513,10374.595};
 						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
@@ -9954,13 +9953,14 @@ class Mission
 					};
 					id=8953;
 					type="Land_Wall_IndCnc_4_F";
+					atlOffset=1.5258789e-005;
 				};
-				class Item62
+				class Item61
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5948.5005,197.75134,10356.922};
+						position[]={5985.5815,196.78467,10376.198};
 						angles[]={0,5.3546762,0};
 					};
 					side="Empty";
@@ -9971,14 +9971,13 @@ class Mission
 					};
 					id=8954;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=-1.5258789e-005;
 				};
-				class Item63
+				class Item62
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5952.0947,197.69006,10361.727};
+						position[]={5989.1758,196.57518,10381.003};
 						angles[]={0,5.3546762,0};
 					};
 					side="Empty";
@@ -9989,14 +9988,13 @@ class Mission
 					};
 					id=8955;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=-1.5258789e-005;
 				};
-				class Item64
+				class Item63
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5944.9063,197.86646,10352.118};
+						position[]={5981.9873,196.8956,10371.395};
 						angles[]={0,5.3546762,0};
 					};
 					side="Empty";
@@ -10008,12 +10006,12 @@ class Mission
 					id=8956;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item65
+				class Item64
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5961.0728,197.59293,10358.913};
+						position[]={5998.1538,196.21603,10378.189};
 						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
@@ -10024,14 +10022,14 @@ class Mission
 					};
 					id=8957;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=-1.5258789e-005;
+					atlOffset=1.5258789e-005;
 				};
-				class Item66
+				class Item65
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5922.4722,197.38397,10372.895};
+						position[]={5970.731,196.85808,10402.02};
 						angles[]={0,4.8310776,0};
 					};
 					side="Empty";
@@ -10043,12 +10041,12 @@ class Mission
 					id=8958;
 					type="Land_PortableLight_double_F";
 				};
-				class Item67
+				class Item66
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5954.1709,202.93217,10363.096};
+						position[]={5991.252,201.71964,10382.372};
 						angles[]={0,6.1400743,0};
 					};
 					side="Empty";
@@ -10060,12 +10058,12 @@ class Mission
 					id=8959;
 					type="Land_LampHalogen_F";
 				};
-				class Item68
+				class Item67
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5977.2466,197.54556,10380.532};
+						position[]={5980.7739,195.7121,10424.808};
 						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
@@ -10076,14 +10074,14 @@ class Mission
 					};
 					id=8960;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.48136902;
+					atlOffset=0.40290833;
 				};
-				class Item69
+				class Item68
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5982.0508,197.56488,10376.938};
+						position[]={6019.1318,195.71613,10396.215};
 						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
@@ -10094,32 +10092,31 @@ class Mission
 					};
 					id=8961;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.6363678;
+					atlOffset=0.41383362;
 				};
-				class Item70
+				class Item69
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5972.4419,197.40637,10384.127};
+						position[]={6009.5229,196.43555,10403.403};
 						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
-					flags=1;
+					flags=5;
 					class Attributes
 					{
 						skill=0.2;
 					};
 					id=8962;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.3354187;
 				};
-				class Item71
+				class Item70
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5986.875,197.34998,10373.25};
+						position[]={6023.9561,194.95233,10392.526};
 						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
@@ -10130,14 +10127,14 @@ class Mission
 					};
 					id=8963;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.63569641;
+					atlOffset=0.37948608;
 				};
-				class Item72
+				class Item71
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5962.8335,196.79402,10391.314};
+						position[]={5999.9146,196.5818,10410.591};
 						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
@@ -10149,12 +10146,12 @@ class Mission
 					id=8964;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item73
+				class Item72
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5967.6377,197.04179,10387.721};
+						position[]={6004.7188,196.57672,10406.997};
 						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
@@ -10165,14 +10162,14 @@ class Mission
 					};
 					id=8965;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.080978394;
+					atlOffset=0.071640015;
 				};
-				class Item74
+				class Item73
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5901.125,216.61215,10356.5};
+						position[]={5938.2061,215.66074,10375.776};
 						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
@@ -10184,13 +10181,13 @@ class Mission
 					id=8968;
 					type="Land_TTowerBig_1_F";
 				};
-				class Item75
+				class Item74
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5904.9951,197.34526,10369.95};
-						angles[]={0.11390442,3.8483632,0.021595482};
+						position[]={5942.0762,196.77034,10389.227};
+						angles[]={0.079830162,3.8483632,0.032789111};
 					};
 					side="Empty";
 					flags=4;
@@ -10202,15 +10199,15 @@ class Mission
 					};
 					id=8969;
 					type="Land_Cargo20_light_green_F";
-					atlOffset=-0.023574829;
+					atlOffset=-0.00091552734;
 				};
-				class Item76
+				class Item75
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5972.25,195.87131,10329.625};
-						angles[]={6.2432065,6.1400743,6.215291};
+						position[]={6009.3311,193.73163,10348.901};
+						angles[]={6.204946,6.1400743,6.2049451};
 					};
 					side="Empty";
 					flags=4;
@@ -10220,14 +10217,15 @@ class Mission
 					};
 					id=8971;
 					type="Land_BagFence_Round_F";
+					atlOffset=-1.5258789e-005;
 				};
-				class Item77
+				class Item76
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5974.2417,195.80103,10331.253};
-						angles[]={6.2432065,5.3546762,6.215291};
+						position[]={6011.3228,193.69545,10350.529};
+						angles[]={6.219274,5.3546762,6.2049451};
 					};
 					side="Empty";
 					flags=4;
@@ -10237,15 +10235,14 @@ class Mission
 					};
 					id=8972;
 					type="Land_BagFence_Long_F";
-					atlOffset=1.5258789e-005;
 				};
-				class Item78
+				class Item77
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5969.8574,196.07433,10330.633};
-						angles[]={6.2432065,3.7838798,6.215291};
+						position[]={6006.9385,193.99823,10349.909};
+						angles[]={6.204946,3.7838798,6.2049451};
 					};
 					side="Empty";
 					flags=4;
@@ -10255,15 +10252,15 @@ class Mission
 					};
 					id=8973;
 					type="Land_BagFence_Long_F";
-					atlOffset=1.5258789e-005;
+					atlOffset=-1.5258789e-005;
 				};
-				class Item79
+				class Item78
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5923,196.89293,10370.75};
-						angles[]={0.07346756,5.3940983,0.029591488};
+						position[]={5973.7593,196.19125,10404.931};
+						angles[]={0.023195164,5.3940983,0.035185181};
 					};
 					side="Empty";
 					flags=4;
@@ -10273,13 +10270,14 @@ class Mission
 					};
 					id=8974;
 					type="Land_BagFence_Long_F";
+					atlOffset=1.5258789e-005;
 				};
-				class Item80
+				class Item79
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5981.8169,196.28506,10351.11};
+						position[]={6018.8979,194.57054,10370.387};
 						angles[]={0,2.2130835,0};
 					};
 					side="Empty";
@@ -10291,12 +10289,12 @@ class Mission
 					id=8975;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item81
+				class Item80
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5945.1362,198.2058,10307.144};
+						position[]={5982.2173,195.11119,10326.42};
 						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
@@ -10308,12 +10306,12 @@ class Mission
 					id=8976;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item82
+				class Item81
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5949.3101,197.81053,10307.924};
+						position[]={5986.3911,194.72227,10327.2};
 						angles[]={0,2.2130835,0};
 					};
 					side="Empty";
@@ -10324,13 +10322,14 @@ class Mission
 					};
 					id=8977;
 					type="Land_Wall_IndCnc_4_F";
+					atlOffset=-1.5258789e-005;
 				};
-				class Item83
+				class Item82
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5952.9043,197.52908,10312.729};
+						position[]={5989.9854,194.61833,10332.005};
 						angles[]={0,2.2130835,0};
 					};
 					side="Empty";
@@ -10342,13 +10341,13 @@ class Mission
 					id=8978;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item84
+				class Item83
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5947.189,203.26059,10306.813};
-						angles[]={0,1.6894847,0};
+						position[]={5989.8906,199.97171,10333.642};
+						angles[]={0,0.66358089,0};
 					};
 					side="Empty";
 					flags=5;
@@ -10359,12 +10358,12 @@ class Mission
 					id=8979;
 					type="Land_LampHalogen_F";
 				};
-				class Item85
+				class Item84
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5982.3921,201.58531,10353.602};
+						position[]={6019.4731,199.92181,10372.878};
 						angles[]={0,3.7838798,0};
 					};
 					side="Empty";
@@ -10376,13 +10375,13 @@ class Mission
 					id=8980;
 					type="Land_LampHalogen_F";
 				};
-				class Item86
+				class Item85
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5921.9453,197.03343,10368.417};
-						angles[]={0.07346756,1.4671068,0.029591488};
+						position[]={5972.7046,196.20825,10402.598};
+						angles[]={0.023195164,1.4671068,0.035185181};
 					};
 					side="Empty";
 					flags=4;
@@ -10392,14 +10391,15 @@ class Mission
 					};
 					id=8981;
 					type="Land_BagFence_Round_F";
+					atlOffset=1.5258789e-005;
 				};
-				class Item87
+				class Item86
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5981.8613,195.55629,10342.359};
-						angles[]={6.2456031,4.5692778,6.1922369};
+						position[]={6018.9424,193.76418,10361.636};
+						angles[]={6.1985884,4.5692778,6.1700706};
 					};
 					side="Empty";
 					flags=4;
@@ -10409,14 +10409,15 @@ class Mission
 					};
 					id=8982;
 					type="Land_BagFence_Round_F";
+					atlOffset=1.5258789e-005;
 				};
-				class Item88
+				class Item87
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5980.875,195.5575,10340};
-						angles[]={6.2456031,2.2130835,6.1922369};
+						position[]={6017.9561,193.67613,10359.276};
+						angles[]={6.1985884,2.2130835,6.1700706};
 					};
 					side="Empty";
 					flags=4;
@@ -10426,14 +10427,15 @@ class Mission
 					};
 					id=8983;
 					type="Land_BagFence_Long_F";
+					atlOffset=1.5258789e-005;
 				};
-				class Item89
+				class Item88
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5980.2212,195.78136,10344.367};
-						angles[]={6.2456031,3.7838798,6.1922369};
+						position[]={6017.3022,194.08235,10363.644};
+						angles[]={6.2320304,3.7838798,6.1700706};
 					};
 					side="Empty";
 					flags=4;
@@ -10444,12 +10446,12 @@ class Mission
 					id=8984;
 					type="Land_BagFence_Long_F";
 				};
-				class Item90
+				class Item89
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5989,196.24777,10360.875};
+						position[]={6026.0811,194.22076,10380.151};
 						angles[]={0,2.2130835,0};
 					};
 					side="Empty";
@@ -10461,12 +10463,12 @@ class Mission
 					id=8985;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item91
+				class Item90
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5992.5,196.19618,10365.5};
+						position[]={6029.5811,193.80363,10384.776};
 						angles[]={0,2.2130835,0};
 					};
 					side="Empty";
@@ -10478,12 +10480,12 @@ class Mission
 					id=8986;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item92
+				class Item91
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5985.5,196.23537,10356};
+						position[]={6022.5811,194.48102,10375.276};
 						angles[]={0,2.2130835,0};
 					};
 					side="Empty";
@@ -10495,12 +10497,12 @@ class Mission
 					id=8987;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item93
+				class Item92
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5975.4858,196.66035,10348.13};
+						position[]={6012.5669,195.11856,10367.406};
 						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
@@ -10512,12 +10514,12 @@ class Mission
 					id=8988;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item94
+				class Item93
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5978.4097,196.29758,10346.132};
+						position[]={6015.4907,194.66313,10365.408};
 						angles[]={0,2.2130835,0};
 					};
 					side="Empty";
@@ -10529,12 +10531,12 @@ class Mission
 					id=8989;
 					type="Land_Wall_IndCnc_4_D_F";
 				};
-				class Item95
+				class Item94
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5990.7275,196.25267,10363.021};
+						position[]={6027.8086,194.0096,10382.298};
 						angles[]={0,2.2130835,0};
 					};
 					side="Empty";
@@ -10546,12 +10548,12 @@ class Mission
 					id=8990;
 					type="Land_Wall_IndCnc_Pole_F";
 				};
-				class Item96
+				class Item95
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5976.6162,201.73994,10346.147};
+						position[]={6013.6973,200.14587,10365.424};
 						angles[]={0,1.6894847,0};
 					};
 					side="Empty";
@@ -10563,12 +10565,12 @@ class Mission
 					id=8991;
 					type="Land_LampHalogen_F";
 				};
-				class Item97
+				class Item96
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5973.25,199.7805,10339};
+						position[]={6010.3311,197.99773,10358.276};
 						angles[]={0,2.2130835,0};
 					};
 					side="Empty";
@@ -10580,12 +10582,12 @@ class Mission
 					id=8992;
 					type="Land_BarGate_F";
 				};
-				class Item98
+				class Item97
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5963.75,196.8667,10327.125};
+						position[]={6000.8311,194.54092,10346.401};
 						angles[]={0,2.2130835,0};
 					};
 					side="Empty";
@@ -10597,12 +10599,12 @@ class Mission
 					id=8993;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item99
+				class Item98
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5967.375,196.618,10332};
+						position[]={6004.4561,194.58733,10351.276};
 						angles[]={0,2.2130835,0};
 					};
 					side="Empty";
@@ -10614,12 +10616,12 @@ class Mission
 					id=8994;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item100
+				class Item99
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5960.187,197.15755,10322.392};
+						position[]={5997.2681,194.60495,10341.668};
 						angles[]={0,2.2130835,0};
 					};
 					side="Empty";
@@ -10630,14 +10632,14 @@ class Mission
 					};
 					id=8995;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.10491943;
+					atlOffset=0.095581055;
 				};
-				class Item101
+				class Item100
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5991.75,196.97498,10369.75};
+						position[]={6028.8311,194.56361,10389.026};
 						angles[]={0,0.64228714,0};
 					};
 					side="Empty";
@@ -10648,14 +10650,14 @@ class Mission
 					};
 					id=8996;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.63621521;
+					atlOffset=0.62687683;
 				};
-				class Item102
+				class Item101
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5956.5928,197.22626,10317.587};
+						position[]={5993.6738,194.56065,10336.863};
 						angles[]={0,2.2130835,0};
 					};
 					side="Empty";
@@ -10666,15 +10668,14 @@ class Mission
 					};
 					id=8997;
 					type="Land_Wall_IndCnc_4_F";
-					atlOffset=0.0093078613;
 				};
-				class Item103
+				class Item102
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5945.5,197.0943,10370.375};
-						angles[]={0.033588443,4.6147385,0.011203959};
+						position[]={5996.2593,196.20114,10404.556};
+						angles[]={6.2823396,4.6147385,0.019199125};
 					};
 					side="Empty";
 					flags=4;
@@ -10685,13 +10686,13 @@ class Mission
 					id=9002;
 					type="Land_BagFence_Round_F";
 				};
-				class Item104
+				class Item103
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5943.9849,197.00835,10372.429};
-						angles[]={0.033588443,3.8293405,0.011203959};
+						position[]={5994.7441,196.17368,10406.609};
+						angles[]={6.2823396,3.8293405,0.019199125};
 					};
 					side="Empty";
 					flags=4;
@@ -10702,13 +10703,13 @@ class Mission
 					id=9003;
 					type="Land_BagFence_Long_F";
 				};
-				class Item105
+				class Item104
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5944.397,197.16127,10368.045};
-						angles[]={0.05115639,2.2585435,6.2767911};
+						position[]={5995.1563,196.20113,10402.226};
+						angles[]={0.0080009829,2.2585435,0.010398259};
 					};
 					side="Empty";
 					flags=4;
@@ -10718,15 +10719,14 @@ class Mission
 					};
 					id=9004;
 					type="Land_BagFence_Long_F";
-					atlOffset=1.5258789e-005;
 				};
-				class Item106
+				class Item105
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5932.625,196.1916,10381.125};
-						angles[]={0.079829417,3.0443094,0.034386542};
+						position[]={5983.3843,195.79005,10415.306};
+						angles[]={0.090948075,3.0443094,6.2815661};
 					};
 					side="Empty";
 					flags=4;
@@ -10737,13 +10737,13 @@ class Mission
 					id=9005;
 					type="Land_BagFence_Round_F";
 				};
-				class Item107
+				class Item106
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5930.5703,196.28291,10379.61};
-						angles[]={0.097292177,2.2589114,0.016798066};
+						position[]={5981.3296,195.93144,10413.791};
+						angles[]={0.090948075,2.2589114,6.2815661};
 					};
 					side="Empty";
 					flags=4;
@@ -10754,13 +10754,13 @@ class Mission
 					id=9006;
 					type="Land_BagFence_Long_F";
 				};
-				class Item108
+				class Item107
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5934.9546,196.36012,10380.021};
-						angles[]={0.079829417,0.68811464,0.034386542};
+						position[]={5985.7139,195.88693,10414.202};
+						angles[]={0.090948075,0.68811464,6.2815661};
 					};
 					side="Empty";
 					flags=4;
@@ -10771,12 +10771,12 @@ class Mission
 					id=9007;
 					type="Land_BagFence_Long_F";
 				};
-				class Item109
+				class Item108
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5901.875,196.75899,10369.375};
+						position[]={5938.9561,196.11063,10388.651};
 						angles[]={0,0.69813168,0};
 					};
 					side="Empty";
@@ -10789,12 +10789,12 @@ class Mission
 					id=9008;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item110
+				class Item109
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5906.5,197.30219,10365.5};
+						position[]={5943.5811,196.5135,10384.776};
 						angles[]={0,0.69813168,0};
 					};
 					side="Empty";
@@ -10806,12 +10806,12 @@ class Mission
 					id=9009;
 					type="Land_Wall_IndCnc_4_F";
 				};
-				class Item111
+				class Item110
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={5911.125,197.80618,10361.625};
+						position[]={5948.2061,196.89149,10380.901};
 						angles[]={0,0.69813168,0};
 					};
 					side="Empty";
@@ -10846,9 +10846,43 @@ class Mission
 						nAttributes=1;
 					};
 				};
+				class Item111
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={6003.6885,194.91527,10355.461};
+						angles[]={0,0.6481536,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9047;
+					type="Land_Wall_IndCnc_4_F";
+				};
+				class Item112
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={5998.9058,195.50543,10359.083};
+						angles[]={0,0.6481536,0};
+					};
+					side="Empty";
+					flags=5;
+					class Attributes
+					{
+						skill=0.2;
+					};
+					id=9048;
+					type="Land_Wall_IndCnc_4_F";
+				};
 			};
 			id=7888;
-			atlOffset=-0.033935547;
+			atlOffset=-0.83552551;
 		};
 		class Item489
 		{
@@ -14152,16 +14186,16 @@ class Mission
 				class Item17
 				{
 					dataType="Marker";
-					position[]={5945.1201,10681.125,10357.63};
+					position[]={5975.5117,10681.125,10385.423};
 					name="outpost_12";
 					markerType="RECTANGLE";
 					type="rectangle";
 					colorName="ColorGreen";
 					a=58.343082;
 					b=46.417057;
-					angle=216.99591;
+					angle=216.99579;
 					id=183;
-					atlOffset=10484.08;
+					atlOffset=10484.82;
 				};
 				class Item18
 				{
@@ -14287,7 +14321,7 @@ class Mission
 				};
 			};
 			id=8484;
-			atlOffset=35.85553;
+			atlOffset=35.842239;
 		};
 		class Item593
 		{
@@ -21115,15 +21149,15 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={5945.1533,196.90634,10356.715};
-				angles[]={0.07346756,0.64228117,6.277586};
+				position[]={5974.5171,196.34088,10386.335};
+				angles[]={0.023195164,0.64228117,0.004796607};
 			};
-			areaSize[]={56.117241,0,43.735672};
+			areaSize[]={58.170315,0,48.357121};
 			areaIsRectangle=1;
 			flags=1;
 			id=8998;
 			type="ModuleHideTerrainObjects_F";
-			atlOffset=-0.14245605;
+			atlOffset=0.036178589;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -21172,8 +21206,8 @@ class Mission
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={5913.5981,199.51453,10333.729};
-				angles[]={0.073466748,0,6.2264457};
+				position[]={5951.0664,197.53584,10352.195};
+				angles[]={0.004796607,3.7571216,6.2543945};
 			};
 			side="Empty";
 			flags=4;
@@ -21182,15 +21216,14 @@ class Mission
 			};
 			id=9000;
 			type="Land_GarbageHeap_03_F";
-			atlOffset=0.0023040771;
 		};
 		class Item869
 		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={5889.375,198.28455,10350.875};
-				angles[]={0.10758245,0.54572666,0.0064037596};
+				position[]={6014.9116,195.22394,10381.714};
+				angles[]={6.2599878,0.54572666,6.1803503};
 			};
 			side="Empty";
 			flags=4;
@@ -21202,19 +21235,139 @@ class Mission
 		};
 		class Item870
 		{
+			dataType="Marker";
+			position[]={5037.6235,59.503517,3738.2615};
+			name="marker_35";
+			type="mil_circle";
+			id=9014;
+		};
+		class Item871
+		{
+			dataType="Marker";
+			position[]={3785.9294,68.754272,4934.2417};
+			name="marker_36";
+			type="mil_circle";
+			id=9015;
+		};
+		class Item872
+		{
+			dataType="Marker";
+			position[]={4057.447,369.1442,6326.9438};
+			name="marker_37";
+			type="mil_circle";
+			id=9016;
+		};
+		class Item873
+		{
+			dataType="Marker";
+			position[]={7074.5698,96.740334,6751.6738};
+			name="marker_38";
+			type="mil_circle";
+			id=9017;
+		};
+		class Item874
+		{
+			dataType="Layer";
+			name="Check Point (Large)";
+			id=9037;
+			atlOffset=96.5;
+		};
+		class Item875
+		{
 			dataType="Object";
 			class PositionInfo
 			{
-				position[]={5933.875,193.45494,10414.25};
-				angles[]={0.13517158,3.6839166,0.068690397};
+				position[]={6009.2451,195.32214,10373.922};
+				angles[]={6.232029,3.809119,6.2328267};
 			};
 			side="Empty";
 			flags=4;
 			class Attributes
 			{
 			};
-			id=9013;
-			type="Land_GarbageHeap_04_F";
+			id=9039;
+			type="MetalBarrel_burning_F";
+			atlOffset=-0.00045776367;
+		};
+		class Item876
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5997.0967,195.00629,10345.985};
+				angles[]={6.2168822,0.53670949,6.2073317};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=9045;
+			type="Land_ScrapHeap_2_F";
+		};
+		class Item877
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5998.1821,195.75606,10353.575};
+				angles[]={6.2192731,6.1168904,6.2200685};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=9053;
+			type="Land_RepairDepot_01_tan_ruins_F";
+		};
+		class Item878
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5992.2061,195.02406,10342.909};
+				angles[]={6.2320313,3.8692553,6.1922374};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=9054;
+			type="Land_CargoBox_V1_F";
+		};
+		class Item879
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={5993.5889,194.83401,10341.66};
+				angles[]={6.2320313,5.4596691,6.1922374};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=9055;
+			type="Land_CargoBox_V1_F";
+		};
+		class Item880
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={6008.4395,195.3168,10373.016};
+				angles[]={6.232029,3.809119,6.2328267};
+			};
+			side="Empty";
+			flags=4;
+			class Attributes
+			{
+			};
+			id=9058;
+			type="MetalBarrel_burning_F";
 		};
 	};
 	class Connections

--- a/Map-Templates/Antistasi-Malden.Malden/mission.sqm
+++ b/Map-Templates/Antistasi-Malden.Malden/mission.sqm
@@ -217,24 +217,16 @@ class AddonsMetaData
 	};
 };
 randomSeed=13388897;
-class ScenarioData
-{
-	author="Dad";
-};
 class Mission
 {
 	class Intel
 	{
+		briefingName=$STR_antistasi_mission_info_malden_mapname_text;
 		resistanceWest=0;
-		startWind=0.1;
-		forecastWind=0.1;
-		forecastWaves=0.1;
 		year=2035;
 		month=6;
 		hour=10;
 		minute=0;
-		startFogDecay=0.0049333;
-		forecastFogDecay=0.0049333;
 	};
 	class Entities
 	{
@@ -10836,29 +10828,6 @@ class Mission
 					};
 					id=9010;
 					type="Land_Wall_IndCnc_4_F";
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="allowDamage";
-							expression="_this allowdamage _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"BOOL"
-										};
-									};
-									value=0;
-								};
-							};
-						};
-						nAttributes=1;
-					};
 				};
 				class Item109
 				{
@@ -12725,29 +12694,6 @@ class Mission
 					id=9301;
 					type="Land_Wall_IndCnc_4_F";
 					atlOffset=9.1552734e-005;
-					class CustomAttributes
-					{
-						class Attribute0
-						{
-							property="allowDamage";
-							expression="_this allowdamage _value;";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"BOOL"
-										};
-									};
-									value=0;
-								};
-							};
-						};
-						nAttributes=1;
-					};
 				};
 				class Item213
 				{


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Updated the location of outpost_12, Outpost now supports ammo missions.

### Please specify which Issue this PR Resolves.
closes #1636 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?
### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: Start the mission and run the following as local:
```[["outpost_12"],"A3A_fnc_LOG_Ammo"] remoteExec ["A3A_fnc_scheduler",2]```

********************************************************
Notes:
![20210204181936_1](https://user-images.githubusercontent.com/78278253/106972062-be52be80-6715-11eb-881c-d157b6d018e0.jpg)
![20210204181947_1](https://user-images.githubusercontent.com/78278253/106972066-beeb5500-6715-11eb-8f22-0a5ef3aaa9e9.jpg)

Need to verify the quality of outpost. @Bob-Murphy 
Check that the props used do not require DLC ownership ("A3_Props_F_Exp")