### PR TITLE
Hr fix block towing off logistics cargo

### DIFF
--- a/A3-Antistasi/functions/Logistics/functions/fn_logistics_load.sqf
+++ b/A3-Antistasi/functions/Logistics/functions/fn_logistics_load.sqf
@@ -79,6 +79,7 @@ _cargo setVariable ["AttachmentOffset", _location];
 //block seats
 [_cargo, true] remoteExec ["A3A_fnc_logistics_toggleLock", 0, _cargo];
 [_vehicle, true, _seats] remoteExecCall ["A3A_fnc_logistics_toggleLock", 0, _vehicle];
+_cargo engineOn false;
 
 //break undercover
 if (_weapon && !_instant) then {

--- a/A3-Antistasi/functions/Logistics/functions/fn_logistics_toggleLock.sqf
+++ b/A3-Antistasi/functions/Logistics/functions/fn_logistics_toggleLock.sqf
@@ -43,5 +43,17 @@ if !(isNil "_seats") then {//for vehicle loading cargo
 } else {//for cargo, lock it fully and kick out any crew
     if (_vehicle isKindOf "StaticWeapon") exitWith {}; // dont lock statics, cant get out otherwise
     _vehicle lock _lock;
-    if (_lock) then {{moveOut _x}forEach crew _vehicle};
+    if (_lock) then {
+        //move out crew
+        {moveOut _x}forEach crew _vehicle;
+
+        //detach tow ropes attached to cargo
+        {
+            _veh = ropeAttachedTo _x;
+            if (!isNull _veh) then {[_veh,player] call SA_Put_Away_Tow_Ropes};
+        } forEach attachedObjects _vehicle;
+
+        //detach tow ropes from cargo
+        [_vehicle,player] call SA_Put_Away_Tow_Ropes
+    };
 };


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    towing cargo loaded would result in funny behavior, i stow towropes off from and to the cargo as its loaded, attaching new towropes while cargo is prevented as cargo is locked when loaded. also added a small qol of turning off the engine of the cargo

### Please specify which Issue this PR Resolves.
closes #1459

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in singleplayer?
2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
