### PR TITLE
Remove Vanilla Weapons from Punishment/Change weapon selection on INV Punishment

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_invaderPunish.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_invaderPunish.sqf
@@ -123,17 +123,14 @@ for "_i" from 0 to _numCiv do {
 		if (!surfaceIsWater _pos) exitWith {};
 	};
 	_civ = [_groupCivil, _typeUnit,_pos, [],0,"NONE"] call A3A_fnc_createUnit;
-	_civ forceAddUniform (selectRandom allCivilianUniforms);
-	_rnd = random 100;
-	if (_rnd < 90) then {
-		if (_rnd < 25) then {
-			[_civ, "hgun_PDW2000_F", 5, 0] call BIS_fnc_addWeapon;
-		} else {
-			[_civ, "hgun_Pistol_heavy_02_F", 5, 0] call BIS_fnc_addWeapon;
-		};
-	};
-	_civilians pushBack _civ;
 	[_civ] call A3A_fnc_civInit;
+	_rnd = random 100; 
+  	if (_rnd < 75) then { 
+			[_civ, selectRandom (unlockedsniperrifles + unlockedshotguns + Unlockedrifles + unlockedsmgs), 5, 0] call BIS_fnc_addWeapon;  
+		} else {  
+			[_civ, selectRandom (unlockedmachineguns + unlockedshotguns + Unlockedrifles + unlockedsmgs), 5, 0] call BIS_fnc_addWeapon;   
+	}; 
+	_civilians pushBack _civ;
 	_civ setSkill 0.5;
 	sleep 0.5;
 };


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [x] Enhancement

### What have you changed and why?
Information:
Removed Civ uniforms being given as its given by A3A_fnc_civInit,

Removed random 10% chance of Civ not getting any weapon,

Changed Weapon Selection to use Unlocked Equipment to ensure Template based equipment.
```sqf
	_rnd = random 100; 
  	if (_rnd < 75) then { 
			[_civ, selectRandom (unlockedsniperrifles + unlockedshotguns + Unlockedrifles + unlockedsmgs), 5, 0] call BIS_fnc_addWeapon;  
		} else {  
			[_civ, selectRandom (unlockedmachineguns + unlockedshotguns + Unlockedrifles + unlockedsmgs), 5, 0] call BIS_fnc_addWeapon;
```
Sniperrifles as the Kar98 and other Bolt Action Weapons count towards that Category,
SMG as thats the Vanilla Starting Equipment on most Terrains,
Shotgun as thats used in RHS, 3CB Factions and possibly even future Modsets.
Rifles are not given in Starting Equipment but would be useful for CIVs when unlocked,
These should always be Equipment given in Starting Gear to ensure CIVs not being unarmed.

For the 2. Case so when rnd is above 75 (25%) i allowed the Machinegun Category, as its in theory a lot rarer to happen, they would mostlikely stick to Shotguns Rifles and SMGs anyway.

I didn't use UnlockedHandguns as they contain Flashlights, Flare launchers, Minedetectors by Ace these would need more tweaking to be used.

### Please specify which Issue this PR Resolves.
closes #1594 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Unlock a few weapons:
```sqf
{ [_x] call A3A_fnc_unlockEquipment } forEach initialRebelEquipment
```
Then Execute this and look at Civs spawning in, these should always have some sort of Weapon in each Modset that.
```sqf
 _civ = [group player, sdkunarmed,getpos (player), [],0,"NONE"] call A3A_fnc_createUnit; 
 [_civ] call A3A_fnc_civInit; 
 _rnd = random 100;  
   if (_rnd < 75) then {  
 [_civ, selectRandom (unlockedsniperrifles + unlockedshotguns + Unlockedrifles + unlockedsmgs), 5, 0] call BIS_fnc_addWeapon;   
 } else {   
 [_civ, selectRandom (unlockedmachineguns + unlockedshotguns + Unlockedrifles + unlockedsmgs), 5, 0] call BIS_fnc_addWeapon;    
}; 
```
********************************************************
Notes:
