### PR TITLE
Fix Ace without Medical for Ai (Equipment)

### DIFF
--- a/A3-Antistasi/functions/Templates/Itemsets/fn_itemset_medicalSupplies.sqf
+++ b/A3-Antistasi/functions/Templates/Itemsets/fn_itemset_medicalSupplies.sqf
@@ -14,7 +14,7 @@
  params ["_level"];
 
 if (_level == "MEDIC") exitWith {
-	if (A3A_hasACE) then {
+	if (A3A_hasACEMedical) then {
 		[
 			["ACE_surgicalKit",1],
 
@@ -42,7 +42,7 @@ if (_level == "MEDIC") exitWith {
 };
 
 if (_level == "STANDARD") exitWith {
-	if (A3A_hasACE) then {
+	if (A3A_hasACEMedical) then {
 		[
 			["ACE_Tourniquet",1],
 			["ACE_SalineIV_500",1],
@@ -62,7 +62,7 @@ if (_level == "STANDARD") exitWith {
 };
 
 //If neither of them, return minimal medical supplies
-if (A3A_hasACE) then {
+if (A3A_hasACEMedical) then {
 	[
 		["ACE_Morphine",1],
 		["ACE_Epinephrine",1],


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Changed A3A_hasACE to A3A_hasACEMedical in fn_itemset_medicalSupplies.sqf
The same mistake is still in GetLoadout, but that is unimportant.

### Please specify which Issue this PR Resolves.
closes #1879 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:
Load an Up to Date Ace without Medical,
Find Occupant/Invader Ai and check their Inventory they should have Vanilla Medical Equipment.
Or use this:
```sqf
[group player, "loadouts_occ_military_Rifleman", getpos (player)] call A3A_fnc_createUnit; 
[group player, "loadouts_occ_military_Medic", getpos (player)] call A3A_fnc_createUnit;
```
Spawn Units, Check their Inventory they should have Vanilla Medical Equipment.
********************************************************
Notes:
