### PR TITLE
Fix setWaypointStatements calls from support system

### DIFF
--- a/A3-Antistasi/functions/AI/fn_combatLanding.sqf
+++ b/A3-Antistasi/functions/AI/fn_combatLanding.sqf
@@ -108,7 +108,7 @@ _helicopter flyInHeight 100;
 
 private _vehWP1 = _crewGroup addWaypoint [_originPos, 0];
 _vehWP1 setWaypointType "MOVE";
-_vehWP1 setWaypointStatements ["true", "deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
+_vehWP1 setWaypointStatements ["true", "if !(local this) exitWith {}; deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
 _vehWP1 setWaypointBehaviour "CARELESS";
 _crewGroup setCurrentWaypoint _vehWP1;
 

--- a/A3-Antistasi/functions/AI/fn_fastrope.sqf
+++ b/A3-Antistasi/functions/AI/fn_fastrope.sqf
@@ -103,5 +103,5 @@ _wp3 = _heli addWaypoint [_posOrigin, 1];
 _wp3 setWaypointType "MOVE";
 _wp3 setWaypointSpeed "NORMAL";
 _wp3 setWaypointBehaviour "CARELESS";
-_wp3 setWaypointStatements ["true", "deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
+_wp3 setWaypointStatements ["true", "if !(local this) exitWith {}; deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
 {_x setBehaviour "CARELESS";} forEach units _heli;

--- a/A3-Antistasi/functions/CREATE/fn_createVehicleQRFBehaviour.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createVehicleQRFBehaviour.sqf
@@ -40,7 +40,7 @@ switch (true) do
         private _vehWP1 = _crewGroup addWaypoint [_landPos,count (wayPoints _crewGroup)];
         _vehWP1 setWaypointType "TR UNLOAD";
         _vehWP1 setWaypointBehaviour "AWARE";
-        _vehWP1 setWaypointStatements ["true", "[vehicle this] call A3A_fnc_smokeCoverAuto"];
+        _vehWP1 setWaypointStatements ["true", "if !(local this) exitWith {}; [vehicle this] call A3A_fnc_smokeCoverAuto"];
         private _vehWP2 = _crewGroup addWaypoint [_posDestination, count (wayPoints _crewGroup)];
         _vehWP2 setWaypointType "SAD";
         _vehWP2 setWaypointBehaviour "COMBAT";
@@ -50,7 +50,7 @@ switch (true) do
         //Set the waypoints for cargoGroup
         private _cargoWP0 = _cargoGroup addWaypoint [_landpos, 0];
         _cargoWP0 setWaypointType "GETOUT";
-        _cargoWP0 setWaypointStatements ["true", "(group this) spawn A3A_fnc_attackDrillAI"];
+        _cargoWP0 setWaypointStatements ["true", "if !(local this) exitWith {}; (group this) spawn A3A_fnc_attackDrillAI"];
         private _cargoWP1 = _cargoGroup addWaypoint [_posDestination, 1];
         _cargoWP1 setWaypointType "SAD";
         _cargoWP1 setWaypointBehaviour "COMBAT";

--- a/A3-Antistasi/functions/Supports/fn_SUP_ASFRoutine.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_ASFRoutine.sqf
@@ -328,7 +328,7 @@ if (alive _strikePlane && {!(isNull (driver _strikePlane)) && {[driver _strikePl
     _wpBase setWaypointType "MOVE";
     _wpBase setWaypointBehaviour "CARELESS";
     _wpBase setWaypointSpeed "FULL";
-    _wpBase setWaypointStatements ["", "deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
+    _wpBase setWaypointStatements ["true", "if !(local this) exitWith {}; deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
     _strikeGroup setCurrentWaypoint _wpBase;
 
     waitUntil {sleep 0.5;_strikePlane distance2D (getMarkerPos _airport) < 100};

--- a/A3-Antistasi/functions/Supports/fn_SUP_CASRoutine.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_CASRoutine.sqf
@@ -605,7 +605,7 @@ if (alive _strikePlane && [driver _strikePlane] call A3A_fnc_canFight) then
     _wpBase setWaypointType "MOVE";
     _wpBase setWaypointBehaviour "CARELESS";
     _wpBase setWaypointSpeed "FULL";
-    _wpBase setWaypointStatements ["", "deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
+    _wpBase setWaypointStatements ["true", "if !(local this) exitWith {}; deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
     _strikeGroup setCurrentWaypoint _wpBase;
 
     waitUntil {sleep 0.5;_strikePlane distance2D (getMarkerPos _airport) < 100};

--- a/A3-Antistasi/functions/Supports/fn_SUP_airstrikeRoutine.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_airstrikeRoutine.sqf
@@ -158,7 +158,5 @@ _wp3 setWaypointBehaviour "CARELESS";
 private _wp4 = _strikeGroup addWaypoint [_airportPos, 2];
 _wp4 setWaypointType "MOVE";
 _wp4 setWaypointSpeed "FULL";
-_wp4 setWaypointStatements ["true", "[(objectParent this) getVariable 'supportName', side (group this)] spawn A3A_fnc_endSupport; deleteVehicle (objectParent this); deleteVehicle this"];
+_wp4 setWaypointStatements ["true", "if !(isServer) exitWith {}; [(objectParent this) getVariable 'supportName', side (group this)] spawn A3A_fnc_endSupport; deleteVehicle (objectParent this); deleteVehicle this"];
 
-_strikePlane hideObjectGlobal false;
-_strikePlane enableSimulation true;

--- a/A3-Antistasi/functions/Supports/fn_SUP_gunshipRoutineCSAT.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_gunshipRoutineCSAT.sqf
@@ -384,7 +384,7 @@ if (alive _gunship) then
     _wpBase setWaypointType "MOVE";
     _wpBase setWaypointBehaviour "CARELESS";
     _wpBase setWaypointSpeed "FULL";
-    _wpBase setWaypointStatements ["", "deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
+    _wpBase setWaypointStatements ["true", "if !(local this) exitWith {}; deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
     _strikeGroup setCurrentWaypoint _wpBase;
     _gunship flyInHeight 1000;
 

--- a/A3-Antistasi/functions/Supports/fn_SUP_gunshipRoutineNATO.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_gunshipRoutineNATO.sqf
@@ -465,7 +465,7 @@ if (alive _gunship) then
     _wpBase setWaypointType "MOVE";
     _wpBase setWaypointBehaviour "CARELESS";
     _wpBase setWaypointSpeed "FULL";
-    _wpBase setWaypointStatements ["", "deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
+    _wpBase setWaypointStatements ["true", "if !(local this) exitWith {}; deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
     _strikeGroup setCurrentWaypoint _wpBase;
     _gunship flyInHeight 1000;
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The new support system added a lot of incorrect setWaypointStatements calls. Two common problems:
1. Empty-string conditions. These were probably never called, hence the backup aircraft-deletion routines.
2. Global execution. Very bad for attackDrillAI. Probably caused the A-10 ejection seat spam too.

### Please specify which Issue this PR Resolves.
closes #1869

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

Could probably improve the aircraft despawn code based on the airstrike code from 2.3.1, but that's a lot more work.