### PR TITLE
set max civ amount for punishment-mission

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_invaderPunish.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_invaderPunish.sqf
@@ -114,6 +114,7 @@ if (sidesX getVariable [_attackDestination,sideUnknown] == Occupants) then
     [_posDestination, 4, ["QRF"], Invaders, _reveal] remoteExec ["A3A_fnc_sendSupport", 2];
 };
 if (_numCiv < 8) then {_numCiv = 8};
+if (_numCiv > 40) then {_numCiv = 40};
 
 _size = [_attackDestination] call A3A_fnc_sizeMarker;
 


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
set max amount to 40 as some cities like Hue have up to 2,000 inhabitants which leads to 200 units spawning

### Please specify which Issue this PR Resolves.
closes #1919 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)
