### PR TITLE
Fix NatoUnarmed Loadout

### DIFF
--- a/A3-Antistasi/Templates/NewTemplates/#Examples/FactionExample.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/#Examples/FactionExample.sqf
@@ -742,3 +742,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_BAF_Arctic.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_BAF_Arctic.sqf
@@ -920,3 +920,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_BAF_Arid.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_BAF_Arid.sqf
@@ -924,3 +924,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_BAF_Temperate.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_BAF_Temperate.sqf
@@ -923,3 +923,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_BAF_Tropical.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_BAF_Tropical.sqf
@@ -923,3 +923,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_CW_SOV.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_CW_SOV.sqf
@@ -838,3 +838,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_CW_US.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_CW_US.sqf
@@ -830,3 +830,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_TKA_East.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_TKA_East.sqf
@@ -887,3 +887,7 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_TKA_East.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_TKA_East.sqf
@@ -889,5 +889,3 @@ private _unitTypes = [
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
 ["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
-//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
-["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_TKA_West.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/3CB/3CB_AI_TKA_West.sqf
@@ -960,3 +960,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/RHS/RHS_AI_AFRF_Arid.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/RHS/RHS_AI_AFRF_Arid.sqf
@@ -883,3 +883,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/RHS/RHS_AI_AFRF_Temperate.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/RHS/RHS_AI_AFRF_Temperate.sqf
@@ -882,3 +882,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/RHS/RHS_AI_CDF_Temperate.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/RHS/RHS_AI_CDF_Temperate.sqf
@@ -920,3 +920,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/RHS/RHS_AI_USAF_Army_Arid.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/RHS/RHS_AI_USAF_Army_Arid.sqf
@@ -958,3 +958,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/RHS/RHS_AI_USAF_Army_Temperate.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/RHS/RHS_AI_USAF_Army_Temperate.sqf
@@ -959,3 +959,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/RHS/RHS_AI_USAF_Marines_Arid.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/RHS/RHS_AI_USAF_Marines_Arid.sqf
@@ -967,3 +967,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/RHS/RHS_AI_USAF_Marines_Temperate.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/RHS/RHS_AI_USAF_Marines_Temperate.sqf
@@ -967,3 +967,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_AI_AAF_Arid.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_AI_AAF_Arid.sqf
@@ -847,3 +847,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_AI_CSAT_Arid.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_AI_CSAT_Arid.sqf
@@ -866,3 +866,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_AI_CSAT_Enoch.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_AI_CSAT_Enoch.sqf
@@ -870,3 +870,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_AI_CSAT_Tropical.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_AI_CSAT_Tropical.sqf
@@ -876,3 +876,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_AI_LDF_Enoch.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_AI_LDF_Enoch.sqf
@@ -878,3 +878,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_AI_NATO_Arid.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_AI_NATO_Arid.sqf
@@ -870,3 +870,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_AI_NATO_Temperate.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_AI_NATO_Temperate.sqf
@@ -861,3 +861,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_AI_NATO_Tropical.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_AI_NATO_Tropical.sqf
@@ -884,3 +884,5 @@ private _unitTypes = [
 ["other", [["Official", _policeTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
 //The following lines are determining the loadout for the AI used in the "kill the traitor" mission
 ["other", [["Traitor", _traitorTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3-Antistasi/functions/Templates/fn_compatabilityLoadFaction.sqf
+++ b/A3-Antistasi/functions/Templates/fn_compatabilityLoadFaction.sqf
@@ -57,6 +57,7 @@ if (_side isEqualTo east) then {
 	CSATOfficer = "loadouts_inv_other_Official";
 	CSATBodyG = "loadouts_inv_military_Rifleman";
 	CSATCrew = "loadouts_inv_other_Crew";
+	CSATUnarmed = "loadouts_inv_other_Unarmed";
 	CSATMarksman = "loadouts_inv_military_Marksman";
 	staticCrewInvaders = "loadouts_inv_military_Rifleman";
 	CSATPilot = "loadouts_inv_other_Pilot";

--- a/A3-Antistasi/functions/Templates/fn_compatabilityLoadFaction.sqf
+++ b/A3-Antistasi/functions/Templates/fn_compatabilityLoadFaction.sqf
@@ -242,7 +242,7 @@ if (_side isEqualTo west) then {
 	NATOOfficer2 = "loadouts_occ_other_Traitor";
 	NATOBodyG = "loadouts_occ_military_Rifleman";
 	NATOCrew = "loadouts_occ_other_Crew";
-	NATOUnarmed = "loadouts_occ_Unarmed";
+	NATOUnarmed = "loadouts_occ_other_Unarmed";
 	NATOMarksman = "loadouts_occ_military_Marksman";
 	staticCrewOccupants = "loadouts_occ_military_Rifleman";
 	NATOPilot = "loadouts_occ_other_Pilot";

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -391,6 +391,7 @@ private _templateVariables = [
 	"CSATOfficer",
 	"CSATBodyG",
 	"CSATCrew",
+	"CSATUnarmed",
 	"CSATMarksman",
 	"staticCrewInvaders",
 	"CSATPilot",


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Added Nato Unarmed in each Template including the Example,
Added the added Prefix to Natounarmed in fn_compatabilityLoadFaction
Added CSAT Unarmed in Compatfile

### Please specify which Issue this PR Resolves.
Not linked on purpose:
Solution 1 of #1834 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Execute this on an Occupant Town, it should spawn Civies.
```sqf
//Target, Origin
//Targets are Cities in CitiesX
["Georgetown01", "airport_1"] spawn A3A_fnc_invaderPunish;
```
Creates Civs the same way as the Traitor Mission does right now, just in your Group
```sqf
 _civ = [group player, NATOUnarmed,player, [],0,"NONE"] call A3A_fnc_createUnit; 
 _civ forceAddUniform (selectRandom allCivilianUniforms); 
 _rnd = random 100; 
 if (_rnd < 90) then { 
  if (_rnd < 25) then { 
   [_civ, "hgun_PDW2000_F", 5, 0] call BIS_fnc_addWeapon; 
  } else { 
   [_civ, "hgun_Pistol_heavy_02_F", 5, 0] call BIS_fnc_addWeapon; 
  }; 
 };
 ```

********************************************************
Notes:
