### PR TITLE
VN, Fix Missing Item / Expand Item Filtering

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_equipmentIsValidForCurrentModset.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentIsValidForCurrentModset.sqf
@@ -1,25 +1,19 @@
 params ["_configClass", "_categories"];
 
-private _remove = false;
-
 private _itemMod = (_configClass call A3A_fnc_getModOfConfigClass);
 private _itemIsVanilla = [_itemMod] call A3A_fnc_isModNameVanilla;
 
 //Mod is disabled, remove item.
-if (_itemMod in disabledMods) exitWith {
-	true;
-};
+if (_itemMod in disabledMods) exitWith { true };
 
 //We remove anything without a picture, because it's a surprisingly good indicator if whether something
 //is actually a valid item or not.
 //Despite all the filtering, we still get a few RHS guns, etc that are for APCs, but are still classed the item type as normal weapons.
 //This is a pretty hard filter that removes anything that shouldn't be in there - I'm hoping it isn't prone to false positives!
-if (getText (_configClass >> "picture") == "") exitWith {
-	true;
-};
+if (getText (_configClass >> "picture") == "") exitWith { true };
 
 //Remove vanilla items if no vanilla sides (IFA handled seperately)
-if (_itemIsVanilla && {A3A_hasRHS}) then {
+if (_itemIsVanilla && {A3A_hasRHS}) exitWith {
 	switch (_categories select 0) do {
 		case "Item": {
 			switch (_categories select 1) do {
@@ -27,25 +21,17 @@ if (_itemIsVanilla && {A3A_hasRHS}) then {
 				case "AccessoryPointer";
 				case "AccessorySights";
 				case "AccessoryBipod";
-				case "NVGoggles": {
-					_remove = true;
-				};
+				case "NVGoggles": { true };
 			};
 		};
-		case "Weapon": {
-			_remove = true;
-		};
+		case "Weapon": { true };
 		case "Equipment": {
 			switch (_categories select 1) do {
 				case "Headgear": {
-					if (getNumber (_configClass >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Head" >> "armor") > 0) then {
-						_remove = true;
-					};
+					if (getNumber (_configClass >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Head" >> "armor") > 0) then { true };
 				};
 				case "Vest": {
-					if (getNumber (_configClass >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Chest" >> "armor") > 5) then {
-						_remove = true;
-					};
+					if (getNumber (_configClass >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Chest" >> "armor") > 5) then { true };
 				};
 			};
 		};
@@ -60,7 +46,7 @@ private _acemods = ["@ace", "@ACE - No medical [Updated]", "@Automated Ace No Me
 
 private _TFARmods = ["@task_force_radio", "@taskforceradio", "@Task Force Arrowhead Radio (BETA!!!)", "@TaskForceArrowheadRadioBETA"];
 
-if (A3A_hasIFA && !_remove && {(_itemIsVanilla || _itemMod in _acemods || _itemMod in _TFARmods)}) then {
+if (A3A_hasIFA && !_remove && {(_itemIsVanilla || _itemMod in _acemods || _itemMod in _TFARmods)}) exitWith {
 	switch (_categories select 0) do {
 		case "Item": {
 			switch (_categories select 1) do {
@@ -77,27 +63,17 @@ if (A3A_hasIFA && !_remove && {(_itemIsVanilla || _itemMod in _acemods || _itemM
 				case "Radio";
 				case "UAVTerminal";
 				case "Unknown";
-				case "Watch": {
-					_remove = true;
-				};
+				case "Watch": { true };
 			};
 		};
-		case "Weapon": {
-			_remove = true;
-		};
-		case "Equipment": {
-			_remove = true;
-		};
-		case "Magazine": {
-			_remove = true;
-		};
-		case "Mine": {
-			_remove = true;
-		};
+		case "Weapon";
+		case "Equipment";
+		case "Magazine";
+		case "Mine": { true };
 	};
 
 };
-if (A3A_hasVN && !_remove && {(_itemIsVanilla || _itemMod in _acemods || _itemMod in _TFARmods)}) then {
+if (A3A_hasVN && {(_itemIsVanilla || _itemMod in _acemods || _itemMod in _TFARmods)}) exitWith {
 	switch (_categories select 0) do {
 		case "Item": {
 			switch (_categories select 1) do {
@@ -115,24 +91,16 @@ if (A3A_hasVN && !_remove && {(_itemIsVanilla || _itemMod in _acemods || _itemMo
 				case "UAVTerminal";
 				case "Compasses";
 				case "Unknown";
-				case "Watch": {
-					_remove = true;
-				};
+				case "Watch": { true };
 			};
 		};
-		case "Weapon": {
-			_remove = true;
-		};
-		case "Equipment": {
-			_remove = true;
-		};
-		case "Magazine": {
-			_remove = true;
-		};
-		case "Mine": {
-			_remove = true;
-		};
+		case "Weapon";
+		case "Equipment";
+		case "Magazine";
+		case "Mine": { true };
 	};
 };
 
-_remove;
+//no other CDLC content when using VN
+//if (A3A_hasVN && !_remove && {_itemMod isNotEqualTo "VN"} && {_itemMod in (allCDLC apply {_x#1})}) exitWith {true}; //for some reason remove all items, wtf!!!
+false

--- a/A3-Antistasi/functions/Ammunition/fn_equipmentIsValidForCurrentModset.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentIsValidForCurrentModset.sqf
@@ -56,9 +56,9 @@ if (_itemIsVanilla && {A3A_hasRHS}) then {
 //Avoid listing all of the mods here.
 
 //we should find a Solution that is not bound to Foldernames
-private _acemods = ["@ace", "@ACE - No medical [Updated]", "@Automated Ace No Medical"];
+private _acemods = ["@ace", "@ACE - No medical [Updated]", "@Automated Ace No Medical", "@ACENomedical"];
 
-private _TFARmods = ["@task_force_radio", "@Task Force Arrowhead Radio (BETA!!!)"];
+private _TFARmods = ["@task_force_radio", "@taskforceradio", "@Task Force Arrowhead Radio (BETA!!!)", "@TaskForceArrowheadRadioBETA"];
 
 if (A3A_hasIFA && !_remove && {(_itemIsVanilla || _itemMod in _acemods || _itemMod in _TFARmods)}) then {
 	switch (_categories select 0) do {

--- a/A3-Antistasi/functions/Ammunition/fn_equipmentIsValidForCurrentModset.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentIsValidForCurrentModset.sqf
@@ -113,7 +113,6 @@ if (A3A_hasVN && !_remove && {(_itemIsVanilla || _itemMod in _acemods || _itemMo
 				case "NVGoggles";
 				case "Radio";
 				case "UAVTerminal";
-				case "FirstAidKit";
 				case "Compasses";
 				case "Unknown";
 				case "Watch": {

--- a/A3-Antistasi/functions/Ammunition/fn_equipmentSort.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentSort.sqf
@@ -178,4 +178,5 @@ allMagBullet = allMagBullet - _props;
 allMedikits deleteAt (allMedikits find "Medikit");
 allToolkits deleteAt (allToolkits find "ToolKit");
 allMaps deleteAt (allMaps find "ItemMap");
+allFirstAidKits deleteAt (allFirstAidKits find "FirstAidKit");
 };

--- a/A3-Antistasi/functions/ModsAndDLC/fn_initDisabledMods.sqf
+++ b/A3-Antistasi/functions/ModsAndDLC/fn_initDisabledMods.sqf
@@ -10,11 +10,11 @@ if (!allowDLCExpansion) then {_disabledMods pushBack "expansion"};
 if (!allowDLCJets) then {_disabledMods pushBack "jets"};
 if (!allowDLCOrange) then {_disabledMods pushBack "orange"};
 if (!allowDLCTanks) then {_disabledMods pushBack "tanks"};
-if (!allowDLCGlobMob) then {_disabledMods pushBack "globmob"};
+if (!allowDLCGlobMob) then {_disabledMods pushBack "GM"};
 if (!allowDLCEnoch) then {_disabledMods pushBack "enoch"};
 if (!allowDLCOfficialMod) then {_disabledMods pushBack "officialmod"};
 if (!allowDLCAoW) then {_disabledMods pushBack "aow"};
-if (!allowDLCVN) then {_disabledMods pushBack "vn"};
+if (!allowDLCVN) then {_disabledMods pushBack "VN"};
 
 Info_1("Disabled DLC: %1",_disabledMods);
 

--- a/A3-Antistasi/functions/ModsAndDLC/fn_isModNameVanilla.sqf
+++ b/A3-Antistasi/functions/ModsAndDLC/fn_isModNameVanilla.sqf
@@ -10,4 +10,4 @@
 
 params ["_modName"];
 
-_modName == "" || {_modName in allDLCMods};
+_modName == "" || { _modName in (allDLCMods apply {_x#1}) };

--- a/A3-Antistasi/functions/init/fn_initVarCommon.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarCommon.sqf
@@ -77,7 +77,10 @@ allCategories = allCategoriesExceptSpecial + specialCategories;
 //     BEGIN MOD DETECTION       ///
 ////////////////////////////////////
 Info("Starting mod detection");
-allDLCMods = ["kart", "mark", "heli", "expansion", "jets", "orange", "tank", "globmob", "enoch", "officialmod", "tacops", "argo", "warlords", "aow", "vn"];
+private _modsInfo = getLoadedModsInfo;
+allDLCMods = _modsInfo select {_x#2};
+allCDLC = _modsInfo select { !(_x#2) && _x#3 };
+allmods = _modsInfo - allDLCMods - allCDLC;
 
 
 // Short Info of loaded mods needs to be added to this array. eg: `A3A_loadedTemplateInfoXML pushBack ["RHS","All factions will be replaced by RHS (AFRF &amp; USAF &amp; GREF)."];`


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information:
Due to VN Counting towards Vanilla, the Vanilla filtering removed almost all VN Items

Improved fn_equipmentIsValidForCurrentModset a bit,
Changed FirstAidKit removal to avoid removal of VN FirstAidKits,
Changed DLC Filtering, added a Category for CDLCs and BIDLCs
Added a few Possible TFAR/Ace Names to ensure Item filtering to work.
### Please specify which Issue this PR Resolves.
closes #1908 
closes #1905 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Type
```sqf
Allweapons
```
Into the Debug console on a Server.
It should return only VN Weapon/Weapons at all, as everything was removed earlier
Type
```Sqf
 AllRadios
 ```
 Into the Debug console, it should only return VN Radios.
********************************************************
Notes:
