### PR TITLE
Switch to using setPosWorld/getPosWorld for saved vehicle positions

### DIFF
--- a/A3-Antistasi/functions/Save/fn_loadServer.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadServer.sqf
@@ -5,6 +5,8 @@ if (isServer) then {
     Info("Starting Persistent Load.");
 	petros allowdamage false;
 
+	A3A_saveVersion = 0;
+	["version"] call A3A_fnc_getStatVariable;
 	["savedPlayers"] call A3A_fnc_getStatVariable;
 	["outpostsFIA"] call A3A_fnc_getStatVariable; publicVariable "outpostsFIA";
 	["mrkSDK"] call A3A_fnc_getStatVariable;

--- a/A3-Antistasi/functions/Save/fn_loadStat.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadStat.sqf
@@ -25,7 +25,7 @@ private _specialVarLoads = [
 	"garrison","tasks","smallCAmrk","membersX","vehInGarage","destroyedBuildings","idlebases",
 	"idleassets","chopForest","weather","killZones","jna_dataList","controlsSDK","mrkCSAT","nextTick",
 	"bombRuns","wurzelGarrison","aggressionOccupants", "aggressionInvaders",
-	"countCA", "attackCountdownInvaders", "testingTimerIsActive"
+	"countCA", "attackCountdownInvaders", "testingTimerIsActive", "version"
 ];
 
 private _varName = _this select 0;
@@ -33,6 +33,10 @@ private _varValue = _this select 1;
 if (isNil '_varValue') exitWith {};
 
 if (_varName in _specialVarLoads) then {
+	if (_varName == 'version') then {
+		_s = antistasiVersion splitString ".";
+		A3A_saveVersion = 10000*parsenumber(_s#0) + 100*parseNumber(_s#1) + parseNumber(_s#2);
+	};
 	if (_varName == 'attackCountdownOccupants') then {attackCountdownOccupants = _varValue; publicVariable "attackCountdownOccupants"};
 	if (_varName == 'attackCountdownInvaders') then {attackCountdownInvaders = _varValue; publicVariable "attackCountdownInvaders"};
 	//Keep this for backwards compatiblity
@@ -255,7 +259,7 @@ if (_varName in _specialVarLoads) then {
 			_posVeh = _varvalue select _i select 1;
 			_xVectorUp = _varvalue select _i select 2;
 			_xVectorDir = _varvalue select _i select 3;
-			private _veh = createVehicle [_typeVehX,[0,0,1000],[],0,"NONE"];
+			private _veh = createVehicle [_typeVehX,[0,0,1000],[],0,"CAN_COLLIDE"];
 			// This is only here to handle old save states. Could be removed after a few version itterations. -Hazey
 			if ((_varvalue select _i select 2) isEqualType 0) then { // We have to check number because old save state might still be using getDir. -Hazey
 				_dirVeh = _varvalue select _i select 2;
@@ -263,7 +267,7 @@ if (_varName in _specialVarLoads) then {
 				_veh setVectorUp surfaceNormal (_posVeh);
 				_veh setPosATL _posVeh;
 			} else {
-				_veh setPosATL _posVeh;
+				if (A3A_saveVersion >= 20401) then { _veh setPosWorld _posVeh } else { _veh setPosATL _posVeh };
 				_veh setVectorDirAndUp [_xVectorDir,_xVectorUp];
 			};
 			[_veh, teamPlayer] call A3A_fnc_AIVEHinit;

--- a/A3-Antistasi/functions/Save/fn_loadStat.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadStat.sqf
@@ -34,7 +34,10 @@ if (isNil '_varValue') exitWith {};
 
 if (_varName in _specialVarLoads) then {
 	if (_varName == 'version') then {
-		_s = antistasiVersion splitString ".";
+		_s = _varValue splitString ".";
+		if (count _s < 2) exitWith {
+			Error_1("Bad version string: %1", _varValue);
+		};
 		A3A_saveVersion = 10000*parsenumber(_s#0) + 100*parseNumber(_s#1) + parseNumber(_s#2);
 	};
 	if (_varName == 'attackCountdownOccupants') then {attackCountdownOccupants = _varValue; publicVariable "attackCountdownOccupants"};

--- a/A3-Antistasi/functions/Save/fn_saveLoop.sqf
+++ b/A3-Antistasi/functions/Save/fn_saveLoop.sqf
@@ -40,6 +40,7 @@ Debug_1("Saving params: %1", _savedParams);
 ["params", _savedParams] call A3A_fnc_setStatVariable;
 
 private ["_garrison"];
+["version", antistasiVersion] call A3A_fnc_setStatVariable;
 ["attackCountdownOccupants", attackCountdownOccupants] call A3A_fnc_setStatVariable;
 ["attackCountdownInvaders", attackCountdownInvaders] call A3A_fnc_setStatVariable;
 ["gameMode", gameMode] call A3A_fnc_setStatVariable;					// backwards compatibility
@@ -119,7 +120,7 @@ _arrayEst = [];
 	_typeVehX = typeOf _veh;
 	if ((_veh distance getMarkerPos respawnTeamPlayer < 50) and !(_veh in staticsToSave) and !(_typeVehX in ["ACE_SandbagObject","Land_FoodSacks_01_cargo_brown_F","Land_Pallet_F"])) then {
 		if (((not (_veh isKindOf "StaticWeapon")) and (not (_veh isKindOf "ReammoBox")) and (not (_veh isKindOf "ReammoBox_F")) and (not (_veh isKindOf "FlagCarrier")) and (not(_veh isKindOf "Building"))) and (not (_typeVehX == "C_Van_01_box_F")) and (count attachedObjects _veh == 0) and (alive _veh) and ({(alive _x) and (!isPlayer _x)} count crew _veh == 0) and (not(_typeVehX == "WeaponHolderSimulated"))) then {
-			_posVeh = getPos _veh;
+			_posVeh = getPosWorld _veh;
 			_xVectorUp = vectorUp _veh;
 			_xVectorDir = vectorDir _veh;
 			_arrayEst pushBack [_typeVehX,_posVeh,_xVectorUp,_xVectorDir];
@@ -131,7 +132,7 @@ _sites = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
 {
 	_positionX = position _x;
 	if ((alive _x) and !(surfaceIsWater _positionX) and !(isNull _x)) then {
-		_arrayEst pushBack [typeOf _x,getPosATL _x,getDir _x];
+		_arrayEst pushBack [typeOf _x,getPosWorld _x,vectorUp _x, vectorDir _x];
 	};
 } forEach staticsToSave;
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Turns out setPosATL/getPosATL is absolute trash on Sahrani, spawning vehicles halfway through the ground and either hurling them into the air or dropping to -200. It wasn't amazing on other maps, causing minor position shifts and the occasional vehicle explosion. setPosWorld/getPosWorld seems to give near-perfect results.

- Switched new saves to getPosWorld/setPosWorld.
- Stick to setPosATL for old saves, because the Z coord will be incompatible.
- Changed statics to use up/dir vectors as they were overlooked before.
- Added a basic version number system to the load/save code to handle backwards compatibility.
 
### Please specify which Issue this PR Resolves.
closes #1816

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Default Sahrani start. Spam a few vehicles and statics around the HQ. Save. Load. 
