### PR TITLE
Prevent Petros from being added to Garrisons

### DIFF
--- a/A3-Antistasi/REINF/addToGarrison.sqf
+++ b/A3-Antistasi/REINF/addToGarrison.sqf
@@ -48,7 +48,7 @@ if _alreadyInGarrison exitWith {["Garrison", "The units selected already are in 
 
 {
 	private _unitType = _x getVariable "unitType";
-	if ((_unitType == staticCrewTeamPlayer) or (_unitType == SDKUnarmed) or (_unitType in typePetros) or (_unitType in arrayCivs) or (!alive _x)) exitWith {_leave = true}
+	if ((_unitType == staticCrewTeamPlayer) or (_unitType == SDKUnarmed) or (_unitType == typePetros) or (_unitType in arrayCivs) or (!alive _x)) exitWith {_leave = true}
 } forEach _unitsX;
 
 if (_leave) exitWith {["Garrison", "Static crewman, prisoners, refugees, Petros or dead units cannot be added to any garrison"] call A3A_fnc_customHint;};

--- a/A3-Antistasi/REINF/addToGarrison.sqf
+++ b/A3-Antistasi/REINF/addToGarrison.sqf
@@ -48,10 +48,10 @@ if _alreadyInGarrison exitWith {["Garrison", "The units selected already are in 
 
 {
 	private _unitType = _x getVariable "unitType";
-	if ((_unitType == staticCrewTeamPlayer) or (_unitType == SDKUnarmed) or (_unitType in arrayCivs) or (!alive _x)) exitWith {_leave = true}
+	if ((_unitType == staticCrewTeamPlayer) or (_unitType == SDKUnarmed) or (_unitType in typePetros) or (_unitType in arrayCivs) or (!alive _x)) exitWith {_leave = true}
 } forEach _unitsX;
 
-if (_leave) exitWith {["Garrison", "Static crewman, prisoners, refugees or dead units cannot be added to any garrison"] call A3A_fnc_customHint;};
+if (_leave) exitWith {["Garrison", "Static crewman, prisoners, refugees, Petros or dead units cannot be added to any garrison"] call A3A_fnc_customHint;};
 
 if ((groupID _groupX == "MineF") or (groupID _groupX == "Watch") or (isPlayer(leader _groupX))) exitWith {["Garrison", "You cannot garrison player led, Watchpost, Roadblocks or Minefield building squads"] call A3A_fnc_customHint;};
 


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Added TypePetros to the check to prevent units from being added to a Garrison.
Updated the Hint, in case someone wonders why they can't add Units to a Garrison.

### Please specify which Issue this PR Resolves.
closes #1808 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Move HQ, Select Petros, try adding Petros to a Garrison, this should throw the Unable to Garrison hint.


********************************************************
Notes:
