### PR TITLE
Fix Crew Selection for UAVsmall

### DIFF
--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -634,7 +634,7 @@ DECLARE_SERVER_VAR(vehHelis, _vehHelis);
 private _vehFixedWing = [vehNATOPlane,vehNATOPlaneAA,vehCSATPlane,vehCSATPlaneAA,vehSDKPlane] + vehNATOTransportPlanes + vehCSATTransportPlanes;
 DECLARE_SERVER_VAR(vehFixedWing, _vehFixedWing);
 
-private _vehUAVs = [vehNATOUAV,vehCSATUAV];
+private _vehUAVs = [vehNATOUAV,vehCSATUAV,vehNATOUAVSmall,vehCSATUAVSmall];
 DECLARE_SERVER_VAR(vehUAVs, _vehUAVs);
 
 private _vehAmmoTrucks = [vehNATOAmmoTruck,vehCSATAmmoTruck];


### PR DESCRIPTION
This was forgotten by accident

## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Added the Small UAV Drones to _VehUAVs in InitVarserver which is used
this should allow fn_initVehClassToCrew to select Ai for the Small UAVs and not default to Rifleman D:

### Please specify which Issue this PR Resolves.
closes none

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: I dont have good way of testing besides:
```sqf
A3A_vehClassToCrew getOrDefault 
[vehNATOUAVSmall,[NATOGrunt, CSATGrunt, staticCrewTeamPlayer, "C_Man_1"]] select 0;
```
This should return one of these, depending on Side: ["B_UAV_AI", "O_UAV_AI", "I_UAV_AI", "C_UAV_AI"]],
********************************************************
Notes:
