### PR TITLE
Enable faster vanilla revive cancels

### DIFF
--- a/A3-Antistasi/functions/Revive/fn_actionRevive.sqf
+++ b/A3-Antistasi/functions/Revive/fn_actionRevive.sqf
@@ -1,186 +1,149 @@
-private ["_cured","_medicX","_healed","_player","_timer","_sideX","_actionX"];
+params ["_cured", "_medic"];
 
-_cured = _this select 0;
-_medicX = _this select 1;
+private _player = isPlayer _medic;
+private _inPlayerGroup = if !(_player) then {if ({isPlayer _x} count (units group _medic) > 0) then {true} else {false}} else {false};
+private _isMedic = [_medic] call A3A_fnc_isMedic;
+
+if (captive _medic) then { _medic setCaptive false };         // medic is will be local
+if !(alive _cured) exitWith
+{
+    if (_player) then {["Revive", format ["%1 is already dead",name _cured]] call A3A_fnc_customHint;};
+    if (_inPlayerGroup) then {_medic groupChat format ["%1 is already dead",name _cured]};
+    false
+};
+if !([_medic] call A3A_fnc_canFight) exitWith
+{
+    if (_player) then { ["Revive", "You are not able to revive anyone"] call A3A_fnc_customHint };
+    false
+};
+if (([_cured] call A3A_fnc_fatalWound) and !_isMedic) exitWith
+{
+    if (_player) then {["Revive", format ["%1 is injured by a fatal wound, only a medic can revive him",name _cured]] call A3A_fnc_customHint;};
+    if (_inPlayerGroup) then {_medic groupChat format ["%1 is injured by a fatal wound, only a medic can revive him",name _cured]};
+    false
+};
+if !(isNull attachedTo _cured) exitWith
+{
+    if (_player) then {["Revive", format ["%1 is being carried or transported and you cannot heal him",name _cured]] call A3A_fnc_customHint;};
+    if (_inPlayerGroup) then {_medic groupChat format ["%1 is being carried or transported and I cannot heal him",name _cured]};
+    false
+};
+if !(_cured getVariable ["incapacitated",false]) exitWith
+{
+    if (_player) then {["Revive", format ["%1 no longer needs your help",name _cured]] call A3A_fnc_customHint;};
+    if (_inPlayerGroup) then {_medic groupChat format ["%1 no longer needs my help",name _cured]};
+    false
+};
+
 private _medkits = ["Medikit"];
 private _firstAidKits = ["FirstAidKit"];
 if (A3A_hasVN) then {
     _medkits append ["vn_b_item_medikit_01"];
     _firstAidKits append ["vn_o_item_firstaidkit", "vn_b_item_firstaidkit"];
 };
-_medicX setVariable ["A3A_medkits", _medkits];
-_medicX setVariable ["A3A_firstAidKits", _firstAidKits];
-_actionX = 0;
-_healed = false;
-_player = isPlayer _medicX;
-_inPlayerGroup = if !(_player) then {if ({isPlayer _x} count (units group _medicX) > 0) then {true} else {false}} else {false};
-if (captive _medicX) then
-    {
-    [_medicX,false] remoteExec ["setCaptive",0,_medicX];
-    _medicX setCaptive false;
-    };
-if !(alive _cured) exitWith
-    {
-    if (_player) then {["Revive", format ["%1 is already dead",name _cured]] call A3A_fnc_customHint;};
-    if (_inPlayerGroup) then {_medicX groupChat format ["%1 is already dead",name _cured]};
-    _healed
-    };
-if !([_medicX] call A3A_fnc_canFight) exitWith {if (_player) then {["Revive", "You are not able to revive anyone"] call A3A_fnc_customHint;};_healed};
-if  (
-        (!([_medicX] call A3A_fnc_isMedic && (_medkits arrayIntersect (items _medicX)) isNotEqualTo [])) &&
-        {((_firstAidKits arrayIntersect (items _medicX)) isEqualTo []) && //medic dosnt have first aid kit
-        {(_firstAidKits arrayIntersect (items _cured)) isEqualTo [] }} // patient dosnt have first aid kit
-    ) exitWith
+private _hasMedkit = (count (_medkits arrayIntersect items _medic) > 0);
+private _medicFAKs = if (!_hasMedkit) then { _firstAidKits arrayIntersect items _medic };
+private _curedFAKs = if (!_hasMedkit) then { _firstAidKits arrayIntersect items _cured };
+
+if (!_hasMedkit && {count _medicFAKs == 0 && count _curedFAKs == 0}) exitWith
 {
     if (_player) then {["Revive", format ["You or %1 need a First Aid Kit or Medikit to be able to revive",name _cured]] call A3A_fnc_customHint;};
-    if (_inPlayerGroup) then {_medicX groupChat "I'm out of FA kits and I have no Medikit!"};
-    _healed
+    if (_inPlayerGroup) then {_medic groupChat "I'm out of FA kits and I have no Medikit!"};
+    false
 };
-//medic dosnt have first aid kit and cant take one from patient
-if (((_firstAidKits arrayIntersect (items _medicX)) isEqualTo []) and !(_firstAidKits findIf {_medicX canAdd _x} > -1)) exitWith
-    {
-    if (_player) then {["Revive", format ["%1 has a First Aid Kit but you do not have enough space in your inventory to use it",name _cured]] call A3A_fnc_customHint;};
-    if (_inPlayerGroup) then {_medicX groupChat "I'm out of FA kits!"};
-    _healed
-    };
-if ((([_cured] call A3A_fnc_fatalWound)) and !([_medicX] call A3A_fnc_isMedic)) exitWith
-    {
-    if (_player) then {["Revive", format ["%1 is injured by a fatal wound, only a medic can revive him",name _cured]] call A3A_fnc_customHint;};
-    if (_inPlayerGroup) then {_medicX groupChat format ["%1 is injured by a fatal wound, only a medic can revive him",name _cured]};
-    _healed
-    };
-if !(isNull attachedTo _cured) exitWith
-    {
-    if (_player) then {["Revive", format ["%1 is being carried or transported and you cannot heal him",name _cured]] call A3A_fnc_customHint;};
-    if (_inPlayerGroup) then {_medicX groupChat format ["%1 is being carried or transported and I cannot heal him",name _cured]};
-    _healed
-    };
-if !(_cured getVariable ["incapacitated",false]) exitWith
-    {
-    if (_player) then {["Revive", format ["%1 no longer needs your help",name _cured]] call A3A_fnc_customHint;};
-    if (_inPlayerGroup) then {_medicX groupChat format ["%1 no longer needs my help",name _cured]};
-    _healed
-    };
-if (_player) then
-    {
-    _cured setVariable ["helped",_medicX,true];
-    };
-_medicX setVariable ["helping",true];
-if  ( //medic dosnt have first aid kit or medkit
-        ((_firstAidKits arrayIntersect (items _medicX)) isEqualTo []) &&
-        { (_medkits arrayIntersect (items _medicX)) isEqualTo []}
-    ) then
+
+private _timer = if ([_cured] call A3A_fnc_fatalWound) then
 {
-    _medicX addItem selectRandom _firstAidKits;
-    _cured removeItem selectRandom (_firstAidKits arrayIntersect (items _cured));
-};
-_timer = if ([_cured] call A3A_fnc_fatalWound) then
-            {
-            time + 35 + (random 20)
-            }
-        else
-            {
-            if ((!isMultiplayer and (isPlayer _cured)) or ([_medicX] call A3A_fnc_isMedic)) then
-                {
-                time + 10 + (random 5)
-                }
-            else
-                {
-                time + 15 + (random 10)
-                };
-            };
-
-
-_medicX setVariable ["timeToHeal",_timer];
-_medicX playMoveNow selectRandom medicAnims;
-_medicX setVariable ["animsDone",false];
-_medicX setVariable ["cured",_cured];
-_medicX setVariable ["success",false];
-_medicX setVariable ["cancelRevive",false];
-if (!_player) then
-    {
-    {_medicX disableAI _x} forEach ["ANIM","AUTOTARGET","FSM","MOVE","TARGET"];
-    }
+    time + 35 + (random 20)
+}
 else
-    {
-    _actionX = _medicX addAction ["Cancel Revive", {(_this select 1) setVariable ["cancelRevive",true]},nil,6,true,true,"","(_this getVariable [""helping"",false]) and (isPlayer _this)"];
-    };
-_medicX addEventHandler ["AnimDone",
 {
-    private _medicX = _this select 0;
-    private _cured = _medicX getVariable ["cured",objNull];
-    private _medkits = _medicX getVariable ["A3A_medkits", []];
-    private _firstAidKits = _medicX getVariable ["A3A_firstAidKits", []];
-    if (([_medicX] call A3A_fnc_canFight) and (time <= (_medicX getVariable ["timeToHeal",time])) and !(_medicX getVariable ["cancelRevive",false]) and (alive _cured) and (_cured getVariable ["incapacitated",false]) and (_medicX == vehicle _medicX)) then
+    if (_isMedic) then
     {
-        _medicX playMoveNow selectRandom medicAnims;
+        time + 10 + (random 5)
     }
     else
     {
-        _medicX removeEventHandler ["AnimDone",_thisEventHandler];
-        _medicX setVariable ["animsDone",true];
-        if (([_medicX] call A3A_fnc_canFight) and !(_medicX getVariable ["cancelRevive",false]) and (_medicX == vehicle _medicX) and (alive _cured)) then
-        {
-            if (_cured getVariable ["incapacitated",false]) then
-            {
-                _medicX setVariable ["success",true];
-                //_cured setVariable ["incapacitated",false,true];
-                //_medicX action ["HealSoldier",_cured];
-                if ([_medicX] call A3A_fnc_isMedic) then {_cured setDamage 0.25} else {_cured setDamage 0.5};
-                if((_medkits arrayIntersect (items _medicX)) isEqualTo []) then {
-                    _medicX removeItem selectRandom (_firstAidKits arrayIntersect items _medicX);
-                };
-            };
-        };
+        time + 15 + (random 10)
     };
-}];
-waitUntil {sleep 0.5; (_medicX getVariable ["animsDone",true])};
-_medicX setVariable ["animsDone",nil];
-_medicX setVariable ["timeToHeal",nil];
-_medicX setVariable ["cured",nil];
-_medicX setVariable ["helping",false];
+};
+
+_medic setVariable ["helping",true];
+_medic playMoveNow selectRandom medicAnims;
+_medic setVariable ["cancelRevive",false];
+
+private _actionX = 0;
 if (!_player) then
-    {
-    {_medicX enableAI _x} forEach ["ANIM","AUTOTARGET","FSM","MOVE","TARGET"];
-    }
+{
+    {_medic disableAI _x} forEach ["ANIM","AUTOTARGET","FSM","MOVE","TARGET"];
+}
 else
-    {
-    _medicX removeAction _actionX;
+{
+    _actionX = _medic addAction ["Cancel Revive", {(_this select 1) setVariable ["cancelRevive",true]},nil,6,true,true,"",""];
+    _cured setVariable ["helped",_medic,true];
+};
+
+private _animHandler = _medic addEventHandler ["AnimDone",
+{
+    private _medic = _this select 0;
+    _medic playMoveNow selectRandom medicAnims;
+}];
+
+waitUntil {
+    sleep 1;
+    !([_medic] call A3A_fnc_canFight)
+    or (time > _timer)
+    or (_medic getVariable "cancelRevive")
+    or !(alive _cured)
+};
+
+_medic removeEventHandler ["AnimDone", _animHandler];
+_medic setVariable ["helping",false];
+_medic playMoveNow "AinvPknlMstpSnonWnonDnon_medicEnd";
+
+if (!_player) then
+{
+    {_medic enableAI _x} forEach ["ANIM","AUTOTARGET","FSM","MOVE","TARGET"];
+}
+else
+{
+    _medic removeAction _actionX;
     _cured setVariable ["helped",objNull,true];
-    _medicX setVariable ["helping",false];
-    };
-if (_medicX getVariable ["cancelRevive",false]) exitWith
-    {
+};
+
+if (_medic getVariable ["cancelRevive",false]) exitWith
+{
+    // AI medics can be cancelled from A3A_fnc_help
     if (_player) then
-        {
+    {
         ["Revive", "Revive cancelled"] call A3A_fnc_customHint;
-        _medicX setVariable ["cancelRevive",nil];
-        };
-    _healed
+        _medic setVariable ["cancelRevive",nil];
     };
+    false;
+};
 if !(alive _cured) exitWith
-    {
+{
     if (_player) then {["Revive", format ["We lost %1",name _cured]] call A3A_fnc_customHint;};
-    if (_inPlayerGroup) then {_medicX groupChat format ["We lost %1",name _cured]};
-    _healed
-    };
-if (!([_medicX] call A3A_fnc_canFight) or (_medicX != vehicle _medicX) or (_medicX distance _cured > 3)) exitWith {if (_player) then {["Revive", "Revive cancelled"] call A3A_fnc_customHint;};_healed};
+    if (_inPlayerGroup) then {_medic groupChat format ["We lost %1",name _cured]};
+    false;
+};
+if (!([_medic] call A3A_fnc_canFight)) exitWith
+{
+    if (_player) then {["Revive", "Revive cancelled"] call A3A_fnc_customHint;};
+    false;
+};
 
-if (_medicX getVariable ["success",true]) then
-    {
-    _sideX = side (group _cured);
-    if ((_sideX != side (group _medicX)) and ((_sideX == Occupants) or (_sideX == Invaders))) then
-        {
-        _cured setVariable ["surrendering",true,true];
-        sleep 2;
-        };
-    _cured setVariable ["incapacitated",false,true];
-    _healed = true;
-    }
-else
-    {
-    if (_player) then {["Revive", "Revive unsuccesful"] call A3A_fnc_customHint;};
-    if (_inPlayerGroup) then {_medicX groupChat "Revive failed"};
-    };
-
-_healed
+// Successful revive
+if (_isMedic) then {_cured setDamage 0.25} else {_cured setDamage 0.5};
+if (!_hasMedkit) then {
+    if (count _medicFAKs == 0) then { _cured removeItem selectRandom _curedFAKs }
+    else { _medic removeItem selectRandom _medicFAKs };
+};
+private _sideX = side (group _cured);
+if ((_sideX != side (group _medic)) and ((_sideX == Occupants) or (_sideX == Invaders))) then
+{
+    _cured setVariable ["surrendering",true,true];
+    sleep 2;
+};
+_cured setVariable ["incapacitated",false,true];        // why is this applied later? check
+true;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Cleaned up fn_actionRevive and rewrote the second half to be more stable and allow faster revive cancellations. The AI function that calls this (fn_help) is an abomination but this seems to be compatible with it.

Based on vn-development to avoid later merge conflicts.

Note that `switchMove ""` is a faster cancel but ultra-janky. This seems to be a good compromise.

### Please specify which Issue this PR Resolves.
closes #1930

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
1. Revive some AIs, cancel halfway.
2. Let AIs revive each other, try shooting the reviver halfway to make them cancel.  