### PR TITLE
Disable incorrect icon-colouring code in vehicle arsenal

### DIFF
--- a/A3-Antistasi/JeroenArsenal/JNA/fn_vehicleArsenal.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_vehicleArsenal.sqf
@@ -327,6 +327,8 @@ switch _mode do {
 	///////////////////////////////////////////////////////////////////////////////////////////
 	case "ColorTabs":{
 		_display = _this select 0;
+/* 
+		// everything here is wrong
 		{
 			_ctrlTab = _display displayctrl (IDC_RSCDISPLAYARSENAL_TAB + _forEachIndex);
 
@@ -341,6 +343,7 @@ switch _mode do {
 			_ctrlTab ctrlSetBackgroundColor _color;
 			_ctrlTab ctrlSetForegroundColor _color;
 		} forEach jnva_loadout;
+*/
 	};
 
 	///////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The disabled code was never correct: It sets too many values (ctrlSetTextColor is sufficient) which causes icon blanking, and appears to be setting the wrong indices anyway. I suspect that until Arma 2.02 the bugs cancelled each other out and the function had no effect at all, but now it causes the icons to be blanked.

This PR restores the previous behaviour by disabling the icon-colouring code. Substantially more effort would be required to make it work as originally intended (colouring category tabs already present in the vehicle inventory), and the functionality isn't important.

### Please specify which Issue this PR Resolves.
closes #1803

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
