### PR TITLE
Improve logging on Bad spawns.

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_cleanserVeh.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_cleanserVeh.sqf
@@ -2,6 +2,9 @@
 FIX_LINE_NUMBERS()
 params ["_veh"];
 
+private _vehpos = getpos _veh;
+private _near = ([markersX, _vehpos] call BIS_fnc_nearestPosition);
+
 sleep 5;
 
 if (isNull _veh) exitWith {
@@ -10,7 +13,7 @@ if (isNull _veh) exitWith {
 
 if (!alive _veh) then
 {
-    Debug_2("%1 destroyed on spawn at %2", typeof _veh, getpos _veh);
+    Debug_4("%1 destroyed on spawn at %2, %3 Meters from %4", typeof _veh, _vehpos, _vehpos distance getmarkerpos _near, _near);
 	_veh hideObjectGlobal true;
 	deleteVehicle _veh;
 };

--- a/A3-Antistasi/functions/CREATE/fn_cleanserVeh.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_cleanserVeh.sqf
@@ -10,7 +10,7 @@ if (isNull _veh) exitWith {
 
 if (!alive _veh) then
 {
-    Debug_1("%1 destroyed on spawn", typeof _veh);
+    Debug_2("%1 destroyed on spawn at %2", typeof _veh, getpos _veh);
 	_veh hideObjectGlobal true;
 	deleteVehicle _veh;
 };

--- a/A3-Antistasi/functions/CREATE/fn_cleanserVeh.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_cleanserVeh.sqf
@@ -3,7 +3,7 @@ FIX_LINE_NUMBERS()
 params ["_veh"];
 
 private _vehpos = getpos _veh;
-private _near = ([markersX, _vehpos] call BIS_fnc_nearestPosition);
+private _nearestMarker  = ([markersX, _vehpos] call BIS_fnc_nearestPosition);
 
 sleep 5;
 
@@ -13,7 +13,7 @@ if (isNull _veh) exitWith {
 
 if (!alive _veh) then
 {
-    Debug_4("%1 destroyed on spawn at %2, %3 Meters from %4", typeof _veh, _vehpos, _vehpos distance getmarkerpos _near, _near);
+    Debug_3("%1 destroyed on spawn at %2, near %3", typeof _veh, _vehpos, _nearestMarker);
 	_veh hideObjectGlobal true;
 	deleteVehicle _veh;
 };


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [x] Enhancement

### What have you changed and why?
Information:
Added getpos to the Cleanup of CleanseVeh, so we could log where something spawned bad.
Basicly changing this:
```
12:24:42 2021-05-30 10:24:42:303 | Antistasi | Debug | File: A3A_fnc_cleanserVeh | UK3CB_BAF_Merlin_HC3_CSAR_DDPM_RM destroyed on spawn
```
to
```
12:24:42 2021-05-30 10:24:42:303 | Antistasi | Debug | File: A3A_fnc_cleanserVeh | UK3CB_BAF_Merlin_HC3_CSAR_DDPM_RM destroyed on spawn at [4555.01,15409.3,0.406067]
```
### Please specify which Issue this PR Resolves.
closes #1967 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Have something spawn bad,
putting a Vehicle on a Helipad and spawning the Outpost in does cause bad spawns.
********************************************************
Notes:
