### PR TITLE
Disable Gunship on everything exept vanilla

### DIFF
--- a/A3-Antistasi/functions/Supports/fn_SUP_gunshipAvailable.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_gunshipAvailable.sqf
@@ -6,7 +6,7 @@ private _lastSupport = server getVariable ["lastSupport", ["", 0]];
 if((_lastSupport select 0) == "GUNSHIP" && {(_lastSupport select 1) > time}) exitWith {-1};
 
 //Vehicles not available, block support
-if(A3A_has3CB || A3A_hasFFAA) exitWith {-1};
+if(A3A_hasRHS || A3A_hasFFAA) exitWith {-1};
 
 private _timerIndex = -1;
 private _playerAdjustment = (floor ((count allPlayers)/10)) + 1;


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Added a HasRHS to the Gunship Availible Check, as all Modsets exept Vanilla are build on RHS, the Gunship will be disabled in every other Modset than Vanilla.
There are better solutions but this will do for now.
### Please specify which Issue this PR Resolves.
closes #1855

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
