### PR TITLE
🔥 Napalm Checks that Player has UID

### DIFF
--- a/A3-Antistasi/functions/AI/fn_napalm.sqf
+++ b/A3-Antistasi/functions/AI/fn_napalm.sqf
@@ -79,7 +79,12 @@ while {_endTime > serverTime && !([_cancellationTokenUUID] call _fnc_cancelReque
     private _allRenderers = allPlayers;
     //_allRenderers = _allRenderers select {(_x distance2D _pos) < 1500};  // Turn on if optimisation is required (A good way to show progress to your boss without doing any work!)
     isNil {  // Run in unscheduled scope to prevent parallel filtering.
-        _allRenderers = _allRenderers select {!isNull _x && { !(_storageNamespace getVariable [getPlayerUID _x, false]) }};    // Per napalm as every effect needs to be rendered.
+        private _currentUID = "";
+        _allRenderers = _allRenderers select {
+            !isNull _x &&
+            {_currentUID = getPlayerUID _x; !(_currentUID isEqualTo "")} &&
+            {!(_storageNamespace getVariable [_currentUID, false])}
+        };    // Per napalm as every effect needs to be rendered.
         { _storageNamespace setVariable [getPlayerUID _x, true]; } forEach _allRenderers;
     };
     { [_pos, _startTime,_cancellationTokenUUID] remoteExec ["A3A_fnc_napalmParticles",_x]; } forEach _allRenderers;

--- a/A3-Antistasi/functions/AI/fn_napalm.sqf
+++ b/A3-Antistasi/functions/AI/fn_napalm.sqf
@@ -79,11 +79,10 @@ while {_endTime > serverTime && !([_cancellationTokenUUID] call _fnc_cancelReque
     private _allRenderers = allPlayers;
     //_allRenderers = _allRenderers select {(_x distance2D _pos) < 1500};  // Turn on if optimisation is required (A good way to show progress to your boss without doing any work!)
     isNil {  // Run in unscheduled scope to prevent parallel filtering.
-        private _currentUID = "";
         _allRenderers = _allRenderers select {
             !isNull _x &&
-            {_currentUID = getPlayerUID _x; !(_currentUID isEqualTo "")} &&
-            {!(_storageNamespace getVariable [_currentUID, false])}
+            {!(getPlayerUID _x isEqualTo "")} &&
+            {!(_storageNamespace getVariable [getPlayerUID _x, false])}
         };    // Per napalm as every effect needs to be rendered.
         { _storageNamespace setVariable [getPlayerUID _x, true]; } forEach _allRenderers;
     };

--- a/A3-Antistasi/functions/AI/fn_napalmDamage.sqf
+++ b/A3-Antistasi/functions/AI/fn_napalmDamage.sqf
@@ -74,7 +74,7 @@ switch (true) do {
         };
     };
     case (_victim isKindOf "Man"): {_invalidVictim = true;};  // Goats, Sneks, butterflies, Rabbits can be blessed by Petros himself.
-    case (_victim isKindOf "AllVehicles" && {isClass (configFile >> "cfgVehicles" >> typeOf _victim >> "HitPoints" >> "HitHull")}): {
+    case (_victim isKindOf "AllVehicles"): {
         // Vehicles should be damaged as much as possible but salvageable. This would give napalm a unique tactic of clearing AI from vehicles allowing them to be repaired, refuelled and requestioned.
         _fnc_init = _fnc_init +
             'clearMagazineCargoGlobal _victim;
@@ -82,13 +82,18 @@ switch (true) do {
             clearItemCargoGlobal _victim;
             clearBackpackCargoGlobal _victim;';
 
-        _fnc_onTick = _fnc_onTick +
-            '_victim setHitPointDamage ["HitHull",(((_victim getHitPointDamage "HitHull") + ' + str _damagePerTick + ') min 0.8) max (_victim getHitPointDamage "HitHull")];'+ // Limited to avoid vehicle being destroyed. Will not decrease vehicle damage if it was initially above 80%
-            '{
-                _victim setHitPointDamage [_x,((_victim getHitPointDamage _x) + ' + str _damagePerTick + ') min 1];
-            } forEach ' + str ((getAllHitPointsDamage _victim)#0 - ["hithull"]) + ';
+        if !(getAllHitPointsDamage _victim isEqualTo []) then { // The static has a class entry, but its empty and getAllHitPointsDamage will return empty array
+            _fnc_onTick = _fnc_onTick +
+                '_victim setHitPointDamage ["HitHull",(((_victim getHitPointDamage "HitHull") + ' + str _damagePerTick + ') min 0.8) max (_victim getHitPointDamage "HitHull")];'+ // Limited to avoid vehicle being destroyed. Will not decrease vehicle damage if it was initially above 80%
+                '{
+                    _victim setHitPointDamage [_x,((_victim getHitPointDamage _x) + ' + str _damagePerTick + ') min 1];
+                } forEach ' + str ((getAllHitPointsDamage _victim)#0 - ["hithull"]) + ';';
+        } else {
+            _fnc_onTick = _fnc_onTick + '_victim setDamage (((damage _victim + ' + str _damagePerTick + ') min 0.8) max damage _victim);'; // Limited to avoid vehicle being destroyed. Will not decrease vehicle damage if it was initially above 80%
+        };
 
-            private _thermalHeat = 0.75*(_tickCount/'+ str _totalTicks +') + 0.25;'+  // The vehicles shouldn't snap to cold when the napalm effect starts begin.
+        _fnc_onTick = _fnc_onTick +
+            'private _thermalHeat = 0.75*(_tickCount/'+ str _totalTicks +') + 0.25;'+  // The vehicles shouldn't snap to cold when the napalm effect starts begin.
             '_victim setVehicleTIPars [_thermalHeat, _thermalHeat, _thermalHeat];';
 
         private _horn = getArray (configFile >> "cfgVehicles" >> typeOf _victim >> "weapons");

--- a/A3-Antistasi/functions/AI/fn_napalmDamage.sqf
+++ b/A3-Antistasi/functions/AI/fn_napalmDamage.sqf
@@ -32,7 +32,7 @@ private _filename = "functions\AI\fn_napalmDamage.sqf";
 if (isNull _victim) exitWith {false};  // Silent, likely for script to find some null objects somehow.
 
 if (isNil {
-    if (!alive _victim || {!isDamageAllowed _victim}) exitWith {nil};
+    if (!alive _victim || {!isDamageAllowed _victim} || {isObjectHidden _victim}) exitWith {nil};   // Hidden objects could be Zeus or other important mission things.
     1;
 }) exitWith {true};
 private _overKill = 5;  // In case the the unit starts getting healed.


### PR DESCRIPTION
## What type of PR is this.
* [x] Bug Fix
* Change
* Enhancement

### What have you changed and why?
* #️⃣ Napalm checks that a player has a UID before trying to save it and render the fire particles.
  * Without this, a player that joined before it's UID propergated to the server: will make getPlayerUID return "" which will not save and cause the player to atleast double render.
* ♨Damage will fall back to global damage if hitPoints can not be retreived. 
* ⚡ Hidden objects (commonly Zeus) will no longer burn and take damage.

### Please specify which Issue this PR Resolves.
closes https://github.com/official-antistasi-community/A3-Antistasi/issues/1724

### Please verify the following and ensure all checks are completed.

2. [x] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

## How can the changes be tested?

### Empty UID
1.  Spawn napalm `[screenToWorld [0.5,0.5]] remoteExec  ["A3A_fnc_napalm",2];`
2.  Have other players join in progress before their UID propagates, this is not easy to pull off.

### Static weapons taking damage.
1. Find a static weapon (or some modded vehicles from a sketch mod)
1.  Spawn napalm `[screenToWorld [0.5,0.5]] remoteExec  ["A3A_fnc_napalm",2];` on it and see if errors are reported and that the static takes damage.

### Zeus immunity
1. Hide Zeus.
1.  Spawn napalm `[screenToWorld [0.5,0.5]] remoteExec  ["A3A_fnc_napalm",2];` on Zeus.
 
