### PR TITLE
Doom move hq split

### DIFF
--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -43,6 +43,7 @@ class A3A
 		class blackout {};
 		class buildHQ {};
         class calculateAggression {};
+        class canMoveHQ {};
         class chooseAttackType {};
 		class citiesToCivPatrol {};
 		class citySupportChange {};

--- a/A3-Antistasi/functions/Base/fn_canMoveHQ.sqf
+++ b/A3-Antistasi/functions/Base/fn_canMoveHQ.sqf
@@ -20,22 +20,34 @@ Example:
 [] call A3A_fnc_canMoveHQ;
 */
 
-if (player != theBoss) exitWith
+private _result = [false];
+if (player != theBoss) then
 {
     ["Move HQ", "Only our Commander has access to this function"] call A3A_fnc_customHint;
-    [false, "Commander only"];
+    _result pushBack "Commander only";
 };
 
-if ((count weaponCargo boxX >0) or (count magazineCargo boxX >0) or (count itemCargo boxX >0) or (count backpackCargo boxX >0)) exitWith
+if ((count weaponCargo boxX >0) or (count magazineCargo boxX >0) or (count itemCargo boxX >0) or (count backpackCargo boxX >0)) then
 {
-    ["Move HQ", "You must first empty your Ammobox in order to move the HQ"] call A3A_fnc_customHint;
-    [false, "Ammobox must be empty"];
+    if(count _result == 1) then
+    {
+        ["Move HQ", "You must first empty your Arsenal inventory in order to move the HQ"] call A3A_fnc_customHint;
+    };
+    _result pushBack "Arsenal inventory must be empty";
 };
 
-if !(isNull attachedTo petros) exitWith
+if !(isNull attachedTo petros) then
 {
-    ["Move HQ", "Put Petros down before you move the HQ!"] call A3A_fnc_customHint;
-    [false, "Petros currently picked up"];
+    if(count _result == 1) then
+    {
+        ["Move HQ", "Put Petros down before you move the HQ!"] call A3A_fnc_customHint;
+    };
+    _result pushBack "Petros currently picked up";
+};
+
+if(count _result != 1) exitWith
+{
+    _result;
 };
 
 [true, ""];

--- a/A3-Antistasi/functions/Base/fn_canMoveHQ.sqf
+++ b/A3-Antistasi/functions/Base/fn_canMoveHQ.sqf
@@ -1,0 +1,41 @@
+/*
+Maintainer: Wurzel0701
+    Checks if the HQ can currently be moved
+
+Arguments:
+    <NIL>
+
+Return Value:
+    <ARRAY> If the HQ can be moved right now, first element bool, every other afterwards string, at least 2 elements
+
+Scope: Local
+Environment: Any
+Public: Yes
+Dependencies:
+    <OBJECT> theBoss
+    <OBJECT> boxX
+    <OBJECT> petros
+
+Example:
+[] call A3A_fnc_canMoveHQ;
+*/
+
+if (player != theBoss) exitWith
+{
+    ["Move HQ", "Only our Commander has access to this function"] call A3A_fnc_customHint;
+    [false, "Commander only"];
+};
+
+if ((count weaponCargo boxX >0) or (count magazineCargo boxX >0) or (count itemCargo boxX >0) or (count backpackCargo boxX >0)) exitWith
+{
+    ["Move HQ", "You must first empty your Ammobox in order to move the HQ"] call A3A_fnc_customHint;
+    [false, "Ammobox must be empty"];
+};
+
+if !(isNull attachedTo petros) exitWith
+{
+    ["Move HQ", "Put Petros down before you move the HQ!"] call A3A_fnc_customHint;
+    [false, "Petros currently picked up"];
+};
+
+[true, ""];

