### PR TITLE
Logging serialisation warning hotfix. Format unified with macro.

### DIFF
--- a/A3-Antistasi/functions/Utility/fn_log.sqf
+++ b/A3-Antistasi/functions/Utility/fn_log.sqf
@@ -24,7 +24,7 @@ if (_level > LogLevel) exitwith {};
 private _logLine = if (1 <= _level && _level <= 4) then {
 	(systemTimeUTC call A3A_fnc_systemTime_format_S) + " | Antistasi | " + ["Error","Info","Debug","Verbose"]#(_level-1) + " | File: " + _file + " | " + _message;
 } else {
-	(systemTimeUTC call A3A_fnc_systemTime_format_S) + " | Antistasi | Error | File: fn_log | Invalid Log Level | Dump: " + str _message;
+	(systemTimeUTC call A3A_fnc_systemTime_format_S) + " | Antistasi | Error | File: fn_log | Invalid Log Level | Dump: " + str _this;
 };
 
 if (isNil "blockServerLogging" && _toServer && !isServer) then {

--- a/A3-Antistasi/functions/Utility/fn_log.sqf
+++ b/A3-Antistasi/functions/Utility/fn_log.sqf
@@ -24,7 +24,7 @@ if (_level > LogLevel) exitwith {};
 private _logLine = if (1 <= _level && _level <= 4) then {
 	(systemTimeUTC call A3A_fnc_systemTime_format_S) + " | Antistasi | " + ["Error","Info","Debug","Verbose"]#(_level-1) + " | File: " + _file + " | " + _message;
 } else {
-	format ["%1: [Antistasi] | Unknown Log Level Specified, please use 1= Errors, 2= Info, 3= Debug | %2 | %3", servertime, _file, _message];
+	(systemTimeUTC call A3A_fnc_systemTime_format_S) + " | Antistasi | Error | File: fn_log | Invalid Log Level | Dump: " + str _message;
 };
 
 if (isNil "blockServerLogging" && _toServer && !isServer) then {

--- a/A3-Antistasi/functions/Utility/fn_log.sqf
+++ b/A3-Antistasi/functions/Utility/fn_log.sqf
@@ -42,8 +42,8 @@ switch (_level) do {
 
 if (isNil "blockServerLogging" && _toServer && !isServer) then {
 	// Tag remote log lines with player. HCs return hc, hc_1, hc_2 etc
-	_logLine = format ["%1 | (R) %2", _logLine, str player];
-	text _logLine remoteExec ["diag_log", 2];
+	_logLine = _logLine + " | Client: "+str player+" ["+str clientOwner+"]";
+	_logLine remoteExec ["A3A_fnc_localLog", 2];
 } else {
 	diag_log text _logLine;
 };

--- a/A3-Antistasi/functions/Utility/fn_log.sqf
+++ b/A3-Antistasi/functions/Utility/fn_log.sqf
@@ -21,23 +21,10 @@ private _filename = "fn_log";
 if (_level > LogLevel) exitwith {};
 
 // Sets up the actual log event.
-private _logLine = "";
-switch (_level) do {
-	case 1: {
-		_logLine = format ["%1: [Antistasi] | ERROR | %2 | %3", servertime, _file, _message];
-	};
-	case 2: {
-		_logLine = format ["%1: [Antistasi] | INFO | %2 | %3", servertime, _file, _message];
-	};
-	case 3: {
-		_logLine = format ["%1: [Antistasi] | DEBUG | %2 | %3", servertime, _file, _message];
-	};
-	case 4: {
-		_logLine = format ["%1: [Antistasi] | VERBOSE | %2 | %3", servertime, _file, _message];
-	};
-	default {
-		_logLine = format ["%1: [Antistasi] | Unknown Log Level Specified, please use 1= Errors, 2= Info, 3= Debug | %2 | %3", servertime, _file, _message];
-	};
+private _logLine = if (1 <= _level && _level <= 4) then {
+	(systemTimeUTC call A3A_fnc_systemTime_format_S) + " | Antistasi | " + ["Error","Info","Debug","Verbose"]#(_level-1) + " | File: " + _file + " | " + _message;
+} else {
+	format ["%1: [Antistasi] | Unknown Log Level Specified, please use 1= Errors, 2= Info, 3= Debug | %2 | %3", servertime, _file, _message];
 };
 
 if (isNil "blockServerLogging" && _toServer && !isServer) then {


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
* Change
3. [x] Enhancement

### What have you changed and why?

* 🔠 log uses localLog for remote logging.
* ↔ log function output format unified with maco. 

### Please verify the following and ensure all checks are completed.

* [x] Have you loaded the mission in LAN host?
* [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
* Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
1. Use the Arma 3 Launcher to start a dedicated server.
2. use `[1, "or thank vacation", "very filed"] call A3A_fnc_log;`
3. Check that log goes to the server
4. Check that there is no serialisation warning
5. Check that the error format matches the multitude of errors thrown when Antistasi starts up.

## NOTE
This will conflict for into master branch merge, it should completely replace the old file.