### PR TITLE
Fix various locality and JIP problems with prisoner and refugee missions

### DIFF
--- a/A3-Antistasi/functions/AI/fn_liberatePOW.sqf
+++ b/A3-Antistasi/functions/AI/fn_liberatePOW.sqf
@@ -1,30 +1,24 @@
-_unit = _this select 0;
-_playerX = _this select 1;
+params ["_unit", "_playerX"];
 
-[_unit,"remove"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_unit];
-
-//removeAllActions _unit;
-
-if (captive _playerX) then
-	{
-	[_playerX,false] remoteExec ["setCaptive",0,_playerX];
-	_playerX setCaptive false;
-	};
+if (captive _playerX) then { _playerX setCaptive false };
 
 _playerX globalChat "You are free. Come with us!";
 _unit setDir (getDir _playerX);
 _playerX playMove "MountSide";
-sleep 3;
-_unit sideChat "Thank you. I owe you my life!";
+sleep 5;
+_playerX playMove "";
 
+[_unit] join group _playerX;
+private _timeout = 10;
+waituntil {sleep 1; _timeout = _timeout-1; _timeout < 0 or (local _unit and group _unit == group _playerX)};
+if (_timeout < 0) exitWith {};
+
+[_unit,"remove"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_unit];
+
+_unit globalChat "Thank you. I owe you my life!";
 _unit enableAI "MOVE";
 _unit enableAI "AUTOTARGET";
 _unit enableAI "TARGET";
 _unit enableAI "ANIM";
-sleep 5;
-_playerX playMove "";
-//_unit playMove "SitStandUp";
-[_unit,false] remoteExec ["setCaptive",0,_unit];
-_unit setCaptive false;
-[_unit] join group _playerX;
 [_unit] spawn A3A_fnc_FIAInit;
+if (captive _unit) then { _unit setCaptive false };

--- a/A3-Antistasi/functions/AI/fn_liberaterefugee.sqf
+++ b/A3-Antistasi/functions/AI/fn_liberaterefugee.sqf
@@ -1,23 +1,21 @@
-private ["_unit","_playerX"];
+params ["_unit", "_playerX"];
 
-_unit = _this select 0;
-_playerX = _this select 1;
-
-[_unit,"remove"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_unit];
-//removeAllActions _unit;
+if (captive _playerX) then { _playerX setCaptive false };
 
 _playerX globalChat "You are free. Come with us!";
-if (captive _playerX) then
-	{
-	[_playerX,false] remoteExec ["setCaptive",0,_playerX];
-	_playerX setCaptive false;
-	};
 sleep 3;
+
+[_unit] join group _playerX;
+private _timeout = 10;
+waituntil {sleep 1; _timeout = _timeout-1; _timeout < 0 or (local _unit and group _unit == group _playerX)};
+if (_timeout < 0) exitWith {};
+
+[_unit,"remove"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_unit];
+
 _unit globalChat "Thank you. I owe you my life!";
 _unit enableAI "MOVE";
 _unit enableAI "AUTOTARGET";
 _unit enableAI "TARGET";
 _unit enableAI "ANIM";
-[_unit] join group _playerX;
 [_unit] spawn A3A_fnc_FIAInit;
-if (captive _unit) then {[_unit,false] remoteExec ["setCaptive",0,_unit]; _unit setCaptive false};
+if (captive _unit) then { _unit setCaptive false };

--- a/A3-Antistasi/functions/Missions/fn_RES_Prisoners.sqf
+++ b/A3-Antistasi/functions/Missions/fn_RES_Prisoners.sqf
@@ -64,7 +64,6 @@ for "_i" from 0 to _countX do
 	{
 	_unit = [_grpPOW, SDKUnarmed, (_posHouse select _i), [], 0, "NONE"] call A3A_fnc_createUnit;
 	_unit allowDamage false;
-	[_unit,true] remoteExec ["setCaptive",0,_unit];
 	_unit setCaptive true;
 	_unit disableAI "MOVE";
 	_unit disableAI "AUTOTARGET";
@@ -104,7 +103,6 @@ if (dateToNumber date > _dateLimitNum) then
 		{
 		if (group _x == _grpPOW) then
 			{
-			[_x,false] remoteExec ["setCaptive",0,_x];
 			_x setCaptive false;
 			_x enableAI "MOVE";
 			_x doMove _positionX;

--- a/A3-Antistasi/functions/Missions/fn_RES_Refugees.sqf
+++ b/A3-Antistasi/functions/Missions/fn_RES_Refugees.sqf
@@ -59,7 +59,7 @@ for "_i" from 1 to (((count _posHouse) - 1) min 15) do
 	_unit setSkill 0;
 	_POWs pushBack _unit;
 	[_unit,"refugee"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_unit];
-	if (_sideX == Occupants) then {[_unit,true] remoteExec ["setCaptive",0,_unit]; _unit setCaptive true};
+	if (_sideX == Occupants) then {_unit setCaptive true};
 	[_unit] call A3A_fnc_reDress;
 	sleep 0.5;
 	};


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed a lot of locality and JIP bugs with the prisoner and refugee missions. Should be about as solid as it's going to get.

Released prisoners will still struggle to leave some buildings, but that's just Arma pathing. Zeus-spawned troops have the same problem. Remote control is the workaround.

### Please specify which Issue this PR Resolves.
closes #1574

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?
Tested with HC, as that's the primary fail case.

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

These missions can be pretty tough because occupants will happily drop airstrikes and mortar supports on the prisoners. Should do something about that.