### PR TITLE
Update fn_actionRevive.sqf

### DIFF
--- a/A3-Antistasi/functions/Revive/fn_actionRevive.sqf
+++ b/A3-Antistasi/functions/Revive/fn_actionRevive.sqf
@@ -28,7 +28,7 @@ if  (
     if (_inPlayerGroup) then {_medicX groupChat "I'm out of FA kits and I have no Medikit!"};
     _healed
 };
-if ((not("FirstAidKit" in (items _medicX))) and !(_medicX canAdd "FirstAidKit")) exitWith
+if (((!("FirstAidKit" in (items _medicX))) and !(_medicX canAdd "FirstAidKit")) and !("Medikit" in (items _medicX))) exitWith
     {
     if (_player) then {["Revive", format ["%1 has a First Aid Kit but you do not have enough space in your inventory to use it",name _cured]] call A3A_fnc_customHint;};
     if (_inPlayerGroup) then {_medicX groupChat "I'm out of FA kits!"};


### PR DESCRIPTION
Allow players with Medikits to revive even if they don't have the inventory space to add a FirstAidKit

## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Added to check to see if a medic has a Medikit when checking to see if they have room for a FirstAidKit. Previously, a player with a Medikit would be unable to revive if their inventory was too full to receive a FirstAidKit, even though having one added was unnecessary.

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)
