### PR TITLE
Add Factions Mortar HE ammo / BAF Template remove Cargo Trucks

### DIFF
--- a/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_BAF_Arctic.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_BAF_Arctic.sqf
@@ -53,7 +53,7 @@
 
 //Config special vehicles - militia vehicles are mostly used in the early game, police cars are being used by troops around cities -- Example:
 ["vehiclesMilitiaLightArmed", ["UK3CB_BAF_LandRover_WMIK_GPMG_FFR_Green_B_DPMW"]] call _fnc_saveToTemplate; //this line determines lightly armed militia vehicles -- Example: ["vehiclesMilitiaLightArmed", ["B_G_Offroad_01_armed_F"]] -- Array, can contain multiple assets
-["vehiclesMilitiaTrucks", ["UK3CB_BAF_MAN_HX60_Cargo_Green_B_DPMW"]] call _fnc_saveToTemplate; 	//this line determines militia trucks (unarmed) -- Example: ["vehiclesMilitiaTrucks", ["B_G_Van_01_transport_F"]] -- Array, can contain multiple assets
+["vehiclesMilitiaTrucks", ["UK3CB_BAF_MAN_HX60_Transport_Green_DPMW"]] call _fnc_saveToTemplate; 	//this line determines militia trucks (unarmed) -- Example: ["vehiclesMilitiaTrucks", ["B_G_Van_01_transport_F"]] -- Array, can contain multiple assets
 ["vehiclesMilitiaCars", ["UK3CB_BAF_LandRover_Soft_FFR_Green_B_DPMW"]] call _fnc_saveToTemplate; 		//this line determines militia cars (unarmed) -- Example: ["vehiclesMilitiaCars", ["	B_G_Offroad_01_F"]] -- Array, can contain multiple assets
 
 ["vehiclesPolice", ["UK3CB_BAF_LandRover_Snatch_FFR_Police_A"]] call _fnc_saveToTemplate; 			//this line determines police cars -- Example: ["vehiclesPolice", ["B_GEN_Offroad_01_gen_F"]] -- Array, can contain multiple assets

--- a/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_BAF_Temperate.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_BAF_Temperate.sqf
@@ -53,7 +53,7 @@
 
 //Config special vehicles - militia vehicles are mostly used in the early game, police cars are being used by troops around cities -- Example:
 ["vehiclesMilitiaLightArmed", ["UK3CB_BAF_LandRover_WMIK_GPMG_FFR_Green_B_DPMW"]] call _fnc_saveToTemplate; //this line determines lightly armed militia vehicles -- Example: ["vehiclesMilitiaLightArmed", ["B_G_Offroad_01_armed_F"]] -- Array, can contain multiple assets
-["vehiclesMilitiaTrucks", ["UK3CB_BAF_MAN_HX60_Cargo_Green_B_DPMW"]] call _fnc_saveToTemplate; 	//this line determines militia trucks (unarmed) -- Example: ["vehiclesMilitiaTrucks", ["B_G_Van_01_transport_F"]] -- Array, can contain multiple assets
+["vehiclesMilitiaTrucks", ["UK3CB_BAF_MAN_HX60_Transport_Green_DPMW"]] call _fnc_saveToTemplate; 	//this line determines militia trucks (unarmed) -- Example: ["vehiclesMilitiaTrucks", ["B_G_Van_01_transport_F"]] -- Array, can contain multiple assets
 ["vehiclesMilitiaCars", ["UK3CB_BAF_LandRover_Soft_FFR_Green_B_DPMW"]] call _fnc_saveToTemplate; 		//this line determines militia cars (unarmed) -- Example: ["vehiclesMilitiaCars", ["	B_G_Offroad_01_F"]] -- Array, can contain multiple assets
 
 ["vehiclesPolice", ["UK3CB_BAF_LandRover_Snatch_FFR_Police_A"]] call _fnc_saveToTemplate; 			//this line determines police cars -- Example: ["vehiclesPolice", ["B_GEN_Offroad_01_gen_F"]] -- Array, can contain multiple assets

--- a/A3-Antistasi/functions/Supports/fn_SUP_mortar.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_mortar.sqf
@@ -18,7 +18,7 @@ params ["_side", "_timerIndex", "_supportPos", "_supportName"];
 #include "..\..\Includes\common.inc"
 FIX_LINE_NUMBERS()
 private _mortarType = if(_side == Occupants) then {NATOMortar} else {CSATMortar};
-private _shellType = SDKMortarHEMag;
+private _shellType = if(_side == Occupants) then {NATOmortarMagazineHE} else {CSATmortarMagazineHE};
 private _isMortar = true;
 
 //If war level between 6 and 8 there is a chance (25%/50%/75%) that it switches to a howitzer instead, above it howitzer is guaranteed

--- a/A3-Antistasi/functions/Templates/fn_compatabilityLoadFaction.sqf
+++ b/A3-Antistasi/functions/Templates/fn_compatabilityLoadFaction.sqf
@@ -207,6 +207,7 @@ if (_side isEqualTo east) then {
 	staticATInvaders = _faction getVariable "staticAT" select 0;
 	staticAAInvaders = _faction getVariable "staticAA" select 0;
 	CSATMortar = _faction getVariable "staticMortars" select 0;
+	CSATmortarMagazineHE = _faction getVariable "mortarMagazineHE";
 
 	MGStaticCSATB = _faction getVariable "baggedMGs" select 0 select 0;
 	//TODO: Add tall/short support support.
@@ -400,6 +401,7 @@ if (_side isEqualTo west) then {
 	staticATOccupants = _faction getVariable "staticAT" select 0;
 	staticAAOccupants = _faction getVariable "staticAA" select 0;
 	NATOMortar = _faction getVariable "staticMortars" select 0;
+	NATOmortarMagazineHE = _faction getVariable "mortarMagazineHE";
 
 	MGStaticNATOB = _faction getVariable "baggedMGs" select 0 select 0;
 	//TODO: Add tall/short support support.

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -376,6 +376,7 @@ private _templateVariables = [
 	"staticATOccupants",
 	"staticAAOccupants",
 	"NATOMortar",
+	"NATOmortarMagazineHE",
 
 	//Invaders
 	"nameInvaders",
@@ -441,7 +442,8 @@ private _templateVariables = [
 	"CSATMG",
 	"staticATInvaders",
 	"staticAAInvaders",
-	"CSATMortar"
+	"CSATMortar",
+	"CSATmortarMagazineHE"
 ];
 
 {


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Added Mortar HE Ammo for CSAT/Nato Faction.
Removed 2 missed Cargotrucks with Loaded box from BAF Factions.

### Please specify which Issue this PR Resolves.
closes #1842 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Probably miss used the Command but it works:
```sqf
tierWar = 6; 

[Occupants, 0, "MORTAR", getpos (player), 1, 4] spawn A3A_fnc_createSupport;
```
********************************************************
Notes:
