### PR TITLE
Fix logi Mount Block

### DIFF
--- a/A3-Antistasi/functions/Logistics/functions/fn_logistics_addWeaponAction.sqf
+++ b/A3-Antistasi/functions/Logistics/functions/fn_logistics_addWeaponAction.sqf
@@ -28,7 +28,7 @@ private _actionID = _vehicle addAction [
     {
         params ["_vehicle", "_caller", "_id", "_static"];
         if !(attachedTo _static isEqualTo _vehicle) exitWith {[_vehicle, _id] remoteExecCall ["removeAction", 0]};// incase of code break in unloading static
-        if ((gunner _static) isEqualTo objNull) then  {
+        if (!alive gunner _static) then {
             _caller moveInGunner _static;
         } else {["Logistics", "Someone is already in the static"] call A3A_fnc_customHint};
     },


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    fix a bug preventing getting in mounted statics if there was a dead unit in it.

### Please specify which Issue this PR Resolves.
closes #1708

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: try to get in it using the action on the vehicle, in the 3 different states: none in it, someone in it, someone dead in it.
this should result in: gets in, is blocked, gets in.

********************************************************
Notes:


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>