### PR TITLE
CS-1774-OneMillionGuns

### DIFF
--- a/A3-Antistasi/MissionDescription/params.hpp
+++ b/A3-Antistasi/MissionDescription/params.hpp
@@ -112,8 +112,8 @@ class Params
     class unlockItem
     {
         title = "Number of the same item required to unlock";
-        values[] = {9999,15,25,40};
-        texts[] = {"Default (25)","15","25","40"};
+        values[] = {9999,15,25,40,1e6};
+        texts[] = {"Default (25)","15","25","40","1 000 000"};
         default = 9999;
     };
     class memberOnlyMagLimit


### PR DESCRIPTION
## What type of PR is this.
* Bug
* [x] Change
* Enhancement

### What have you changed and why?
Added 1e6 (1 000 000) to the arsenal unlock amount list. 

### Why
One Million Guns (Doctor Evil voice https://youtu.be/cKKHSAE1gIs?t=14).
It will serve as a stop gap until a better solution replaces what we have now.
These people will need to accept that they must manually arm their AI if they want to give them better weapons (I believe the AI take unlocked guns?).

### Please specify which Issue this PR Resolves.
closes https://github.com/official-antistasi-community/A3-Antistasi/issues/1774

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
* Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Select 1 000 000 as unlock limit, spawn in many guns.
