### PR TITLE
Fix HQ inital flag texture

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_createSDKgarrisons.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createSDKgarrisons.sqf
@@ -15,7 +15,7 @@ if (_markerX != "Synd_HQ") then
 	if (!(_markerX in citiesX)) then
 	{
 		private _veh = createVehicle [SDKFlag, _positionX, [],0, "NONE"];
-		if (A3A_hasIFA) then {_veh setFlagTexture SDKFlagTexture};
+		_veh setFlagTexture SDKFlagTexture;
 		_veh allowDamage false;
 		_vehiclesX pushBack _veh;
 		[_veh,"SDKFlag"] remoteExec ["A3A_fnc_flagaction",0,_veh];

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -424,6 +424,7 @@ boxX allowDamage false;
 boxX addAction ["Transfer Vehicle cargo to Ammobox", {[] spawn A3A_fnc_empty;}, 4];
 boxX addAction ["Move this asset", A3A_fnc_moveHQObject,nil,0,false,true,"","(_this == theBoss)", 4];
 flagX allowDamage false;
+flagX setFlagTexture SDKFlagTexture;
 flagX addAction ["Unit Recruitment", {if ([player,300] call A3A_fnc_enemyNearCheck) then {["Recruit Unit", "You cannot recruit units while there are enemies near you"] call A3A_fnc_customHint;} else { [] spawn A3A_fnc_unit_recruit; }},nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull]) and (side (group _this) == teamPlayer)"];
 flagX addAction ["Move this asset", A3A_fnc_moveHQObject,nil,0,false,true,"","(_this == theBoss)", 4];
 


### PR DESCRIPTION
Flag texture does seem to never be set for the HQ, only for garrisons. This will update the texture of the HQs SDKFlag to the one defined in the templates `flagTexture`.

## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
 This change does set the texture for the HQ flag for every client. Currently, this is only done for garrisons in `CREATE/fn_createSDKgarrisons.sqf`.

### Please specify which Issue this PR Resolves.
#1827, #724

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No (I would not mind you to test it anyways)
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: Start a new Antistasi mission and look at the flag.

********************************************************
Notes:
