### PR TITLE
CS-spawnVehiclePresice-FixedAircraftDetection

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_spawnVehiclePrecise.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_spawnVehiclePrecise.sqf
@@ -91,7 +91,6 @@ if (isNil { // Make sure vehicle is spawned and placed within the same physics s
     _vehicle setVelocityModelSpace [0, _velocity, 0];
 
     if (_emptyPositionRadius > 0) then {
-        [2,"94 "+str [_emptyPositionRadius],_filename] call A3A_fnc_log;
         [_vehicle,_position] call A3A_fnc_setPos;
         _safePosition = getPos _vehicle findEmptyPosition [0, _emptyPositionRadius, _className];
         if (_safePosition isEqualTo []) then {

--- a/A3-Antistasi/functions/CREATE/fn_spawnVehiclePrecise.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_spawnVehiclePrecise.sqf
@@ -24,10 +24,10 @@ private _vehicle = ["B_T_LSV_01_armed_F",getPos player, 0, 20] call A3A_fnc_spaw
 _unitType = [_side, _vehicle] call A3A_fnc_crewTypeForVehicle;
 [resistance, _vehicle, _unitType] call A3A_fnc_createVehicleCrew;
 
-    // Spawn rebel LSV on roof above you
+    // Spawn empty LSV on roof above you
 private _myPos = getPosWorld player;
 _myPos = [_myPos#0,_myPos#1,0,"AGLS"];  // Spawn 0m above highest roof above the player.
-["B_T_LSV_01_armed_F",_myPos, 0, 20] call A3A_fnc_spawnVehiclePrecise;
+["B_T_LSV_01_armed_F",_myPos] call A3A_fnc_spawnVehiclePrecise;
 
 
     // Spawn rebel ghost-hawk roof above you motionless, until being released.
@@ -58,7 +58,7 @@ private _createVehicleSpecial = "CAN_COLLIDE";
 
 if !(isNil {_aircraftPhysics}) then {
     if !((toLower getText(configFile >> "CfgVehicles" >> _className >> "simulation")) in ["airplanex","helicopterrtd","helicopterx"]) exitWith {};
-    private _addAircraftPhysics = true;
+    _addAircraftPhysics = true;
     _createVehicleSpecial = "FLY";
 
     _aircraftPhysics params [
@@ -91,17 +91,18 @@ if (isNil { // Make sure vehicle is spawned and placed within the same physics s
     _vehicle setVelocityModelSpace [0, _velocity, 0];
 
     if (_emptyPositionRadius > 0) then {
+        [2,"94 "+str [_emptyPositionRadius],_filename] call A3A_fnc_log;
         [_vehicle,_position] call A3A_fnc_setPos;
         _safePosition = getPos _vehicle findEmptyPosition [0, _emptyPositionRadius, _className];
         if (_safePosition isEqualTo []) then {
-            [2, "EmptyPositionNotFound | Unable to find suitable empty position """+_emptyPositionRadius+"""m within """+getPosASL _vehicle+"""(ASL) for """+_className+""" on """+worldName+""".", _filename] remoteExecCall ["A3A_fnc_log",2,false];
+            [2, "EmptyPositionNotFound | Unable to find suitable empty position """+str _emptyPositionRadius+"""m within """+str getPosASL _vehicle+"""(ASL) for """+_className+""" on """+worldName+""".", _filename] remoteExecCall ["A3A_fnc_log",2,false];
         } else {
             _position = _safePosition + ["AGLS"];   // Is set in following setPos call.
         };
     };
     [_vehicle,_position] call A3A_fnc_setPos;
     if (_addAircraftPhysics && getPosVisual _vehicle #2 < _aircraftMinHeight) then {    // Enforces minimum height above surface.
-        [_vehicle,[_position#0,_position#1,_aircraftMinHeight],"AGLS"] call A3A_fnc_setPos
+        [_vehicle,[_position#0,_position#1,_aircraftMinHeight],"AGLS"] call A3A_fnc_setPos;
     };
 
     true;


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
* Change
* Enhancement

### What have you changed and why?
Fixed creating a new nested private field rather than setting the parent scope's variable.

### Please verify the following and ensure all checks are completed.
1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
* Yes (Please provide further detail below.)

### How can the changes be tested?
Spawn rebel crewed LSV in proximity to the player.
Spawn rebel LSV nearby
```sqf
private _vehicle = ["B_T_LSV_01_armed_F",getPos player, 0, 20] call A3A_fnc_spawnVehiclePrecise;
_unitType = [_side, _vehicle] call A3A_fnc_crewTypeForVehicle;
[resistance, _vehicle, _unitType] call A3A_fnc_createVehicleCrew;
```
Spawn empty LSV on roof above you
```sqf
private _myPos = getPosWorld player;
_myPos = [_myPos#0,_myPos#1,0,"AGLS"];  // Spawn 0m above highest roof above the player.
["B_T_LSV_01_armed_F",_myPos] call A3A_fnc_spawnVehiclePrecise;
```
Spawn rebel ghost-hawk roof above you motionless, until being released.
```sqf
private _myPosW = getPosWorld player;
private _vectorDirAndUp = [[0.676148,-0.736273,-0.0269321],[-0.571476,-0.547179,0.611565]];
private _vehicle = ["B_Heli_Transport_01_F",[_myPosW,"WORLD"], _vectorDirAndUp, nil, [10,40]] call A3A_fnc_spawnVehiclePrecise;
_unitType = [_side, _vehicle] call A3A_fnc_crewTypeForVehicle;
[resistance, _vehicle, _unitType] call A3A_fnc_createVehicleCrew;
_vehicle enableSimulation false; // For admiring the artwork
// Release.
cursorObject enableSimulation true;
```
