### PR TITLE
Fix safeVehicleSpawn to spawn air vehicles in the air

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_safeVehicleSpawn.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_safeVehicleSpawn.sqf
@@ -28,8 +28,12 @@ private _finished = false;
 for "_i" from 1 to _attempts do {
 	//We keep changing around the start position, to avoid findEmptyPosition repeatedly returning the same thing.
 	//Makes the function more likely to succeed.
-	private _randomOffset = [random (_radius - _radius / 2), random (_radius - _radius / 2), 0];
-	_spawnPosition = (_pos vectorAdd _randomOffset) findEmptyPosition [0, (_radius / 2), _vehicleType];
+	_spawnPosition = _pos vectorAdd [random (_radius*2) - _radius, random (_radius*2) - _radius, 0];
+
+	if !(_vehicleType isKindOf "Air") then {
+		// findEmptyPosition always searches on the ground, regardless of input height
+		_spawnPosition = _spawnPosition findEmptyPosition [0, (_radius / 2), _vehicleType];
+	};
 
 	if !(_spawnPosition isEqualTo []) then {
 		_willCollide = [_vehicle, _spawnPosition] call A3A_fnc_vehicleWillCollideAtPosition;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed a bug where safeVehicleSpawn was spawning air vehicles on the ground (with FLY velocity and suicidal consequences) due to unexpected behaviour of findEmptyPosition. 

Also fixed an old bug where the placement randomization was only using one quadrant of the available space.

### Please specify which Issue this PR Resolves.
closes #1891

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

There's probably a lot of other broken behaviour but there shouldn't be anything *new*.

### How to test
`["B_T_VTOL_01_infantry_F", getpos player, 100, 5, true] call A3A_fnc_safeVehicleSpawn`