--- a/A3-Antistasi/functions/Base/fn_moveHQ.sqf
+++ b/A3-Antistasi/functions/Base/fn_moveHQ.sqf
@@ -1,8 +1,38 @@
+/*
+Maintainer: Wurzel0701
+    Starts the HQ moving process if possible
 
+Arguments:
+    <NIL>
 
+Return Value:
+    <NIL>
+
+Scope: Local
+Environment: Scheduled
+Public: Yes
+Dependencies:
+    <OBJECT> petros
+    <OBJECT> theBoss
+    <OBJECT> fireX
+    <STRING> respawnTeamPlayer
+    <SIDE> teamPlayer
+    <NAMESPACE> garrison
+    <SIDE> Occupants
+    <SIDE> Invaders
+    <ARRAY> soldiersSDK
+    <STRING> staticCrewTeamPlayer
+    <STRING> SDKMortar
+    <NAMESPACE> server
+
+Example:
+[] call A3A_fnc_moveHQ;
+*/
+
+private _possible = [] call A3A_fnc_canMoveHQ;
+if !(_possible#0) exitWith {};
 
 [petros,"remove"] remoteExec ["A3A_fnc_flagaction",0];
-//removeAllActions petros;
 private _groupPetros = group petros;
 [petros] join theBoss;
 deleteGroup _groupPetros;
@@ -11,72 +41,62 @@ petros setBehaviour "AWARE";
 petros enableAI "MOVE";
 petros enableAI "AUTOTARGET";
 
-/*
-if (isMultiplayer) then
-	{
-	// these would need to be remoteExec'd on the server
-	boxX hideObjectGlobal true;
-	vehicleBox hideObjectGlobal true;
-	mapX hideObjectGlobal true;
-	fireX hideObjectGlobal true;
-	flagX hideObjectGlobal true;
-	}
-else
-	{
-	boxX hideObject true;
-	vehicleBox hideObject true;
-	mapX hideObject true;
-	fireX hideObject true;
-	flagX hideObject true;
-	};
-*/
-
 fireX inflame false;
 
 [respawnTeamPlayer, 0, teamPlayer] call A3A_fnc_setMarkerAlphaForSide;
 [respawnTeamPlayer, 0, civilian] call A3A_fnc_setMarkerAlphaForSide;
 
-_garrison = garrison getVariable ["Synd_HQ", []];
-_positionX = getMarkerPos "Synd_HQ";
+private _garrison = garrison getVariable ["Synd_HQ", []];
+private _posHQ = getMarkerPos "Synd_HQ";
+
 if (count _garrison > 0) then
-	{
-	_costs = 0;
-	_hr = 0;
-	if ({(alive _x) and (!captive _x) and ((side _x == Occupants) or (side _x == Invaders)) and (_x distance _positionX < 500)} count allUnits > 0) then
-		{
-		["Garrison", "HQ Garrison will stay here and hold the enemy"] call A3A_fnc_customHint;
-		}
-	else
-		{
-		_size = ["Synd_HQ"] call A3A_fnc_sizeMarker;
-		{
-		if ((side group _x == teamPlayer) and (not(_x getVariable ["spawner",false])) and (_x distance _positionX < _size) and (_x != petros)) then
-			{
-			if (!alive _x) then
-				{
-				private _unitType = _x getVariable "unitType";
-				if (_unitType in soldiersSDK) then
-					{
-					if (_unitType == staticCrewTeamPlayer) then {_costs = _costs - ([SDKMortar] call A3A_fnc_vehiclePrice)};
-					_hr = _hr - 1;
-					_costs = _costs - (server getVariable (_unitType));
-					};
-				};
-			if (typeOf (vehicle _x) == SDKMortar) then {deleteVehicle vehicle _x};
-			deleteVehicle _x;
-			};
-		} forEach allUnits;
-		};
-	{
-	if (_x == staticCrewTeamPlayer) then {_costs = _costs + ([SDKMortar] call A3A_fnc_vehiclePrice)};
-	_hr = _hr + 1;
-	_costs = _costs + (server getVariable _x);
-	} forEach _garrison;
-	[_hr,_costs] remoteExec ["A3A_fnc_resourcesFIA",2];
-	garrison setVariable ["Synd_HQ",[],true];
-	["Garrison", format ["Garrison removed<br/><br/>Recovered Money: %1 €<br/>Recovered HR: %2",_costs,_hr]] call A3A_fnc_customHint;
-	};
+{
+    private _costs = 0;
+    private _hr = 0;
+    if (allUnits findIf {(alive _x) && (!captive _x) && ((side (group _x) == Occupants) || (side (group _x) == Invaders)) && {_x distance2D _posHQ < 500}} != -1) then
+    {
+        ["Garrison", "HQ Garrison will stay here and distract the enemy"] call A3A_fnc_customHint;
+    }
+    else
+    {
+        private _size = ["Synd_HQ"] call A3A_fnc_sizeMarker;
+        {
+            if ((side (group _x) == teamPlayer) && (!(_x getVariable ["spawner",false])) && (_x distance2D _posHQ < _size) && (_x != petros)) then
+            {
+                if (!alive _x) then
+                {
+                    private _unitType = _x getVariable "unitType";
+                    if (_unitType in soldiersSDK) then
+                    {
+                        if (_unitType == staticCrewTeamPlayer) then
+                        {
+                            _costs = _costs - ([SDKMortar] call A3A_fnc_vehiclePrice)
+                        };
+                        _hr = _hr - 1;
+                        _costs = _costs - (server getVariable (_unitType));
+                    };
+                };
+                if (typeOf (vehicle _x) == SDKMortar) then
+                {
+                    deleteVehicle vehicle _x
+                };
+                deleteVehicle _x;
+            };
+        } forEach allUnits;
+    };
+    {
+        if (_x == staticCrewTeamPlayer) then
+        {
+            _costs = _costs + ([SDKMortar] call A3A_fnc_vehiclePrice)
+        };
+        _hr = _hr + 1;
+        _costs = _costs + (server getVariable _x);
+    } forEach _garrison;
+    [_hr,_costs] remoteExec ["A3A_fnc_resourcesFIA",2];
+    garrison setVariable ["Synd_HQ",[],true];
+    ["Garrison", format ["Garrison removed<br/><br/>Recovered Money: %1 €<br/>Recovered HR: %2",_costs,_hr]] call A3A_fnc_customHint;
+};
 
 sleep 5;
 
-petros addAction ["Build HQ here", A3A_fnc_buildHQ,nil,0,false,true];
+petros addAction ["Build HQ here", A3A_fnc_buildHQ, nil, 0, false, true];

--- a/A3-Antistasi/functions/Base/fn_moveHQ.sqf
+++ b/A3-Antistasi/functions/Base/fn_moveHQ.sqf
@@ -56,6 +56,8 @@ if (count _garrison > 0) then
     if (allUnits findIf {(alive _x) && (!captive _x) && ((side (group _x) == Occupants) || (side (group _x) == Invaders)) && {_x distance2D _posHQ < 500}} != -1) then
     {
         ["Garrison", "HQ Garrison will stay here and distract the enemy"] call A3A_fnc_customHint;
+        //Is there a despawn routine attached to them?
+        //Why are they getting refunded if they stay?
     }
     else
     {

--- a/A3-Antistasi/functions/Base/fn_moveHQ.sqf
+++ b/A3-Antistasi/functions/Base/fn_moveHQ.sqf
@@ -1,8 +1,4 @@
-if (player != theBoss) exitWith {["Move HQ", "Only our Commander has access to this function"] call A3A_fnc_customHint;};
 
-if ((count weaponCargo boxX >0) or (count magazineCargo boxX >0) or (count itemCargo boxX >0) or (count backpackCargo boxX >0)) exitWith {["Move HQ", "You must first empty your Ammobox in order to move the HQ"] call A3A_fnc_customHint;};
-
-if !(isNull attachedTo petros) exitWith {["Move HQ", "Put Petros down before you move the HQ!"] call A3A_fnc_customHint;};
 
 
 [petros,"remove"] remoteExec ["A3A_fnc_flagaction",0];


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Information:
Split the moveHQ function into two functions (moveHQ and canMoveHQ), where canMoveHQ contains all checks and returns the reasons if that is not possible. MoveHQ contains the steps to actually start the HQ moving process.

moveHQ has been updated with the new headers, replaced all tabs with spaces and restructured to code to a readable form.
    
There are no gameplay or mechanic changes. This is done for Dooms UI rework to work.

### Please specify which Issue this PR Resolves.
closes #1794

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes: There are still tabs in functions.hpp which should be removed, but this PR should stay as small as it is (will open issue)
