### PR TITLE
Fix-LTC-nonLocalBodiesDupe

### DIFF
--- a/A3-Antistasi/functions/LTC/fn_lootToCrate.sqf
+++ b/A3-Antistasi/functions/LTC/fn_lootToCrate.sqf
@@ -90,8 +90,9 @@ _lootBodies = {
     };
 
     //to ensure proper cleanup
-    removeAllWeapons _unit;
-    removeAllItems _unit;
+    private _uniform = uniform _unit;
+    _unit setUnitLoadout (configFile >> "EmptyLoadout");
+    _unit forceAddUniform _uniform;
 
     //try to add items to container
     _remaining = [[],[],[],[]];


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    non local bodies looted with ltc would not remove the original hmd and (reportedly sidearm)
moved to setUindLoadout to ensure bodies are stripped

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
