### PR TITLE
Damage does not log AI or Null

### DIFF
--- a/A3-Antistasi/functions/Punishment/fn_punishment_FF.sqf
+++ b/A3-Antistasi/functions/Punishment/fn_punishment_FF.sqf
@@ -50,7 +50,8 @@ if (_instigator isEqualType []) then {
     _isCollision = !(((_instigator#0) isEqualType objNull) && {isPlayer (_instigator#0)});
     _instigator = _instigator select _isCollision;  // First one in EH will be unit by default, if its a collision the eh returns the instigator in "source" or "killer"
 };
-if (!(_instigator isEqualType objNull)) exitWith {"NOT OBJECT"};
+if (!(_instigator isEqualType objNull) || {isNull _instigator}) exitWith {"NOT OBJECT"};
+if (!isPlayer _instigator) exitWith {"AI"};
 private _vehicle = vehicle _instigator;
 private _vehicleType = typeOf _vehicle;
 


### PR DESCRIPTION
## What type of PR is this.
* Bug
2. [x] Change
3. [x] Enhancement

### What have you changed and why?
Checks for obj null.
Checks for is player.
The extra info is not needed.

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
* Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Crash into tree -> no log.
Get shot by AI -> no log.