### PR TITLE
Fix partial distribution of controlsX

### DIFF
--- a/A3-Antistasi/functions/init/fn_initGarrisons.sqf
+++ b/A3-Antistasi/functions/init/fn_initGarrisons.sqf
@@ -235,4 +235,6 @@ if (debug) then {
 //New system, adding cities
 [citiesX, "City", [0,0,0]] call A3A_fnc_createGarrison;
 
+publicVariable "controlsX";		// because it adds to the array
+
 Info("InitGarrisons completed");


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
controlsX was being expanded by initGarrisons but not publicVariable'd afterwards, which meant that HCs and clients couldn't see the whole list. This caused problems including broken text on the conquer roadblock mission.

The init order is an abomination but this is an easy quick-fix.

### Please specify which Issue this PR Resolves.
closes #1961

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Start game on Altis with DS. Check that `count controlsX` has the same value with both local and server execution.