### PR TITLE
Fix rebel city garrisons not spawning

### DIFF
--- a/A3-Antistasi/functions/Base/fn_distance.sqf
+++ b/A3-Antistasi/functions/Base/fn_distance.sqf
@@ -249,6 +249,8 @@ private _processFIAMarker = {
                             && { _x distance2D _position < distanceSPWN }} != -1
                         || { _marker in forcedSpawn } })
                     then { [[_marker], "A3A_fnc_createCIV"] call A3A_fnc_scheduler; };
+
+                    [[_marker], "A3A_fnc_createSDKGarrisons"] call A3A_fnc_scheduler;
                 };
 
                 case (_marker in outpostsFIA):


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
A bug added in the fn_distance refactor prevented the rebel city garrison spawning code from executing. This PR restores the call.

### Please specify which Issue this PR Resolves.
closes #1836

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

There's a general (old) problem with the civ and military spawning functions not being fully synchronized though, which may cause civilian vehicles to be inappropriately spawned or not spawned. Could maybe fix with separate spawner tags but that's a much tougher problem.
