### PR TITLE
Fixed paradrops, distances and unit counts

### DIFF
--- a/A3-Antistasi/functions/AI/fn_airdrop.sqf
+++ b/A3-Antistasi/functions/AI/fn_airdrop.sqf
@@ -11,8 +11,8 @@ if (_markerX isEqualType "") then {_positionX = getMarkerPos _markerX};
 _groupPilot = group driver _veh;
 {_x disableAI "TARGET"; _x disableAI "AUTOTARGET"} foreach units _groupPilot;
 _dist = 500;
-_distEng = if (_veh isKindOf "Helicopter") then {1000} else {2000};
-_distExit = if (_veh isKindOf "Helicopter") then {400} else {1000};
+_distEng = if (_veh isKindOf "Helicopter") then {500} else {1000};
+_distExit = if (_veh isKindOf "Helicopter") then {200} else {500};
 _orig = getMarkerPos _originX;
 
 

--- a/A3-Antistasi/functions/CREATE/fn_createAttackVehicle.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAttackVehicle.sqf
@@ -33,7 +33,8 @@ private _crewGroup = createVehicleCrew _vehicle;
 [_vehicle, _side] call A3A_fnc_AIVEHinit;
 
 private _cargoGroup = grpNull;
-if ((([_vehicleType, true] call BIS_fnc_crewCount) - ([_vehicleType, false] call BIS_fnc_crewCount)) > 0) then
+private _expectedCargo = ([_vehicleType, true] call BIS_fnc_crewCount) - ([_vehicleType, false] call BIS_fnc_crewCount);
+if (_expectedCargo > 0) then
 {
     //Vehicle is able to transport units
     private _groupType = if (_typeOfAttack == "Normal") then
@@ -65,6 +66,18 @@ if ((([_vehicleType, true] call BIS_fnc_crewCount) - ([_vehicleType, false] call
             deleteVehicle _x;
         };
     } forEach units _cargoGroup;
+};
+
+if(count (units _cargoGroup) < _expectedCargo) exitWith
+{
+    [3, "Unit limit reached, deleting vehicle and crew", _fileName] call A3A_fnc_log;
+    {
+        deleteVehicle _x;
+    } forEach ((units _cargoGroup) + (units _crewGroup));
+    deleteVehicle _vehicle;
+    deleteGroup _cargoGroup;
+    deleteGroup _crewGroup;
+    objNull;
 };
 
 _landPosBlacklist = [_vehicle, _crewGroup, _cargoGroup, _posDestination, _markerOrigin, _landPosBlacklist] call A3A_fnc_createVehicleQRFBehaviour;

--- a/A3-Antistasi/functions/CREATE/fn_createAttackVehicle.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAttackVehicle.sqf
@@ -33,6 +33,7 @@ private _crewGroup = createVehicleCrew _vehicle;
 [_vehicle, _side] call A3A_fnc_AIVEHinit;
 
 private _cargoGroup = grpNull;
+private _spawnPerformed = false;
 private _expectedCargo = ([_vehicleType, true] call BIS_fnc_crewCount) - ([_vehicleType, false] call BIS_fnc_crewCount);
 if (_expectedCargo > 0) then
 {
@@ -52,30 +53,44 @@ if (_expectedCargo > 0) then
             if (_side == Occupants) then {groupsNATOAT} else {groupsCSATAT}
         };
     };
-    _cargoGroup = [_posOrigin, _side, _groupType] call A3A_fnc_spawnGroup;
+
+    private _allUnits = {(local _x) and (alive _x)} count allUnits;
+
+    private _allUnitsSide = 0;
+    private _maxUnitsSide = maxUnits;
+    if (gameMode < 3) then
     {
-        _x assignAsCargo _vehicle;
-        _x moveInCargo _vehicle;
-        if !(isNull objectParent _x) then
+        _allUnitsSide = {(local _x) and (alive _x) and (side group _x == _sideX)} count allUnits;
+        _maxUnitsSide = round (maxUnits * 0.7);
+    };
+
+    if ((_allUnits + _expectedCargo) <= maxUnits  && (_allUnitsSide + _expectedCargo) <= _maxUnitsSide) then
+    {
+        _spawnPerformed = true;
+        _cargoGroup = [_posOrigin, _side, _groupType] call A3A_fnc_spawnGroup;
         {
-            [_x] call A3A_fnc_NATOinit;
-            _x setVariable ["originX", _markerOrigin];
-        }
-        else
-        {
-            deleteVehicle _x;
-        };
-    } forEach units _cargoGroup;
+            _x assignAsCargo _vehicle;
+            _x moveInCargo _vehicle;
+            if !(isNull objectParent _x) then
+            {
+                [_x] call A3A_fnc_NATOinit;
+                _x setVariable ["originX", _markerOrigin];
+            }
+            else
+            {
+                deleteVehicle _x;
+            };
+        } forEach units _cargoGroup;
+    };
 };
 
-if(count (units _cargoGroup) < _expectedCargo) exitWith
+if(!_spawnPerformed) exitWith
 {
     [3, "Unit limit reached, deleting vehicle and crew", _fileName] call A3A_fnc_log;
     {
         deleteVehicle _x;
-    } forEach ((units _cargoGroup) + (units _crewGroup));
+    } forEach (units _crewGroup);
     deleteVehicle _vehicle;
-    deleteGroup _cargoGroup;
     deleteGroup _crewGroup;
     objNull;
 };

--- a/A3-Antistasi/functions/CREATE/fn_wavedCA.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_wavedCA.sqf
@@ -586,7 +586,7 @@ while {(_waves > 0)} do
 					}
 				else
 					{
-					_landPos = _posDestination getPos [300, random 360];
+					_landPos = _posDestination getPos [150, random 360];
 					_landPos = [_landPos, 0, 550, 10, 0, 0.20, 0,[],[[0,0,0],[0,0,0]]] call BIS_fnc_findSafePos;
 					if !(_landPos isEqualTo [0,0,0]) then
 						{


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
The new support QRFs tried to paradrop entire squads near the AI limit, which then resulted into paradropping one guy.
Readded the block, the ensures that this isnt happening. Also decreased the radius in which they can drop, so it doesnt take forever for them to arrive.

### Please specify which Issue this PR Resolves.
None opened for that

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: Was on the test server during the large test, no further testing required

********************************************************
Notes:
