### PR TITLE
Fix ace stamina disabling force walk while carrying LTC crate

### DIFF
--- a/A3-Antistasi/functions/LTC/fn_carryCrate.sqf
+++ b/A3-Antistasi/functions/LTC/fn_carryCrate.sqf
@@ -29,10 +29,9 @@ if (_pickUp) then {
     if !(count _attachedObj == 0) exitWith {systemChat "you are already carrying something."};
     _crate attachTo [_player, [0, 1.5, 0], "Pelvis"];
     _player setVariable ["carryingCrate", true];
-    _player forceWalk true;
     [_player ,_crate] spawn {
         params ["_player", "_crate"];
-        waitUntil { !alive _crate or !(_player getVariable ["carryingCrate", false]) or !(vehicle _player isEqualTo _player) or _player getVariable ["incapacitated",false] or !alive _player or !(isPlayer attachedTo _crate) };
+        waitUntil {_player forceWalk true; !alive _crate or !(_player getVariable ["carryingCrate", false]) or !(vehicle _player isEqualTo _player) or _player getVariable ["incapacitated",false] or !alive _player or !(isPlayer attachedTo _crate) };
         [_crate, false, _player] call A3A_fnc_carryCrate;
     };
 } else {


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    moved the force walk set into the waitUntil loop, this will reapply it even if ace resets it, kind of heavy handed but didnt have a noticeable performance impact and command is local only so no network trafic

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
