### PR TITLE
Implement type-dependent classes for rebel AIs

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_createUnit.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createUnit.sqf
@@ -21,13 +21,7 @@ params ["_group", "_type", "_position", ["_markers", []], ["_placement", 0], ["_
 private _unitDefinition = customUnitTypes getVariable [_type, []];
 
 if !(_unitDefinition isEqualTo []) exitWith {
-	_unitDefinition params ["_loadouts", "_traits"];
-	private _unitClass = switch (side _group) do {
-		case west: { "B_G_Soldier_F" };
-		case east: { "O_G_Soldier_F" };
-		case independent: { "I_G_Soldier_F" };
-		case civilian: { "C_Man_1" };
-	};
+	_unitDefinition params ["_loadouts", "_traits", "_unitClass"];
 	private _unit = _group createUnit  [_unitClass, _position, _markers, _placement, _special];
 	_unit setUnitLoadout selectRandom _loadouts;
 	_unit setVariable ["unitType", _type, true];

--- a/A3-Antistasi/functions/CREATE/fn_registerUnitType.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_registerUnitType.sqf
@@ -1,10 +1,10 @@
 #include "..\..\Includes\common.inc"
 FIX_LINE_NUMBERS()
 
-params [["_unitTypeName", nil, [""]], ["_unitLoadouts", nil, [[]]]];
+params [["_unitTypeName", nil, [""]], ["_unitDefinition", nil, [[]]]];
 
 if (!isServer) exitWith {};
 
-Debug_2("Registering unit %1 with %2 loadouts", _unitTypeName, count _unitLoadouts);
+Debug_3("Registering unit %1 with class %2 and %3 loadouts", _unitTypeName, _unitDefinition#2, count (_unitDefinition#0));
 
-customUnitTypes setVariable [_unitTypeName, _unitLoadouts, true];
+customUnitTypes setVariable [_unitTypeName, _unitDefinition, true];

--- a/A3-Antistasi/functions/Templates/fn_compatabilityLoadFaction.sqf
+++ b/A3-Antistasi/functions/Templates/fn_compatabilityLoadFaction.sqf
@@ -26,14 +26,42 @@ private _factionPrefix =
 
 missionNamespace setVariable ["faction_" + _factionPrefix, _faction, true];
 
+private _baseUnitClass = switch (_side) do {
+	case west: { "B_G_Soldier_F" };
+	case east: { "O_G_Soldier_F" };
+	case independent: { "I_G_Soldier_F" };
+	case civilian: { "C_Man_1" };
+};
+
+private _unitClassMap = if (_side isNotEqualTo independent) then { createHashMap } else {
+	createHashMapFromArray [				// Cases matter. Lower case here because allVariables on namespace returns lowercase
+		["militia_unarmed", "I_G_Survivor_F"],
+		["militia_rifleman", "I_G_Soldier_F"],
+		["militia_staticcrew", "I_G_Soldier_F"],
+		["militia_medic", "I_G_medic_F"],
+		["militia_sniper", "I_G_Sharpshooter_F"],
+		["militia_marksman", "I_G_Soldier_M_F"],
+		["militia_lat", "I_G_Soldier_LAT_F"],
+		["militia_machinegunner", "I_G_Soldier_AR_F"],
+		["militia_explosivesexpert", "I_G_Soldier_exp_F"],
+		["militia_grenadier", "I_G_Soldier_GL_F"],
+		["militia_squadleader", "I_G_Soldier_SL_F"],
+		["militia_engineer", "I_G_engineer_F"],
+		["militia_at", "I_Soldier_AT_F"],
+		["militia_aa", "I_Soldier_AA_F"],
+		["militia_petros", "I_G_officer_F"]
+	]
+};
+
 //Register loadouts globally.
 private _loadoutsPrefix = format ["loadouts_%1_", _factionPrefix];
-private _allLoadouts = _faction getVariable "loadouts";
+private _allDefinitions = _faction getVariable "loadouts";
 {
 	private _loadoutName = _x;
-	private _loadouts = _allLoadouts getVariable _loadoutName;
-	[_loadoutsPrefix + _loadoutName, _loadouts] call A3A_fnc_registerUnitType;
-} forEach allVariables _allLoadouts;
+	private _definition = _allDefinitions getVariable _loadoutName;
+	private _unitClass = _unitClassMap getOrDefault [_loadoutName, _baseUnitClass];
+	[_loadoutsPrefix + _loadoutName, _definition + [_unitClass]] call A3A_fnc_registerUnitType;
+} forEach allVariables _allDefinitions;
 
 if (_side isEqualTo east) then {
 	nameInvaders = _faction getVariable "name";


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Implemented type-dependent classes for rebel AIs. This makes the unit type icons in the command bar work correctly (medics and engineers now have the appropriate symbol), plus the overlay names no longer all say "riflemen". Petros is now "officer", for example.

Each element of customUnitTypes now has an additional parameter for the unit class to be used for that unit type. These are varied for rebel units only, as we don't much care about the UI for enemy troops. 

Also fixed some misnamed loadout -> definition variables, and fixed the incorrect loadout count debug text. Definitions already had an extra parameter of unit traits, so the format apparently changed at some point.

Based on vn-development so that we can get the merge conflicts in early.

I haven't checked the code for civ creation but they seem to work for whatever reason. Enemies should be fine.

### Please specify which Issue this PR Resolves.
mentioned in #1914

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Enable command bar and the server difficulty option that gives you information about your troops on mouseover. Recruit all the different rebels and look at them. Also check out Petros. He likes it.