### PR TITLE
Add 3CB Factions to 3CB Detection to Prevent Petros gone.

### DIFF
--- a/A3-Antistasi/Templates/detector.sqf
+++ b/A3-Antistasi/Templates/detector.sqf
@@ -37,13 +37,14 @@ if (isClass (configFile >> "CfgFactionClasses" >> "rhs_faction_vdv") && isClass 
   [2,"RHS Detected.",_fileName] call A3A_fnc_log;
 };
 
-//3CB Detection
+//3CB BAF + Factions Detection
 if (A3A_hasRHS && (
   isClass (configfile >> "CfgPatches" >> "UK3CB_BAF_Weapons") &&
   isClass (configfile >> "CfgPatches" >> "UK3CB_BAF_Vehicles") &&
   isClass (configfile >> "CfgPatches" >> "UK3CB_BAF_Units_Common") &&
   isClass (configfile >> "CfgPatches" >> "UK3CB_BAF_Equipment") &&
-  isClass (configfile >> "CfgPatches" >> "UK3CB_BAF_Factions")
+  isClass (configfile >> "CfgPatches" >> "UK3CB_BAF_Factions") &&
+  isClass (configFile >> "CfgPatches" >> "UK3CB_Factions_Vehicles_SUV")
 ) ) then {A3A_has3CB = true; [2,"3CB Detected.",_fileName] call A3A_fnc_log;};
 
 //FFAA Detection

--- a/A3-Antistasi/Templates/detector.sqf
+++ b/A3-Antistasi/Templates/detector.sqf
@@ -43,7 +43,6 @@ if (A3A_hasRHS && (
   isClass (configfile >> "CfgPatches" >> "UK3CB_BAF_Vehicles") &&
   isClass (configfile >> "CfgPatches" >> "UK3CB_BAF_Units_Common") &&
   isClass (configfile >> "CfgPatches" >> "UK3CB_BAF_Equipment") &&
-  isClass (configfile >> "CfgPatches" >> "UK3CB_BAF_Factions") &&
   isClass (configFile >> "CfgPatches" >> "UK3CB_Factions_Vehicles_SUV")
 ) ) then {A3A_has3CB = true; [2,"3CB Detected.",_fileName] call A3A_fnc_log;};
 


### PR DESCRIPTION
Included 3CB Factions to ensure Petros gone issue being gone.

## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information: Added 3CB Factions to 3CB Detection, due to it missing People would still face Petros gone issues and Issue of Missing a lot of Vehicles + Weapons.
Removed a False check for a Class that never existed, 3CB Detection never worked.

### Please specify which Issue this PR Resolves.
closes #1709 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in singleplayer?
2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: Load with all Requiered mods,
Try to load 3CB without 3CB Factions.

********************************************************
Notes:
