### PR TITLE
Fix town markers not being placed on roads

### DIFF
--- a/A3-Antistasi/functions/init/fn_initZones.sqf
+++ b/A3-Antistasi/functions/init/fn_initZones.sqf
@@ -134,7 +134,6 @@ configClasses (configfile >> "CfgWorlds" >> worldName >> "Names") apply {
 	_size = [_sizeY, _sizeX] select (_sizeX > _sizeY);
 	_pos = getArray (_x >> "position");
 	_size = [_size, 400] select (_size < 400);
-	_roads = [];
 	_numCiv = 0;
 
 	if (_hardcodedPop) then
@@ -150,15 +149,12 @@ configClasses (configfile >> "CfgWorlds" >> worldName >> "Names") apply {
 		_numCiv = (count (nearestObjects [_pos, ["house"], _size]));
 	};
 
-	_numVeh = round (_numCiv / 3);
-	_nroads = count _roads;
-	if(_nroads > 0) then
-	{
-		//Fixed issue with a town on tembledan having no roads
-		_nearRoadsFinalSorted = [_roads, [], { _pos distance _x }, "ASCEND"] call BIS_fnc_sortBy;
-		_pos = _nearRoadsFinalSorted select 0;
+	_roads = nearestTerrainObjects [_pos, ["MAIN ROAD", "ROAD", "TRACK"], _size, true, true];
+	if (count _roads > 0) then {
+		// Move marker position to the nearest road, if any
+		_pos = _roads select 0;
 	};
-	if (_nroads < _numVeh) then {_numVeh = _nroads};
+	_numVeh = (count _roads) min (_numCiv / 3);
 
 	_mrk = createmarker [format ["%1", _nameX], _pos];
 	_mrk setMarkerSize [_size, _size];


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
During the new pathfinding merge, the code that places town markers on the nearest road rather than the location marker was accidentally disabled, making some city supply missions on Tanoa impossible and probably breaking other functionality. This PR restores that functionality by using nearestTerrainObjects to find a suitable road, as that function is surprisingly fast.

Note that placements are sometimes far from the real centre of the town, but better placement can wait.

### Please specify which Issue this PR Resolves.
closes #1817

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

I've only checked Tanoa so far but I'm fairly confident in the method.

### How can the changes be tested?
Load up mission on various maps, check that city markers are placed on a semi-reasonable road.