### PR TITLE
Update System Mod detection to A3A Preset / TFAR Beta detection

### DIFF
--- a/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal.sqf
@@ -279,7 +279,7 @@ switch _mode do {
 	case "SaveTFAR": {
 		jna_backpackRadioSettings = nil;
 		jna_swRadioSettings = nil;
-		if (hasTFAR) then {
+		if (A3A_hasTFAR) then {
 			private _backpackRadio = player call TFAR_fnc_backpackLr;
 			if (!isNil "_backpackRadio" && {count _backpackRadio >= 2}) then {
 				jna_backpackRadioSettings = _backpackRadio call TFAR_fnc_getLrSettings;
@@ -295,7 +295,7 @@ switch _mode do {
 	//Restore TFAR radio settings
 
 	case "RestoreTFAR": {
-		if (hasTFAR) then {
+		if (A3A_hasTFAR) then {
 			private _backpackRadio = player call TFAR_fnc_backpackLr;
 			if (!isNil "_backpackRadio" && {count _backpackRadio >= 2}) then {
 				if (isNil "jna_backpackRadioSettings" || {typeName jna_backpackRadioSettings != typeName []}) exitWith {
@@ -2612,7 +2612,7 @@ switch _mode do {
 		/////////////////////////////////////////////////////////////////////////////////
 		// unifrom
 		_itemsUnifrom = [];
-		if(hasACEMedical)then{
+		if(A3A_hasACEMedical)then{
 			_itemsUnifrom pushBack ["ACE_elasticBandage",2];
 			_itemsUnifrom pushBack ["ACE_packingBandage",2];
 			_itemsUnifrom pushBack ["ACE_morphine",1];
@@ -2622,14 +2622,14 @@ switch _mode do {
 			_itemsUnifrom pushBack ["ACE_splint", 1];
 		}else{
 			_itemsUnifrom pushBack ["FirstAidKit",2];
-			if(hasACE) then {
+			if(A3A_hasACE) then {
 				_itemsUnifrom pushBack ["ACE_EarPlugs",1];
 				_itemsUnifrom pushBack ["ACE_MapTools",1];
 				_itemsUnifrom pushBack ["ACE_CableTie",2];
 			};
 		};
 
-		if ((hasACE) AND (sunOrMoon <1)) then {
+		if ((A3A_hasACE) AND (sunOrMoon <1)) then {
 			_itemsUnifrom pushback ["ACE_HandFlare_Red",1];
 			_itemsUnifrom pushback ["ACE_Chemlight_HiRed",1];
 			_itemsUnifrom pushBack ["ACE_Flashlight_MX991",1];
@@ -2661,7 +2661,7 @@ switch _mode do {
 
 		if([player] call A3A_fnc_isMedic)then{
 
-			if(hasACEMedical) then { //Medic equipment
+			if(A3A_hasACEMedical) then { //Medic equipment
 				_itemsBackpack pushBack ["ACE_elasticBandage",15];
 				_itemsBackpack pushBack ["ACE_packingBandage",15];
 				_itemsBackpack pushBack ["ACE_tourniquet",5];
@@ -2674,7 +2674,7 @@ switch _mode do {
 				_itemsBackpack pushBack ["FirstAidKit",1];
 			};
 		} else {
-		 		if(hasACEMedical) then {
+		 		if(A3A_hasACEMedical) then {
 					_itemsBackpack pushBack ["ACE_fieldDressing",5];
 					_itemsBackpack pushBack ["ACE_packingBandage",5];
 					_itemsBackpack pushBack ["ACE_elasticBandage",5];
@@ -2690,7 +2690,7 @@ switch _mode do {
 
 		if(player getUnitTrait "Engineer")then {
 					_itemsBackpack pushback ["ToolKit",1];
-					if(hasACE) then {
+					if(A3A_hasACE) then {
 						_itemsbackpack pushback ["ACE_Clacker",1];
 						_itemsbackpack pushback ["ACE_SpraypaintRed",4];
 					};

--- a/A3-Antistasi/Templates/NewTemplates/#Examples/RebelExample.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/#Examples/RebelExample.sqf
@@ -50,8 +50,10 @@
 ///////////////////////////
 
 private _initialRebelEquipment = [];
-if (hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
-if (hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "tf_anprc155"};
+if (A3A_hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
+if (A3A_hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "tf_anprc155"};
+if (A3A_hasTFARBeta) then {_initialRebelEquipment append ["TFAR_microdagr","TFAR_anprc154"]};
+if (A3A_hasTFARBeta && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "TFAR_anprc155"};
 
 ["initialRebelEquipment", _initialRebelEquipment] call _fnc_saveToTemplate;
 
@@ -135,12 +137,12 @@ private _squadLeaderTemplate = {
 	["helmets"] call _fnc_setHelmet;
 	["vests"] call _fnc_setVest;
 	["uniforms"] call _fnc_setUniform;
-	
+
 	["backpacks"] call _fnc_setBackpack;
 
 	[["grenadeLaunchers", "rifles"] call _fnc_fallback] call _fnc_setPrimary;
 	["primary", 5] call _fnc_addMagazines;
-	
+
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 2] call _fnc_addMagazines;
@@ -221,7 +223,7 @@ private _grenadierTemplate = {
 
 	["grenadeLaunchers"] call _fnc_setPrimary;
 	["primary", 5] call _fnc_addMagazines;
-	
+
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 2] call _fnc_addMagazines;
@@ -248,7 +250,7 @@ private _explosivesExpertTemplate = {
 
 	["rifles"] call _fnc_setPrimary;
 	["primary", 5] call _fnc_addMagazines;
-	
+
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 2] call _fnc_addMagazines;

--- a/A3-Antistasi/Templates/NewTemplates/3CB/3CB_Reb_CNM_Temperate.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/3CB/3CB_Reb_CNM_Temperate.sqf
@@ -65,9 +65,10 @@ private _initialRebelEquipment = [
 "UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_Small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK",
 "rhs_acc_2dpZenit","Binocular"
 ];
-if (hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
-if (hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "tf_anprc155"};
-
+if (A3A_hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
+if (A3A_hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "tf_anprc155"};
+if (A3A_hasTFARBeta) then {_initialRebelEquipment append ["TFAR_microdagr","TFAR_anprc154"]};
+if (A3A_hasTFARBeta && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "TFAR_anprc155"};
 ["initialRebelEquipment", _initialRebelEquipment] call _fnc_saveToTemplate;
 
 //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/A3-Antistasi/Templates/NewTemplates/3CB/3CB_Reb_TKM_Arid.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/3CB/3CB_Reb_TKM_Arid.sqf
@@ -65,9 +65,10 @@ private _initialRebelEquipment = [
 "UK3CB_V_CW_Chestrig","UK3CB_V_CW_Chestrig_2_Small","UK3CB_V_Belt_KHK","UK3CB_V_Belt_Rig_KHK","UK3CB_V_Belt_Rig_Lite_KHK","UK3CB_V_Pouch","UK3CB_V_Chestrig_TKA_OLI","UK3CB_V_Chestrig_2_Small_OLI","UK3CB_V_Chestrig_TKA_BRUSH","UK3CB_V_Chestrig_Lite_KHK","UK3CB_V_Chestrig_Lite_2_Small_KHK",
 "rhs_acc_2dpZenit","Binocular"
 ];
-if (hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
-if (hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "tf_anprc155_coyote"};
-
+if (A3A_hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
+if (A3A_hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "tf_anprc155_coyote"};
+if (A3A_hasTFARBeta) then {_initialRebelEquipment append ["TFAR_microdagr","TFAR_anprc154"]};
+if (A3A_hasTFARBeta && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "TFAR_anprc155_coyote"};
 ["initialRebelEquipment", _initialRebelEquipment] call _fnc_saveToTemplate;
 
 //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/A3-Antistasi/Templates/NewTemplates/RHS/RHS_Reb_NAPA_Arid.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/RHS/RHS_Reb_NAPA_Arid.sqf
@@ -63,9 +63,10 @@ private _initialRebelEquipment = [
 "B_FieldPack_blk","B_FieldPack_cbr","B_FieldPack_green_F","B_FieldPack_khk","B_FieldPack_oli",
 "rhsgref_chestrig","rhsgref_chicom","rhs_vydra_3m","rhs_vest_pistol_holster","rhs_vest_commander","rhs_6sh46","rhsgref_alice_webbing",
 "rhs_acc_2dpZenit","Binocular"];
-if (hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
-if (hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "tf_anprc155_coyote"};
-
+if (A3A_hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
+if (A3A_hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "tf_anprc155_coyote"};
+if (A3A_hasTFARBeta) then {_initialRebelEquipment append ["TFAR_microdagr","TFAR_anprc154"]};
+if (A3A_hasTFARBeta && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "TFAR_anprc155_coyote"};
 ["initialRebelEquipment", _initialRebelEquipment] call _fnc_saveToTemplate;
 
 //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/A3-Antistasi/Templates/NewTemplates/RHS/RHS_Reb_NAPA_Temperate.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/RHS/RHS_Reb_NAPA_Temperate.sqf
@@ -63,9 +63,11 @@ private _initialRebelEquipment = [
 "B_FieldPack_blk","B_FieldPack_cbr","B_FieldPack_green_F","B_FieldPack_khk","B_FieldPack_oli",
 "rhsgref_chestrig","rhsgref_chicom","rhs_vydra_3m","rhs_vest_pistol_holster","rhs_vest_commander","rhs_6sh46","rhsgref_alice_webbing",
 "rhs_acc_2dpZenit","Binocular"];
-if (hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
-if (hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "tf_anprc155"};
-
+Switch
+if (A3A_hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
+if (A3A_hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "tf_anprc155"};
+if (A3A_hasTFARBeta) then {_initialRebelEquipment append ["TFAR_microdagr","TFAR_anprc154"]};
+if (A3A_hasTFARBeta && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "TFAR_anprc155"};
 ["initialRebelEquipment", _initialRebelEquipment] call _fnc_saveToTemplate;
 
 //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Reb_FIA_Arid.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Reb_FIA_Arid.sqf
@@ -39,8 +39,8 @@
 ["baggedAA", [["I_AA_01_weapon_F","I_G_HMG_02_support_F"]]] call _fnc_saveToTemplate; 					//this line determines bagged static AAs -- Example: ["baggedAA", [["B_AA_01_weapon_F", "B_HMG_01_support_F"]]] -- Array, can contain multiple assets
 ["baggedMortars", [["I_Mortar_01_weapon_F","I_Mortar_01_support_F"]]] call _fnc_saveToTemplate; 			//this line determines bagged static mortars -- Example: ["baggedMortars", [["B_Mortar_01_F", "B_Mortar_01_weapon_F"]]] -- Array, can contain multiple assets
 
-["mineAT", "ATMine_Range_Mag"] call _fnc_saveToTemplate; 				
-["mineAPERS", "APERSMine_Range_Mag"] call _fnc_saveToTemplate; 			
+["mineAT", "ATMine_Range_Mag"] call _fnc_saveToTemplate;
+["mineAPERS", "APERSMine_Range_Mag"] call _fnc_saveToTemplate;
 
 ["breachingExplosivesAPC", [["DemoCharge_Remote_Mag", 1]]] call _fnc_saveToTemplate;
 ["breachingExplosivesTank", [["SatchelCharge_Remote_Mag", 1], ["DemoCharge_Remote_Mag", 2]]] call _fnc_saveToTemplate;
@@ -60,9 +60,10 @@ private _initialRebelEquipment = [
 "V_BandollierB_khk","V_BandollierB_oli","V_Rangemaster_belt",
 "Binocular",
 "acc_flashlight","acc_flashlight_smg_01","acc_flashlight_pistol"];
-if (hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
-if (hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "tf_anprc155_coyote"};
-
+if (A3A_hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
+if (A3A_hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "tf_anprc155_coyote"};
+if (A3A_hasTFARBeta) then {_initialRebelEquipment append ["TFAR_microdagr","TFAR_anprc154"]};
+if (A3A_hasTFARBeta && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "TFAR_anprc155_coyote"};
 ["initialRebelEquipment", _initialRebelEquipment] call _fnc_saveToTemplate;
 
 //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -145,12 +146,12 @@ private _squadLeaderTemplate = {
 	["helmets"] call _fnc_setHelmet;
 	["vests"] call _fnc_setVest;
 	["uniforms"] call _fnc_setUniform;
-	
+
 	["backpacks"] call _fnc_setBackpack;
 
 	[["grenadeLaunchers", "rifles"] call _fnc_fallback] call _fnc_setPrimary;
 	["primary", 5] call _fnc_addMagazines;
-	
+
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 2] call _fnc_addMagazines;
@@ -231,7 +232,7 @@ private _grenadierTemplate = {
 
 	["grenadeLaunchers"] call _fnc_setPrimary;
 	["primary", 5] call _fnc_addMagazines;
-	
+
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 2] call _fnc_addMagazines;
@@ -258,7 +259,7 @@ private _explosivesExpertTemplate = {
 
 	["rifles"] call _fnc_setPrimary;
 	["primary", 5] call _fnc_addMagazines;
-	
+
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 2] call _fnc_addMagazines;

--- a/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Reb_FIA_Enoch.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Reb_FIA_Enoch.sqf
@@ -39,8 +39,8 @@
 ["baggedAA", [["I_AA_01_weapon_F","I_G_HMG_02_support_F"]]] call _fnc_saveToTemplate; 					//this line determines bagged static AAs -- Example: ["baggedAA", [["B_AA_01_weapon_F", "B_HMG_01_support_F"]]] -- Array, can contain multiple assets
 ["baggedMortars", [["I_Mortar_01_weapon_F","I_Mortar_01_support_F"]]] call _fnc_saveToTemplate; 			//this line determines bagged static mortars -- Example: ["baggedMortars", [["B_Mortar_01_F", "B_Mortar_01_weapon_F"]]] -- Array, can contain multiple assets
 
-["mineAT", "ATMine_Range_Mag"] call _fnc_saveToTemplate; 				
-["mineAPERS", "APERSMine_Range_Mag"] call _fnc_saveToTemplate; 			
+["mineAT", "ATMine_Range_Mag"] call _fnc_saveToTemplate;
+["mineAPERS", "APERSMine_Range_Mag"] call _fnc_saveToTemplate;
 
 ["breachingExplosivesAPC", [["DemoCharge_Remote_Mag", 1]]] call _fnc_saveToTemplate;
 ["breachingExplosivesTank", [["SatchelCharge_Remote_Mag", 1], ["DemoCharge_Remote_Mag", 2]]] call _fnc_saveToTemplate;
@@ -61,9 +61,10 @@ private _initialRebelEquipment = [
 "V_BandollierB_rgr","V_SmershVest_01_radio_F","V_BandollierB_oli","V_Rangemaster_belt",
 "Binocular","acc_flashlight"
 ];
-if (hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
-if (hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "tf_anprc155"};
-
+if (A3A_hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
+if (A3A_hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "tf_anprc155"};
+if (A3A_hasTFARBeta) then {_initialRebelEquipment append ["TFAR_microdagr","TFAR_anprc154"]};
+if (A3A_hasTFARBeta && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "TFAR_anprc155"};
 ["initialRebelEquipment", _initialRebelEquipment] call _fnc_saveToTemplate;
 
 //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -148,12 +149,12 @@ private _squadLeaderTemplate = {
 	["helmets"] call _fnc_setHelmet;
 	["vests"] call _fnc_setVest;
 	["uniforms"] call _fnc_setUniform;
-	
+
 	["backpacks"] call _fnc_setBackpack;
 
 	[["grenadeLaunchers", "rifles"] call _fnc_fallback] call _fnc_setPrimary;
 	["primary", 5] call _fnc_addMagazines;
-	
+
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 2] call _fnc_addMagazines;
@@ -234,7 +235,7 @@ private _grenadierTemplate = {
 
 	["grenadeLaunchers"] call _fnc_setPrimary;
 	["primary", 5] call _fnc_addMagazines;
-	
+
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 2] call _fnc_addMagazines;
@@ -261,7 +262,7 @@ private _explosivesExpertTemplate = {
 
 	["rifles"] call _fnc_setPrimary;
 	["primary", 5] call _fnc_addMagazines;
-	
+
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 2] call _fnc_addMagazines;

--- a/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Reb_SDK_Tanoa.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Reb_SDK_Tanoa.sqf
@@ -39,8 +39,8 @@
 ["baggedAA", [["I_AA_01_weapon_F","I_G_HMG_02_support_F"]]] call _fnc_saveToTemplate; 					//this line determines bagged static AAs -- Example: ["baggedAA", [["B_AA_01_weapon_F", "B_HMG_01_support_F"]]] -- Array, can contain multiple assets
 ["baggedMortars", [["I_Mortar_01_weapon_F","I_Mortar_01_support_F"]]] call _fnc_saveToTemplate; 			//this line determines bagged static mortars -- Example: ["baggedMortars", [["B_Mortar_01_F", "B_Mortar_01_weapon_F"]]] -- Array, can contain multiple assets
 
-["mineAT", "ATMine_Range_Mag"] call _fnc_saveToTemplate; 				
-["mineAPERS", "APERSMine_Range_Mag"] call _fnc_saveToTemplate; 			
+["mineAT", "ATMine_Range_Mag"] call _fnc_saveToTemplate;
+["mineAPERS", "APERSMine_Range_Mag"] call _fnc_saveToTemplate;
 
 ["breachingExplosivesAPC", [["DemoCharge_Remote_Mag", 1]]] call _fnc_saveToTemplate;
 ["breachingExplosivesTank", [["SatchelCharge_Remote_Mag", 1], ["DemoCharge_Remote_Mag", 2]]] call _fnc_saveToTemplate;
@@ -64,9 +64,10 @@ private _initialRebelEquipment = [
 "Binocular",
 "acc_flashlight","acc_flashlight_smg_01","acc_flashlight_pistol"
 ];
-if (hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
-if (hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "tf_anprc155"};
-
+if (A3A_hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
+if (A3A_hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "tf_anprc155"};
+if (A3A_hasTFARBeta) then {_initialRebelEquipment append ["TFAR_microdagr","TFAR_anprc154"]};
+if (A3A_hasTFARBeta && startWithLongRangeRadio) then {_initialRebelEquipment pushBack "TFAR_anprc155"};
 ["initialRebelEquipment", _initialRebelEquipment] call _fnc_saveToTemplate;
 
 //!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -152,12 +153,12 @@ private _squadLeaderTemplate = {
 	["helmets"] call _fnc_setHelmet;
 	["vests"] call _fnc_setVest;
 	["uniforms"] call _fnc_setUniform;
-	
+
 	["backpacks"] call _fnc_setBackpack;
 
 	[["grenadeLaunchers", "rifles"] call _fnc_fallback] call _fnc_setPrimary;
 	["primary", 5] call _fnc_addMagazines;
-	
+
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 2] call _fnc_addMagazines;
@@ -238,7 +239,7 @@ private _grenadierTemplate = {
 
 	["grenadeLaunchers"] call _fnc_setPrimary;
 	["primary", 5] call _fnc_addMagazines;
-	
+
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 2] call _fnc_addMagazines;
@@ -265,7 +266,7 @@ private _explosivesExpertTemplate = {
 
 	["rifles"] call _fnc_setPrimary;
 	["primary", 5] call _fnc_addMagazines;
-	
+
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 2] call _fnc_addMagazines;

--- a/A3-Antistasi/Templates/detector.sqf
+++ b/A3-Antistasi/Templates/detector.sqf
@@ -58,7 +58,7 @@ if (isClass (configfile >> "CfgPatches" >> "Ivory_Data")) then {A3A_hasIvory = t
 //TCGM_BikeBackpack Detection
 if (isClass (configfile >> "CfgPatches" >> "TCGM_BikeBackpack")) then {A3A_hasTCGM = true; Info("TCGM Detected.") };
 //ADV-CPR Pike Edition detection
-if (hasACEMedical && isClass (configFile >> "CfgPatches" >> "adv_aceCPR")) then {A3A_hasADV = true; Info("ADV Detected.") };
+if (A3A_hasACEMedical && isClass (configFile >> "CfgPatches" >> "adv_aceCPR")) then {A3A_hasADV = true; Info("ADV Detected.") };
 
 //D3S Car Pack Detection !!!--- Currently using vehicle classname check. Needs config viewer to work to find cfgPatches. ---!!!
 if (isClass (configfile >> "CfgVehicles" >> "d3s_baumaschinen")) then {A3A_hasD3S = true; Info("D3S Detected.") };

--- a/A3-Antistasi/functions/AI/fn_napalmDamage.sqf
+++ b/A3-Antistasi/functions/AI/fn_napalmDamage.sqf
@@ -17,7 +17,7 @@ Scope: _victim, Local Arguments, Global Effect
 Environment: Any
 Public: Yes. Can be called on objects independently, might make for an "interesting" punishment.
 Dependencies:
-    <BOOL> hasACEMedical
+    <BOOL> A3A_hasACEMedical
 
 Example:
     [cursorObject, true] call A3A_fnc_napalmDamage;  // Burn whatever you are looking at.
@@ -50,7 +50,7 @@ private _fnc_final = 'params ["_victim"];';                 // params ["_victim"
 private _invalidVictim = false;
 switch (true) do {
     case (_victim isKindOf "CAManBase"): {  // Man includes everything biological, even animals such as goats ect...
-        if (hasACEMedical) then {
+        if (A3A_hasACEMedical) then {
             _fnc_onTick = _fnc_onTick +
             'if (alive _victim) then {
                 [ _victim, 1*' + str _damagePerTick + ' , "Body", "grenade"] call ace_medical_fnc_addDamageToUnit;'+  // Multiplier might need to be raised for ACE.

--- a/A3-Antistasi/functions/AI/fn_occupantInvaderUnitKilledEH.sqf
+++ b/A3-Antistasi/functions/AI/fn_occupantInvaderUnitKilledEH.sqf
@@ -13,7 +13,7 @@ private _victimGroup = group _victim;
 private _victimSide = side (group _victim);
 [_victim] spawn A3A_fnc_postmortem;
 
-if (hasACE) then
+if (A3A_hasACE) then
 {
 	if ((isNull _killer) || (_killer == _victim)) then
 	{

--- a/A3-Antistasi/functions/Ammunition/fn_ACEpvpReDress.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_ACEpvpReDress.sqf
@@ -7,7 +7,7 @@ for "_i" from 1 to (_x select 1) do
 	};
 } forEach [["ACE_HandFlare_White",3],["ACE_Flashlight_XL50",1],["ACE_CableTie",1],["ACE_MapTools",1]];
 player addItemToUniform "ACE_EarPlugs";
-if (hasACEMedical) then
+if (A3A_hasACEMedical) then
 	{
 	player removeItems "FirstAidKit";
 	player removeItem "Medikit";

--- a/A3-Antistasi/functions/Ammunition/fn_checkRadiosUnlocked.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_checkRadiosUnlocked.sqf
@@ -10,7 +10,7 @@
 #include "\A3\Ui_f\hpp\defineResinclDesign.inc"
 
 // ACRE doesn't use the standard radio slot. We need to bypass the check for this and just set haveRadio to true if ACRE is enabled -Hazey
-if (hasAcre) then {
+if (A3A_hasACRE) then {
     haveRadio = true;
 } else {
     //See if any of the radios available in the arsenal are unlocked.

--- a/A3-Antistasi/functions/Ammunition/fn_equipmentSort.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentSort.sqf
@@ -136,7 +136,7 @@ allCivilianGlasses deleteAt (allCivilianGlasses find "LIB_Glasses");
 ////////////////
 //   Radios   //
 ////////////////
-If (hasTFAR) then {
+If (A3A_hasTFAR || A3A_hasTFARBeta) then {
 private _encryptRebel = if (teamPlayer == west) then { ["tf_west_radio_code"] } else { ["tf_guer_radio_code", "tf_independent_radio_code"] };
 allRadios = allRadios select {
     private _encrypt = getText (configFile >> "CfgWeapons" >> _x >> "tf_encryptionCode");

--- a/A3-Antistasi/functions/Ammunition/fn_launcherInfo.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_launcherInfo.sqf
@@ -68,7 +68,7 @@ private _airMagazines = [];
 	if (_ammoType isKindOf "MissileCore") then {
 		private _ammoConfig = configFile >> "CfgAmmo" >> _ammoType;
 		//If have ACE and ACE Guidance is enabled, then it can target whatever it damn well likes. ACE isn't picky.
-		if(hasACE && {isClass (_ammoConfig >> "ace_missileguidance") && {getNumber (_ammoConfig >> "ace_missileguidance" >> "enabled") == 1}}) exitWith {
+		if(A3A_hasACE && {isClass (_ammoConfig >> "ace_missileguidance") && {getNumber (_ammoConfig >> "ace_missileguidance" >> "enabled") == 1}}) exitWith {
 			_targetGround = true;
 			_targetAir = true;
 			_groundMagazines pushBackUnique _mag;

--- a/A3-Antistasi/functions/Base/fn_garbageCleaner.sqf
+++ b/A3-Antistasi/functions/Base/fn_garbageCleaner.sqf
@@ -20,7 +20,7 @@ private _fnc_distCheck = {
 { deleteVehicle _x } forEach (allMissionObjects "Leaflet_05_F");				// Drone drop leaflets
 { deleteVehicle _x } forEach (allMissionObjects "Ejection_Seat_Base_F");		// All vanilla ejection seats
 
-if (hasACE) then {
+if (A3A_hasACE) then {
 	{ deleteVehicle _x } forEach (allMissionObjects "ACE_bodyBagObject");
 	{ deleteVehicle _x } forEach (allMissionObjects "UserTexture1m_F");						// ACE spraycan tags
 	{ deleteVehicle _x } forEach (allMissionObjects "ace_cookoff_Turret_MBT_01");			//MBT turret wrecks

--- a/A3-Antistasi/functions/Base/fn_healAndRepair.sqf
+++ b/A3-Antistasi/functions/Base/fn_healAndRepair.sqf
@@ -20,7 +20,7 @@ boxX setVariable ["lastUsed", _time, true];
 		else {
 			[_x, 0] remoteExec ["setFatigue", _x];
 		};
-		if (hasACEMedical) then
+		if (A3A_hasACEMedical) then
 		{
 			[_x, _x] call ace_medical_treatment_fnc_fullHeal;
 		};

--- a/A3-Antistasi/functions/Base/fn_initPetros.sqf
+++ b/A3-Antistasi/functions/Base/fn_initPetros.sqf
@@ -95,10 +95,10 @@ petros addMPEventHandler ["mpkilled",
 
 private _removeProblematicAceInteractions = {
     _this spawn {
-        //Wait until we've got hasACE initialised fully
+        //Wait until we've got A3A_hasACE initialised fully
         waitUntil {!isNil "initVar"};
         //Disable ACE Interactions
-        if (hasInterface && hasACE) then {
+        if (hasInterface && A3A_hasACE) then {
             [typeOf _this, 0,["ACE_ApplyHandcuffs"]] call ace_interact_menu_fnc_removeActionFromClass;
             [typeOf _this, 0,["ACE_MainActions", "ACE_JoinGroup"]] call ace_interact_menu_fnc_removeActionFromClass;
         };

--- a/A3-Antistasi/functions/Base/fn_keys.sqf
+++ b/A3-Antistasi/functions/Base/fn_keys.sqf
@@ -24,7 +24,7 @@ else
 	{
 	if (_key == 207) then
 		{
-		if (!hasACEhearing) then
+		if (!A3A_hasACEhearing) then
 			{
 			if (soundVolume <= 0.5) then
 				{

--- a/A3-Antistasi/functions/Base/fn_stripGearFromLoadout.sqf
+++ b/A3-Antistasi/functions/Base/fn_stripGearFromLoadout.sqf
@@ -26,7 +26,7 @@ private _newSpecialItems = _newLoadout select 9;
 } forEach [0,1,2,3,4];
 
 //Keep our radio, if we have TFAR or ACRE.
-if (hasTFAR || hasACRE) then {
+if (A3A_hasTFAR || A3A_hasACRE || A3A_hasTFARBeta) then {
 	_newSpecialItems set [2, _oldSpecialItems select 2];
 };
 

--- a/A3-Antistasi/functions/Dialogs/fn_createDialog_setParams.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_createDialog_setParams.sqf
@@ -30,7 +30,7 @@ if (!isNil "loadLastSave" && {!loadLastSave}) then {
 			server setVariable ["hr",25,true];
 			server setVariable ["resourcesFIA",5000,true];
 			vehInGarage = [vehSDKTruck,vehSDKTruck,SDKMortar,SDKMGStatic,staticAAteamPlayer];
-			if !(hasTFAR) then
+			if !(A3A_hasTFAR || A3A_hasTFARBeta) then
 				{
 				["ItemRadio"] call A3A_fnc_unlockEquipment;
 				haveRadio = true;
@@ -51,4 +51,3 @@ if (!isNil "loadLastSave" && {!loadLastSave}) then {
 	waitUntil {!dialog};
 	if (isNil "gamemode") then {gamemode = 1};
 };
-

--- a/A3-Antistasi/functions/Punishment/fn_punishment_FF_AddEH.sqf
+++ b/A3-Antistasi/functions/Punishment/fn_punishment_FF_AddEH.sqf
@@ -54,7 +54,7 @@ _unit addEventHandler ["Hit", {
 
 if (_isAI) exitWith {true};
 
-if (hasACE) then {
+if (A3A_hasACE) then {
     ["ace_firedPlayer", {
         params ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile"];
         [_unit,_weapon,_projectile] call A3A_fnc_punishment_FF_checkNearHQ;
@@ -80,7 +80,7 @@ true;
 All other public variables referenced:
 | Name              | Type          | Machine   | Domain            | Description                                                           |
 |-------------------|---------------|-----------|-------------------|-----------------------------------------------------------------------|
-| hasACE            | BOOLEAN       | Public    | missionNamespace  | If ACE is loaded.                                                     |
+| A3A_hasACE            | BOOLEAN       | Public    | missionNamespace  | If ACE is loaded.                                                     |
 | tkPunish          | BOOLEAN       | Public    | missionNamespace  | Parameter. If the FF system should be enabled.                        |
 | petros            | OBJECT        | Public    | missionNamespace  | AI that rebels need to protect and access.                            |
 | posHQ             | POS3D<AGL>    | Public    | missionNamespace  | getMarkerPos respawnTeamPlayer. The position of the HQ marker.        |

--- a/A3-Antistasi/functions/Revive/fn_handleDamage.sqf
+++ b/A3-Antistasi/functions/Revive/fn_handleDamage.sqf
@@ -40,7 +40,7 @@ if (_part == "" && _damage > 0.1) then
 
 
 // Let ACE medical handle the rest (inc return value) if it's running
-if (hasACEMedical) exitWith {};
+if (A3A_hasACEMedical) exitWith {};
 
 
 private _makeUnconscious =

--- a/A3-Antistasi/functions/Revive/fn_handleDamageAAF.sqf
+++ b/A3-Antistasi/functions/Revive/fn_handleDamageAAF.sqf
@@ -47,7 +47,7 @@ if (side group _injurer == teamPlayer) then
 };
 
 // Let ACE medical handle the rest (inc return value) if it's running
-if (hasACEMedical) exitWith {};
+if (A3A_hasACEMedical) exitWith {};
 
 
 private _makeUnconscious =

--- a/A3-Antistasi/functions/Revive/fn_unconscious.sqf
+++ b/A3-Antistasi/functions/Revive/fn_unconscious.sqf
@@ -68,7 +68,7 @@ _unit setFatigue 1;
 sleep 2;
 if (_isPlayer) then
 	{
-	if (hasTFAR) then
+	if (A3A_hasTFAR || A3A_hasTFARBeta) then
 		{
 		_saveVolume = player getVariable ["tf_globalVolume", 1.0];
 		player setVariable ["tf_unable_to_use_radio", true, true];
@@ -140,7 +140,7 @@ while {(time < _bleedOut) and (_unit getVariable ["incapacitated",false]) and (a
 if (_isPlayer) then
 	{
 	(findDisplay 46) displayRemoveEventHandler ["KeyDown", respawnMenu];
-	if (hasTFAR) then
+	if (A3A_hasTFAR || A3A_hasTFARBeta) then
 		{
 		player setVariable ["tf_unable_to_use_radio", false, true];
 		player setVariable ["tf_globalVolume", _saveVolume];

--- a/A3-Antistasi/functions/Templates/Itemsets/fn_itemset_medicalSupplies.sqf
+++ b/A3-Antistasi/functions/Templates/Itemsets/fn_itemset_medicalSupplies.sqf
@@ -14,7 +14,7 @@
  params ["_level"];
 
 if (_level == "MEDIC") exitWith {
-	if (hasACE) then {
+	if (A3A_hasACE) then {
 		[
 			["ACE_surgicalKit",1],
 
@@ -42,7 +42,7 @@ if (_level == "MEDIC") exitWith {
 };
 
 if (_level == "STANDARD") exitWith {
-	if (hasACE) then {
+	if (A3A_hasACE) then {
 		[
 			["ACE_Tourniquet",1],
 			["ACE_SalineIV_500",1],
@@ -62,7 +62,7 @@ if (_level == "STANDARD") exitWith {
 };
 
 //If neither of them, return minimal medical supplies
-if (hasACE) then {
+if (A3A_hasACE) then {
 	[
 		["ACE_Morphine",1],
 		["ACE_Epinephrine",1],

--- a/A3-Antistasi/functions/Templates/Itemsets/fn_itemset_miscEssentials.sqf
+++ b/A3-Antistasi/functions/Templates/Itemsets/fn_itemset_miscEssentials.sqf
@@ -13,7 +13,7 @@
 
 private _items = [];
 
-if (hasACE) then {
+if (A3A_hasACE) then {
 	_items append [
 		["ACE_EarPlugs", 1],
 		["ACE_MapTools", 1],

--- a/A3-Antistasi/functions/Templates/fn_aceModCompat.sqf
+++ b/A3-Antistasi/functions/Templates/fn_aceModCompat.sqf
@@ -62,7 +62,7 @@ initialRebelEquipment append aceItems;
 
 
 //ACE medical starting items
-if (hasACEMedical) then {
+if (A3A_hasACEMedical) then {
 	initialRebelEquipment append aceMedItems;
 };
 

--- a/A3-Antistasi/functions/Templates/fn_getLoadout.sqf
+++ b/A3-Antistasi/functions/Templates/fn_getLoadout.sqf
@@ -1,7 +1,7 @@
 params ["_loadoutName"];
 
 private _basicMedicalSupplies =
-	if (hasACE) then {
+	if (A3A_hasACE) then {
 		[
 			["ACE_Tourniquet",3],
 			["ACE_SalineIV_500",1],
@@ -20,7 +20,7 @@ private _basicMedicalSupplies =
 	};
 
 private _basicMiscItems =
-	if (hasACE) then {
+	if (A3A_hasACE) then {
 		[
 			["ACE_Earplugs",1],
 			["ACE_Cabletie",3]
@@ -32,7 +32,7 @@ private _basicMiscItems =
 	};
 
 private _medicSupplies =
-	if (hasACE) then {
+	if (A3A_hasACE) then {
 		[
 			["ACE_surgicalKit",1],
 
@@ -77,17 +77,17 @@ private _fnc_modItemNoArray = {
 
 private _fnc_tfarRadio = {
 	params ["_radio"];
-	[hasTFAR, _radio, "ItemRadio"] call _fnc_modItemNoArray;
+	[A3A_hasTFAR, _radio, "ItemRadio"] call _fnc_modItemNoArray;
 };
 
-private _tfarMicroDAGRNoArray = [hasTFAR, "TF_MicroDagr", "ItemWatch"] call _fnc_modItemNoArray;
+private _tfarMicroDAGRNoArray = [A3A_hasTFAR, "TF_MicroDagr", "ItemWatch"] call _fnc_modItemNoArray;
 
-private _aceFlashlight = [hasACE, ["ACE_Flashlight_XL50", 1]] call _fnc_modItem;
-private _aceM84 = [hasACE, ["ACE_M84",2,1]] call _fnc_modItem;
-private _aceDefusalKit = [hasACE, ["ACE_DefusalKit", 1]] call _fnc_modItem;
-private _aceClacker = [hasACE, ["ACE_Clacker", 1]] call _fnc_modItem;
-private _aceRangecard = [hasACE, ["ACE_Rangecard", 1]] call _fnc_modItem;
-private _aceKestrel = [hasACE, ["ACE_Kestrel14500", 1]] call _fnc_modItem;
+private _aceFlashlight = [A3A_hasACE, ["ACE_Flashlight_XL50", 1]] call _fnc_modItem;
+private _aceM84 = [A3A_hasACE, ["ACE_M84",2,1]] call _fnc_modItem;
+private _aceDefusalKit = [A3A_hasACE, ["ACE_DefusalKit", 1]] call _fnc_modItem;
+private _aceClacker = [A3A_hasACE, ["ACE_Clacker", 1]] call _fnc_modItem;
+private _aceRangecard = [A3A_hasACE, ["ACE_Rangecard", 1]] call _fnc_modItem;
+private _aceKestrel = [A3A_hasACE, ["ACE_Kestrel14500", 1]] call _fnc_modItem;
 
 private _loadoutArray = missionNamespace getVariable [_loadoutName, []];
 

--- a/A3-Antistasi/functions/Templates/fn_ifaModCompat.sqf
+++ b/A3-Antistasi/functions/Templates/fn_ifaModCompat.sqf
@@ -12,7 +12,7 @@ lootVest = [];
 allArmoredHeadgear = [];
 {allArmoredHeadgear pushBackUnique (getUnitLoadout _x select 6)} forEach NATOSquad;
 */
-if (hasACE) then {
+if (A3A_hasACE) then {
 	lootItem append ["ACE_LIB_LadungPM","ACE_SpareBarrel"];
 };
 

--- a/A3-Antistasi/functions/Undercover/fn_goUndercover.sqf
+++ b/A3-Antistasi/functions/Undercover/fn_goUndercover.sqf
@@ -115,7 +115,7 @@ do {
 								};
 							};
 						};
-						if (hasACE) then {
+						if (A3A_hasACE) then {
 							if (((position _player nearObjects["DemoCharge_Remote_Ammo", 5]) select 0) mineDetectedBy Occupants) then {
 								_changeX = "SpotBombTruck";
 							};

--- a/A3-Antistasi/functions/Undercover/fn_initUndercover.sqf
+++ b/A3-Antistasi/functions/Undercover/fn_initUndercover.sqf
@@ -1,5 +1,5 @@
 //Attempt to figure out our current ace medical target;
-if (hasACE) then {
+if (A3A_hasACE) then {
 currentAceTarget = objNull;
 	["ace_interactMenuOpened", {
 		//player setVariable ["lastMenuOpened", "INTERACT"];

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -62,7 +62,7 @@ if (isMultiplayer) then {
 	cutText ["Starting Mission","BLACK IN",0];
 	Info("Server loaded!");
     Info_1("JIP client: %1",_isJIP);
-	if (hasTFAR) then {
+	if (A3A_hasTFAR || A3A_hasTFARBeta) then {
 		[] execVM "orgPlayers\radioJam.sqf";
 	};
 	if (!isNil "placementDone") then {_isJip = true};//workaround for BIS fail on JIP detection
@@ -92,7 +92,7 @@ if (isMultiplayer && {playerMarkersEnabled}) then {
 [player] spawn A3A_fnc_initRevive;		// with ACE medical, only used for helmet popping & TK checks
 [] spawn A3A_fnc_outOfBounds;
 
-if (!hasACE) then {
+if (!A3A_hasACE) then {
 	[] spawn A3A_fnc_tags;
 };
 
@@ -100,7 +100,7 @@ if (player getVariable ["pvp",false]) exitWith {
 	lastVehicleSpawned = objNull;
 	[player] call A3A_fnc_pvpCheck;
 	[player] call A3A_fnc_dress;
-	if (hasACE) then {[] call A3A_fnc_ACEpvpReDress};
+	if (A3A_hasACE) then {[] call A3A_fnc_ACEpvpReDress};
 	respawnTeamPlayer setMarkerAlphaLocal 0;
 
 	player addEventHandler ["GetInMan", {_this call A3A_fnc_ejectPvPPlayerIfInvalidVehicle}];
@@ -116,7 +116,7 @@ if (player getVariable ["pvp",false]) exitWith {
 	gameMenu = (findDisplay 46) displayAddEventHandler ["KeyDown", {
 		_handled = FALSE;
 		if (_this select 1 == 207) then {
-			if (!hasACEhearing) then {
+			if (!A3A_hasACEhearing) then {
 				if (soundVolume <= 0.5) then {
 					0.5 fadeSound 1;
 					["Ear Plugs", "You've taken out your ear plugs.", true] call A3A_fnc_customHint;
@@ -377,10 +377,10 @@ A3A_customHintEnable = true; // Was false in initVarCommon to allow debug progre
 
 if (isServer || player isEqualTo theBoss || (call BIS_fnc_admin) > 0) then {  // Local Host || Commander || Dedicated Admin
 	private _modsAndLoadText = [
-		[hasTFAR,"TFAR","Players will use TFAR radios. Unconscious players' radios will be muted."],
-		[hasACRE,"ACRE","Players will use ACRE radios. Unconscious players' radios will be muted."],
-		[hasACE,"ACE 3","ACE items added to arsenal and ammo-boxes."],
-		[hasACEMedical,"ACE 3 Medical","Default revive system will be disabled"],
+		[A3A_hasTFAR || A3A_hasTFARBeta,"TFAR","Players will use TFAR radios. Unconscious players' radios will be muted."],
+		[A3A_hasACRE,"ACRE","Players will use ACRE radios. Unconscious players' radios will be muted."],
+		[A3A_hasACE,"ACE 3","ACE items added to arsenal and ammo-boxes."],
+		[A3A_hasACEMedical,"ACE 3 Medical","Default revive system will be disabled"],
 		[A3A_hasRHS,"RHS","All factions will be replaced by RHS (AFRF &amp; USAF &amp; GREF)."],
 		[A3A_has3CBFactions,"3CB Factions","All Factions will be Replaced by 3CB Factions."],
 		[A3A_has3CBBAF,"3CB BAF","Occupant Faction will be Replaced by British Armed forces."],
@@ -403,7 +403,7 @@ gameMenu = (findDisplay 46) displayAddEventHandler ["KeyDown",A3A_fnc_keys];
 //if ((!isServer) and (isMultiplayer)) then {boxX call jn_fnc_arsenal_init};
 
 
-if (hasACE) then
+if (A3A_hasACE) then
 {
 	if (isNil "ace_interact_menu_fnc_compileMenu" || isNil "ace_interact_menu_fnc_compileMenuSelfAction") exitWith {
         Error("ACE non-public functions have changed, rebel group join/leave actions will not be removed");
@@ -439,7 +439,7 @@ _flagLight setLightAttenuation [7, 0, 0.5, 0.5];
 vehicleBox allowDamage false;
 vehicleBox addAction ["Heal, Repair and Rearm", A3A_fnc_healAndRepair,nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull]) and (side (group _this) == teamPlayer)", 4];
 vehicleBox addAction ["Vehicle Arsenal", JN_fnc_arsenal_handleAction, [], 0, true, false, "", "alive _target && vehicle _this != _this", 10];
-if (hasACE) then { [vehicleBox, VehicleBox] call ace_common_fnc_claim;};	//Disables ALL Ace Interactions
+if (A3A_hasACE) then { [vehicleBox, VehicleBox] call ace_common_fnc_claim;};	//Disables ALL Ace Interactions
 if (isMultiplayer) then {
 	vehicleBox addAction ["Personal Garage", { [GARAGE_PERSONAL] spawn A3A_fnc_garage },nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull]) and (side (group _this) == teamPlayer)", 4];
 };

--- a/A3-Antistasi/functions/init/fn_initServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initServer.sqf
@@ -81,7 +81,7 @@ call A3A_fnc_logistics_initNodes;
 savingServer = true;
 Info_2("%1 server version: %2", ["SP","MP"] select isMultiplayer, localize "STR_antistasi_credits_generic_version_text");
 bookedSlots = floor ((memberSlots/100) * (playableSlotsNumber teamPlayer)); publicVariable "bookedSlots";
-if (hasACEMedical) then { call A3A_fnc_initACEUnconsciousHandler };
+if (A3A_hasACEMedical) then { call A3A_fnc_initACEUnconsciousHandler };
 call A3A_fnc_loadNavGrid;
 call A3A_fnc_initZones;
 if (gameMode != 1) then {			// probably shouldn't be here...

--- a/A3-Antistasi/functions/init/fn_initVarCommon.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarCommon.sqf
@@ -84,20 +84,23 @@ A3A_loadedTemplateInfoXML = [];
 
 //Mod detection is done locally to each client, in case some clients have different modsets for some reason.
 //Systems Mods
-hasACE = false;
-hasACEHearing = false;
-hasACEMedical = false;
+A3A_hasACE = false;
+A3A_hasACEHearing = false;
+A3A_hasACEMedical = false;
 //Radio Mods
-hasACRE = false;
-hasTFAR = false;
+A3A_hasACRE = false;
+A3A_hasTFAR = false;
+A3A_hasTFARBeta = false;
 
 //Radio Detection
-hasTFAR = isClass (configFile >> "CfgPatches" >> "task_force_radio");
-hasACRE = isClass (configFile >> "cfgPatches" >> "acre_main");
+A3A_hasTFAR = isClass (configFile >> "CfgPatches" >> "task_force_radio");
+A3A_hasACRE = isClass (configFile >> "cfgPatches" >> "acre_main");
+A3A_hasTFARBeta = isClass (configFile >> "CfgPatches" >> "tfar_static_radios");
+if (A3A_hasTFARBeta) then {A3A_hasTFAR = false};
 //ACE Detection
-hasACE = (!isNil "ace_common_fnc_isModLoaded");
-hasACEHearing = isClass (configFile >> "CfgSounds" >> "ACE_EarRinging_Weak");
-hasACEMedical = isClass (configFile >> "CfgSounds" >> "ACE_heartbeat_fast_3");
+A3A_hasACE = (!isNil "ace_common_fnc_isModLoaded");
+A3A_hasACEHearing = isClass (configFile >> "CfgSounds" >> "ACE_EarRinging_Weak");
+A3A_hasACEMedical = isClass (configFile >> "CfgSounds" >> "ACE_heartbeat_fast_3");
 //Content Mods (Units, Vehicles, Weapons, Clothes etc.)
 //These are handled by a script in the Templates folder to keep integrators away from critical code.
 call compile preProcessFileLineNumbers "Templates\detector.sqf";

--- a/A3-Antistasi/functions/init/fn_initVarCommon.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarCommon.sqf
@@ -83,15 +83,6 @@ allDLCMods = ["kart", "mark", "heli", "expansion", "jets", "orange", "tank", "gl
 A3A_loadedTemplateInfoXML = [];
 
 //Mod detection is done locally to each client, in case some clients have different modsets for some reason.
-//Systems Mods
-A3A_hasACE = false;
-A3A_hasACEHearing = false;
-A3A_hasACEMedical = false;
-//Radio Mods
-A3A_hasACRE = false;
-A3A_hasTFAR = false;
-A3A_hasTFARBeta = false;
-
 //Radio Detection
 A3A_hasTFAR = isClass (configFile >> "CfgPatches" >> "task_force_radio");
 A3A_hasACRE = isClass (configFile >> "cfgPatches" >> "acre_main");

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -102,7 +102,7 @@ DECLARE_SERVER_VAR(missionsX, []);
 //List of statics (MGs, AA, etc) that will be saved and loaded.
 DECLARE_SERVER_VAR(staticsToSave, []);
 //Whether the players have access to radios.
-DECLARE_SERVER_VAR(haveRadio, hasTFAR || hasACRE);
+DECLARE_SERVER_VAR(haveRadio, A3A_hasTFAR || A3A_hasACRE || A3A_hasTFARBeta);
 //List of vehicles that are reported (I.e - Players can't go undercover in them)
 DECLARE_SERVER_VAR(reportedVehs, []);
 //Currently destroyed buildings.
@@ -204,7 +204,7 @@ DECLARE_SERVER_VAR(customUnitTypes, [true] call A3A_fnc_createNamespace);
 Info("Setting mod configs");
 
 //TFAR config
-if (hasTFAR) then
+if (A3A_hasTFAR) then
 {
 	if (isServer) then
 	{
@@ -684,7 +684,7 @@ DECLARE_SERVER_VAR(A3A_vehClassToCrew,_vehClassToCrew);
 ///////////////////////////
 //Please respect the order in which these are called,
 //and add new entries to the bottom of the list.
-if (hasACE) then {
+if (A3A_hasACE) then {
 	[] call A3A_fnc_aceModCompat;
 };
 if (A3A_hasRHS) then {
@@ -697,7 +697,7 @@ if (A3A_hasIFA) then {
 ////////////////////////////////////
 //     ACRE ITEM MODIFICATIONS   ///
 ////////////////////////////////////
-if (hasACRE) then {initialRebelEquipment append ["ACRE_PRC343","ACRE_PRC148","ACRE_PRC152","ACRE_PRC77","ACRE_PRC117F"];};
+if (A3A_hasACRE) then {initialRebelEquipment append ["ACRE_PRC343","ACRE_PRC148","ACRE_PRC152","ACRE_PRC77","ACRE_PRC117F"];};
 
 ////////////////////////////////////
 //    UNIT AND VEHICLE PRICES    ///

--- a/A3-Antistasi/onPlayerRespawn.sqf
+++ b/A3-Antistasi/onPlayerRespawn.sqf
@@ -69,7 +69,7 @@ if (side group player == teamPlayer) then
 
 
 	// don't reinit revive because damage handlers are respawn-persistent
-	//if (!hasACEMedical) then {[_newUnit] call A3A_fnc_initRevive};
+	//if (!A3A_hasACEMedical) then {[_newUnit] call A3A_fnc_initRevive};
 	disableUserInput false;
 	//_newUnit enableSimulation true;
 	if (_oldUnit == theBoss) then
@@ -244,5 +244,5 @@ else
 	_oldUnit setVariable ["spawner",nil,true];
 	_newUnit setVariable ["spawner",true,true];
 	[player] call A3A_fnc_dress;
-	if (hasACE) then {[] call A3A_fnc_ACEpvpReDress};
+	if (A3A_hasACE) then {[] call A3A_fnc_ACEpvpReDress};
 	};


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information:
Added the A3A_ Preset to System Mods in InitVarCommon,
Added TFAR Beta Detection in InitVarCommon,
Added a Check that returns TFAR Stable as False when Beta is detected,
Added A3A_HasTFARBeta to all Cases which would not cause Errors,
Added TFARBeta Radios to Rebell Templates.

### Please specify which Issue this PR Resolves.
closes #1604 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Quick general check:
A3A_HasTFARBeta should return true when loaded,
A3A_HasTFAR should return false when Beta is loaded.
Try to run the Mission with TFAR Beta,
Beta items are given to Starting Items,
Other BackpacksRadio are apearing in Loot (allBackpacksRadio will return all of them),

********************************************************
Notes:
