### PR TITLE
fix error from equipmentIsValidForCurrentmodset

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_equipmentIsValidForCurrentModset.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentIsValidForCurrentModset.sqf
@@ -46,7 +46,7 @@ private _acemods = ["@ace", "@ACE - No medical [Updated]", "@Automated Ace No Me
 
 private _TFARmods = ["@task_force_radio", "@taskforceradio", "@Task Force Arrowhead Radio (BETA!!!)", "@TaskForceArrowheadRadioBETA"];
 
-if (A3A_hasIFA && !_remove && {(_itemIsVanilla || _itemMod in _acemods || _itemMod in _TFARmods)}) exitWith {
+if (A3A_hasIFA && {(_itemIsVanilla || _itemMod in _acemods || _itemMod in _TFARmods)}) exitWith {
 	switch (_categories select 0) do {
 		case "Item": {
 			switch (_categories select 1) do {
@@ -102,5 +102,5 @@ if (A3A_hasVN && {(_itemIsVanilla || _itemMod in _acemods || _itemMod in _TFARmo
 };
 
 //no other CDLC content when using VN
-//if (A3A_hasVN && !_remove && {_itemMod isNotEqualTo "VN"} && {_itemMod in (allCDLC apply {_x#1})}) exitWith {true}; //for some reason remove all items, wtf!!!
+//if (A3A_hasVN && {_itemMod isNotEqualTo "VN"} && {_itemMod in (allCDLC apply {_x#1})}) exitWith {true}; //for some reason remove all items, wtf!!!
 false

--- a/A3-Antistasi/functions/Ammunition/fn_equipmentIsValidForCurrentModset.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentIsValidForCurrentModset.sqf
@@ -4,7 +4,7 @@ private _itemMod = (_configClass call A3A_fnc_getModOfConfigClass);
 private _itemIsVanilla = [_itemMod] call A3A_fnc_isModNameVanilla;
 
 //Mod is disabled, remove item.
-if (_itemMod in disabledMods) exitWith { true };
+if (toLower _itemMod in disabledMods) exitWith { true };
 
 //We remove anything without a picture, because it's a surprisingly good indicator if whether something
 //is actually a valid item or not.
@@ -102,5 +102,6 @@ if (A3A_hasVN && {(_itemIsVanilla || _itemMod in _acemods || _itemMod in _TFARmo
 };
 
 //no other CDLC content when using VN
-//if (A3A_hasVN && {_itemMod isNotEqualTo "VN"} && {_itemMod in (allCDLC apply {_x#1})}) exitWith {true}; //for some reason remove all items, wtf!!!
+if (A3A_hasVN && {toLower _itemMod isNotEqualTo "vn"} && {toLower _itemMod in (allCDLC apply {toLower (_x#1)})}) exitWith {true};
+
 false

--- a/A3-Antistasi/functions/ModsAndDLC/fn_initDisabledMods.sqf
+++ b/A3-Antistasi/functions/ModsAndDLC/fn_initDisabledMods.sqf
@@ -10,11 +10,11 @@ if (!allowDLCExpansion) then {_disabledMods pushBack "expansion"};
 if (!allowDLCJets) then {_disabledMods pushBack "jets"};
 if (!allowDLCOrange) then {_disabledMods pushBack "orange"};
 if (!allowDLCTanks) then {_disabledMods pushBack "tanks"};
-if (!allowDLCGlobMob) then {_disabledMods pushBack "GM"};
+if (!allowDLCGlobMob) then {_disabledMods pushBack "gm"};
 if (!allowDLCEnoch) then {_disabledMods pushBack "enoch"};
 if (!allowDLCOfficialMod) then {_disabledMods pushBack "officialmod"};
 if (!allowDLCAoW) then {_disabledMods pushBack "aow"};
-if (!allowDLCVN) then {_disabledMods pushBack "VN"};
+if (!allowDLCVN) then {_disabledMods pushBack "vn"};
 
 Info_1("Disabled DLC: %1",_disabledMods);
 

--- a/A3-Antistasi/functions/ModsAndDLC/fn_isModNameVanilla.sqf
+++ b/A3-Antistasi/functions/ModsAndDLC/fn_isModNameVanilla.sqf
@@ -1,13 +1,13 @@
 /**
 	Checks if a mod name belongs to vanilla
-	
+
 	Params:
 		modName - Mod name (as returned by getModOfConfigClass)
-		
+
 	Returns:
 		Boolean, true if mod is vanilla or DLC.
 **/
 
 params ["_modName"];
 
-_modName == "" || { _modName in (allDLCMods apply {_x#1}) };
+_modName == "" || { toLower _modName in (allDLCMods apply {toLower (_x#1)}) };


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information: the old ``_remove`` var was left over in the IFA check, still dont know why the last line will remove everything if commented back in, if @jaj22, @Spoffy , or @CalebSerafin  can take a look and figure it out i would appreciate it, note it only breaks on DS, works perfectly on LH.
    

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: load in check the variable ``allWeapons`` it should only have appropriate items, not when running VN with GM on you will have GM items too unless you blacklist GM

********************************************************
Notes:
