### PR TITLE
Add new param to scale the time limits for tasks

### DIFF
--- a/A3-Antistasi/MissionDescription/params.hpp
+++ b/A3-Antistasi/MissionDescription/params.hpp
@@ -88,6 +88,13 @@ class Params
         texts[] = {"Default (4000)","2000","4000","6000","8000","10000","12000"};
         default = 9999;
     };
+    class taskTimerMultiplier
+    {
+        title = "Task time limit multiplier";
+        values[] = {9999,1,2,3,4};
+        texts[] = {"Default (1x)","1x","2x","3x","4x"};
+        default = 9999;
+    };
     class pMarkers
     {
         title = "Allow Friendly Player Markers";

--- a/A3-Antistasi/functions/Missions/fn_AS_Official.sqf
+++ b/A3-Antistasi/functions/Missions/fn_AS_Official.sqf
@@ -13,6 +13,7 @@ _sideX = if (sidesX getVariable [_markerX,sideUnknown] == Occupants) then {Occup
 _positionX = getMarkerPos _markerX;
 
 _timeLimit = if (_difficultX) then {15} else {30};//120
+_timeLimit = _timeLimit * taskTimerMultiplier;
 if (A3A_hasIFA) then {_timeLimit = _timeLimit * 2};
 _dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + _timeLimit];
 _dateLimitNum = dateToNumber _dateLimit;

--- a/A3-Antistasi/functions/Missions/fn_AS_Traitor.sqf
+++ b/A3-Antistasi/functions/Missions/fn_AS_Traitor.sqf
@@ -14,6 +14,7 @@ _tsk1 = "";
 _positionX = getMarkerPos _markerX;
 
 _timeLimit = if (_difficultX) then {30} else {60};
+_timeLimit = _timeLimit * taskTimerMultiplier;
 if (A3A_hasIFA) then {_timeLimit = _timeLimit * 2};
 _dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + _timeLimit];
 _dateLimitNum = dateToNumber _dateLimit;

--- a/A3-Antistasi/functions/Missions/fn_AS_specOP.sqf
+++ b/A3-Antistasi/functions/Missions/fn_AS_specOP.sqf
@@ -11,6 +11,7 @@ _tsk = "";
 _positionX = getMarkerPos _markerX;
 _sideX = if (sidesX getVariable [_markerX,sideUnknown] == Occupants) then {Occupants} else {Invaders};
 _timeLimit = if (_difficultX) then {60} else {120};
+_timeLimit = _timeLimit * taskTimerMultiplier;
 if (A3A_hasIFA) then {_timeLimit = _timeLimit * 2};
 _dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + _timeLimit];
 _dateLimitNum = dateToNumber _dateLimit;

--- a/A3-Antistasi/functions/Missions/fn_CON_Outpost.sqf
+++ b/A3-Antistasi/functions/Missions/fn_CON_Outpost.sqf
@@ -12,6 +12,7 @@ _groupContact = grpNull;
 _tsk = "";
 _positionX = getMarkerPos _markerX;
 _timeLimit = if (_difficultX) then {30} else {90};//120
+_timeLimit = _timeLimit * taskTimerMultiplier;
 if (A3A_hasIFA) then {_timeLimit = _timeLimit * 2};
 _dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + _timeLimit];
 _dateLimitNum = dateToNumber _dateLimit;

--- a/A3-Antistasi/functions/Missions/fn_DES_Antenna.sqf
+++ b/A3-Antistasi/functions/Missions/fn_DES_Antenna.sqf
@@ -17,6 +17,7 @@ _positionX = getPos _antenna;
 private _side = sidesX getVariable [_markerX, sideUnknown];
 
 _timeLimit = if (_difficultX) then {30} else {120};
+_timeLimit = _timeLimit * taskTimerMultiplier;
 if (A3A_hasIFA) then {_timeLimit = _timeLimit * 2};
 _dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + _timeLimit];
 _dateLimitNum = dateToNumber _dateLimit;

--- a/A3-Antistasi/functions/Missions/fn_DES_Heli.sqf
+++ b/A3-Antistasi/functions/Missions/fn_DES_Heli.sqf
@@ -78,6 +78,7 @@ _taskMrk setMarkerShape "ICON";
 
 //finding timelimit for mission
 private _timeLimit = 120;
+_timeLimit = _timeLimit * taskTimerMultiplier;
 private _dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + _timeLimit];
 private _dateLimitNum = dateToNumber _dateLimit;
 

--- a/A3-Antistasi/functions/Missions/fn_DES_Vehicle.sqf
+++ b/A3-Antistasi/functions/Missions/fn_DES_Vehicle.sqf
@@ -13,6 +13,7 @@ _tsk = "";
 _positionX = getMarkerPos _markerX;
 _sideX = if (sidesX getVariable [_markerX,sideUnknown] == Occupants) then {Occupants} else {Invaders};
 _timeLimit = if (_difficultX) then {30} else {120};
+_timeLimit = _timeLimit * taskTimerMultiplier;
 if (A3A_hasIFA) then {_timeLimit = _timeLimit * 2};
 _dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + _timeLimit];
 _dateLimitNum = dateToNumber _dateLimit;

--- a/A3-Antistasi/functions/Missions/fn_LOG_Ammo.sqf
+++ b/A3-Antistasi/functions/Missions/fn_LOG_Ammo.sqf
@@ -13,6 +13,7 @@ _tsk = "";
 _positionX = getMarkerPos _markerX;
 _sideX = if (sidesX getVariable [_markerX,sideUnknown] == Occupants) then {Occupants} else {Invaders};
 _timeLimit = if (_difficultX) then {30} else {60};
+_timeLimit = _timeLimit * taskTimerMultiplier;
 if (A3A_hasIFA) then {_timeLimit = _timeLimit * 2};
 _dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + _timeLimit];
 _dateLimitNum = dateToNumber _dateLimit;

--- a/A3-Antistasi/functions/Missions/fn_LOG_Bank.sqf
+++ b/A3-Antistasi/functions/Missions/fn_LOG_Bank.sqf
@@ -17,6 +17,7 @@ _positionX = getPosASL _banco;
 _posbase = getMarkerPos respawnTeamPlayer;
 
 _timeLimit = if (_difficultX) then {60} else {120};
+_timeLimit = _timeLimit * taskTimerMultiplier;
 if (A3A_hasIFA) then {_timeLimit = _timeLimit * 2};
 _dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + _timeLimit];
 _dateLimitNum = dateToNumber _dateLimit;

--- a/A3-Antistasi/functions/Missions/fn_LOG_Salvage.sqf
+++ b/A3-Antistasi/functions/Missions/fn_LOG_Salvage.sqf
@@ -41,6 +41,7 @@ _boxType = [_boxType, "Box_NATO_Equip_F"] select isNil "_boxType"; //so we add t
 
 //Set time limit on mission
 private _timeLimit = if (_difficultX) then {30} else {60};
+_timeLimit = _timeLimit * taskTimerMultiplier;
 private _dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + _timeLimit];
 private _dateLimitNum = dateToNumber _dateLimit;
 _dateLimit = numberToDate [date select 0, _dateLimitNum];//converts datenumber back to date array so that time formats correctly

--- a/A3-Antistasi/functions/Missions/fn_LOG_Supplies.sqf
+++ b/A3-Antistasi/functions/Missions/fn_LOG_Supplies.sqf
@@ -13,6 +13,7 @@ _tsk = "";
 _positionX = getMarkerPos _markerX;
 
 _timeLimit = if (_difficultX) then {30} else {60};
+_timeLimit = _timeLimit * taskTimerMultiplier;
 if (A3A_hasIFA) then {_timeLimit = _timeLimit * 2};
 _dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + _timeLimit];
 _dateLimitNum = dateToNumber _dateLimit;

--- a/A3-Antistasi/functions/Missions/fn_RES_Prisoners.sqf
+++ b/A3-Antistasi/functions/Missions/fn_RES_Prisoners.sqf
@@ -15,6 +15,7 @@ _positionX = getMarkerPos _markerX;
 _POWs = [];
 
 _timeLimit = if (_difficultX) then {30} else {120};//120
+_timeLimit = _timeLimit * taskTimerMultiplier;
 if (A3A_hasIFA) then {_timeLimit = _timeLimit * 2};
 
 _dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + _timeLimit];

--- a/A3-Antistasi/functions/Missions/fn_RES_Refugees.sqf
+++ b/A3-Antistasi/functions/Missions/fn_RES_Refugees.sqf
@@ -30,6 +30,7 @@ while {count _posHouse < 3} do
 
 _nameDest = [_markerX] call A3A_fnc_localizar;
 _timeLimit = if (_difficultX) then {30} else {60};
+_timeLimit = _timeLimit * taskTimerMultiplier;
 if (A3A_hasIFA) then {_timeLimit = _timeLimit * 2};
 
 _dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + _timeLimit];

--- a/A3-Antistasi/functions/Missions/fn_convoy.sqf
+++ b/A3-Antistasi/functions/Missions/fn_convoy.sqf
@@ -22,6 +22,7 @@ private _reinforcementsX = [];
 // Setup start/end times and convoy type
 
 private _timeXfin = 120;
+_timeXfin = _timeXfin * taskTimerMultiplier;
 private _dateFinal = [date select 0, date select 1, date select 2, date select 3, (date select 4) + _timeXfin];
 private _enddateNum = dateToNumber _dateFinal;
 
@@ -47,6 +48,7 @@ else
 if (_convoyType == "") then { _convoyType = selectRandom _convoyTypes };
 
 private _timeLimit = if (_difficult) then {0} else { (round random 5)+5 }; // 0 or 5-10 minute limit - there's already good a chance for 0 seconds, why have a double chance (0-10)?
+_timeLimit = _timeLimit * taskTimerMultiplier;
 private _dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + _timeLimit];
 private _dateLimitNum = dateToNumber _dateLimit;
 _dateLimit = numberToDate [date select 0, _dateLimitNum];//converts datenumber back to date array so that time formats correctly when put through the function

--- a/A3-Antistasi/functions/init/fn_initParams.sqf
+++ b/A3-Antistasi/functions/init/fn_initParams.sqf
@@ -29,6 +29,7 @@ A3A_paramTable = [
     ["autoSave", "autoSave", [], true],
     ["autoSaveInterval", "autoSaveInterval", [], 3600],
     ["distanceMission", "mRadius", [], 4000],
+    ["taskTimerMultiplier", "taskTimerMultiplier", [], 1],
     ["skillMult", "AISkill", [], 2],
     ["personalGarageMax", "personalGarageMax", [], 2],
     ["civTraffic", "civTraffic", [], 2],


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?

Many of the mission time limits are essentially unachievable on Cam Lao Nam when playing with the VN DLC, particularly with a smaller player count. There is some precedence for explicitly scaling the time limits based on loaded content, as seen here:
https://github.com/official-antistasi-community/A3-Antistasi/blob/dc7e93be3718f7dbd5edb768b388819687991812/A3-Antistasi/functions/Missions/fn_AS_Official.sqf#L16
but it seemed like this could be more flexible and more easily adjusted to taste with a parameterized multiplier rather than hardcoding a specific multiplier for specific optional content.

I've added this param and set it up with 1x (existing value as default), 2x, 3x, 4x and 8x multipliers. This seemed to give a good spread of options for the various missions, resulting in times as seen below. No modifications to the actual previously defined times have been made for this--it's simply applying a global modifier to them.

| mission               | 1x (difficult, std) | 2x         | 3x         | 4x         | 8x         |
| --------------------- | ------------------- | ---------- | ---------- | ---------- | ---------- |
| A3A_fnc_AS_Official   | 15, 30              | 30, 60     | 45, 90     | 60, 120    | 120, 240   |
| A3A_fnc_AS_Traitor    | 30, 60              | 60, 120    | 90, 180    | 120, 240   | 240, 480   |
| A3A_fnc_AS_SpecOP     | 60, 120             | 120, 240   | 180, 360   | 240, 480   | 480, 960   |
| A3A_fnc_CON_Outpost   | 30, 90              | 60, 180    | 90, 270    | 120, 360   | 240, 720   |
| A3A_fnc_DES_Vehicle   | 30, 120             | 60, 240    | 90, 360    | 120, 480   | 240, 960   |
| A3A_fnc_DES_Heli      | 120                 | 240        | 360        | 480        | 960        |
| A3A_fnc_DES_antenna   | 30, 120             | 60, 240    | 90, 360    | 120, 480   | 240, 960   |
| A3A_fnc_LOG_Ammo      | 30, 60              | 60, 120    | 90, 180    | 120, 240   | 240, 480   |
| A3A_fnc_LOG_Bank      | 60, 120             | 120, 240   | 180, 360   | 240, 480   | 480, 960   |
| A3A_fnc_LOG_Salvage   | 30, 60              | 60, 120    | 90, 180    | 120, 240   | 240, 480   |
| A3A_fnc_LOG_Supplies  | 30, 60              | 60, 120    | 90, 180    | 120, 240   | 240, 480   |
| A3A_fnc_RES_Refugees  | 30, 60              | 60, 120    | 90, 180    | 120, 240   | 240, 480   |
| A3A_fnc_RES_Prisoners | 30, 120             | 60, 240    | 90, 360    | 120, 480   | 240, 960   |
| A3A_fnc_convoy        | 0 or 5-10           | 0 or 10-20 | 0 or 15-30 | 0 or 20-40 | 0 or 40-80 |


### Please specify which Issue this PR Resolves.

N/A

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?

Set the modifier (or leave as default) and request missions from Petros. Verify the times fall within the expected ranges given the game state and selected parameters.

