### PR TITLE
Fix createVehicleCrew leader selection

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_createVehicleCrew.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createVehicleCrew.sqf
@@ -59,7 +59,7 @@ private _fnc_addCrewToTurrets = {
 [_config] call _fnc_addCrewToTurrets;
 
 if (_newGroup) then {
-	_group selectLeader (commander _vehicle);
+	_group selectLeader (effectiveCommander _vehicle);
 };
 
 _group addVehicle _vehicle;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Antistasi's createVehicleCrew (added in 2.4) sets the group leader to the commander. Some vehicles (such as the AT cars) don't have a commander slot (`commander _veh` returns null), but the driver isn't the effective commander. This causes the group to act very oddly when given waypoints. I don't know if this was also a problem for enemy vehicles.

This PR sets the group leader to `effectiveCommander` instead, which will hopefully work correctly in all cases. Another option would be to set the effective commander to the leader if there's no commander, but that seems riskier.

### Please specify which Issue this PR Resolves.
closes #1861

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Recruit rebel AT cars, give them high command orders.
