### PR TITLE
Prevent arsenalManage errors on zero-cap or broken magazine configs

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_arsenalManage.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_arsenalManage.sqf
@@ -25,7 +25,7 @@ private _count = objNull;
 {
 	_type = _x select 0;
 	_magConfig = configFile >> "CfgMagazines" >> _type;
-	_capacity = getNumber (_magConfig >> "count");
+	_capacity = 1 max getNumber (_magConfig >> "count");			// Avoid div-by-zero on broken/missing config
 
 	// control unlocking missile launcher magazines
 	// the capacity check is an optimisation to bypass the config check. ~18% perf gain on the loop.


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed RPT errors when the arsenal unlock routine runs with zero-cap or broken magazine configs in the arsenal. The code now assumes the magazine capacity is 1 if zero or missing.

Shouldn't have any side effects, although it's possible that other code will behave oddly with zero-cap or broken magazine configs.

### Please specify which Issue this PR Resolves.
closes #1799 
closes #1658

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
