### PR TITLE
Improve performance of distanceUnits

### DIFF
--- a/A3-Antistasi/functions/Base/fn_distanceUnits.sqf
+++ b/A3-Antistasi/functions/Base/fn_distanceUnits.sqf
@@ -15,26 +15,8 @@
 
 params ["_distanceX","_modeX","_center","_targetSide"];
 
-private _result = false;
+if (_center isEqualType objNull) then { _center = getpos _center };
+private _allSideClose = units _targetSide inAreaArray [_center, _distanceX, _distanceX];
 
-//All units capable of triggering a marker to spawn.
-private _allUnits = allUnits select {_x getVariable ["spawner",false]};
-if (_modeX == 0) then
-	{
-	_result = [];
-	{
-	if (side group _x == _targetSide) then
-		{
-		if (_x distance2D _center < _distanceX) then
-			{
-			_result pushBack _x;
-			};
-		};
-	} forEach _allUnits;
-	}
-else
-	{
-	{if ((side group _x == _targetSide) and (_x distance2D _center < _distanceX)) exitWith {_result = true}} count _allUnits;
-	};
-
-_result
+if (_modeX == 0) exitWith { _allSideClose select {_x getVariable ["spawner",false]} };
+_allSideClose findIf { _x getVariable ["spawner",false] } != -1;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement
4. [X] Performance

### What have you changed and why?
distanceUnits is heavily used in waitUntil loops, and extremely suboptimal. This PR improves the performance with no functionality changes.

In a test with three rebel HC squads, a handful of blufor spawners and ~145 total units, the speedup was typically 5-10x depending on the location used.

### Please specify which Issue this PR Resolves.
closes #1970

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
