### PR TITLE
Set initial airstrike aircraft velocity to reasonable value

### DIFF
--- a/A3-Antistasi/functions/Supports/fn_SUP_airstrikeRoutine.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_airstrikeRoutine.sqf
@@ -12,15 +12,10 @@ while {_sleepTime > 0} do
 private _plane = if (_side == Occupants) then {vehNATOPlane} else {vehCSATPlane};
 private _crewUnits = if(_side == Occupants) then {NATOPilot} else {CSATPilot};
 
-private _spawnPos = (getMarkerPos _airport);
-private _strikePlane = createVehicle [_plane, _spawnPos, [], 0, "FLY"];
-private _dir = _spawnPos getDir _targetPos;
-_strikePlane setDir _dir;
-
-//Put it in the sky
-_strikePlane setPosATL (_spawnPos vectorAdd [0, 0, 500]);
-
-_strikePlane setVelocityModelSpace (velocityModelSpace _strikePlane vectorAdd [0, 150, 0]);
+private _spawnPos = (getMarkerPos _airport) vectorAdd [0, 0, 500];
+private _strikePlane = createVehicle [_plane, _spawnPos, [], 0, "NONE"];
+_strikePlane setDir (_spawnPos getDir _targetPos);
+_strikePlane setVelocityModelSpace [0, 100, 0];
 
 private _strikeGroup = createGroup _side;
 private _pilot = [_strikeGroup, _crewUnits, getPos _strikePlane] call A3A_fnc_createUnit;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
The airstrike code was adding the initial speed from createVehicle with FLY (152m/s for an A-10) to a fixed 150m/s, giving an excessive starting speed that may have been causing apparent late spawns.

This PR simplifies the spawning code a bit and sets the initial speed to 100m/s regardless of aircraft. I considered using the stalling speed with a minimum of ~100m/s (starting too slow would delay the airstrike), but as no plausible aircraft have a stalling speed below 100m/s anyway, the complexity would have had no effect.

### Please specify which Issue this PR Resolves.
closes #1864

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Enable at least one airstrike for occupants:
`occupantsAirstrikeTimer set [0, -1]` run as server

Clear the last support type, in case it was airstrike:
`server setVariable ["lastSupport", nil]` run as server

Aim somewhere near the player:
`[getpos player vectorAdd [200,0,0], 4, ["AIRSTRIKE"], Occupants, 1] remoteExec ["A3A_fnc_sendSupport", 2]` run as local

Would recommend cutting the final sleep time in airstrikeRoutine to 0, otherwise it'll take a while. I tested both vanilla and both RHS airstrike aircraft with a few different positions anyway.