### PR TITLE
Fix occasional divide-by-zero in AIReactOnKill

### DIFF
--- a/A3-Antistasi/functions/AI/fn_AIreactOnKill.sqf
+++ b/A3-Antistasi/functions/AI/fn_AIreactOnKill.sqf
@@ -125,7 +125,7 @@ if(_group getVariable ["canCallSupportAt", -1] < dateToNumber date) then
 			};
             if (random 1 < 0.5) then
             {
-                if (_unitCount > 0) then
+                if (count units _group > 0) then
                 {
                     _x allowFleeing (1 -(_x skill "courage") + (_unitCount/(count units _group)));
                 };


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed error introduced in refactor which could cause divide-by-zero RPT errors.

Because AIReactOnKill has significant execution time, `count units _group` is not necessarily non-zero by the end, even if it is at the start.

### Please specify which Issue this PR Resolves.
closes #1733

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
