### PR TITLE
CS-1773-NoEscapedLogStrings

### DIFF
--- a/A3-Antistasi/functions/Utility/fn_log.sqf
+++ b/A3-Antistasi/functions/Utility/fn_log.sqf
@@ -43,7 +43,7 @@ switch (_level) do {
 if (isNil "blockServerLogging" && _toServer && !isServer) then {
 	// Tag remote log lines with player. HCs return hc, hc_1, hc_2 etc
 	_logLine = format ["%1 | (R) %2", _logLine, str player];
-	_logLine remoteExec ["diag_log", 2];
+	text _logLine remoteExec ["diag_log", 2];
 } else {
-	diag_log _logLine;
+	diag_log text _logLine;
 };


### PR DESCRIPTION
## What type of PR is this.
* Bug
* Change
* [x] Enhancement

### What have you changed and why?
log info is converted to structured text before being fed into diag_log

### Why
Allows log colour filtering without having to remove quotations manually. Quotations do not need to be there. Requires addition of text between diag_logand an input string.

### Please specify which Issue this PR Resolves.
closes https://github.com/official-antistasi-community/A3-Antistasi/issues/1773

### Please verify the following and ensure all checks are completed.
1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
* [x] No
* Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Load antistasi, examine log output.

![New log](https://user-images.githubusercontent.com/31820984/111044675-e4206100-8441-11eb-8984-372701d22ba1.PNG)

