### PR TITLE
Update fn_SUP_CASRoutine.sqf

### DIFF
--- a/A3-Antistasi/functions/Supports/fn_SUP_CASRoutine.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_CASRoutine.sqf
@@ -100,7 +100,7 @@ _strikePlane addEventHandler
                 };
             };
         };
-    nil; //HandleDamage must return Nothing for damage to apply normally.
+        nil; //HandleDamage must return Nothing for damage to apply normally.
     }
 ];
 

--- a/A3-Antistasi/functions/Supports/fn_SUP_CASRoutine.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_CASRoutine.sqf
@@ -100,6 +100,7 @@ _strikePlane addEventHandler
                 };
             };
         };
+    nil; //HandleDamage must return Nothing for damage to apply normally.
     }
 ];
 


### PR DESCRIPTION
Fix HandleDamage event returning scriptHandlers when CAS plane is struck by bullets

## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Added a single nil line to the end of the HandleDamage EH to make sure the EH always returns Nothing, which is necessary for damage to be applied normally per https://community.bistudio.com/wiki/Arma_3:_Event_Handlers#HandleDamage

### Please specify which Issue this PR Resolves.
closes #1938 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
1. Spawn an empty ZSU-39 and get in
2. Make ZSU-39 and units inside invincible (e.g. with Zeus)
3. Spawn a CAS support onto the player's position
4. When the CAS arrives, strike it with the ZSU-39's autocannon
5. Check the CAS plane's health with Zeus

Current behavior: CAS plane is undamaged by autocannon
Fixed behavior: CAS plane takes damage 
********************************************************
Notes:
