### PR TITLE
Dressup simulator

### DIFF
--- a/A3-Antistasi/Templates/NewTemplates/3CB/3CB_Civ_Arid.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/3CB/3CB_Civ_Arid.sqf
@@ -3,35 +3,30 @@
 //////////////////////////////
 
 ["uniforms", [
-    "UK3CB_ADC_C_Shorts_U_05",
-    "UK3CB_ADC_C_Shorts_U_01",
-    "UK3CB_ADC_C_Shorts_U_06",
-    "UK3CB_ADC_C_Shorts_U_03",
-    "UK3CB_CHC_C_U_VILL_01",
-    "UK3CB_CHC_C_U_VILL_03",
-    "UK3CB_CHC_C_U_VILL_04",
-    "UK3CB_CHC_C_U_POLITIC_01",
-    "UK3CB_CHC_C_U_POLITIC_02",
-    "UK3CB_CHC_C_U_POLITIC_03",
-    "UK3CB_CHC_C_U_Overall_02",
-    "UK3CB_ADC_C_Hunter_U_06",
-    "UK3CB_ADC_C_Hunter_U_08",
-    "UK3CB_ADC_C_Hunter_U_07",
-    "UK3CB_CHC_C_U_DOC_01",
-    "UK3CB_CHC_C_U_PROF_04",
-    "UK3CB_CHC_C_U_PROF_01",
-    "UK3CB_CHC_C_U_COACH_03",
-    "UK3CB_CHC_C_U_COACH_05",
-    "UK3CB_CHC_C_U_COACH_02",
-    "UK3CB_CHC_C_U_COACH_04",
-    "UK3CB_CHC_C_U_CAN_01"
+    "UK3CB_TKC_C_U_01",
+    "UK3CB_TKC_C_U_01_B",
+    "UK3CB_TKC_C_U_01_C",
+    "UK3CB_TKC_C_U_01_D",
+    "UK3CB_TKC_C_U_01_E",
+    "UK3CB_TKC_C_U_02",
+    "UK3CB_TKC_C_U_02_B",
+    "UK3CB_TKC_C_U_02_C",
+    "UK3CB_TKC_C_U_02_D",
+    "UK3CB_TKC_C_U_02_E"
 ]] call _fnc_saveToTemplate;
 
-["headgear", [""]] call _fnc_saveToTemplate;
+["headgear", [
+	"UK3CB_TKC_H_Turban_01_1",
+	"UK3CB_TKC_H_Turban_02_1",
+	"UK3CB_TKC_H_Turban_06_1",
+	"UK3CB_TKC_H_Turban_03_1",
+	"UK3CB_TKC_H_Turban_04_1",
+	"UK3CB_TKC_H_Turban_05_1"
+]] call _fnc_saveToTemplate;
 
 
 
-["vehiclesCivCar", ["UK3CB_CHC_C_Ikarus", 0					// bus, dangerously large
+["vehiclesCivCar", ["UK3CB_TKC_C_Ikarus", 0					// bus, dangerously large
 	,"UK3CB_TKC_C_Datsun_Civ_Closed", 0.5
 	,"UK3CB_TKC_C_Datsun_Civ_Open", 1.0			// cargo capable
 	,"UK3CB_TKC_C_Hatchback", 0.5

--- a/A3-Antistasi/Templates/NewTemplates/3CB/3CB_Civ_Arid.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/3CB/3CB_Civ_Arid.sqf
@@ -16,12 +16,12 @@
 ]] call _fnc_saveToTemplate;
 
 ["headgear", [
-	"UK3CB_TKC_H_Turban_01_1",
-	"UK3CB_TKC_H_Turban_02_1",
-	"UK3CB_TKC_H_Turban_06_1",
-	"UK3CB_TKC_H_Turban_03_1",
-	"UK3CB_TKC_H_Turban_04_1",
-	"UK3CB_TKC_H_Turban_05_1"
+    "UK3CB_TKC_H_Turban_01_1",
+    "UK3CB_TKC_H_Turban_02_1",
+    "UK3CB_TKC_H_Turban_06_1",
+    "UK3CB_TKC_H_Turban_03_1",
+    "UK3CB_TKC_H_Turban_04_1",
+    "UK3CB_TKC_H_Turban_05_1"
 ]] call _fnc_saveToTemplate;
 
 

--- a/A3-Antistasi/Templates/NewTemplates/3CB/3CB_Civ_Temperate.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/3CB/3CB_Civ_Temperate.sqf
@@ -1,0 +1,85 @@
+//////////////////////////////
+//   Civilian Information   //
+//////////////////////////////
+
+["uniforms", [
+    "UK3CB_ADC_C_Shorts_U_05",
+    "UK3CB_ADC_C_Shorts_U_01",
+    "UK3CB_ADC_C_Shorts_U_06",
+    "UK3CB_ADC_C_Shorts_U_03",
+    "UK3CB_CHC_C_U_VILL_01",
+    "UK3CB_CHC_C_U_VILL_03",
+    "UK3CB_CHC_C_U_VILL_04",
+    "UK3CB_CHC_C_U_POLITIC_01",
+    "UK3CB_CHC_C_U_POLITIC_02",
+    "UK3CB_CHC_C_U_POLITIC_03",
+    "UK3CB_CHC_C_U_Overall_02",
+    "UK3CB_ADC_C_Hunter_U_06",
+    "UK3CB_ADC_C_Hunter_U_08",
+    "UK3CB_ADC_C_Hunter_U_07",
+    "UK3CB_CHC_C_U_DOC_01",
+    "UK3CB_CHC_C_U_PROF_04",
+    "UK3CB_CHC_C_U_PROF_01",
+    "UK3CB_CHC_C_U_COACH_03",
+    "UK3CB_CHC_C_U_COACH_05",
+    "UK3CB_CHC_C_U_COACH_02",
+    "UK3CB_CHC_C_U_COACH_04",
+    "UK3CB_CHC_C_U_CAN_01"
+]] call _fnc_saveToTemplate;
+
+["headgear", []] call _fnc_saveToTemplate;
+
+
+
+["vehiclesCivCar", ["UK3CB_CHC_C_Ikarus", 0					// bus, dangerously large
+	,"UK3CB_CHC_C_Datsun_Civ_Closed", 0.5
+	,"UK3CB_CHC_C_Datsun_Civ_Open", 1.0			// cargo capable
+	,"UK3CB_CHC_C_Hatchback", 0.5
+	,"UK3CB_CHC_C_Hilux_Civ_Closed", 0.5
+	,"UK3CB_CHC_C_Hilux_Civ_Open", 1.0			// cargo capable
+	,"UK3CB_CHC_C_Lada", 0.5
+	,"UK3CB_CHC_C_Lada_Taxi", 0.5
+	,"UK3CB_CHC_C_LR_Closed", 0.5		// land rovers
+	,"UK3CB_CHC_C_LR_Open", 0.5
+	,"UK3CB_CHC_C_Sedan", 0.5
+	,"UK3CB_CHC_C_Skoda", 0.5
+	,"UK3CB_CHC_C_S1203", 0.5
+	,"UK3CB_CHC_C_SUV", 0.3
+	,"UK3CB_CHC_C_UAZ_Closed", 0.5
+	,"UK3CB_CHC_C_UAZ_Open", 0.5
+	,"UK3CB_CHC_C_Gaz24", 0.5
+	,"UK3CB_CHC_C_Golf", 0.5]] call _fnc_saveToTemplate; 			//this line determines civilian cars -- Example: ["vehiclesCivCar", ["C_Offroad_01_F"]] -- Array, can contain multiple assets
+
+["vehiclesCivIndustrial", ["UK3CB_CHC_C_Tractor", 0.2
+	,"UK3CB_CHC_C_Tractor_Old", 0.2
+	,"UK3CB_CHC_C_Kamaz_Covered", 0.3
+	,"UK3CB_CHC_C_Kamaz_Open", 0.3
+	,"UK3CB_CHC_C_Ural", 0.3				// Urals
+	,"UK3CB_CHC_C_Ural_Open", 0.3
+	,"UK3CB_CHC_C_V3S_Closed", 0.3
+	,"UK3CB_CHC_C_V3S_Open", 0.3]] call _fnc_saveToTemplate; 			//this line determines civilian trucks -- Example: ["vehiclesCivIndustrial", ["C_Truck_02_transport_F"]] -- Array, can contain multiple assets
+
+["vehiclesCivHeli", ["not_supported"]] call _fnc_saveToTemplate; 			//this line determines civilian helis -- Example: ["vehiclesCivHeli", ["C_Heli_Light_01_civil_F"]] -- Array, can contain multiple assets
+
+["vehiclesCivBoat", ["C_Boat_Civil_01_rescue_F", 0.1			// motorboats
+	,"C_Boat_Civil_01_police_F", 0.1
+	,"UK3CB_C_Fishing_Boat", 0.3
+	,"UK3CB_C_Fishing_Boat_Smuggler_VIV_FFV", 0.1
+	,"UK3CB_C_Fishing_Boat_Smuggler", 0.2
+	,"UK3CB_C_Fishing_Boat_VIV_FFV", 0.1
+	,"UK3CB_C_Small_Boat_Closed", 0.7
+	,"UK3CB_C_Small_Boat_Open", 0.8
+	,"UK3CB_C_Small_Boat_Wood", 0.9
+	,"C_Rubberboat", 1.0					// rescue boat
+	,"C_Boat_Transport_02_F", 1.0			// RHIB
+	,"C_Scooter_Transport_01_F", 0.5]] call _fnc_saveToTemplate; 			//this line determines civilian boats -- Example: ["vehiclesCivBoat", ["C_Boat_Civil_01_F"]] -- Array, can contain multiple assets
+
+["vehiclesCivRepair", ["UK3CB_CHC_C_Kamaz_Repair", 0.1
+	,"UK3CB_CHC_C_Ural_Repair", 0.1
+	,"UK3CB_CHC_C_V3S_Repair", 0.1]] call _fnc_saveToTemplate;			//this line determines civilian repair vehicles
+
+["vehiclesCivMedical", ["UK3CB_CHC_C_S1203_Amb", 0.1]] call _fnc_saveToTemplate;			//this line determines civilian medic vehicles
+
+["vehiclesCivFuel", ["UK3CB_CHC_C_Kamaz_Fuel", 0.1
+	,"UK3CB_CHC_C_Ural_Fuel", 0.1				// Ural
+	,"UK3CB_CHC_C_V3S_Refuel", 0.1]] call _fnc_saveToTemplate;			//this line determines civilian fuel vehicles

--- a/A3-Antistasi/Templates/NewTemplates/3CB/3CB_Civ_Temperate.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/3CB/3CB_Civ_Temperate.sqf
@@ -38,7 +38,7 @@
 	,"UK3CB_CHC_C_Hilux_Civ_Closed", 0.5
 	,"UK3CB_CHC_C_Hilux_Civ_Open", 1.0			// cargo capable
 	,"UK3CB_CHC_C_Lada", 0.5
-	,"UK3CB_CHC_C_Lada_Taxi", 0.5
+	,"UK3CB_TKC_C_Lada_Taxi", 0.5
 	,"UK3CB_CHC_C_LR_Closed", 0.5		// land rovers
 	,"UK3CB_CHC_C_LR_Open", 0.5
 	,"UK3CB_CHC_C_Sedan", 0.5

--- a/A3-Antistasi/Templates/NewTemplates/3CB/3CB_Reb_CNM_Temperate.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/3CB/3CB_Reb_CNM_Temperate.sqf
@@ -50,31 +50,33 @@
 ///////////////////////////
 
 ["uniforms", [
-    "U_IG_Guerilla1_1"
-    ,"U_IG_Guerilla2_1"
-    ,"U_IG_Guerilla2_2"
-    ,"U_IG_Guerilla2_3"
-    ,"U_IG_Guerilla3_1"
-    ,"U_IG_leader"
-    ,"U_IG_Guerrilla_6_1"
-    ,"UK3CB_ADE_I_U_02"
-    ,"UK3CB_ADE_I_U_02_B"
-    ,"UK3CB_ADE_I_U_02_C"
-    ,"UK3CB_ADE_I_U_02_D"
-    ,"UK3CB_ADE_I_U_02_E"
-    ,"UK3CB_ADE_I_U_02_F"
-    ,"UK3CB_ADE_I_U_02_G"
-    ,"UK3CB_ADE_I_U_02_H"
-    ,"UK3CB_ADE_I_U_02_I"
-    ,"UK3CB_ADE_I_U_02_J"
-    ,"UK3CB_ADE_I_U_02_K"
-    ,"UK3CB_ADM_B_U_Tshirt_01_TCC"
-    ,"UK3CB_NAP_I_U_Tshirt_BLK"
-    ,"UK3CB_NAP_I_U_Tshirt_FLK"
-    ,"UK3CB_NAP_I_U_Tshirt_FLR"
+    "UK3CB_CCM_I_U_COM_01",
+    "UK3CB_NAP_I_U_Officer_Uniform_GRN",
+    "UK3CB_NAP_I_U_Officer_Uniform_FLK_GRN",
+    "UK3CB_NAP_I_U_Officer_Uniform_WDL_GRN",
+    "UK3CB_ADE_I_U_02_B",
+    "UK3CB_ADE_I_U_02_C",
+    "UK3CB_ADE_I_U_02_D",
+    "UK3CB_ADE_I_U_02_E",
+    "UK3CB_ADE_I_U_02_F",
+    "UK3CB_ADE_I_U_02_G",
+    "UK3CB_ADE_I_U_02_H",
+    "UK3CB_ADE_I_U_02_I",
+    "UK3CB_ADE_I_U_02_J",
+    "UK3CB_ADE_I_U_02_K",
+    "UK3CB_ADM_I_U_Tshirt_01_TCC",
+    "UK3CB_NAP_I_U_Tshirt_BLK",
+	"UK3CB_NAP_I_U_Tshirt_FLK",
+    "UK3CB_NAP_I_U_Tshirt_FLR"
 ]] call _fnc_saveToTemplate;
 
-["headgear", [""]] call _fnc_saveToTemplate;
+["headgear", [
+	"UK3CB_H_Beanie_02_BLK",
+	"rhs_beanie",
+	"H_Cap_oli_hs",
+	"UK3CB_H_Ushanka_Cap_03",
+	"UK3CB_H_Ushanka_Cap_01"
+]] call _fnc_saveToTemplate;
 
 private _initialRebelEquipment = [
 "UK3CB_BHP","rhs_weap_tt33",
@@ -134,7 +136,26 @@ _loadoutData setVariable ["gpses", []];
 _loadoutData setVariable ["NVGs", []]; //this line determines NVGs -- Array, can contain multiple assets
 _loadoutData setVariable ["binoculars", ["Binocular"]];
 
-_loadoutData setVariable ["uniforms", ["UK3CB_ADE_I_U_02", "UK3CB_ADE_I_U_02_B", "UK3CB_ADE_I_U_02_C", "UK3CB_ADE_I_U_02_D", "UK3CB_ADE_I_U_02_E", "UK3CB_ADE_I_U_02_F", "UK3CB_ADE_I_U_02_G", "UK3CB_ADE_I_U_02_H", "UK3CB_ADE_I_U_02_I", "UK3CB_ADE_I_U_02_J", "UK3CB_ADE_I_U_02_K", "UK3CB_ADM_B_U_Tshirt_01_TCC", "UK3CB_NAP_I_U_Tshirt_BLK", "UK3CB_NAP_I_U_Tshirt_FLK", "UK3CB_NAP_I_U_Tshirt_FLR"]];
+_loadoutData setVariable ["uniforms", [
+	"UK3CB_CCM_I_U_COM_01",
+    "UK3CB_NAP_I_U_Officer_Uniform_GRN",
+    "UK3CB_NAP_I_U_Officer_Uniform_FLK_GRN",
+    "UK3CB_NAP_I_U_Officer_Uniform_WDL_GRN",
+    "UK3CB_ADE_I_U_02",
+    "UK3CB_ADE_I_U_02_B",
+    "UK3CB_ADE_I_U_02_C",
+    "UK3CB_ADE_I_U_02_D",
+    "UK3CB_ADE_I_U_02_E",
+    "UK3CB_ADE_I_U_02_F",
+    "UK3CB_ADE_I_U_02_G",
+    "UK3CB_ADE_I_U_02_H",
+    "UK3CB_ADE_I_U_02_I",
+    "UK3CB_ADE_I_U_02_K",
+    "UK3CB_ADM_I_U_Tshirt_01_TCC",
+    "UK3CB_NAP_I_U_Tshirt_BLK",
+	"UK3CB_NAP_I_U_Tshirt_FLK",
+    "UK3CB_NAP_I_U_Tshirt_FLR"
+]];
 _loadoutData setVariable ["vests", []];
 _loadoutData setVariable ["backpacks", []];
 _loadoutData setVariable ["longRangeRadios", []];

--- a/A3-Antistasi/Templates/NewTemplates/3CB/3CB_Reb_CNM_Temperate.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/3CB/3CB_Reb_CNM_Temperate.sqf
@@ -66,16 +66,16 @@
     "UK3CB_ADE_I_U_02_K",
     "UK3CB_ADM_I_U_Tshirt_01_TCC",
     "UK3CB_NAP_I_U_Tshirt_BLK",
-	"UK3CB_NAP_I_U_Tshirt_FLK",
+    "UK3CB_NAP_I_U_Tshirt_FLK",
     "UK3CB_NAP_I_U_Tshirt_FLR"
 ]] call _fnc_saveToTemplate;
 
 ["headgear", [
-	"UK3CB_H_Beanie_02_BLK",
-	"rhs_beanie",
-	"H_Cap_oli_hs",
-	"UK3CB_H_Ushanka_Cap_03",
-	"UK3CB_H_Ushanka_Cap_01"
+    "UK3CB_H_Beanie_02_BLK",
+    "rhs_beanie",
+    "H_Cap_oli_hs",
+    "UK3CB_H_Ushanka_Cap_03",
+    "UK3CB_H_Ushanka_Cap_01"
 ]] call _fnc_saveToTemplate;
 
 private _initialRebelEquipment = [
@@ -137,7 +137,7 @@ _loadoutData setVariable ["NVGs", []]; //this line determines NVGs -- Array, can
 _loadoutData setVariable ["binoculars", ["Binocular"]];
 
 _loadoutData setVariable ["uniforms", [
-	"UK3CB_CCM_I_U_COM_01",
+    "UK3CB_CCM_I_U_COM_01",
     "UK3CB_NAP_I_U_Officer_Uniform_GRN",
     "UK3CB_NAP_I_U_Officer_Uniform_FLK_GRN",
     "UK3CB_NAP_I_U_Officer_Uniform_WDL_GRN",
@@ -153,7 +153,7 @@ _loadoutData setVariable ["uniforms", [
     "UK3CB_ADE_I_U_02_K",
     "UK3CB_ADM_I_U_Tshirt_01_TCC",
     "UK3CB_NAP_I_U_Tshirt_BLK",
-	"UK3CB_NAP_I_U_Tshirt_FLK",
+    "UK3CB_NAP_I_U_Tshirt_FLK",
     "UK3CB_NAP_I_U_Tshirt_FLR"
 ]];
 _loadoutData setVariable ["vests", []];

--- a/A3-Antistasi/Templates/NewTemplates/3CB/3CB_Reb_TKM_Arid.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/3CB/3CB_Reb_TKM_Arid.sqf
@@ -2,7 +2,7 @@
 //   Rebel Information   //
 ///////////////////////////
 
-["name", "TTF"] call _fnc_saveToTemplate; 						//this line determines the faction name -- Example: ["name", "NATO"] - ENTER ONLY ONE OPTION
+["name", "TKM"] call _fnc_saveToTemplate; 						//this line determines the faction name -- Example: ["name", "NATO"] - ENTER ONLY ONE OPTION
 
 ["flag", "Flag_TKM_B"] call _fnc_saveToTemplate; 						//this line determines the flag -- Example: ["flag", "Flag_NATO_F"] - ENTER ONLY ONE OPTION
 ["flagTexture", "uk3cb_factions\addons\uk3cb_factions_tkm\flag\tkm_b_flag_co.paa"] call _fnc_saveToTemplate; 				//this line determines the flag texture -- Example: ["flagTexture", "\A3\Data_F\Flags\Flag_NATO_CO.paa"] - ENTER ONLY ONE OPTION
@@ -50,31 +50,33 @@
 ///////////////////////////
 
 ["uniforms", [
-    "U_IG_Guerilla1_1"
-    ,"U_IG_Guerilla2_1"
-    ,"U_IG_Guerilla2_2"
-    ,"U_IG_Guerilla2_3"
-    ,"U_IG_Guerilla3_1"
-    ,"U_IG_leader"
-    ,"U_IG_Guerrilla_6_1"
-    ,"UK3CB_TKM_I_U_01"
-    ,"UK3CB_TKM_I_U_01_B"
-    ,"UK3CB_TKM_I_U_01_C"
-    ,"UK3CB_TKM_I_U_03"
-    ,"UK3CB_TKM_I_U_03_B"
-    ,"UK3CB_TKM_I_U_03_C"
-    ,"UK3CB_TKM_I_U_04"
-    ,"UK3CB_TKM_I_U_04_B"
-    ,"UK3CB_TKM_I_U_04_C"
-    ,"UK3CB_TKM_I_U_05"
-    ,"UK3CB_TKM_I_U_05_B"
-    ,"UK3CB_TKM_I_U_05_C"
-    ,"UK3CB_TKM_I_U_06"
-    ,"UK3CB_TKM_I_U_06_B"
-    ,"UK3CB_TKM_I_U_06_C"
+    "UK3CB_ADE_I_U_02_J",
+    "UK3CB_ADM_I_U_Tshirt_01_WDL_03",
+    "UK3CB_ADM_B_U_Tshirt_01_WDL",
+    "UK3CB_TKM_I_U_01",
+    "UK3CB_TKM_I_U_01_B",
+    "UK3CB_TKM_I_U_01_C",
+    "UK3CB_TKM_I_U_03",
+    "UK3CB_TKM_I_U_03_B",
+    "UK3CB_TKM_I_U_03_C",
+    "UK3CB_TKM_I_U_04",
+    "UK3CB_TKM_I_U_04_B",
+    "UK3CB_TKM_I_U_04_C",
+    "UK3CB_TKM_I_U_05",
+    "UK3CB_TKM_I_U_05_B",
+    "UK3CB_TKM_I_U_05_C",
+    "UK3CB_TKM_I_U_06",
+    "UK3CB_TKM_I_U_06_B",
+    "UK3CB_TKM_I_U_06_C"
 ]] call _fnc_saveToTemplate;
 
-["headgear", [""]] call _fnc_saveToTemplate;
+["headgear", [
+	"UK3CB_TKC_H_Turban_01_1",
+	"UK3CB_TKC_H_Turban_02_1",
+	"UK3CB_TKC_H_Turban_06_1",
+	"UK3CB_TKC_H_Turban_04_1",
+	"UK3CB_TKC_H_Turban_05_1"
+]] call _fnc_saveToTemplate;
 
 
 private _initialRebelEquipment = [
@@ -135,7 +137,23 @@ _loadoutData setVariable ["gpses", []];
 _loadoutData setVariable ["NVGs", []]; //this line determines NVGs -- Array, can contain multiple assets
 _loadoutData setVariable ["binoculars", ["Binocular"]];
 
-_loadoutData setVariable ["uniforms", ["UK3CB_TKM_I_U_01","UK3CB_TKM_I_U_01_B","UK3CB_TKM_I_U_01_C","UK3CB_TKM_I_U_03","UK3CB_TKM_I_U_03_B","UK3CB_TKM_I_U_03_C","UK3CB_TKM_I_U_04","UK3CB_TKM_I_U_04_B","UK3CB_TKM_I_U_04_C","UK3CB_TKM_I_U_05","UK3CB_TKM_I_U_05_B","UK3CB_TKM_I_U_05_C","UK3CB_TKM_I_U_06","UK3CB_TKM_I_U_06_B","UK3CB_TKM_I_U_06_C"]];
+_loadoutData setVariable ["uniforms", [
+	"UK3CB_TKM_I_U_01",
+    "UK3CB_TKM_I_U_01_B",
+    "UK3CB_TKM_I_U_01_C",
+    "UK3CB_TKM_I_U_03",
+    "UK3CB_TKM_I_U_03_B",
+    "UK3CB_TKM_I_U_03_C",
+    "UK3CB_TKM_I_U_04",
+    "UK3CB_TKM_I_U_04_B",
+    "UK3CB_TKM_I_U_04_C",
+    "UK3CB_TKM_I_U_05",
+    "UK3CB_TKM_I_U_05_B",
+    "UK3CB_TKM_I_U_05_C",
+    "UK3CB_TKM_I_U_06",
+    "UK3CB_TKM_I_U_06_B",
+    "UK3CB_TKM_I_U_06_C"
+]];
 _loadoutData setVariable ["vests", []];
 _loadoutData setVariable ["backpacks", []];
 _loadoutData setVariable ["longRangeRadios", []];

--- a/A3-Antistasi/Templates/NewTemplates/3CB/3CB_Reb_TKM_Arid.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/3CB/3CB_Reb_TKM_Arid.sqf
@@ -71,11 +71,11 @@
 ]] call _fnc_saveToTemplate;
 
 ["headgear", [
-	"UK3CB_TKC_H_Turban_01_1",
-	"UK3CB_TKC_H_Turban_02_1",
-	"UK3CB_TKC_H_Turban_06_1",
-	"UK3CB_TKC_H_Turban_04_1",
-	"UK3CB_TKC_H_Turban_05_1"
+    "UK3CB_TKC_H_Turban_01_1",
+    "UK3CB_TKC_H_Turban_02_1",
+    "UK3CB_TKC_H_Turban_06_1",
+    "UK3CB_TKC_H_Turban_04_1",
+    "UK3CB_TKC_H_Turban_05_1"
 ]] call _fnc_saveToTemplate;
 
 
@@ -138,7 +138,7 @@ _loadoutData setVariable ["NVGs", []]; //this line determines NVGs -- Array, can
 _loadoutData setVariable ["binoculars", ["Binocular"]];
 
 _loadoutData setVariable ["uniforms", [
-	"UK3CB_TKM_I_U_01",
+    "UK3CB_TKM_I_U_01",
     "UK3CB_TKM_I_U_01_B",
     "UK3CB_TKM_I_U_01_C",
     "UK3CB_TKM_I_U_03",

--- a/A3-Antistasi/Templates/NewTemplates/RHS/RHS_Civ.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/RHS/RHS_Civ.sqf
@@ -3,6 +3,21 @@
 //////////////////////////////
 
 ["uniforms", [
+    "U_C_Man_casual_1_F",
+    "U_C_Man_casual_2_F",
+    "U_C_Man_casual_3_F",
+    "U_C_Man_casual_4_F",
+    "U_C_Man_casual_5_F",
+    "U_C_Man_casual_6_F",
+    "U_C_ArtTShirt_01_v1_F",
+    "U_C_ArtTShirt_01_v2_F",
+    "U_C_ArtTShirt_01_v3_F",
+    "U_C_ArtTShirt_01_v4_F",
+    "U_C_ArtTShirt_01_v5_F",
+    "U_C_ArtTShirt_01_v6_F",
+    "U_NikosBody",
+    "U_NikosAgedBody",
+    "U_C_Journalist",
     "U_C_Poloshirt_blue",
     "U_C_Poloshirt_burgundy",
     "U_C_Poloshirt_stripped",
@@ -13,24 +28,14 @@
     "U_C_Poor_1",
     "U_C_WorkerCoveralls",
     "U_C_HunterBody_grn",
-    "U_C_Journalist",
+    "U_C_Uniform_Farmer_01_F",
+    "U_I_L_Uniform_01_tshirt_skull_F",
+    "U_I_L_Uniform_01_tshirt_black_F",
+    "U_I_L_Uniform_01_tshirt_sport_F",
     "U_C_Scientist",
-    "U_C_ArtTShirt_01_v1_F",
-    "U_C_ArtTShirt_01_v2_F",
-    "U_C_ArtTShirt_01_v3_F",
-    "U_C_ArtTShirt_01_v4_F",
-    "U_C_ArtTShirt_01_v5_F",
-    "U_C_ArtTShirt_01_v6_F",
     "U_C_Uniform_Scientist_02_formal_F",
     "U_C_Uniform_Scientist_02_F",
-    "U_C_Uniform_Scientist_01_F",
-    "U_C_Uniform_Farmer_01_F",
-    "U_C_Man_casual_1_F",
-    "U_C_Man_casual_2_F",
-    "U_C_Man_casual_3_F",
-    "U_C_Man_casual_4_F",
-    "U_C_Man_casual_5_F",
-    "U_C_Man_casual_6_F"
+    "U_C_Uniform_Scientist_01_F"
 ]] call _fnc_saveToTemplate;
 
 ["headgear", [
@@ -38,8 +43,6 @@
     "H_Bandanna_cbr",
     "H_Bandanna_gry",
     "H_Bandanna_khk",
-    "H_Bandanna_khk_hs",
-    "H_Bandanna_mcamo",
     "H_Bandanna_sand",
     "H_Bandanna_sgg",
     "H_Bandanna_surfer",
@@ -55,7 +58,8 @@
     "H_Cap_surfer",
     "H_Cap_tan",
     "H_StrawHat",
-    "H_StrawHat_dark"
+    "H_StrawHat_dark",
+    "H_Hat_checker"
 ]] call _fnc_saveToTemplate;
 
 

--- a/A3-Antistasi/Templates/NewTemplates/RHS/RHS_Reb_NAPA_Arid.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/RHS/RHS_Reb_NAPA_Arid.sqf
@@ -49,14 +49,50 @@
 //  Rebel Starting Gear  //
 ///////////////////////////
 
-["uniforms", ["U_IG_Guerilla1_1","U_IG_Guerilla2_1","U_IG_Guerilla2_2","U_IG_Guerilla2_3","U_IG_Guerilla3_1","U_IG_leader",
-"U_IG_Guerrilla_6_1","rhsgref_uniform_alpenflage","rhsgref_uniform_flecktarn","rhsgref_uniform_flecktarn_full",
-"rhsgref_uniform_tigerstripe","rhsgref_uniform_woodland","rhsgref_uniform_woodland_olive","rhsgref_uniform_olive",
-"rhsgref_uniform_altis_lizard","rhsgref_uniform_altis_lizard_olive","rhsgref_uniform_dpm","rhsgref_uniform_dpm_olive",
-"rhsgref_uniform_3color_desert","rhsgref_uniform_gorka_1_f","rhsgref_uniform_TLA_1","rhsgref_uniform_TLA_2","rhs_insurgent_uniform_1",
-"rhs_insurgent_uniform_2","rhs_insurgent_uniform_3","rhs_insurgent_uniform_4","rhs_insurgent_uniform_5"]] call _fnc_saveToTemplate;
+["uniforms", [
+	"U_IG_Guerilla1_1",
+	"U_IG_Guerilla2_1",
+	"U_IG_Guerilla2_2",
+	"U_IG_Guerilla2_3",
+	"U_IG_Guerilla3_1",
+	"U_IG_leader",
+	"U_IG_Guerrilla_6_1",
+	"U_I_G_resistanceLeader_F",
+	"rhsgref_uniform_alpenflage",
+	"rhsgref_uniform_flecktarn",
+	"rhsgref_uniform_flecktarn_full",
+	"rhsgref_uniform_tigerstripe",
+	"rhsgref_uniform_woodland",
+	"rhsgref_uniform_woodland_olive",
+	"rhsgref_uniform_olive",
+	"rhsgref_uniform_altis_lizard",
+	"rhsgref_uniform_altis_lizard_olive",
+	"rhsgref_uniform_dpm",
+	"rhsgref_uniform_dpm_olive",
+	"rhsgref_uniform_3color_desert",
+	"rhsgref_uniform_gorka_1_f",
+	"rhsgref_uniform_TLA_1",
+	"rhsgref_uniform_TLA_2",
+	"rhs_insurgent_uniform_1",
+	"rhs_insurgent_uniform_2",
+	"rhs_insurgent_uniform_3",
+	"rhs_insurgent_uniform_4",
+	"rhs_insurgent_uniform_5"
+]] call _fnc_saveToTemplate;
 
-["headgear", [""]] call _fnc_saveToTemplate;
+["headgear", [
+	"H_Booniehat_khk_hs",
+	"H_Booniehat_tan",
+	"H_Cap_tan",
+	"H_Cap_oli_hs",
+	"H_Cap_blk",
+	"H_Cap_headphones",
+	"H_ShemagOpen_tan",
+	"H_Shemag_olive_hs",
+	"H_Bandanna_khk_hs",
+	"H_Bandanna_sand",
+	"H_Bandanna_cbr"
+]] call _fnc_saveToTemplate;
 
 private _initialRebelEquipment = [
 "rhs_weap_type94_new","rhs_weap_tt33","rhs_weap_Izh18","rhs_weap_kar98k",
@@ -114,12 +150,16 @@ _loadoutData setVariable ["gpses", []];
 _loadoutData setVariable ["NVGs", []]; //this line determines NVGs -- Array, can contain multiple assets
 _loadoutData setVariable ["binoculars", ["Binocular"]];
 
-_loadoutData setVariable ["uniforms", ["U_IG_Guerilla1_1","U_IG_Guerilla2_1","U_IG_Guerilla2_2","U_IG_Guerilla2_3","U_IG_Guerilla3_1","U_IG_leader",
-"U_IG_Guerrilla_6_1","rhsgref_uniform_alpenflage","rhsgref_uniform_flecktarn","rhsgref_uniform_flecktarn_full",
-"rhsgref_uniform_tigerstripe","rhsgref_uniform_woodland","rhsgref_uniform_woodland_olive","rhsgref_uniform_olive",
-"rhsgref_uniform_altis_lizard","rhsgref_uniform_altis_lizard_olive","rhsgref_uniform_dpm","rhsgref_uniform_dpm_olive",
-"rhsgref_uniform_3color_desert","rhsgref_uniform_gorka_1_f","rhsgref_uniform_TLA_1","rhsgref_uniform_TLA_2","rhs_insurgent_uniform_1",
-"rhs_insurgent_uniform_2","rhs_insurgent_uniform_3","rhs_insurgent_uniform_4","rhs_insurgent_uniform_5"]];
+_loadoutData setVariable ["uniforms", [
+	"rhs_insurgent_uniform_1",
+	"rhs_insurgent_uniform_2",
+	"rhs_insurgent_uniform_3",
+	"rhs_insurgent_uniform_4",
+	"rhs_insurgent_uniform_5",
+	"rhsgref_uniform_altis_lizard",
+	"rhsgref_uniform_altis_lizard_olive",
+	"rhsgref_uniform_3color_desert"
+]];
 _loadoutData setVariable ["vests", []];
 _loadoutData setVariable ["backpacks", []];
 _loadoutData setVariable ["longRangeRadios", []];

--- a/A3-Antistasi/Templates/NewTemplates/RHS/RHS_Reb_NAPA_Arid.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/RHS/RHS_Reb_NAPA_Arid.sqf
@@ -50,48 +50,48 @@
 ///////////////////////////
 
 ["uniforms", [
-	"U_IG_Guerilla1_1",
-	"U_IG_Guerilla2_1",
-	"U_IG_Guerilla2_2",
-	"U_IG_Guerilla2_3",
-	"U_IG_Guerilla3_1",
-	"U_IG_leader",
-	"U_IG_Guerrilla_6_1",
-	"U_I_G_resistanceLeader_F",
-	"rhsgref_uniform_alpenflage",
-	"rhsgref_uniform_flecktarn",
-	"rhsgref_uniform_flecktarn_full",
-	"rhsgref_uniform_tigerstripe",
-	"rhsgref_uniform_woodland",
-	"rhsgref_uniform_woodland_olive",
-	"rhsgref_uniform_olive",
-	"rhsgref_uniform_altis_lizard",
-	"rhsgref_uniform_altis_lizard_olive",
-	"rhsgref_uniform_dpm",
-	"rhsgref_uniform_dpm_olive",
-	"rhsgref_uniform_3color_desert",
-	"rhsgref_uniform_gorka_1_f",
-	"rhsgref_uniform_TLA_1",
-	"rhsgref_uniform_TLA_2",
-	"rhs_insurgent_uniform_1",
-	"rhs_insurgent_uniform_2",
-	"rhs_insurgent_uniform_3",
-	"rhs_insurgent_uniform_4",
-	"rhs_insurgent_uniform_5"
+    "U_IG_Guerilla1_1",
+    "U_IG_Guerilla2_1",
+    "U_IG_Guerilla2_2",
+    "U_IG_Guerilla2_3",
+    "U_IG_Guerilla3_1",
+    "U_IG_leader",
+    "U_IG_Guerrilla_6_1",
+    "U_I_G_resistanceLeader_F",
+    "rhsgref_uniform_alpenflage",
+    "rhsgref_uniform_flecktarn",
+    "rhsgref_uniform_flecktarn_full",
+    "rhsgref_uniform_tigerstripe",
+    "rhsgref_uniform_woodland",
+    "rhsgref_uniform_woodland_olive",
+    "rhsgref_uniform_olive",
+    "rhsgref_uniform_altis_lizard",
+    "rhsgref_uniform_altis_lizard_olive",
+    "rhsgref_uniform_dpm",
+    "rhsgref_uniform_dpm_olive",
+    "rhsgref_uniform_3color_desert",
+    "rhsgref_uniform_gorka_1_f",
+    "rhsgref_uniform_TLA_1",
+    "rhsgref_uniform_TLA_2",
+    "rhs_insurgent_uniform_1",
+    "rhs_insurgent_uniform_2",
+    "rhs_insurgent_uniform_3",
+    "rhs_insurgent_uniform_4",
+    "rhs_insurgent_uniform_5"
 ]] call _fnc_saveToTemplate;
 
 ["headgear", [
-	"H_Booniehat_khk_hs",
-	"H_Booniehat_tan",
-	"H_Cap_tan",
-	"H_Cap_oli_hs",
-	"H_Cap_blk",
-	"H_Cap_headphones",
-	"H_ShemagOpen_tan",
-	"H_Shemag_olive_hs",
-	"H_Bandanna_khk_hs",
-	"H_Bandanna_sand",
-	"H_Bandanna_cbr"
+    "H_Booniehat_khk_hs",
+    "H_Booniehat_tan",
+    "H_Cap_tan",
+    "H_Cap_oli_hs",
+    "H_Cap_blk",
+    "H_Cap_headphones",
+    "H_ShemagOpen_tan",
+    "H_Shemag_olive_hs",
+    "H_Bandanna_khk_hs",
+    "H_Bandanna_sand",
+    "H_Bandanna_cbr"
 ]] call _fnc_saveToTemplate;
 
 private _initialRebelEquipment = [
@@ -151,14 +151,14 @@ _loadoutData setVariable ["NVGs", []]; //this line determines NVGs -- Array, can
 _loadoutData setVariable ["binoculars", ["Binocular"]];
 
 _loadoutData setVariable ["uniforms", [
-	"rhs_insurgent_uniform_1",
-	"rhs_insurgent_uniform_2",
-	"rhs_insurgent_uniform_3",
-	"rhs_insurgent_uniform_4",
-	"rhs_insurgent_uniform_5",
-	"rhsgref_uniform_altis_lizard",
-	"rhsgref_uniform_altis_lizard_olive",
-	"rhsgref_uniform_3color_desert"
+    "rhs_insurgent_uniform_1",
+    "rhs_insurgent_uniform_2",
+    "rhs_insurgent_uniform_3",
+    "rhs_insurgent_uniform_4",
+    "rhs_insurgent_uniform_5",
+    "rhsgref_uniform_altis_lizard",
+    "rhsgref_uniform_altis_lizard_olive",
+    "rhsgref_uniform_3color_desert"
 ]];
 _loadoutData setVariable ["vests", []];
 _loadoutData setVariable ["backpacks", []];

--- a/A3-Antistasi/Templates/NewTemplates/RHS/RHS_Reb_NAPA_Temperate.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/RHS/RHS_Reb_NAPA_Temperate.sqf
@@ -49,14 +49,49 @@
 //  Rebel Starting Gear  //
 ///////////////////////////
 
-["uniforms", ["U_IG_Guerilla1_1","U_IG_Guerilla2_1","U_IG_Guerilla2_2","U_IG_Guerilla2_3","U_IG_Guerilla3_1","U_IG_leader",
-"U_IG_Guerrilla_6_1","rhsgref_uniform_alpenflage","rhsgref_uniform_flecktarn","rhsgref_uniform_flecktarn_full",
-"rhsgref_uniform_tigerstripe","rhsgref_uniform_woodland","rhsgref_uniform_woodland_olive","rhsgref_uniform_olive",
-"rhsgref_uniform_altis_lizard","rhsgref_uniform_altis_lizard_olive","rhsgref_uniform_dpm","rhsgref_uniform_dpm_olive",
-"rhsgref_uniform_3color_desert","rhsgref_uniform_gorka_1_f","rhsgref_uniform_TLA_1","rhsgref_uniform_TLA_2","rhs_insurgent_uniform_1",
-"rhs_insurgent_uniform_2","rhs_insurgent_uniform_3","rhs_insurgent_uniform_4","rhs_insurgent_uniform_5"]] call _fnc_saveToTemplate;
+["uniforms", [
+	"U_IG_Guerilla1_1",
+	"U_IG_Guerilla2_1",
+	"U_IG_Guerilla2_2",
+	"U_IG_Guerilla2_3",
+	"U_IG_Guerilla3_1",
+	"U_IG_leader",
+	"U_IG_Guerrilla_6_1",
+	"U_I_G_resistanceLeader_F",
+	"rhsgref_uniform_alpenflage",
+	"rhsgref_uniform_flecktarn",
+	"rhsgref_uniform_flecktarn_full",
+	"rhsgref_uniform_tigerstripe",
+	"rhsgref_uniform_woodland",
+	"rhsgref_uniform_woodland_olive",
+	"rhsgref_uniform_olive",
+	"rhsgref_uniform_altis_lizard",
+	"rhsgref_uniform_altis_lizard_olive",
+	"rhsgref_uniform_dpm",
+	"rhsgref_uniform_dpm_olive",
+	"rhsgref_uniform_3color_desert",
+	"rhsgref_uniform_gorka_1_f",
+	"rhsgref_uniform_TLA_1",
+	"rhsgref_uniform_TLA_2",
+	"rhs_insurgent_uniform_1",
+	"rhs_insurgent_uniform_2",
+	"rhs_insurgent_uniform_3",
+	"rhs_insurgent_uniform_4",
+	"rhs_insurgent_uniform_5"
+]] call _fnc_saveToTemplate;
 
-["headgear", [""]] call _fnc_saveToTemplate;
+	["headgear", [
+	"H_Booniehat_khk_hs",
+	"H_Booniehat_oli",
+	"H_Cap_oli_hs",
+	"H_Cap_blk",
+	"H_Cap_headphones",
+	"H_Shemag_olive_hs",
+	"H_Bandanna_gry",
+	"H_Bandanna_khk_hs",
+	"H_Bandanna_sgg",
+	"H_Bandanna_camo"
+]] call _fnc_saveToTemplate;
 
 private _initialRebelEquipment = [
 "rhs_weap_type94_new","rhs_weap_tt33","rhs_weap_Izh18","rhs_weap_kar98k",
@@ -114,12 +149,17 @@ _loadoutData setVariable ["gpses", []];
 _loadoutData setVariable ["NVGs", []]; //this line determines NVGs -- Array, can contain multiple assets
 _loadoutData setVariable ["binoculars", ["Binocular"]];
 
-_loadoutData setVariable ["uniforms", ["U_IG_Guerilla1_1","U_IG_Guerilla2_1","U_IG_Guerilla2_2","U_IG_Guerilla2_3","U_IG_Guerilla3_1","U_IG_leader",
-"U_IG_Guerrilla_6_1","rhsgref_uniform_alpenflage","rhsgref_uniform_flecktarn","rhsgref_uniform_flecktarn_full",
-"rhsgref_uniform_tigerstripe","rhsgref_uniform_woodland","rhsgref_uniform_woodland_olive","rhsgref_uniform_olive",
-"rhsgref_uniform_altis_lizard","rhsgref_uniform_altis_lizard_olive","rhsgref_uniform_dpm","rhsgref_uniform_dpm_olive",
-"rhsgref_uniform_3color_desert","rhsgref_uniform_gorka_1_f","rhsgref_uniform_TLA_1","rhsgref_uniform_TLA_2","rhs_insurgent_uniform_1",
-"rhs_insurgent_uniform_2","rhs_insurgent_uniform_3","rhs_insurgent_uniform_4","rhs_insurgent_uniform_5"]];
+_loadoutData setVariable ["uniforms", [
+	"rhs_insurgent_uniform_1",
+	"rhs_insurgent_uniform_2",
+	"rhs_insurgent_uniform_3",
+	"rhs_insurgent_uniform_4",
+	"rhs_insurgent_uniform_5",
+	"rhsgref_uniform_dpm",
+	"rhsgref_uniform_dpm_olive",
+	"rhsgref_uniform_altis_lizard_olive",
+	"rhsgref_uniform_flecktarn_full"
+]];
 _loadoutData setVariable ["vests", []];
 _loadoutData setVariable ["backpacks", []];
 _loadoutData setVariable ["longRangeRadios", []];

--- a/A3-Antistasi/Templates/NewTemplates/RHS/RHS_Reb_NAPA_Temperate.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/RHS/RHS_Reb_NAPA_Temperate.sqf
@@ -50,47 +50,47 @@
 ///////////////////////////
 
 ["uniforms", [
-	"U_IG_Guerilla1_1",
-	"U_IG_Guerilla2_1",
-	"U_IG_Guerilla2_2",
-	"U_IG_Guerilla2_3",
-	"U_IG_Guerilla3_1",
-	"U_IG_leader",
-	"U_IG_Guerrilla_6_1",
-	"U_I_G_resistanceLeader_F",
-	"rhsgref_uniform_alpenflage",
-	"rhsgref_uniform_flecktarn",
-	"rhsgref_uniform_flecktarn_full",
-	"rhsgref_uniform_tigerstripe",
-	"rhsgref_uniform_woodland",
-	"rhsgref_uniform_woodland_olive",
-	"rhsgref_uniform_olive",
-	"rhsgref_uniform_altis_lizard",
-	"rhsgref_uniform_altis_lizard_olive",
-	"rhsgref_uniform_dpm",
-	"rhsgref_uniform_dpm_olive",
-	"rhsgref_uniform_3color_desert",
-	"rhsgref_uniform_gorka_1_f",
-	"rhsgref_uniform_TLA_1",
-	"rhsgref_uniform_TLA_2",
-	"rhs_insurgent_uniform_1",
-	"rhs_insurgent_uniform_2",
-	"rhs_insurgent_uniform_3",
-	"rhs_insurgent_uniform_4",
-	"rhs_insurgent_uniform_5"
+    "U_IG_Guerilla1_1",
+    "U_IG_Guerilla2_1",
+    "U_IG_Guerilla2_2",
+    "U_IG_Guerilla2_3",
+    "U_IG_Guerilla3_1",
+    "U_IG_leader",
+    "U_IG_Guerrilla_6_1",
+    "U_I_G_resistanceLeader_F",
+    "rhsgref_uniform_alpenflage",
+    "rhsgref_uniform_flecktarn",
+    "rhsgref_uniform_flecktarn_full",
+    "rhsgref_uniform_tigerstripe",
+    "rhsgref_uniform_woodland",
+    "rhsgref_uniform_woodland_olive",
+    "rhsgref_uniform_olive",
+    "rhsgref_uniform_altis_lizard",
+    "rhsgref_uniform_altis_lizard_olive",
+    "rhsgref_uniform_dpm",
+    "rhsgref_uniform_dpm_olive",
+    "rhsgref_uniform_3color_desert",
+    "rhsgref_uniform_gorka_1_f",
+    "rhsgref_uniform_TLA_1",
+    "rhsgref_uniform_TLA_2",
+    "rhs_insurgent_uniform_1",
+    "rhs_insurgent_uniform_2",
+    "rhs_insurgent_uniform_3",
+    "rhs_insurgent_uniform_4",
+    "rhs_insurgent_uniform_5"
 ]] call _fnc_saveToTemplate;
 
-	["headgear", [
-	"H_Booniehat_khk_hs",
-	"H_Booniehat_oli",
-	"H_Cap_oli_hs",
-	"H_Cap_blk",
-	"H_Cap_headphones",
-	"H_Shemag_olive_hs",
-	"H_Bandanna_gry",
-	"H_Bandanna_khk_hs",
-	"H_Bandanna_sgg",
-	"H_Bandanna_camo"
+["headgear", [
+    "H_Booniehat_khk_hs",
+    "H_Booniehat_oli",
+    "H_Cap_oli_hs",
+    "H_Cap_blk",
+    "H_Cap_headphones",
+    "H_Shemag_olive_hs",
+    "H_Bandanna_gry",
+    "H_Bandanna_khk_hs",
+    "H_Bandanna_sgg",
+    "H_Bandanna_camo"
 ]] call _fnc_saveToTemplate;
 
 private _initialRebelEquipment = [
@@ -150,15 +150,15 @@ _loadoutData setVariable ["NVGs", []]; //this line determines NVGs -- Array, can
 _loadoutData setVariable ["binoculars", ["Binocular"]];
 
 _loadoutData setVariable ["uniforms", [
-	"rhs_insurgent_uniform_1",
-	"rhs_insurgent_uniform_2",
-	"rhs_insurgent_uniform_3",
-	"rhs_insurgent_uniform_4",
-	"rhs_insurgent_uniform_5",
-	"rhsgref_uniform_dpm",
-	"rhsgref_uniform_dpm_olive",
-	"rhsgref_uniform_altis_lizard_olive",
-	"rhsgref_uniform_flecktarn_full"
+    "rhs_insurgent_uniform_1",
+    "rhs_insurgent_uniform_2",
+    "rhs_insurgent_uniform_3",
+    "rhs_insurgent_uniform_4",
+    "rhs_insurgent_uniform_5",
+    "rhsgref_uniform_dpm",
+    "rhsgref_uniform_dpm_olive",
+    "rhsgref_uniform_altis_lizard_olive",
+    "rhsgref_uniform_flecktarn_full"
 ]];
 _loadoutData setVariable ["vests", []];
 _loadoutData setVariable ["backpacks", []];

--- a/A3-Antistasi/Templates/NewTemplates/VN/VN_CIV.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/VN/VN_CIV.sqf
@@ -14,7 +14,14 @@
     "vn_o_uniform_vc_03_03"
 ]] call _fnc_saveToTemplate;
 
-["headgear", [""]] call _fnc_saveToTemplate;
+["headgear", [
+    "vn_c_headband_04",
+    "vn_c_headband_03",
+    "vn_c_headband_02",
+    "vn_c_headband_01",
+    "vn_c_conehat_02",
+    "vn_c_conehat_01"
+]] call _fnc_saveToTemplate;
 
 // All of bellow are optional overrides.
 ["firstAidKits", ["vn_o_item_firstaidkit"]] call _fnc_saveToTemplate;  // Relies on autodetection. However, item is tested for for help and reviving.

--- a/A3-Antistasi/Templates/NewTemplates/VN/VN_Reb_POF.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/VN/VN_Reb_POF.sqf
@@ -79,13 +79,13 @@
 ]] call _fnc_saveToTemplate;
 
 ["headgear", [
-	"vn_c_conehat_02",
+    "vn_c_conehat_02",
     "vn_c_conehat_01",
-	"vn_b_headband_05",
-	"vn_b_headband_04",
-	"vn_b_headband_01",
-	"vn_o_boonie_vc_01_01",
-	"vn_o_boonie_vc_01_02"
+    "vn_b_headband_05",
+    "vn_b_headband_04",
+    "vn_b_headband_01",
+    "vn_o_boonie_vc_01_01",
+    "vn_o_boonie_vc_01_02"
 ]] call _fnc_saveToTemplate;
 
 private _initialRebelEquipment = [

--- a/A3-Antistasi/Templates/NewTemplates/VN/VN_Reb_POF.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/VN/VN_Reb_POF.sqf
@@ -78,7 +78,15 @@
     "vn_o_uniform_vc_03_03"
 ]] call _fnc_saveToTemplate;
 
-["headgear", [""]] call _fnc_saveToTemplate;
+["headgear", [
+	"vn_c_conehat_02",
+    "vn_c_conehat_01",
+	"vn_b_headband_05",
+	"vn_b_headband_04",
+	"vn_b_headband_01",
+	"vn_o_boonie_vc_01_01",
+	"vn_o_boonie_vc_01_02"
+]] call _fnc_saveToTemplate;
 
 private _initialRebelEquipment = [
 "vn_p38s","vn_welrod",

--- a/A3-Antistasi/Templates/NewTemplates/VN/VN_Reb_POF.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/VN/VN_Reb_POF.sqf
@@ -142,7 +142,17 @@ _loadoutData setVariable ["compasses", ["vn_b_item_compass"]];
 _loadoutData setVariable ["radios", []];
 _loadoutData setVariable ["binoculars", ["vn_m19_binocs_grey"]];
 
-_loadoutData setVariable ["uniforms", ["vn_o_uniform_vc_01_01", "vn_o_uniform_vc_01_02", "vn_o_uniform_vc_02_07", "vn_o_uniform_vc_03_02", "vn_o_uniform_vc_04_02", "vn_o_uniform_vc_05_01"]];
+_loadoutData setVariable ["uniforms", [
+    "vn_o_uniform_vc_01_01",
+    "vn_o_uniform_vc_01_02",
+    "vn_o_uniform_vc_02_07",
+    "vn_o_uniform_vc_03_02",
+    "vn_o_uniform_vc_04_02",
+    "vn_o_uniform_vc_05_01",
+    "vn_o_uniform_vc_02_05",
+    "vn_o_uniform_vc_04_03",
+    "vn_o_uniform_vc_03_03"
+]];
 _loadoutData setVariable ["vests", []];
 _loadoutData setVariable ["backpacks", []];
 _loadoutData setVariable ["longRangeRadios", []];

--- a/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Civ.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Civ.sqf
@@ -3,6 +3,21 @@
 //////////////////////////////
 
 ["uniforms", [
+    "U_C_Man_casual_1_F",
+    "U_C_Man_casual_2_F",
+    "U_C_Man_casual_3_F",
+    "U_C_Man_casual_4_F",
+    "U_C_Man_casual_5_F",
+    "U_C_Man_casual_6_F",
+    "U_C_ArtTShirt_01_v1_F",
+    "U_C_ArtTShirt_01_v2_F",
+    "U_C_ArtTShirt_01_v3_F",
+    "U_C_ArtTShirt_01_v4_F",
+    "U_C_ArtTShirt_01_v5_F",
+    "U_C_ArtTShirt_01_v6_F",
+    "U_NikosBody",
+    "U_NikosAgedBody",
+    "U_C_Journalist",
     "U_C_Poloshirt_blue",
     "U_C_Poloshirt_burgundy",
     "U_C_Poloshirt_stripped",
@@ -13,24 +28,14 @@
     "U_C_Poor_1",
     "U_C_WorkerCoveralls",
     "U_C_HunterBody_grn",
-    "U_C_Journalist",
+    "U_C_Uniform_Farmer_01_F",
+    "U_I_L_Uniform_01_tshirt_skull_F",
+    "U_I_L_Uniform_01_tshirt_black_F",
+    "U_I_L_Uniform_01_tshirt_sport_F",
     "U_C_Scientist",
-    "U_C_ArtTShirt_01_v1_F",
-    "U_C_ArtTShirt_01_v2_F",
-    "U_C_ArtTShirt_01_v3_F",
-    "U_C_ArtTShirt_01_v4_F",
-    "U_C_ArtTShirt_01_v5_F",
-    "U_C_ArtTShirt_01_v6_F",
     "U_C_Uniform_Scientist_02_formal_F",
     "U_C_Uniform_Scientist_02_F",
-    "U_C_Uniform_Scientist_01_F",
-    "U_C_Uniform_Farmer_01_F",
-    "U_C_Man_casual_1_F",
-    "U_C_Man_casual_2_F",
-    "U_C_Man_casual_3_F",
-    "U_C_Man_casual_4_F",
-    "U_C_Man_casual_5_F",
-    "U_C_Man_casual_6_F"
+    "U_C_Uniform_Scientist_01_F"
 ]] call _fnc_saveToTemplate;
 
 ["headgear", [
@@ -38,8 +43,6 @@
     "H_Bandanna_cbr",
     "H_Bandanna_gry",
     "H_Bandanna_khk",
-    "H_Bandanna_khk_hs",
-    "H_Bandanna_mcamo",
     "H_Bandanna_sand",
     "H_Bandanna_sgg",
     "H_Bandanna_surfer",
@@ -55,7 +58,8 @@
     "H_Cap_surfer",
     "H_Cap_tan",
     "H_StrawHat",
-    "H_StrawHat_dark"
+    "H_StrawHat_dark",
+    "H_Hat_checker"
 ]] call _fnc_saveToTemplate;
 
 

--- a/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Reb_FIA_Arid.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Reb_FIA_Arid.sqf
@@ -49,16 +49,29 @@
 //  Rebel Starting Gear  //
 ///////////////////////////
 ["uniforms", [
-    "U_IG_Guerilla1_1"
-    ,"U_IG_Guerilla2_1"
-    ,"U_IG_Guerilla2_2"
-    ,"U_IG_Guerilla2_3"
-    ,"U_IG_Guerilla3_1"
-    ,"U_IG_leader"
-    ,"U_IG_Guerrilla_6_1"
+	"U_IG_Guerilla1_1",
+	"U_IG_Guerilla2_1",
+	"U_IG_Guerilla2_2",
+	"U_IG_Guerilla2_3",
+	"U_IG_Guerilla3_1",
+	"U_IG_leader",
+	"U_IG_Guerrilla_6_1",
+	"U_I_G_resistanceLeader_F"
 ]] call _fnc_saveToTemplate;
 
-["headgear", [""]] call _fnc_saveToTemplate;
+["headgear", [
+	"H_Booniehat_khk_hs",
+	"H_Booniehat_tan",
+	"H_Cap_tan",
+	"H_Cap_oli_hs",
+	"H_Cap_blk",
+	"H_Cap_headphones",
+	"H_ShemagOpen_tan",
+	"H_Shemag_olive_hs",
+	"H_Bandanna_khk_hs",
+	"H_Bandanna_sand",
+	"H_Bandanna_cbr"
+]] call _fnc_saveToTemplate;
 
 private _initialRebelEquipment = [
 "hgun_Pistol_heavy_02_F","hgun_P07_F",
@@ -118,7 +131,15 @@ _loadoutData setVariable ["gpses", []];
 _loadoutData setVariable ["NVGs", []]; //this line determines NVGs -- Array, can contain multiple assets
 _loadoutData setVariable ["binoculars", ["Binocular"]];
 
-_loadoutData setVariable ["uniforms", ["U_IG_Guerilla1_1","U_IG_Guerilla2_1","U_IG_Guerilla2_2","U_IG_Guerilla2_3","U_IG_Guerilla3_1","U_IG_leader","U_IG_Guerrilla_6_1"]];
+_loadoutData setVariable ["uniforms", [
+	"U_IG_Guerilla1_1",
+	"U_IG_Guerilla2_1",
+	"U_IG_Guerilla2_2",
+	"U_IG_Guerilla2_3",
+	"U_IG_Guerilla3_1",
+	"U_IG_leader",
+	"U_IG_Guerrilla_6_1"
+]];
 _loadoutData setVariable ["vests", []];
 _loadoutData setVariable ["backpacks", []];
 _loadoutData setVariable ["longRangeRadios", []];

--- a/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Reb_FIA_Arid.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Reb_FIA_Arid.sqf
@@ -49,28 +49,28 @@
 //  Rebel Starting Gear  //
 ///////////////////////////
 ["uniforms", [
-	"U_IG_Guerilla1_1",
-	"U_IG_Guerilla2_1",
-	"U_IG_Guerilla2_2",
-	"U_IG_Guerilla2_3",
-	"U_IG_Guerilla3_1",
-	"U_IG_leader",
-	"U_IG_Guerrilla_6_1",
-	"U_I_G_resistanceLeader_F"
+    "U_IG_Guerilla1_1",
+    "U_IG_Guerilla2_1",
+    "U_IG_Guerilla2_2",
+    "U_IG_Guerilla2_3",
+    "U_IG_Guerilla3_1",
+    "U_IG_leader",
+    "U_IG_Guerrilla_6_1",
+    "U_I_G_resistanceLeader_F"
 ]] call _fnc_saveToTemplate;
 
 ["headgear", [
-	"H_Booniehat_khk_hs",
-	"H_Booniehat_tan",
-	"H_Cap_tan",
-	"H_Cap_oli_hs",
-	"H_Cap_blk",
-	"H_Cap_headphones",
-	"H_ShemagOpen_tan",
-	"H_Shemag_olive_hs",
-	"H_Bandanna_khk_hs",
-	"H_Bandanna_sand",
-	"H_Bandanna_cbr"
+    "H_Booniehat_khk_hs",
+    "H_Booniehat_tan",
+    "H_Cap_tan",
+    "H_Cap_oli_hs",
+    "H_Cap_blk",
+    "H_Cap_headphones",
+    "H_ShemagOpen_tan",
+    "H_Shemag_olive_hs",
+    "H_Bandanna_khk_hs",
+    "H_Bandanna_sand",
+    "H_Bandanna_cbr"
 ]] call _fnc_saveToTemplate;
 
 private _initialRebelEquipment = [
@@ -132,13 +132,13 @@ _loadoutData setVariable ["NVGs", []]; //this line determines NVGs -- Array, can
 _loadoutData setVariable ["binoculars", ["Binocular"]];
 
 _loadoutData setVariable ["uniforms", [
-	"U_IG_Guerilla1_1",
-	"U_IG_Guerilla2_1",
-	"U_IG_Guerilla2_2",
-	"U_IG_Guerilla2_3",
-	"U_IG_Guerilla3_1",
-	"U_IG_leader",
-	"U_IG_Guerrilla_6_1"
+    "U_IG_Guerilla1_1",
+    "U_IG_Guerilla2_1",
+    "U_IG_Guerilla2_2",
+    "U_IG_Guerilla2_3",
+    "U_IG_Guerilla3_1",
+    "U_IG_leader",
+    "U_IG_Guerrilla_6_1"
 ]];
 _loadoutData setVariable ["vests", []];
 _loadoutData setVariable ["backpacks", []];

--- a/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Reb_FIA_Enoch.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Reb_FIA_Enoch.sqf
@@ -50,30 +50,30 @@
 ///////////////////////////
 
 ["uniforms", [
-	"U_IG_Guerilla1_1",
-	"U_IG_Guerilla2_1",
-	"U_IG_Guerilla2_2",
-	"U_IG_Guerilla2_3",
-	"U_IG_Guerilla3_1",
-	"U_IG_leader",
-	"U_IG_Guerrilla_6_1",
-	"U_I_G_resistanceLeader_F",
-	"U_I_L_Uniform_01_camo_F",
-	"U_I_L_Uniform_01_deserter_F"
-	]] call _fnc_saveToTemplate;
+    "U_IG_Guerilla1_1",
+    "U_IG_Guerilla2_1",
+    "U_IG_Guerilla2_2",
+    "U_IG_Guerilla2_3",
+    "U_IG_Guerilla3_1",
+    "U_IG_leader",
+    "U_IG_Guerrilla_6_1",
+    "U_I_G_resistanceLeader_F",
+    "U_I_L_Uniform_01_camo_F",
+    "U_I_L_Uniform_01_deserter_F"
+]] call _fnc_saveToTemplate;
 
-	["headgear", [
-	"H_Booniehat_khk_hs",
-	"H_Booniehat_oli",
-	"H_Cap_oli_hs",
-	"H_Cap_blk",
-	"H_Cap_headphones",
-	"H_Shemag_olive_hs",
-	"H_Bandanna_gry",
-	"H_Bandanna_khk_hs",
-	"H_Bandanna_sgg",
-	"H_Bandanna_camo"
-	]] call _fnc_saveToTemplate;
+    ["headgear", [
+    "H_Booniehat_khk_hs",
+    "H_Booniehat_oli",
+    "H_Cap_oli_hs",
+    "H_Cap_blk",
+    "H_Cap_headphones",
+    "H_Shemag_olive_hs",
+    "H_Bandanna_gry",
+    "H_Bandanna_khk_hs",
+    "H_Bandanna_sgg",
+    "H_Bandanna_camo"
+]] call _fnc_saveToTemplate;
 
 private _initialRebelEquipment = [
 "hgun_Pistol_heavy_02_F","hgun_Pistol_heavy_01_green_F",
@@ -134,13 +134,13 @@ _loadoutData setVariable ["NVGs", []]; //this line determines NVGs -- Array, can
 _loadoutData setVariable ["binoculars", ["Binocular"]];
 
 _loadoutData setVariable ["uniforms", [
-	"U_IG_Guerilla1_1",
-	"U_IG_Guerilla2_1",
-	"U_IG_Guerilla2_2",
-	"U_IG_Guerilla2_3",
-	"U_IG_Guerilla3_1",
-	"U_IG_leader",
-	"U_IG_Guerrilla_6_1"
+    "U_IG_Guerilla1_1",
+    "U_IG_Guerilla2_1",
+    "U_IG_Guerilla2_2",
+    "U_IG_Guerilla2_3",
+    "U_IG_Guerilla3_1",
+    "U_IG_leader",
+    "U_IG_Guerrilla_6_1"
 ]];
 _loadoutData setVariable ["vests", []];
 _loadoutData setVariable ["backpacks", []];

--- a/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Reb_FIA_Enoch.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Reb_FIA_Enoch.sqf
@@ -49,11 +49,31 @@
 //  Rebel Starting Gear  //
 ///////////////////////////
 
-["uniforms", ["U_IG_Guerilla1_1","U_IG_Guerilla2_1","U_IG_Guerilla2_2","U_IG_Guerilla2_3","U_IG_Guerilla3_1",
-"U_I_L_Uniform_01_camo_F","U_I_L_Uniform_01_deserter_F","U_I_L_Uniform_01_tshirt_black_F","U_I_L_Uniform_01_tshirt_olive_F","U_I_L_Uniform_01_tshirt_skull_F",
-"U_I_L_Uniform_01_tshirt_sport_F"]] call _fnc_saveToTemplate;
+["uniforms", [
+	"U_IG_Guerilla1_1",
+	"U_IG_Guerilla2_1",
+	"U_IG_Guerilla2_2",
+	"U_IG_Guerilla2_3",
+	"U_IG_Guerilla3_1",
+	"U_IG_leader",
+	"U_IG_Guerrilla_6_1",
+	"U_I_G_resistanceLeader_F",
+	"U_I_L_Uniform_01_camo_F",
+	"U_I_L_Uniform_01_deserter_F",
+	]] call _fnc_saveToTemplate;
 
-["headgear", [""]] call _fnc_saveToTemplate;
+	["headgear", [
+	"H_Booniehat_khk_hs",
+	"H_Booniehat_oli",
+	"H_Cap_oli_hs",
+	"H_Cap_blk",
+	"H_Cap_headphones",
+	"H_Shemag_olive_hs",
+	"H_Bandanna_gry",
+	"H_Bandanna_khk_hs",
+	"H_Bandanna_sgg",
+	"H_Bandanna_camo"
+	]] call _fnc_saveToTemplate;
 
 private _initialRebelEquipment = [
 "hgun_Pistol_heavy_02_F","hgun_Pistol_heavy_01_green_F",
@@ -113,9 +133,15 @@ _loadoutData setVariable ["gpses", []];
 _loadoutData setVariable ["NVGs", []]; //this line determines NVGs -- Array, can contain multiple assets
 _loadoutData setVariable ["binoculars", ["Binocular"]];
 
-_loadoutData setVariable ["uniforms", ["U_IG_Guerilla1_1","U_IG_Guerilla2_1","U_IG_Guerilla2_2","U_IG_Guerilla2_3","U_IG_Guerilla3_1",
-"U_I_L_Uniform_01_camo_F","U_I_L_Uniform_01_deserter_F","U_I_L_Uniform_01_tshirt_black_F","U_I_L_Uniform_01_tshirt_olive_F","U_I_L_Uniform_01_tshirt_skull_F",
-"U_I_L_Uniform_01_tshirt_sport_F"]];
+_loadoutData setVariable ["uniforms", [
+	"U_IG_Guerilla1_1",
+	"U_IG_Guerilla2_1",
+	"U_IG_Guerilla2_2",
+	"U_IG_Guerilla2_3",
+	"U_IG_Guerilla3_1",
+	"U_IG_leader",
+	"U_IG_Guerrilla_6_1"
+];
 _loadoutData setVariable ["vests", []];
 _loadoutData setVariable ["backpacks", []];
 _loadoutData setVariable ["longRangeRadios", []];

--- a/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Reb_FIA_Enoch.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Reb_FIA_Enoch.sqf
@@ -59,7 +59,7 @@
 	"U_IG_Guerrilla_6_1",
 	"U_I_G_resistanceLeader_F",
 	"U_I_L_Uniform_01_camo_F",
-	"U_I_L_Uniform_01_deserter_F",
+	"U_I_L_Uniform_01_deserter_F"
 	]] call _fnc_saveToTemplate;
 
 	["headgear", [
@@ -141,7 +141,7 @@ _loadoutData setVariable ["uniforms", [
 	"U_IG_Guerilla3_1",
 	"U_IG_leader",
 	"U_IG_Guerrilla_6_1"
-];
+]];
 _loadoutData setVariable ["vests", []];
 _loadoutData setVariable ["backpacks", []];
 _loadoutData setVariable ["longRangeRadios", []];

--- a/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Reb_SDK_Tanoa.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Reb_SDK_Tanoa.sqf
@@ -49,12 +49,40 @@
 //  Rebel Starting Gear  //
 ///////////////////////////
 
-["uniforms", ["U_IG_Guerilla1_1","U_IG_Guerilla2_1","U_IG_Guerilla2_2","U_IG_Guerilla2_3","U_IG_Guerilla3_1",
-"U_IG_leader","U_IG_Guerrilla_6_1","U_I_C_Soldier_Bandit_4_F","U_I_C_Soldier_Bandit_1_F","U_I_C_Soldier_Bandit_2_F",
-"U_I_C_Soldier_Bandit_5_F","U_I_C_Soldier_Bandit_3_F","U_I_C_Soldier_Para_2_F","U_I_C_Soldier_Para_3_F","U_I_C_Soldier_Para_5_F",
-"U_I_C_Soldier_Para_4_F","U_I_C_Soldier_Para_1_F","U_I_C_Soldier_Camo_F"]] call _fnc_saveToTemplate;
+["uniforms", [
+	"U_IG_Guerilla1_1",
+	"U_IG_Guerilla2_1",
+	"U_IG_Guerilla2_2",
+	"U_IG_Guerilla2_3",
+	"U_IG_Guerilla3_1",
+	"U_IG_leader",
+	"U_IG_Guerrilla_6_1",
+	"U_I_G_resistanceLeader_F",
+	"U_I_C_Soldier_Bandit_4_F",
+	"U_I_C_Soldier_Bandit_1_F",
+	"U_I_C_Soldier_Bandit_2_F",
+	"U_I_C_Soldier_Bandit_5_F",
+	"U_I_C_Soldier_Bandit_3_F",
+	"U_I_C_Soldier_Para_2_F",
+	"U_I_C_Soldier_Para_3_F",
+	"U_I_C_Soldier_Para_5_F",
+	"U_I_C_Soldier_Para_4_F",
+	"U_I_C_Soldier_Para_1_F",
+	"U_I_C_Soldier_Camo_F"
+]] call _fnc_saveToTemplate;
 
-["headgear", [""]] call _fnc_saveToTemplate;
+	["headgear", [
+	"H_Booniehat_khk_hs",
+	"H_Booniehat_oli",
+	"H_Cap_oli_hs",
+	"H_Cap_blk",
+	"H_Cap_headphones",
+	"H_Shemag_olive_hs",
+	"H_Bandanna_gry",
+	"H_Bandanna_khk_hs",
+	"H_Bandanna_sgg",
+	"H_Bandanna_camo"
+]] call _fnc_saveToTemplate;
 
 private _initialRebelEquipment = [
 "hgun_Pistol_01_F","hgun_P07_khk_F",
@@ -115,10 +143,19 @@ _loadoutData setVariable ["gpses", []];
 _loadoutData setVariable ["NVGs", []]; //this line determines NVGs -- Array, can contain multiple assets
 _loadoutData setVariable ["binoculars", ["Binocular"]];
 
-_loadoutData setVariable ["uniforms", ["U_IG_Guerilla1_1","U_IG_Guerilla2_1","U_IG_Guerilla2_2","U_IG_Guerilla2_3","U_IG_Guerilla3_1",
-"U_IG_leader","U_IG_Guerrilla_6_1","U_I_C_Soldier_Bandit_4_F","U_I_C_Soldier_Bandit_1_F","U_I_C_Soldier_Bandit_2_F",
-"U_I_C_Soldier_Bandit_5_F","U_I_C_Soldier_Bandit_3_F","U_I_C_Soldier_Para_2_F","U_I_C_Soldier_Para_3_F","U_I_C_Soldier_Para_5_F",
-"U_I_C_Soldier_Para_4_F","U_I_C_Soldier_Para_1_F","U_I_C_Soldier_Camo_F"]];
+_loadoutData setVariable ["uniforms", [
+	"U_I_C_Soldier_Bandit_4_F",
+	"U_I_C_Soldier_Bandit_1_F",
+	"U_I_C_Soldier_Bandit_2_F",
+	"U_I_C_Soldier_Bandit_5_F",
+	"U_I_C_Soldier_Bandit_3_F",
+	"U_I_C_Soldier_Para_2_F",
+	"U_I_C_Soldier_Para_3_F",
+	"U_I_C_Soldier_Para_5_F",
+	"U_I_C_Soldier_Para_4_F",
+	"U_I_C_Soldier_Para_1_F",
+	"U_I_C_Soldier_Camo_F"
+]];
 _loadoutData setVariable ["vests", []];
 _loadoutData setVariable ["backpacks", []];
 _loadoutData setVariable ["longRangeRadios", []];

--- a/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Reb_SDK_Tanoa.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/Vanilla/Vanilla_Reb_SDK_Tanoa.sqf
@@ -50,38 +50,38 @@
 ///////////////////////////
 
 ["uniforms", [
-	"U_IG_Guerilla1_1",
-	"U_IG_Guerilla2_1",
-	"U_IG_Guerilla2_2",
-	"U_IG_Guerilla2_3",
-	"U_IG_Guerilla3_1",
-	"U_IG_leader",
-	"U_IG_Guerrilla_6_1",
-	"U_I_G_resistanceLeader_F",
-	"U_I_C_Soldier_Bandit_4_F",
-	"U_I_C_Soldier_Bandit_1_F",
-	"U_I_C_Soldier_Bandit_2_F",
-	"U_I_C_Soldier_Bandit_5_F",
-	"U_I_C_Soldier_Bandit_3_F",
-	"U_I_C_Soldier_Para_2_F",
-	"U_I_C_Soldier_Para_3_F",
-	"U_I_C_Soldier_Para_5_F",
-	"U_I_C_Soldier_Para_4_F",
-	"U_I_C_Soldier_Para_1_F",
-	"U_I_C_Soldier_Camo_F"
+    "U_IG_Guerilla1_1",
+    "U_IG_Guerilla2_1",
+    "U_IG_Guerilla2_2",
+    "U_IG_Guerilla2_3",
+    "U_IG_Guerilla3_1",
+    "U_IG_leader",
+    "U_IG_Guerrilla_6_1",
+    "U_I_G_resistanceLeader_F",
+    "U_I_C_Soldier_Bandit_4_F",
+    "U_I_C_Soldier_Bandit_1_F",
+    "U_I_C_Soldier_Bandit_2_F",
+    "U_I_C_Soldier_Bandit_5_F",
+    "U_I_C_Soldier_Bandit_3_F",
+    "U_I_C_Soldier_Para_2_F",
+    "U_I_C_Soldier_Para_3_F",
+    "U_I_C_Soldier_Para_5_F",
+    "U_I_C_Soldier_Para_4_F",
+    "U_I_C_Soldier_Para_1_F",
+    "U_I_C_Soldier_Camo_F"
 ]] call _fnc_saveToTemplate;
 
-	["headgear", [
-	"H_Booniehat_khk_hs",
-	"H_Booniehat_oli",
-	"H_Cap_oli_hs",
-	"H_Cap_blk",
-	"H_Cap_headphones",
-	"H_Shemag_olive_hs",
-	"H_Bandanna_gry",
-	"H_Bandanna_khk_hs",
-	"H_Bandanna_sgg",
-	"H_Bandanna_camo"
+    ["headgear", [
+    "H_Booniehat_khk_hs",
+    "H_Booniehat_oli",
+    "H_Cap_oli_hs",
+    "H_Cap_blk",
+    "H_Cap_headphones",
+    "H_Shemag_olive_hs",
+    "H_Bandanna_gry",
+    "H_Bandanna_khk_hs",
+    "H_Bandanna_sgg",
+    "H_Bandanna_camo"
 ]] call _fnc_saveToTemplate;
 
 private _initialRebelEquipment = [
@@ -144,17 +144,17 @@ _loadoutData setVariable ["NVGs", []]; //this line determines NVGs -- Array, can
 _loadoutData setVariable ["binoculars", ["Binocular"]];
 
 _loadoutData setVariable ["uniforms", [
-	"U_I_C_Soldier_Bandit_4_F",
-	"U_I_C_Soldier_Bandit_1_F",
-	"U_I_C_Soldier_Bandit_2_F",
-	"U_I_C_Soldier_Bandit_5_F",
-	"U_I_C_Soldier_Bandit_3_F",
-	"U_I_C_Soldier_Para_2_F",
-	"U_I_C_Soldier_Para_3_F",
-	"U_I_C_Soldier_Para_5_F",
-	"U_I_C_Soldier_Para_4_F",
-	"U_I_C_Soldier_Para_1_F",
-	"U_I_C_Soldier_Camo_F"
+    "U_I_C_Soldier_Bandit_4_F",
+    "U_I_C_Soldier_Bandit_1_F",
+    "U_I_C_Soldier_Bandit_2_F",
+    "U_I_C_Soldier_Bandit_5_F",
+    "U_I_C_Soldier_Bandit_3_F",
+    "U_I_C_Soldier_Para_2_F",
+    "U_I_C_Soldier_Para_3_F",
+    "U_I_C_Soldier_Para_5_F",
+    "U_I_C_Soldier_Para_4_F",
+    "U_I_C_Soldier_Para_1_F",
+    "U_I_C_Soldier_Camo_F"
 ]];
 _loadoutData setVariable ["vests", []];
 _loadoutData setVariable ["backpacks", []];

--- a/A3-Antistasi/Templates/selector.sqf
+++ b/A3-Antistasi/Templates/selector.sqf
@@ -316,9 +316,19 @@ A3A_Inv_template = switch(true) do {
 //Civ Templates
 A3A_Civ_template = switch(true) do {
     case (A3A_has3CBFactions): {
-        ["Templates\NewTemplates\3CB\3CB_Civ.sqf", civilian] call A3A_fnc_compatabilityLoadFaction;
-        Info("Using 3CB Civ Template");
-        "3CBFactions"
+        switch(true) do {
+            case (toLower worldName in arcticmaps);
+            case (toLower worldName in temperatemaps);
+            case (toLower worldName in tropicalmaps): {
+                ["Templates\NewTemplates\3CB\3CB_Civ_Temperate.sqf", civilian] call A3A_fnc_compatabilityLoadFaction;
+                Info("Using 3CB Civ Temperate Template");
+            };
+            default {
+                ["Templates\NewTemplates\3CB\3CB_Civ_Arid.sqf", civilian] call A3A_fnc_compatabilityLoadFaction;
+                Info("Using 3CB Civ Arid Template");
+                "3CBFactions"
+            };
+        };
     };
     case (A3A_hasRHS): {
         ["Templates\NewTemplates\RHS\RHS_Civ.sqf", civilian] call A3A_fnc_compatabilityLoadFaction;

--- a/A3-Antistasi/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_categoryOverrides.sqf
@@ -109,6 +109,8 @@ private _categoryOverrideTable = [
 ["ACE_DAGR", ["Gadgets","Items"]],
 
 ["rhsusf_Rhino", ["Unknown", "Items"]],    //Just a Headmount not NVG
+["rhs_6m2_nvg", ["Unknown", "Items"]],    //a Headset not NVG
+["rhs_6m2_1_nvg", ["Unknown", "Items"]],    //a Headset not NVG
 ["LIB_PTRD", ["Unknown", "Weapons"]],
 ["LIB_M2_Flamethrower", ["Unknown", "Weapons"]],			// don't want these two being chosen randomly by AIs
 ["LIB_Bagpipes", ["Unknown","Weapons"]],					// wat

--- a/A3-Antistasi/functions/Ammunition/fn_equipmentIsValidForCurrentModset.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentIsValidForCurrentModset.sqf
@@ -28,8 +28,11 @@ if (_itemIsVanilla && {A3A_hasRHS}) exitWith {
 		case "Weapon": { false };
 		case "Equipment": {
 			switch (_categories select 1) do {
+				case "Headgear": {
+					if (getNumber (_configClass >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Head" >> "armor") < 0.1) then { true };
+				};
 				case "Vest": {
-					if (getNumber (_configClass >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Chest" >> "armor") > 5) then { false };
+					if (getNumber (_configClass >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Chest" >> "armor") < 12.1) then { true };
 				};
 				default { true };
 			};

--- a/A3-Antistasi/functions/Ammunition/fn_equipmentIsValidForCurrentModset.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentIsValidForCurrentModset.sqf
@@ -28,9 +28,6 @@ if (_itemIsVanilla && {A3A_hasRHS}) exitWith {
 		case "Weapon": { false };
 		case "Equipment": {
 			switch (_categories select 1) do {
-				case "Headgear": {
-					if (getNumber (_configClass >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Head" >> "armor") > 0) then { false };
-				};
 				case "Vest": {
 					if (getNumber (_configClass >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Chest" >> "armor") > 5) then { false };
 				};

--- a/A3-Antistasi/functions/Ammunition/fn_equipmentSort.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentSort.sqf
@@ -57,19 +57,19 @@ allCivilianVests deleteAt (allCivilianVests find "V_RebreatherIA");
 ////////////////////////////////////
 //WHY is there no clean list?
 //allArmoredHeadgear = allHeadgear select {getNumber (configfile >> "CfgWeapons" >> _x >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Head" >> "armor") > 0};
-allCivilianHeadgear = allHeadgear - allArmoredHeadgear;
+allCosmeticHeadgear = allHeadgear - allArmoredHeadgear;
 
 //////////////////
 //   Glasses   ///
 //////////////////
-allCivilianGlasses append allGlasses;
+allCosmeticGlasses append allGlasses;
 
-allCivilianGlasses deleteAt (allCivilianGlasses find "None");
-allCivilianGlasses deleteAt (allCivilianGlasses find "G_Goggles_VR");
-allCivilianGlasses deleteAt (allCivilianGlasses find "G_I_Diving");
-allCivilianGlasses deleteAt (allCivilianGlasses find "G_O_Diving");
-allCivilianGlasses deleteAt (allCivilianGlasses find "G_B_Diving");
-allCivilianGlasses deleteAt (allCivilianGlasses find "LIB_Glasses");
+allCosmeticGlasses deleteAt (allCosmeticGlasses find "None");
+allCosmeticGlasses deleteAt (allCosmeticGlasses find "G_Goggles_VR");
+allCosmeticGlasses deleteAt (allCosmeticGlasses find "G_I_Diving");
+allCosmeticGlasses deleteAt (allCosmeticGlasses find "G_O_Diving");
+allCosmeticGlasses deleteAt (allCosmeticGlasses find "G_B_Diving");
+allCosmeticGlasses deleteAt (allCosmeticGlasses find "LIB_Glasses");
 
 ////////////////
 //   Radios   //

--- a/A3-Antistasi/functions/Ammunition/fn_loot.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_loot.sqf
@@ -78,5 +78,5 @@ lootDevice append _lootDeviceBag + allBackpacksRadio;
 initialRebelEquipment append lootBasicItem;
 initialRebelEquipment append (A3A_faction_reb getVariable "uniforms");
 initialRebelEquipment append (A3A_faction_civ getVariable "uniforms");
-initialRebelEquipment append (A3A_faction_civ getVariable "headgear");
-initialRebelEquipment append allCivilianGlasses;
+initialRebelEquipment append allCosmeticHeadgear;
+initialRebelEquipment append allCosmeticGlasses;

--- a/A3-Antistasi/functions/REINF/fn_equipRebel.sqf
+++ b/A3-Antistasi/functions/REINF/fn_equipRebel.sqf
@@ -23,7 +23,7 @@ if (haveRadio) then {_unit linkItem selectrandom (unlockedRadios)};
 
 // Chance of picking armored rather than random vests and headgear, rising with unlocked gear counts
 if !(unlockedHeadgear isEqualTo []) then {
-	if (count unlockedArmoredHeadgear * 20 < random(100)) then { _unit addHeadgear (selectRandom unlockedHeadgear) }
+	if (count unlockedArmoredHeadgear * 20 < random(100)) then { _unit addHeadgear (selectRandom (A3A_faction_reb getVariable "headgear")) }
 	else { _unit addHeadgear (selectRandom unlockedArmoredHeadgear) };
 };
 if !(unlockedVests isEqualTo []) then {

--- a/A3-Antistasi/functions/init/fn_initVarCommon.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarCommon.sqf
@@ -66,8 +66,8 @@ aggregateCategories = ["Weapons", "Items", "Magazines", "Explosives"];
 //These are here because it's non-trivial to identify items in them. They might be a very specific subset of items, or the logic that identifies them might not be perfect.
 //It's recommended that these categories be used with caution.
 specialCategories = ["AA", "AT", "GrenadeLaunchers", "LightAttachments", "LaserAttachments", "Chemlights", "SmokeGrenades", "LaunchedSmokeGrenades", "LaunchedFlares", "HandFlares", "IRGrenades","LaserBatteries",
-	"RebelUniforms", "CivilianUniforms", "BackpacksEmpty", "BackpacksTool", "BackpacksStatic", "BackpacksDevice", "BackpacksRadio", "CivilianVests", "ArmoredVests", "ArmoredHeadgear", "CivilianHeadgear",
-	"CivilianGlasses"];
+	"RebelUniforms", "CivilianUniforms", "BackpacksEmpty", "BackpacksTool", "BackpacksStatic", "BackpacksDevice", "BackpacksRadio", "CivilianVests", "ArmoredVests", "ArmoredHeadgear", "CosmeticHeadgear",
+	"CosmeticGlasses"];
 
 
 allCategoriesExceptSpecial = weaponCategories + itemCategories + magazineCategories + explosiveCategories + otherCategories + aggregateCategories;


### PR DESCRIPTION
## What type of PR is this.
1.  Bug
2. [x] Change
3. [x] Enhancement

### What have you changed and why?
Information:
Added more Uniforms/Headgear to the new Arrays in Reb/Civ Templates,
Changed EquipRebell to use the RebellHeadgear array instead of UnlockedHeadGear,
------> This is to avoid Possible PID issues and to give Rebell AI a Faction fitting look.

Renamed 2 Arrays:
AllCivilianGlasses and AllCivilianHeadgear are now called AllCosmeticHeadgear and AllCosmeticGlasses.
These are the Autodetection Arrays given to the Arsenal, the list will be excessive as before, but this is so player can do their normal Barbie Dressup.
-----> Basicly returning it to how it was before GeneralHasVN


Added 2 False NVGs to the Unknown Category to avoid them spawning.

Split 3CB CIV into Arid and Temperate:
Arid will be Takistani Civs, with their Vehicles, Uniforms and Hats
Temperate are Chernarussian Civs, with their Vehicles, Uniforms and Hats.

Changes to fn_equipmentIsValidForCurrentModset.sqf:
Apparently those were broken with General VN,
As it looked the Previous behavior would have allowed Vets below Armor 5 and Hats with 0 Armor,
Somehow that didn't realy work, so i changed it to allow Vests below Armor 12.1 and Hats below 0.1.
8 Armor is on Tac Vets and 12 Armor is on Police Vests from Vanilla which RHS uses too.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2.  Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
