### PR TITLE
Add ACRE Items to Loot, Fix ACRE items unlocking/Stacking

### DIFF
--- a/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal.sqf
@@ -1035,7 +1035,15 @@ switch _mode do {
 				if!(_radioName isEqualTo "")then{_return1 = _radioName};
 
 				_return1;
+
+								//ACRE FIX
+				_radioName = getText(configfile >> "CfgVehicles" >> _return1 >> "acre_baseClass");
+				if!(_radioName isEqualTo "")then{_return1 = _radioName};
+
+				_return1;
+
 			};
+
 			case IDC_RSCDISPLAYARSENAL_TAB_MAP;
 			case IDC_RSCDISPLAYARSENAL_TAB_GPS;
 			case IDC_RSCDISPLAYARSENAL_TAB_COMPASS;
@@ -1924,6 +1932,15 @@ switch _mode do {
 				_OldItemUnequal = _oldItem;
 				if(_index == IDC_RSCDISPLAYARSENAL_TAB_COMPASS)then{
 					_radioName = getText(configfile >> "CfgWeapons" >> _oldItem >> "tf_parent");
+					if!(_radioName isEqualTo "")exitWith{
+						_OldItemUnequal = _radioName;
+					};
+				};
+
+				//ACRE FIX
+				_OldItemUnequal = _oldItem;
+				if(_index == IDC_RSCDISPLAYARSENAL_TAB_COMPASS)then{
+					_radioName = getText(configfile >> "CfgVehicles" >> _oldItem >> "acre_baseClass");
 					if!(_radioName isEqualTo "")exitWith{
 						_OldItemUnequal = _radioName;
 					};

--- a/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_addItem.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_addItem.sqf
@@ -30,6 +30,10 @@ if(typeName (_this select 0) isEqualTo "SCALAR")then{//[_index, _item] and [_ind
 				private _radioName = getText(configfile >> "CfgWeapons" >> _item >> "tf_parent");
 				if!(_radioName isEqualTo "")then{_item = _radioName};
 
+				//ACRE fix
+				private _radioName = getText(configfile >> "CfgVehicles" >> _item >> "acre_baseClass");
+				if!(_radioName isEqualTo "")then{_item = _radioName};
+
 				//update
 				private _playersInArsenal = +(server getVariable ["jna_playersInArsenal",[]]);
 				if!(0 in _playersInArsenal)then{_playersInArsenal pushBackUnique 2;};

--- a/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_loadInventory.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNA/fn_arsenal_loadInventory.sqf
@@ -192,6 +192,12 @@ _assignedItems = ((_inventory select 9) + [_inventory select 3] + [_inventory se
 			_item =_radioName;
 		};
 
+		//ACRE fix
+		private _radioName = getText(configfile >> "CfgVehicles" >> _item >> "acre_baseClass");
+		if!(_radioName isEqualTo "")then{
+			_item =_radioName;
+		};
+		
 		_isBino = _item call _isItemBino;
 
 		call {

--- a/A3-Antistasi/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_categoryOverrides.sqf
@@ -142,6 +142,18 @@ private _categoryOverrideTable = [
 ["vn_sks_gl", ["GrenadeLaunchers","Weapons"]],
 ["vn_type56", ["Rifles","Weapons"]],
 
+//ACRE Radios
+//Using Gadgets instead of Radios to prevent future issues as they don't use the Radio Slot
+["ACRE_PRC148", ["Gadgets","items"]],
+["ACRE_PRC152", ["Gadgets","items"]],
+["ACRE_PRC343", ["Gadgets","items"]],
+["ACRE_PRC77", ["Gadgets","items"]],
+["ACRE_SEM52SL", ["Gadgets","items"]],
+["ACRE_SEM70", ["Gadgets","items"]],
+["ACRE_VHF30108SPIKE", ["Gadgets","items"]],
+["ACRE_VHF30108", ["Gadgets","items"]],
+["ACRE_VHF30108MAST", ["Gadgets","items"]],
+["ACRE_PRC117F", ["Gadgets","items"]],
 
 ["LIB_M2_Tripod", ["StaticWeaponParts","Items"]],
 ["LIB_Laffete_Tripod", ["StaticWeaponParts","Items"]],


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information:
Applied the TFAR Fix for ACRE with slight changes to work with ACRE.
Added ACRE Items to Gadgets so they could apear in Loot.
Using the Category Radios might cause Errors in the Future as ACRE does not use the Radioslot, so linkitem will not work with it.

### Please specify which Issue this PR Resolves.
closes #1949

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Equip ACRE Radios in the Arsenal,
Open and close the Arsenal, they should not stack differently.
********************************************************
Notes:
