### PR TITLE
Fix adding rebel units to unspawned garrisons

### DIFF
--- a/A3-Antistasi/REINF/addToGarrison.sqf
+++ b/A3-Antistasi/REINF/addToGarrison.sqf
@@ -70,7 +70,9 @@ else
 	theBoss hcRemoveGroup _groupX;
 	};
 
-[_unitsX,teamPlayer,_nearX,0] remoteExec ["A3A_fnc_garrisonUpdate",2];
+// Send types, because the units may be deleted before the remoteExec hits
+private _unitTypes = _unitsX apply { _x getVariable "unitType" };
+[_unitTypes,teamPlayer,_nearX,0] remoteExec ["A3A_fnc_garrisonUpdate",2];
 _noBorrar = false;
 
 if (spawner getVariable _nearX != 2) then
@@ -81,6 +83,7 @@ if (spawner getVariable _nearX != 2) then
 	_wp setWaypointType "MOVE";
 	{
 	_x setVariable ["markerX",_nearX,true];
+	_x setVariable ["spawner",nil,true];
 	_x addEventHandler ["killed",
 		{
 		_victim = _this select 0;
@@ -117,6 +120,7 @@ else
 	if (alive _x) then
 		{
 		_x setVariable ["markerX",nil,true];
+		_x setVariable ["spawner",true,true];
 		_x removeAllEventHandlers "killed";
 		_x addEventHandler ["killed", {
 			_victim = _this select 0;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed a bug where troops added to unspawned garrisons were deleted before their types were determined, causing empty strings or nulls to be added to the garrison, depending on whether it was 2.4 or earlier. The bug is old but it was previously disguised by the empty strings being counted in the garrison.

Also fixed spawner status being retained on troops added to spawned garrisons, which will have prevented enemies from despawning in some common cases.

### Please specify which Issue this PR Resolves.
closes #1829
closes #1814

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

Tested all four standard cases: Squad AIs to unspawned & spawned, HC squads to unspawned and spawned. I didn't test the case that returns troops to HC squad status if their target (spawned) garrison is captured, but it's not important whether that works or not. It won't be any worse than it was.
