### PR TITLE
Spawn-related optimization and bugfixes

### DIFF
--- a/A3-Antistasi/functions/Base/fn_distance.sqf
+++ b/A3-Antistasi/functions/Base/fn_distance.sqf
@@ -44,12 +44,11 @@ private _processOccupantMarker = {
         {
             // if somebody green is inside distanceSPWN
             // or somebody opfor is inside distanceSPWN2
-            // or somebody blufor is Player and is inside distanceSPWN2
+            // PvP disabled: or somebody blufor is Player and is inside distanceSPWN2
             // or this marker is forced spawn than exit (marker still ENABLED)
-            if (_teamplayer findIf { _x distance2D _position < distanceSPWN } != -1
-                || { _invaders findIf { _x distance2D _position < distanceSPWN2 } != -1
-                || { _occupants findIf { isPlayer _x && { _x distance2D _position < distanceSPWN2 } } != -1
-                || { _marker in forcedSpawn } }}) exitWith {};
+            if (_teamplayer inAreaArray [_position, distanceSPWN, distanceSPWN] isNotEqualTo []
+                || { _invaders inAreaArray [_position, distanceSPWN2, distanceSPWN2] isNotEqualTo []
+                || { _marker in forcedSpawn } }) exitWith {};
 
             // DISABLE this marker
             spawner setVariable [_marker, DISABLED, true];
@@ -67,8 +66,8 @@ private _processOccupantMarker = {
             // if somebody green is inside distanceSPWN
             // or somebody opfor is inside distanceSPWN2
             // or this marker is forced to spawn than ENABLE marker
-            if (_teamplayer findIf { _x distance2D _position < distanceSPWN } != -1
-                || { _invaders findIf { _x distance2D _position < distanceSPWN2 } != -1
+            if (_teamplayer inAreaArray [_position, distanceSPWN, distanceSPWN] isNotEqualTo []
+                || { _invaders inAreaArray [_position, distanceSPWN2, distanceSPWN2] isNotEqualTo []
                 || { _marker in forcedSpawn } })
             then
             {
@@ -86,8 +85,8 @@ private _processOccupantMarker = {
             {
                 // if somebody green is inside distanceSPWN1
                 // or somebody opfor is inside distanceSPWN than exit (marker still DISABLED)
-                if (_teamplayer findIf { _x distance2D _position < distanceSPWN1 } != -1
-                    || { _invaders findIf { _x distance2D _position < distanceSPWN } != -1 })
+                if (_teamplayer inAreaArray [_position, distanceSPWN1, distanceSPWN1] isNotEqualTo []
+                    || { _invaders inAreaArray [_position, distanceSPWN, distanceSPWN] isNotEqualTo [] })
                 exitWith {};
 
                 // DESPAWN this marker
@@ -100,8 +99,8 @@ private _processOccupantMarker = {
             // if nobody green is inside distanceSPWN
             // and nobody opfor is inside distanceSPWN2
             // and marker is not forced to spawn than exit (marker still DESPAWN)
-            if (_teamplayer findIf { _x distance2D _position < distanceSPWN } == -1
-                && { _invaders findIf { _x distance2D _position < distanceSPWN2 } == -1
+            if (_teamplayer inAreaArray [_position, distanceSPWN, distanceSPWN] isEqualTo []
+                && { _invaders inAreaArray [_position, distanceSPWN2, distanceSPWN2] isEqualTo []
                 && { !(_marker in forcedSpawn) } }) exitWith {};
 
             // ENABLE this marker
@@ -112,20 +111,7 @@ private _processOccupantMarker = {
             {
                 case (_marker in citiesX):
                 {
-                    // if somebody green is inside distanceSPWN
-                    // or somebody blufor is player and inside distanceSPWN2
-                    // or marker is forced to spawn than ...
-                    if (_teamplayer findIf { _x distance2D _position < distanceSPWN } != -1
-                        || { _occupants findIf { isPlayer _x && { _x distance2D _position < distanceSPWN2 } } != -1
-                        || { _marker in forcedSpawn } })
-                    then { [[_marker], "A3A_fnc_createAICities"] call A3A_fnc_scheduler; };
-
-                    // if marker is not in destroyedSites
-                    // and somebody player is inside distanceSPWN or marker is forced to spawn than ...
-                    if (!(_marker in destroyedSites)
-                        && { allUnits findIf { isPlayer _x && { _x distance2D _position < distanceSPWN } } != -1
-                        || { _marker in forcedSpawn } })
-                    then { [[_marker], "A3A_fnc_createCIV"] call A3A_fnc_scheduler; };
+                    [[_marker], "A3A_fnc_createAICities"] call A3A_fnc_scheduler;
                 };
 
                 case (_marker in controlsX):
@@ -165,10 +151,9 @@ private _processFIAMarker = {
             // or somebody opfor is inside distanceSPWN
             // or somebody green is control unit and is inside distanceSPWN2
             // or marker is forced to spawn than exit (marker still ENABLED)
-            if (_occupants findIf { _x distance2D _position < distanceSPWN } != -1
-                || { _invaders findIf { _x distance2D _position < distanceSPWN } != -1
-                || { _teamplayer findIf { _x getVariable ["owner", objNull] == _x
-                    && { _x distance2D _position < distanceSPWN2 }} != -1
+            if (_occupants inAreaArray [_position, distanceSPWN, distanceSPWN] isNotEqualTo []
+                || { _invaders inAreaArray [_position, distanceSPWN, distanceSPWN] isNotEqualTo []
+                || { _players inAreaArray [_position, distanceSPWN2, distanceSPWN2] isNotEqualTo []
                 || { _marker in forcedSpawn } }}) exitWith {};
 
             // DISABLE marker
@@ -187,10 +172,9 @@ private _processFIAMarker = {
             // or sombody opfor is inside distanceSPWN
             // or somebody green is player and is inside distanceSPWN2
             // or marker is forced spawn than ENABLE marker
-            if (_occupants findIf { _x distance2D _position < distanceSPWN } != -1
-                || { _invaders findIf { _x distance2D _position < distanceSPWN } != -1
-                || { _teamplayer findIf { _x getVariable ["owner", objNull] == _x
-                    && { _x distance2D _position < distanceSPWN2 }} != -1
+            if (_occupants inAreaArray [_position, distanceSPWN, distanceSPWN] isNotEqualTo []
+                || { _invaders inAreaArray [_position, distanceSPWN, distanceSPWN] isNotEqualTo []
+                || { _players inAreaArray [_position, distanceSPWN2, distanceSPWN2] isNotEqualTo []
                 || { _marker in forcedSpawn } }})
             then
             {
@@ -209,10 +193,9 @@ private _processFIAMarker = {
                 // or somebody opfor is inside distanceSPWN1
                 // or somebody green is player and is inside distanceSPWN
                 // then exit (marker still DISABLED)
-                if (_occupants findIf { _x distance2D _position < distanceSPWN1 } != -1
-                    || { _invaders findIf { _x distance2D _position < distanceSPWN1 } != -1
-                    || { _teamplayer findIf { _x getVariable ["owner", objNull] == _x
-                        && { _x distance2D _position < distanceSPWN }} != -1 }})
+                if (_occupants inAreaArray [_position, distanceSPWN1, distanceSPWN1] isNotEqualTo []
+                    || { _invaders inAreaArray [_position, distanceSPWN1, distanceSPWN1] isNotEqualTo []
+                    || { _players inAreaArray [_position, distanceSPWN, distanceSPWN] isNotEqualTo [] }})
                 exitWith {};
 
                 // DESPAWN this marker
@@ -224,12 +207,11 @@ private _processFIAMarker = {
         {
             // if nobody blufor is inside distanceSPWN
             // and nobody opfor is inside distanceSPWN
-            // and nobody green player ia inside distanceSPWN2
+            // and nobody green player is inside distanceSPWN2
             // and marker is not forced spawn then exit (marker still DESPAWN)
-            if (_occupants findIf { _x distance2D _position < distanceSPWN } == -1
-                && { _invaders findIf { _x distance2D _position < distanceSPWN } == -1
-                && { _teamplayer findIf { _x getVariable ["owner", objNull] == _x
-                    && { _x distance2D _position < distanceSPWN2 }} == -1
+            if (_occupants inAreaArray [_position, distanceSPWN, distanceSPWN] isEqualTo []
+                && { _invaders inAreaArray [_position, distanceSPWN, distanceSPWN] isEqualTo []
+                && { _players inAreaArray [_position, distanceSPWN2, distanceSPWN2] isEqualTo []
                 && { !(_marker in forcedSpawn) } }}) exitWith {};
 
             // ENABLED this marker
@@ -239,20 +221,6 @@ private _processFIAMarker = {
             switch (true)
             do
             {
-                case (_marker in citiesX):
-                {
-                    // if marker not in destroy cites
-                    // and somebody player is inside distanceSPWN
-                    // or marker is forced spawn then spawn civs
-                    if (!(_marker in destroyedSites)
-                        && { allunits findIf { isPlayer _x
-                            && { _x distance2D _position < distanceSPWN }} != -1
-                        || { _marker in forcedSpawn } })
-                    then { [[_marker], "A3A_fnc_createCIV"] call A3A_fnc_scheduler; };
-
-                    [[_marker], "A3A_fnc_createSDKGarrisons"] call A3A_fnc_scheduler;
-                };
-
                 case (_marker in outpostsFIA):
                 {
                     [[_marker], "A3A_fnc_createFIAOutposts2"] call A3A_fnc_scheduler;
@@ -275,13 +243,11 @@ private _processInvaderMarker = {
         case ENABLED:
         {
             // if somebody green is inside distanceSPWN
-            // or somebody opfor is inside distanceSPWN2
             // or somebody blufor is inside distanceSPWN2
             // or marker is forced spawn then exit (marker still ENABLED)
-            if (_teamplayer findIf { _x distance2D _position < distanceSPWN } != -1
-                || { _invaders findIf { _x distance2D _position < distanceSPWN2 } != -1
-                || { _occupants findif { _x distance2D _position < distanceSPWN2 } != -1
-                || { _marker in forcedSpawn } }}) exitWith {};
+            if (_teamplayer inAreaArray [_position, distanceSPWN, distanceSPWN] isNotEqualTo []
+                || { _occupants inAreaArray [_position, distanceSPWN2, distanceSPWN2] isNotEqualTo []
+                || { _marker in forcedSpawn } }) exitWith {};
 
             // DISABLE this marker
             spawner setVariable [_marker, DISABLED, true];
@@ -298,8 +264,8 @@ private _processInvaderMarker = {
             // if somebody green is inside distanceSPWN
             // or somebody bluefor is inside distanceSPWN2
             // or marker is forced spawn then ENABLED this marker
-            if (_teamplayer findIf { _x distance2D _position < distanceSPWN } != -1
-                || { _occupants findIf { _x distance2D _position < distanceSPWN2 } != -1
+            if (_teamplayer inAreaArray [_position, distanceSPWN, distanceSPWN] isNotEqualTo []
+                || { _occupants inAreaArray [_position, distanceSPWN2, distanceSPWN2] isNotEqualTo []
                 || { _marker in forcedSpawn } })
             then
             {
@@ -316,8 +282,8 @@ private _processInvaderMarker = {
             {
                 // if somebody green is inside distanceSPWN1
                 // or somebody bluefor is inside distanceSPWN then exit (marker still DISABLED)
-                if (_teamplayer findIf { _x distance2D _position < distanceSPWN1 } != -1
-                    || { _occupants findIf { _x distance2D _position < distanceSPWN } != -1 })
+                if (_teamplayer inAreaArray [_position, distanceSPWN1, distanceSPWN1] isNotEqualTo []
+                    || { _occupants inAreaArray [_position, distanceSPWN, distanceSPWN] isNotEqualTo [] })
                 exitWith {};
 
                 // DESPAWN this marker
@@ -330,13 +296,12 @@ private _processInvaderMarker = {
             // if nobody is inside distanceSPWN
             // and nobody is inside distanceSPWN2
             // and marker is not forced to spawn then exit (marker still DESPAWN)
-            if (_teamplayer findIf { _x distance2D _position < distanceSPWN } == -1
-                && { _occupants findIf { _x distance2D _position < distanceSPWN2 } == -1
+            if (_teamplayer inAreaArray [_position, distanceSPWN, distanceSPWN] isEqualTo []
+                && { _occupants inAreaArray [_position, distanceSPWN2, distanceSPWN2] isEqualTo []
                 && { !(_marker in forcedSpawn) } }) exitWith {};
 
             // ENABLE this marker
             spawner setVariable [_marker, ENABLED, true];
-
 
             switch (true)
             do
@@ -367,6 +332,46 @@ private _processInvaderMarker = {
     };
 };
 
+private _processCityCivMarker = {
+
+    // No garrison to disable, so use a despawn time threshold instead of inner/outer radii
+    private _spawnKey = _marker + "_civ";
+    private _timeKey = _spawnKey + "_time";
+
+    switch (spawner getVariable _spawnKey)
+    do
+    {
+        case ENABLED:
+        {
+            // if player is inside distanceSPWN, reset the timer
+            if (_players inAreaArray [_position, distanceSPWN, distanceSPWN] isNotEqualTo []) exitWith 
+            {
+                spawner setVariable [_timeKey, time + 30, false];
+            };
+            if (spawner getVariable _timeKey > time) exitWith {};
+
+            // DESPAWN marker
+            spawner setVariable [_spawnKey, DESPAWN, true];
+        };
+
+        case DESPAWN:
+        {
+            // if no player is inside distanceSPWN, leave despawned
+            if (_players inAreaArray [_position, distanceSPWN, distanceSPWN] isEqualTo []) exitWith {};
+
+            // ENABLED this marker
+            spawner setVariable [_spawnKey, ENABLED, true];
+            spawner setVariable [_timeKey, time + 30, false];
+
+            if !(_marker in destroyedSites) then
+            {
+                [[_marker], "A3A_fnc_createCIV"] call A3A_fnc_scheduler;
+            };
+        };
+    };
+};
+
+
 /* -------------------------------------------------------------------------- */
 /*                                    start                                   */
 /* -------------------------------------------------------------------------- */
@@ -375,13 +380,17 @@ if !(isServer) exitwith {};
 
 waitUntil { sleep 0.1; if !(isnil "theBoss") exitWith { true }; false };
 
+// Prepare spawner values for civ part of city spawning
+{ spawner setVariable [_x + "_civ", 2] } forEach citiesX;
+
 /* ------------------------------ endless cycle ----------------------------- */
 
-private _time = 1 / (count markersX);
+private _time = 1 / count (markersX);
 private _counter = 0;
 private _teamplayer = [];
 private _occupants = [];
 private _invaders = [];
+private _players = [];
 
 private ["_markers", "_marker", "_position"];
 
@@ -410,6 +419,10 @@ do
                 case teamPlayer: { _teamplayer pushBack _x; };
             };
         } forEach _spawners;
+
+        // This array is used to spawn civilians in cities and rebel garrisons, so ignore remote controlled units
+        _players = allPlayers - entities "HeadlessClient_F";
+        _players = _players select { _x getVariable ["owner",objNull] == _x };
     };
 
     {
@@ -425,5 +438,8 @@ do
             case Invaders: _processInvaderMarker;
             case teamPlayer: _processFIAMarker;
         };
+
+        if (_marker in citiesX) then { call _processCityCivMarker };
+
     } forEach markersX;
 };

--- a/A3-Antistasi/functions/CREATE/fn_createAICities.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAICities.sqf
@@ -13,7 +13,7 @@ _positionX = getMarkerPos (_markerX);
 
 _num = [_markerX] call A3A_fnc_sizeMarker;
 _sideX = sidesX getVariable [_markerX,sideUnknown];
-if ({if ((getMarkerPos _x inArea _markerX) and (sidesX getVariable [_x,sideUnknown] != _sideX)) exitWith {1}} count markersX > 0) exitWith {};
+if ((markersX - controlsX) findIf {(getMarkerPos _x inArea _markerX) and (sidesX getVariable [_x,sideUnknown] != _sideX)} != -1) exitWith {};
 _num = round (_num / 100);
 
 Debug_1("Spawning City Patrol in %1", _markerX);

--- a/A3-Antistasi/functions/CREATE/fn_createCIV.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createCIV.sqf
@@ -5,6 +5,7 @@ FIX_LINE_NUMBERS()
 private ["_markerX","_dataX","_numCiv","_numVeh","_prestigeOPFOR","_prestigeBLUFOR","_civs","_groups","_vehiclesX","_civsPatrol","_groupsPatrol","_vehPatrol","_typeCiv","_typeVehX","_dirVeh","_groupX","_size","_road","_typeVehX","_dirVeh","_positionX","_area","_civ","_veh","_roadcon","_pos","_p1","_p2","_mrkMar","_burst","_groupP","_wp","_wp1"];
 
 _markerX = _this select 0;
+private _spawnKey = _markerX + "_civ";				// civ part of cities has a separate spawn state from the garrison
 
 if (_markerX in destroyedSites) exitWith {};
 
@@ -50,7 +51,7 @@ _numTraffic = 1 max (round _numTraffic) min _maxRoads;
 
 private _countParked = 0;
 
-while {(spawner getVariable _markerX != 2) and (_countParked < _numParked)} do
+while {(spawner getVariable _spawnKey != 2) and (_countParked < _numParked)} do
 	{
 	_p1 = _roads select _countParked;
 	_road = roadAt _p1;
@@ -98,7 +99,7 @@ if (count _mrkMar > 0) then
 	{
 	for "_i" from 0 to (round (random 3)) do
 		{
-		if (spawner getVariable _markerX != 2) then
+		if (spawner getVariable _spawnKey != 2) then
 			{
 			_typeVehX = selectRandomWeighted civBoatsWeighted;
 			_pos = (getMarkerPos (_mrkMar select 0)) findEmptyPosition [0,20,_typeVehX];
@@ -116,7 +117,7 @@ if (count _mrkMar > 0) then
 		};
 	};
 
-if ((random 100 < ((aggressionOccupants) + (aggressionInvaders))) and (spawner getVariable _markerX != 2)) then
+if ((random 100 < ((aggressionOccupants) + (aggressionInvaders))) and (spawner getVariable _spawnKey != 2)) then
 	{
 	_pos = [];
 	while {true} do
@@ -140,7 +141,7 @@ if ([_markerX,false] call A3A_fnc_fogCheck > 0.2) then
 	private _patrolCities = [_markerX] call A3A_fnc_citiesToCivPatrol;
 	if (count _patrolCities > 0) then
 		{
-		while {(spawner getVariable _markerX != 2) and (_countTraffic < _numTraffic)} do
+		while {(spawner getVariable _spawnKey != 2) and (_countTraffic < _numTraffic)} do
 			{
 			_p1 = selectRandom _roads;
 			_road = roadAt _p1;
@@ -193,7 +194,7 @@ if ([_markerX,false] call A3A_fnc_fogCheck > 0.2) then
 		};
 	};
 
-waitUntil {sleep 1;(spawner getVariable _markerX == 2)};
+waitUntil {sleep 1; (spawner getVariable _spawnKey == 2)};
 
 {deleteVehicle _x} forEach _civs;
 {deleteGroup _x} forEach _groups;

--- a/A3-Antistasi/functions/Revive/fn_actionRevive.sqf
+++ b/A3-Antistasi/functions/Revive/fn_actionRevive.sqf
@@ -89,9 +89,11 @@ waitUntil {
     sleep 1;
     !([_medic] call A3A_fnc_canFight)
     or (time > _timer)
-    or (_medic getVariable "cancelRevive")
+    or (_medic getVariable ["cancelRevive", false])		// medic might get deleted
     or !(alive _cured)
 };
+
+if (isNull _medic) exitWith {};
 
 _medic removeEventHandler ["AnimDone", _animHandler];
 _medic setVariable ["helping",false];


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement
4. [X] Performance

### What have you changed and why?
- Converted fn_distance from findIf to inAreaArray to improve performance.
- Split cities into separate civ & garrison spawns to resolve several issues.
- Fixed a bug where invaders could spawn their own garrisons.
- Fixed a bug where destroyed roadblocks prevented nearby city patrols from spawning.
- Fixed a bug where deleting an AI while reviving caused error spam.

Other than the new civ city spawning, the spawning logic is largely unchanged. It's just faster. Tempted to switch the other spawns over to a time-threshold system instead of the simulation-disabled region, but I'd need to do more practical performance testing to see the pros and cons.

### Please specify which Issue this PR Resolves.
closes #1972

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

I think I've tested nearly every case, including invaders and occupants spawning each other, plus HC squad vs player differences and occupants versus rebel garrisons.

### How can the changes be tested?
Best done using Zeus with a full unit view, and moving units around. As a shortcut, you can select units in Zeus and use the following command to make them spawners:
`(curatorSelected#0#0) setVariable ["spawner", true, true];`
 