### PR TITLE
Restore missing aggro penalty for killing surrendered enemies

### DIFF
--- a/A3-Antistasi/functions/AI/fn_occupantInvaderUnitKilledEH.sqf
+++ b/A3-Antistasi/functions/AI/fn_occupantInvaderUnitKilledEH.sqf
@@ -49,11 +49,12 @@ if (side (group _killer) == teamPlayer) then
 	if (count weapons _victim < 1 && !(_victim getVariable ["isAnimal", false])) then
     {
         //This doesn't trigger for dogs, only for surrendered units
-        Debug(" aggroEvent | Rebels killed a surrendered unit");
+        Debug("aggroEvent | Rebels killed a surrendered unit");
 		if (_victimSide == Occupants) then
 		{
 			[0,-2,getPos _victim] remoteExec ["A3A_fnc_citySupportChange",2];
 		};
+        [_victimSide, 20, 30] remoteExec ["A3A_fnc_addAggression", 2];
 	}
 	else
 	{


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The aggression cost for killing surrendered enemies got lost in #1788. This PR restores it.    

### Please specify which Issue this PR Resolves.
closes #1974

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
