### PR TITLE
Fix missing variable in fn_equipment_is_valid_for_current_modset.sqf

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_equipmentIsValidForCurrentModset.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentIsValidForCurrentModset.sqf
@@ -1,5 +1,7 @@
 params ["_configClass", "_categories"];
 
+private _remove = false;
+
 private _itemMod = (_configClass call A3A_fnc_getModOfConfigClass);
 private _itemIsVanilla = [_itemMod] call A3A_fnc_isModNameVanilla;
 


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
- The definition of `_remove` in fn_equipment_is_valid_for_current_modset.sqf was missing, cause code exit during scenario initialization.
- Though I think this variable can be deleted, considering of keeping compatibility with main branch, I've reintroduced the variable.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
- Start the scenario, see if there's code error message during initialization.
********************************************************
Notes:
