### PR TITLE
Silence Sanity checks RPT spam

### DIFF
--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -463,7 +463,7 @@ Info("Sanity-checking templates");
 
 // modify these appropriately when adding new template vars
 private _nonClassVars = ["nameTeamPlayer", "SDKFlagTexture", "nameOccupants", "NATOPlayerLoadouts", "NATOFlagTexture", "flagNATOmrk", "nameInvaders", "CSATPlayerLoadouts", "CSATFlagTexture", "flagCSATmrk"];
-private _magazineVars = ["SDKMortarHEMag", "SDKMortarSmokeMag", "ATMineMag", "APERSMineMag", "vehNATOMRLSMags", "vehCSATMRLSMags", "breachingExplosivesAPC", "breachingExplosivesTank"];
+private _magazineVars = ["SDKMortarHEMag", "SDKMortarSmokeMag", "ATMineMag", "APERSMineMag", "vehNATOMRLSMags", "vehCSATMRLSMags", "breachingExplosivesAPC", "breachingExplosivesTank", "NATOmortarMagazineHE", "CSATmortarMagazineHE"];
 
 private _missingVars = [];
 private _badCaseVars = [];
@@ -483,6 +483,8 @@ private _badCaseVars = [];
 
 		private _section = if (_x in _magazineVars) then {"CfgMagazines"} else {"CfgVehicles"};
 		{
+			if ("loadouts_" in _x) then {continue};
+			if ("not_supported" in _x) then {continue};
 			if !(_x isEqualType "") exitWith { Error("Bad template var " + _varName) };
 			if !(_x isEqualTo configName (configFile >> _section >> _x)) then
 			{


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Updated Sanity check with 2 new Magazine Vars,
Silenced it about Loadouts and "Not_supported" as it wont find these in CFG Vehicles

### Please specify which Issue this PR Resolves.
closes nothing

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: Start the Mission,
Check the RPT: Entries like:
```
| Antistasi | Error | File: fn_initVarServer.sqf | Missing classnames: ["loadouts_rebel_militia_Petros","loadouts_rebel_militia_staticCrew","loadouts_rebel_militia_Unarmed","loadouts_rebel_militia_sniper","loadouts_rebel_militia_lat","loadouts_rebel_militia_medic","loadouts_rebel_militia_MachineGunner","loadouts_rebel_militia_ExplosivesExpert","loadouts_rebel_militia_Grenadier","loadouts_rebel_militia_Rifleman","loadouts_rebel_militia_SquadLeader","loadouts_rebel_militia_Engineer","not_supported","loadouts_occ_military_Rifleman","loadouts_occ_other_Official","loadouts_occ_other_Traitor","loadouts_occ_other_Crew","loadouts_occ_other_Unarmed","loadouts_occ_military_Marksman","loadouts_occ_other_Pilot","loadouts_occ_militia_Rifleman","loadouts_occ_militia_Marksman","loadouts_occ_police_SquadLeader","loadouts_occ_police_Standard","loadouts_occ_military_Grenadier","loadouts_occ_military_Sniper","loadouts_occ_military_SquadLeader","loadouts_occ_military_AA","loadouts_occ_military_AT","loado
```
should be gone

********************************************************
Notes:
