### PR TITLE
Synchronize vehicle textures so that everyone sees the same colour

### DIFF
--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -686,6 +686,7 @@ class A3A
         class log {};
         class setPos {};
         class systemTime_format_S {};
+        class vehicleTextureSync {};
         class vehicleWillCollideAtPosition {};
         class getRoadDirection {};
     };

--- a/A3-Antistasi/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_AIVEHinit.sqf
@@ -34,6 +34,9 @@ if (_side == teamPlayer) then
 	clearBackpackCargoGlobal _veh;
 };
 
+// Sync the vehicle textures if necessary
+_veh call A3A_fnc_vehicleTextureSync;
+
 private _typeX = typeOf _veh;
 if ((_typeX in vehNormal) or (_typeX in vehAttack) or (_typeX in vehBoats) or (_typeX in vehAA)) then
 {

--- a/A3-Antistasi/functions/Utility/fn_vehicleTextureSync.sqf
+++ b/A3-Antistasi/functions/Utility/fn_vehicleTextureSync.sqf
@@ -1,0 +1,18 @@
+/*
+    A3A_fnc_vehicleTextureSync
+    Makes local vehicle texture settings global, working around Arma misfeature/bug
+
+    Parameters:
+    0. <OBJECT> vehicle, should have been created locally
+*/
+
+params ["_veh"];
+
+if (isNil "_veh" or {isNull _veh}) exitWith {};
+
+// textureList is weighted array, so >2 means multiple texture options
+if (count getArray (configfile >> "CfgVehicles" >> typeof _veh >> "textureList") > 2) then
+{
+    { _veh setObjectTextureGlobal [_forEachindex, _x] } forEach getObjectTextures _veh;
+    { _veh setObjectMaterialGlobal [_forEachindex, _x] } forEach getObjectMaterials _veh;
+};


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Added a function to network-synchronize vehicle textures if necessary. This is a bit cheaper than using BIS_fnc_initVehicle, which also searches for and applies a new random texture. There's also an optimization to avoid the sync if the vehicle lacks texture variants.

Called from AIVEHinit, as that's conveniently called shortly after vehicle creation.

### Please specify which Issue this PR Resolves.
closes #1885

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
1. On a DS, go to a city and admire the pretty vehicle colours.
2. On a DS, get some vehicles out of your personal garage. Log off and on again. Check that the vehicles are the same colour.
