### PR TITLE
Mitigate some issues with the airstrike supports

### DIFF
--- a/A3-Antistasi/functions/AI/fn_chooseSupport.sqf
+++ b/A3-Antistasi/functions/AI/fn_chooseSupport.sqf
@@ -196,10 +196,22 @@ switch (true) do
     };
 };
 
+// Avoid making area attacks against friendlies, although "mistakes" can be made
+private _friendlyUnits = if (_side == Invaders) then { units Invaders } else { units Occupants + units civilian };
+private _friendlyCount = count (_friendlyUnits inAreaArray [getpos _enemy, 200, 200]);
+private _maxFriendlies = if (_side == Invaders) then { random [1, 2, 10] } else { random [0, 0, 5] };
+
+if (_friendlyCount > _maxFriendlies) then
+{
+    _supportTypes = _supportTypes - ["MORTAR", "AIRSTRIKE", "CARPETBOMB", "MISSILE", "ORBSTRIKE"];
+};
+
 if(_forceSupport) then
 {
     //Remove the slow QRF support if too far away, help needs to be there fast
     _supportTypes = _supportTypes - ["QRF"];
+    //meh, leave it as a fallback at least
+    _supportTypes pushBack "QRF";
 };
 
 _supportTypes;

--- a/A3-Antistasi/functions/Supports/fn_SUP_airstrike.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_airstrike.sqf
@@ -25,48 +25,17 @@ if(_airport == "") exitWith
     ["", 0, 0];
 };
 
-private _targetMarker = createMarker [format ["%1_coverage", _supportName], _supportPos];
-_targetMarker setMarkerShape "ELLIPSE";
-_targetMarker setMarkerBrush "Grid";
-_targetMarker setMarkerSize [25, 100];
-if(_side == Occupants) then
-{
-    _targetMarker setMarkerColor colorOccupants;
-};
-if(_side == Invaders) then
-{
-    _targetMarker setMarkerColor colorInvaders;
-};
-_targetMarker setMarkerAlpha 0;
+private _coverageMarker = createMarkerLocal [format ["%1_coverage", _supportName], _supportPos];
+_coverageMarker setMarkerShapeLocal "ELLIPSE";
+_coverageMarker setMarkerSizeLocal [200, 200];
+_coverageMarker setMarkerAlphaLocal 0;
 
-private _enemies = allUnits select
-{
-    (alive _x) &&
-    {(side (group _x) != _side) && (side (group _x) != civilian) &&
-    {((getPos _x) inArea _targetMarker)}}
-};
+private _aggroValue = if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
+private _weightHE = if (_side == Occupants) then {2} else {1};             // occupants less likely to use the wide-area stuff
+private _weightCluster = 0 max ((tierWar - 5) / 10 + _aggroValue / 200);           // 1 at max warlevel and aggro
+private _weightNapalm = if (napalmEnabled) then {_weightCluster} else {0};
 
-if(isNil "napalmEnabled") then
-{
-    Error("napalmEnabled does not containes a value, assuming false");
-    napalmEnabled = false;
-};
-
-private _bombType = if (napalmEnabled) then {"NAPALM"} else {"CLUSTER"};
-{
-    if (vehicle _x isKindOf "Tank") then
-    {
-        _bombType = "HE";
-    }
-    else
-    {
-        if (vehicle _x != _x) then
-        {
-            if !(vehicle _x isKindOf "StaticWeapon") then {_bombType = "CLUSTER"};
-        };
-    };
-    if (_bombType == "HE") exitWith {};
-} forEach _enemies;
+private _bombType = selectRandomWeighted ["HE", _weightHE, "CLUSTER", _weightCluster, "NAPALM", _weightNapalm];
 
 Info_1("Airstrike will be carried out with bombType %1", _bombType);
 
@@ -74,10 +43,7 @@ private _setupTime = 1200 - ((tierWar - 1) * 110);
 private _minSleepTime = (1 - (tierWar - 1) * 0.1) * _setupTime;
 private _sleepTime = _minSleepTime + random (_setupTime - _minSleepTime);
 
-private _markerDir = (getMarkerPos _airport) getDir _supportPos;
-_targetMarker setMarkerDir _markerDir;
-
 [_side, _timerIndex, _sleepTime, _bombType, _airport, _supportPos, _supportName] spawn A3A_fnc_SUP_airstrikeRoutine;
 
-private _result = [_targetMarker, _minSleepTime, _setupTime];
+private _result = [_coverageMarker, _minSleepTime, _setupTime];
 _result;

--- a/A3-Antistasi/functions/Supports/fn_SUP_airstrikeAvailable.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_airstrikeAvailable.sqf
@@ -11,7 +11,7 @@ if !(_planeType isKindOf "Air") exitWith {-1}; //allow helicopters to also drop 
 
 //Select a timer index and the max number of timers available
 private _timerIndex = -1;
-private _playerAdjustment = (floor ((count allPlayers)/4)) + 1;
+private _playerAdjustment = (floor ((count allPlayers)/6)) + 1;
 
 //Search for a timer which allows the support to be fired
 if(_side == Occupants) then

--- a/A3-Antistasi/functions/Supports/fn_SUP_airstrikeRoutine.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_airstrikeRoutine.sqf
@@ -14,139 +14,102 @@ private _crewUnits = if(_side == Occupants) then {NATOPilot} else {CSATPilot};
 private _isHelicopter = _plane isKindOf "Helicopter";
 
 private _spawnPos = (getMarkerPos _airport) vectorAdd [0, 0, if (_isHelicopter) then {150} else {500}];
-private _strikePlane = createVehicle [_plane, _spawnPos, [], 0, "FLY"];
-_strikePlane setDir (_spawnPos getDir _targetPos);
+private _strikePlane = createVehicle [_plane, _spawnPos, [], 0, "FLY"];     // FLY forces 100m alt
+private _targDir = _spawnPos getDir _targetPos;
+_strikePlane setDir _targDir;
+_strikePlane setPosATL _spawnPos;                                           // setPosATL kills velocity
 _strikePlane setVelocityModelSpace [0, 100, 0];
 
 private _strikeGroup = createGroup _side;
 private _pilot = [_strikeGroup, _crewUnits, getPos _strikePlane] call A3A_fnc_createUnit;
 _pilot moveInDriver _strikePlane;
+_strikeGroup deleteGroupWhenEmpty true;
 
 _strikePlane disableAI "TARGET";
 _strikePlane disableAI "AUTOTARGET";
-_strikePlane setVariable ["bombType", _bombType, true];
 
 private _timerArray = if(_side == Occupants) then {occupantsAirstrikeTimer} else {invadersAirstrikeTimer};
-
 _timerArray set [_timerIndex, time + 1800];
-_strikePlane setVariable ["TimerArray", _timerArray, true];
-_strikePlane setVariable ["TimerIndex", _timerIndex, true];
-_strikePlane setVariable ["supportName", _supportName, true];
-_strikePlane setVariable ["side", _side, true];
 
 //Setting up the EH for support destruction
+// Could probably just use NATOinit/AIVEHinit
 _strikePlane addEventHandler
 [
     "Killed",
     {
         params ["_strikePlane"];
-        Info_1("Plane for %1 destroyed, airstrike aborted", _strikePlane getVariable "supportName");
         ["TaskSucceeded", ["", "Airstrike Vessel Destroyed"]] remoteExec ["BIS_fnc_showNotification", teamPlayer];
-        private _timerArray = _strikePlane getVariable "TimerArray";
-        private _timerIndex = _strikePlane getVariable "TimerIndex";
-        _timerArray set [_timerIndex, (_timerArray select _timerIndex) + 3600];
-        [_strikePlane getVariable "supportName", _strikePlane getVariable "side"] spawn A3A_fnc_endSupport;
         [_strikePlane] spawn A3A_fnc_postMortem;
         [(_strikePlane getVariable "side"), 20, 45] remoteExec ["A3A_fnc_addAggression", 2];
     }
 ];
 
-_pilot setVariable ["Plane", _strikePlane, true];
 _pilot addEventHandler
 [
     "Killed",
     {
         params ["_unit"];
         ["TaskSucceeded", ["", "Airstrike crew killed"]] remoteExec ["BIS_fnc_showNotification", teamPlayer];
-        private _strikePlane = _unit getVariable "Plane";
-        Info_1("Crew for %1 killed, airstrike aborted", _strikePlane getVariable "supportName");
-        private _timerArray = _strikePlane getVariable "TimerArray";
-        private _timerIndex = _strikePlane getVariable "TimerIndex";
-        _timerArray set [_timerIndex, (_timerArray select _timerIndex) + 1800];
         [_unit] spawn A3A_fnc_postMortem;
     }
 ];
 
-_pilot spawn
-{
-    private _pilot = _this;
-    waitUntil {sleep 10; (isNull _pilot) || {!(alive _pilot) || (isNull objectParent _pilot)}};
-    if(isNull _pilot || !(alive _pilot)) exitWith {};
-
-    //Pilot ejected, spawn despawner
-    [group _pilot] spawn A3A_fnc_groupDespawner;
-};
-
-_strikeGroup deleteGroupWhenEmpty true;
-
 private _targetList = server getVariable [format ["%1_targets", _supportName], []];
 private _reveal = _targetList select 0 select 1;
 
-private _textMarker = createMarker [format ["%1_text", _supportName], _targetPos];
-_textMarker setMarkerShape "ICON";
-_textMarker setMarkerType "mil_dot";
-_textMarker setMarkerText "Airstrike";
-if(_side == Occupants) then
-{
-    _textMarker setMarkerColor colorOccupants;
-}
-else
-{
-    _textMarker setMarkerColor colorInvaders;
-};
-_textMarker setMarkerAlpha 0;
+private _markerColor = if(_side == Occupants) then {colorOccupants} else {colorInvaders};
 
-[_reveal, _targetPos, _side, "AIRSTRIKE", format ["%1_coverage", _supportName], _textMarker] spawn A3A_fnc_showInterceptedSupportCall;
-[_side, format ["%1_coverage", _supportName]] spawn A3A_fnc_clearTargetArea;
+private _targetMarker = createMarkerLocal [format ["%1_target", _supportName], _targetPos];
+_targetMarker setMarkerShapeLocal "ELLIPSE";
+_targetMarker setMarkerBrushLocal "Grid";
+_targetMarker setMarkerSizeLocal [25, 100];
+_targetMarker setMarkerDirLocal _targDir;
+_targetMarker setMarkerColorLocal _markerColor;
+_targetMarker setMarkerAlphaLocal 0;
+
+private _textMarker = createMarkerLocal [format ["%1_text", _supportName], _targetPos];
+_textMarker setMarkerShapeLocal "ICON";
+_textMarker setMarkerTypeLocal "mil_dot";
+_textMarker setMarkerTextLocal "Airstrike";
+_textMarker setMarkerColorLocal _markerColor;
+_textMarker setMarkerAlphaLocal 0;
+
+[_reveal, _targetPos, _side, "AIRSTRIKE", _targetMarker, _textMarker] spawn A3A_fnc_showInterceptedSupportCall;
+//[_side, format ["%1_coverage", _supportName]] spawn A3A_fnc_clearTargetArea;
 
 _strikePlane flyInHeight 150;
 private _minAltASL = (ATLToASL [_targetPos select 0, _targetPos select 1, 0])#2 +150;
 _strikePlane flyInHeightASL [_minAltASL, _minAltASL, _minAltASL];
 Debug_2("Fly height ASL: %1 | Target hight: %2", _minAltASL, _targetPos);
 
-private _airportPos = getMarkerPos _airport;
-private _dir = markerDir (format ["%1_coverage", _supportName]);
-
-private _startBombPosition = _targetPos getPos [100, _dir + 180];
+private _startBombPosition = _targetPos getPos [100, _targDir + 180];
 _startBombPosition set [2, 150];
-private _endBombPosition = _targetPos getPos [100, _dir];
+private _endBombPosition = _targetPos getPos [100, _targDir];
 _endBombPosition set [2, 150];
 
 //Determine speed and bomb count on aggression
 private _aggroValue = if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
-private _flightSpeed = "LIMITED";
-private _bombCount = 4;
-if(_aggroValue >= 70) then
-{
-    _flightSpeed = "FULL";
-    _bombCount = 8;
-};
-if(_aggroValue > 30 && _aggroValue < 70) then
-{
-    _flightSpeed = "NORMAL";
-    _bombCount = 6;
-};
+private _flightSpeed = ["LIMITED", "NORMAL", "FULL"] select (round random [1, _aggroValue / 50, 0]);
+private _bombCount = [2, 3, 4] select (round random [1, _aggroValue / 50, 0]);
+if (_bombType == "HE") then {_bombCount = _bombCount * 2};
+private _bombParams = [_strikePlane, _bombType, _bombCount, 200];
 
 if (_isHelicopter) then {_flightSpeed = "FULL"};
 Info_3("Airstrike %1 will be carried out with %2 bombs at %3 speed", _supportName, _bombCount, toLower _flightSpeed);
-
-//Creating bombing parameters
-private _bombParams = [_strikePlane, _strikePlane getVariable "bombType", _bombCount, 200];
-(driver _strikePlane) setVariable ["bombParams", _bombParams, true];
 
 private _wp2 = _strikeGroup addWaypoint [_startBombPosition, 0];
 _wp2 setWaypointType "MOVE";
 _wp2 setWaypointSpeed _flightSpeed;
 _wp2 setWaypointBehaviour "CARELESS";
 
-[_startBombPosition, driver _strikePlane] spawn
+[_startBombPosition, driver _strikePlane, _bombParams] spawn
 {
-    params ["_pos", "_pilot"];
-    waitUntil {sleep 1; ((_pos distance2D _pilot) < 350) || {isNull (objectParent _pilot)}};
+    params ["_pos", "_pilot", "_bombParams"];
+    waitUntil {sleep 1; ((_pos distance2D _pilot) < 500) || {isNull (objectParent _pilot)}};
     if(isNull (objectParent _pilot)) exitWith {};
-    waitUntil {sleep 0.1; ((_pos distance2D _pilot) < 250) || {isNull (objectParent _pilot)}};
+    sleep (((_pos distance2d _pilot) - 250) / (speed vehicle _pilot / 3.6));
     if(isNull (objectParent _pilot)) exitWith {};
-    (_pilot getVariable 'bombParams') spawn A3A_fnc_airbomb;
+    _bombParams spawn A3A_fnc_airbomb;
 };
 
 private _wp3 = _strikeGroup addWaypoint [_endBombPosition, 1];
@@ -154,9 +117,26 @@ _wp3 setWaypointType "MOVE";
 _wp3 setWaypointSpeed _flightSpeed;
 _wp3 setWaypointBehaviour "CARELESS";
 
-private _wp4 = _strikeGroup addWaypoint [_airportPos, 2];
+private _wp4 = _strikeGroup addWaypoint [getMarkerPos _airport, 2];
 _wp4 setWaypointType "MOVE";
 _wp4 setWaypointSpeed "FULL";
-_wp4 setWaypointStatements ["true", "if !(isServer) exitWith {}; [(objectParent this) getVariable 'supportName', side (group this)] spawn A3A_fnc_endSupport; deleteVehicle (objectParent this); deleteVehicle this"];
 
-_strikePlane setPosATL _spawnPos;
+private _timeout = time + (_targetPos distance _spawnPos) / 20;
+waitUntil { sleep 2; (currentWaypoint _strikeGroup == 4) or (time > _timeOut) };
+// could potentially "optimize" with this, or an upper-bounds speed version:
+//sleep ((time - _timeout) min (_targetPos distance _strikePlane / (speed _strikePlane / 3.6)))
+
+if (time >_timeOut) then {
+    Info_1("Plane for %1 did not return before timeout", _supportName);
+    // should this be done anyway? Depends how reliable the waypoints are...
+    if !(canMove _strikePlane) then { _timerArray set [_timerIndex, (_timerArray select _timerIndex) + 3600] };
+    [_strikeGroup] spawn A3A_fnc_groupDespawner;
+    [_strikePlane] spawn A3A_fnc_vehDespawner;
+} else {
+    deleteVehicle _pilot;
+    deleteVehicle _strikePlane;
+};
+
+deleteMarker _targetMarker;
+deleteMarker _textMarker;
+[_supportName, _side, 5] spawn A3A_fnc_endSupport;            // hold the coverage marker for a bit

--- a/A3-Antistasi/functions/Supports/fn_showInterceptedSetupCall.sqf
+++ b/A3-Antistasi/functions/Supports/fn_showInterceptedSetupCall.sqf
@@ -68,10 +68,10 @@ if(_position distance2D (getMarkerPos "Synd_HQ") < distanceMission) then
     }
     else
     {
-        if(occupantsRadioKeys > 0) then
+        if(invaderRadioKeys > 0) then
         {
             invaderRadioKeys = invaderRadioKeys - 1;
-            publicVariable "occupantsRadioKeys";
+            publicVariable "invaderRadioKeys";
             _reveal = 1;
         };
     };

--- a/A3-Antistasi/functions/Supports/fn_showInterceptedSupportCall.sqf
+++ b/A3-Antistasi/functions/Supports/fn_showInterceptedSupportCall.sqf
@@ -32,10 +32,10 @@ if(_position distance2D (getMarkerPos "Synd_HQ") < distanceMission) then
     }
     else
     {
-        if(occupantsRadioKeys > 0) then
+        if(invaderRadioKeys > 0) then
         {
             invaderRadioKeys = invaderRadioKeys - 1;
-            publicVariable "occupantsRadioKeys";
+            publicVariable "invaderRadioKeys";
             _reveal = 1;
         };
     };


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
- Switch HE/cluster/napalm to an aggro/wartier-based probability.
- Prevent wide-area attacks being routinely used near friendly troops.
- Randomly vary bomb count, halve count for cluster & napalm.
- Use separate larger coverage markers to prevent airstrike spam within small area.
- Preserve the coverage marker for a bit after the airstrike completes.
- Reduce maximum airstrike rate a bit.
- Fix some potential holes in cleanup code.
- Remove unnecessary global variable/marker spam.
- Fix some typos that prevented invader radio keys from working.

I'm not doing much with the support selection in this PR, except for (usually) blocking the area supports from use against friendlies, and changing the code that removes QRFs from the long-range options to moving them to the back of the priority list. Otherwise it'd be relatively likely to request a blank support array, which we don't really want.

I don't think there's anything very controversial here. Note that even with the halved bomb count, cluster and napalm still easily cover the target area.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

Well, there are plenty more changes required but not in this PR.

### How can the changes be tested?

Run this lot as server for prep. You will also need an airport that hasn't been used recently:
```
tierWar = 10;
[Occupants, 100, 60] spawn A3A_fnc_addAggression;
occupantsAirstrikeTimer set [0, -1];
server setVariable ["lastSupport", nil];
```

And then this one as local to aim somewhere near the player
`[getpos player vectorAdd [200,0,0], 4, ["AIRSTRIKE"], Occupants, 1] remoteExec ["A3A_fnc_sendSupport", 2]`

The chooseSupport changes are... challenging to test without pulling the code out into the debug console.
