### PR TITLE
Fix bug with maxunits code deleting cargo-less vehicles

### DIFF
--- a/A3-Antistasi/functions/Base/fn_getVehiclePoolForAttacks.sqf
+++ b/A3-Antistasi/functions/Base/fn_getVehiclePoolForAttacks.sqf
@@ -140,9 +140,7 @@ switch (tierWar) do
                 [vehCSATAA, 15],
                 [vehCSATAttackHelis, 15],
                 [vehCSATTank, 20],
-                [vehCSATTransportPlanes, 15],
-                [vehCSATPlane, 5],
-                [vehCSATPlaneAA, 5]
+                [vehCSATTransportPlanes, 15]
             ];
         };
     };
@@ -157,9 +155,7 @@ switch (tierWar) do
                 [vehNATOAA, 10],
                 [vehNATOAttackHelis, 20],
                 [vehNATOTank, 15],
-                [vehNATOTransportPlanes, 15],
-                [vehNATOPlane, 10],
-                [vehNATOPlaneAA, 5]
+                [vehNATOTransportPlanes, 15]
             ];
         };
         if(_side == Invaders) then
@@ -171,9 +167,7 @@ switch (tierWar) do
                 [vehCSATAA, 10],
                 [vehCSATAttackHelis, 20],
                 [vehCSATTank, 20],
-                [vehCSATTransportPlanes, 15],
-                [vehCSATPlane, 10],
-                [vehCSATPlaneAA, 10]
+                [vehCSATTransportPlanes, 15]
             ];
         };
     };
@@ -188,9 +182,7 @@ switch (tierWar) do
                 [vehNATOAA, 5],
                 [vehNATOAttackHelis, 20],
                 [vehNATOTank, 20],
-                [vehNATOTransportPlanes, 15],
-                [vehNATOPlane, 10],
-                [vehNATOPlaneAA, 10]
+                [vehNATOTransportPlanes, 15]
             ];
         };
         if(_side == Invaders) then
@@ -201,9 +193,7 @@ switch (tierWar) do
                 [vehCSATAA, 10],
                 [vehCSATAttackHelis, 25],
                 [vehCSATTank, 25],
-                [vehCSATTransportPlanes, 15],
-                [vehCSATPlane, 5],
-                [vehCSATPlaneAA, 10]
+                [vehCSATTransportPlanes, 15]
             ];
         };
     };
@@ -218,9 +208,7 @@ switch (tierWar) do
                 [vehNATOAA, 5],
                 [vehNATOAttackHelis, 20],
                 [vehNATOTank, 20],
-                [vehNATOTransportPlanes, 15],
-                [vehNATOPlane, 10],
-                [vehNATOPlaneAA, 10]
+                [vehNATOTransportPlanes, 15]
             ];
         };
         if(_side == Invaders) then
@@ -231,9 +219,7 @@ switch (tierWar) do
                 [vehCSATAA, 10],
                 [vehCSATAttackHelis, 25],
                 [vehCSATTank, 25],
-                [vehCSATTransportPlanes, 15],
-                [vehCSATPlane, 5],
-                [vehCSATPlaneAA, 10]
+                [vehCSATTransportPlanes, 15]
             ];
         };
     };
@@ -248,9 +234,7 @@ switch (tierWar) do
                 [vehNATOAA, 5],
                 [vehNATOAttackHelis, 20],
                 [vehNATOTank, 20],
-                [vehNATOTransportPlanes, 15],
-                [vehNATOPlane, 10],
-                [vehNATOPlaneAA, 10]
+                [vehNATOTransportPlanes, 15]
             ];
         };
         if(_side == Invaders) then
@@ -261,9 +245,7 @@ switch (tierWar) do
                 [vehCSATAA, 10],
                 [vehCSATAttackHelis, 25],
                 [vehCSATTank, 25],
-                [vehCSATTransportPlanes, 15],
-                [vehCSATPlane, 5],
-                [vehCSATPlaneAA, 10]
+                [vehCSATTransportPlanes, 15]
             ];
         };
     };
@@ -278,9 +260,7 @@ switch (tierWar) do
                 [vehNATOAA, 5],
                 [vehNATOAttackHelis, 20],
                 [vehNATOTank, 20],
-                [vehNATOTransportPlanes, 15],
-                [vehNATOPlane, 10],
-                [vehNATOPlaneAA, 10]
+                [vehNATOTransportPlanes, 15]
             ];
         };
         if(_side == Invaders) then
@@ -291,9 +271,7 @@ switch (tierWar) do
                 [vehCSATAA, 10],
                 [vehCSATAttackHelis, 25],
                 [vehCSATTank, 25],
-                [vehCSATTransportPlanes, 15],
-                [vehCSATPlane, 5],
-                [vehCSATPlaneAA, 10]
+                [vehCSATTransportPlanes, 15]
             ];
         };
     };

--- a/A3-Antistasi/functions/Base/fn_getVehiclePoolForQRFs.sqf
+++ b/A3-Antistasi/functions/Base/fn_getVehiclePoolForQRFs.sqf
@@ -264,8 +264,7 @@ switch (tierWar) do
                 [vehNATOPatrolHeli, 10],
                 [vehNATOTransportHelis, 40],
                 [vehNATOTransportPlanes, 25],
-                [vehNATOAttackHelis, 20],
-                [vehNATOPlaneAA, 5]
+                [vehNATOAttackHelis, 20]
             ];
         };
         if(_side == Invaders) then
@@ -281,8 +280,7 @@ switch (tierWar) do
                 [vehCSATPatrolHeli, 5],
                 [vehCSATTransportHelis, 40],
                 [vehCSATTransportPlanes, 25],
-                [vehCSATAttackHelis, 25],
-                [vehCSATPlaneAA, 5]
+                [vehCSATAttackHelis, 25]
             ];
         };
     };
@@ -302,9 +300,7 @@ switch (tierWar) do
                 [vehNATOPatrolHeli, 5],
                 [vehNATOTransportHelis, 35],
                 [vehNATOTransportPlanes, 25],
-                [vehNATOAttackHelis, 25],
-                [vehNATOPlane, 5],
-                [vehNATOPlaneAA, 5]
+                [vehNATOAttackHelis, 25]
             ];
         };
         if(_side == Invaders) then
@@ -320,9 +316,7 @@ switch (tierWar) do
                 [vehCSATPatrolHeli, 5],
                 [vehCSATTransportHelis, 35],
                 [vehCSATTransportPlanes, 25],
-                [vehCSATAttackHelis, 30],
-                [vehCSATPlane, 5],
-                [vehCSATPlaneAA, 5]
+                [vehCSATAttackHelis, 30]
             ];
         };
     };
@@ -342,9 +336,7 @@ switch (tierWar) do
                 [vehNATOPatrolHeli, 5],
                 [vehNATOTransportHelis, 30],
                 [vehNATOTransportPlanes, 25],
-                [vehNATOAttackHelis, 25],
-                [vehNATOPlane, 10],
-                [vehNATOPlaneAA, 5]
+                [vehNATOAttackHelis, 25]
             ];
         };
         if(_side == Invaders) then
@@ -360,9 +352,7 @@ switch (tierWar) do
                 [vehCSATPatrolHeli, 5],
                 [vehCSATTransportHelis, 30],
                 [vehCSATTransportPlanes, 25],
-                [vehCSATAttackHelis, 30],
-                [vehCSATPlane, 10],
-                [vehCSATPlaneAA, 5]
+                [vehCSATAttackHelis, 30]
             ];
         };
     };

--- a/A3-Antistasi/functions/CREATE/fn_createAttackVehicle.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAttackVehicle.sqf
@@ -1,4 +1,4 @@
-params ["_vehicleType", "_typeOfAttack", "_landPosBlacklist", "_side", "_markerOrigin"];
+params ["_vehicleType", "_typeOfAttack", "_landPosBlacklist", "_side", "_markerOrigin", "_posDestination"];
 #include "..\..\Includes\common.inc"
 FIX_LINE_NUMBERS()
 /*  Creates a vehicle for a QRF or small attack, including crew and cargo
@@ -13,6 +13,7 @@ FIX_LINE_NUMBERS()
         _landPosBlacklist: ARRAY : List of blacklisted position
         _side: SIDE : The side of the attacker
         _markerOrigin: STRING : The name of the marker marking the origin
+        _posDestination: ARRAY : Target position (ASL or ATL? probably used as 2d anyway)
 
     Returns:
         ARRAY : [_vehicle, _crewGroup, _cargoGroup, _landPosBlacklist]
@@ -31,7 +32,6 @@ private _crewGroup = [_side, _vehicle] call A3A_fnc_createVehicleCrew;
 [_vehicle, _side] call A3A_fnc_AIVEHinit;
 
 private _cargoGroup = grpNull;
-private _spawnPerformed = false;
 private _expectedCargo = ([_vehicleType, true] call BIS_fnc_crewCount) - ([_vehicleType, false] call BIS_fnc_crewCount);
 if (_expectedCargo > 0) then
 {
@@ -52,49 +52,24 @@ if (_expectedCargo > 0) then
         };
     };
 
-    private _allUnits = {(local _x) and (alive _x)} count allUnits;
-
-    private _allUnitsSide = 0;
-    private _maxUnitsSide = maxUnits;
-    if (gameMode < 3) then
+    _cargoGroup = [getMarkerPos _markerOrigin, _side, _groupType, true, false] call A3A_fnc_spawnGroup;         // force spawn, should be pre-checked
     {
-        _allUnitsSide = {(local _x) and (alive _x) and (side group _x == _side)} count allUnits;
-        _maxUnitsSide = round (maxUnits * 0.7);
-    };
-
-    if ((_allUnits + _expectedCargo) <= maxUnits  && (_allUnitsSide + _expectedCargo) <= _maxUnitsSide) then
-    {
-        _spawnPerformed = true;
-        _cargoGroup = [_posOrigin, _side, _groupType] call A3A_fnc_spawnGroup;
+        _x assignAsCargo _vehicle;
+        _x moveInCargo _vehicle;
+        if !(isNull objectParent _x) then
         {
-            _x assignAsCargo _vehicle;
-            _x moveInCargo _vehicle;
-            if !(isNull objectParent _x) then
-            {
-                [_x] call A3A_fnc_NATOinit;
-                _x setVariable ["originX", _markerOrigin];
-            }
-            else
-            {
-                deleteVehicle _x;
-            };
-        } forEach units _cargoGroup;
-    };
-};
-
-if(!_spawnPerformed) exitWith
-{
-    Debug("Unit limit reached, deleting vehicle and crew");
-    {
-        deleteVehicle _x;
-    } forEach (units _crewGroup);
-    deleteVehicle _vehicle;
-    deleteGroup _crewGroup;
-    objNull;
+            [_x] call A3A_fnc_NATOinit;
+            _x setVariable ["originX", _markerOrigin];
+        }
+        else
+        {
+            deleteVehicle _x;
+        };
+    } forEach units _cargoGroup;
 };
 
 _landPosBlacklist = [_vehicle, _crewGroup, _cargoGroup, _posDestination, _markerOrigin, _landPosBlacklist] call A3A_fnc_createVehicleQRFBehaviour;
-Debug_2("Spawn Preformed: Created vehicle %1 with %2 soldiers", typeof _vehicle, count crew _vehicle);
+Debug_2("Spawn Performed: Created vehicle %1 with %2 soldiers", typeof _vehicle, count crew _vehicle);
 
 private _vehicleData = [_vehicle, _crewGroup, _cargoGroup, _landPosBlacklist];
 _vehicleData;

--- a/A3-Antistasi/functions/CREATE/fn_singleAttack.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_singleAttack.sqf
@@ -112,8 +112,12 @@ if(_vehPool isEqualTo []) then
 //Spawn in the vehicles
 for "_i" from 1 to _vehicleCount do
 {
+    if ([_side] call A3A_fnc_remUnitCount < 4) exitWith {
+        Info("Cancelling because maxUnits exceeded");
+    };
+
     private _vehicleType = selectRandomWeighted _vehPool;
-    private _vehicleData = [_vehicleType, _typeOfAttack, _landPosBlacklist, _side, _markerOrigin] call A3A_fnc_createAttackVehicle;
+    private _vehicleData = [_vehicleType, _typeOfAttack, _landPosBlacklist, _side, _markerOrigin, _posDestination] call A3A_fnc_createAttackVehicle;
     if (_vehicleData isEqualType []) then
     {
         _vehicles pushBack (_vehicleData select 0);

--- a/A3-Antistasi/functions/Supports/fn_SUP_QRF.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_QRF.sqf
@@ -100,8 +100,12 @@ if(_vehPool isEqualTo []) then
 
 for "_i" from 1 to _vehicleCount do
 {
+    if ([_side] call A3A_fnc_remUnitCount < 4) exitWith {
+        Info("Cancelling because maxUnits exceeded");
+    };
+
     private _vehicleType = selectRandomWeighted _vehPool;
-    private _vehicleData = [_vehicleType, _typeOfAttack, _landPosBlacklist, _side, _markerOrigin] call A3A_fnc_createAttackVehicle;
+    private _vehicleData = [_vehicleType, _typeOfAttack, _landPosBlacklist, _side, _markerOrigin, _posDestination] call A3A_fnc_createAttackVehicle;
     if (_vehicleData isEqualType []) then
     {
         _vehicles pushBack (_vehicleData select 0);


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fix bug with createAttackVehicle deleting cargo-less vehicles (tanks, attack helis etc):
- Switched to whole-vehicle pre-call maxUnits check, as in wavedCA. It's much simpler and saves create/delete spam. Ending precisely on the maxUnits count is not important.
- Fixed createAttackVehicle using non-private vars from calling function (_posDestination and _posOrigin were used).
- Kept AA and ground attack aircraft out of QRFs/singleAttacks, because they're much better used as supports. They were already disabled by accident.
- Fixed log typo "Spawn preformed" in createAttackVehicle.

### Please specify which Issue this PR Resolves.
closes #1926

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Direct createAttackVehicle usage:
```
[] spawn { 
  private _marker = "outpost_25"; 
  private _posDestination = getMarkerPos _marker vectorAdd [0,1000,0]; 
  [vehNATOattackhelis#0, "Normal", [], Occupants, _marker, _posDestination] call A3A_fnc_createAttackVehicle; 
};
```

SingleAttack usage:
`[["outpost_41", Occupants, true], "A3A_fnc_singleAttack"] call A3A_fnc_scheduler;`
