### PR TITLE
NVG Cleanup

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_categoryOverrides.sqf
@@ -108,9 +108,6 @@ private _categoryOverrideTable = [
 ["ACE_microDAGR", ["Gadgets","Items"]],
 ["ACE_DAGR", ["Gadgets","Items"]],
 
-["rhsusf_Rhino", ["Unknown", "Items"]],    //Just a Headmount not NVG
-["rhs_6m2_nvg", ["Unknown", "Items"]],    //a Headset not NVG
-["rhs_6m2_1_nvg", ["Unknown", "Items"]],    //a Headset not NVG
 ["LIB_PTRD", ["Unknown", "Weapons"]],
 ["LIB_M2_Flamethrower", ["Unknown", "Weapons"]],			// don't want these two being chosen randomly by AIs
 ["LIB_Bagpipes", ["Unknown","Weapons"]],					// wat
@@ -167,18 +164,6 @@ private _categoryOverrideTable = [
 ["LIB_GrWr34_Barrel_g", ["StaticWeaponParts","Items"]],
 ["LIB_M2_60_Tripod", ["StaticWeaponParts","Items"]],
 ["LIB_M2_60_Barrel", ["StaticWeaponParts","Items"]]   ];
-
-/* Not sure if these are a problem
-["LIB_GER_Headset",["NVGs","Items"]],
-["LIB_Headwrap",["NVGs","Items"]],
-["LIB_Headwrap_gloves",["NVGs","Items"]],
-["LIB_Mohawk",["NVGs","Items"]],
-["LIB_GER_Gloves1",["NVGs","Items"]],
-["LIB_GER_Gloves2",["NVGs","Items"]],
-["LIB_GER_Gloves3",["NVGs","Items"]],
-["LIB_GER_Gloves4",["NVGs","Items"]],
-["LIB_GER_Gloves5",["NVGs","Items"]],
-*/
 
 //Create a local namespace. Should only run on the server.
 categoryOverrides = false call A3A_fnc_createNamespace;

--- a/A3-Antistasi/functions/Ammunition/fn_equipmentSort.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentSort.sqf
@@ -108,6 +108,9 @@ allUAVTerminals = allUAVTerminals select {
 //Remove Prop Food
 allMagBullet = allMagBullet select { getText (configFile >> "CfgMagazines" >> _x >> "ammo") isNotEqualTo "FakeAmmo"; };
 
+//Remove False NVGs
+allnvgs = Allnvgs select { getarray (configFile >> "CfgWeapons" >> _x >> "visionMode") isnotequalto ["Normal","Normal"]};
+
 private _removableDefaultItems = [
 	[allFirstAidKits,"FirstAidKit","firstAidKits"],
 	[allMedikits,"Medikit","mediKits"],

--- a/A3-Antistasi/functions/Ammunition/fn_equipmentSort.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentSort.sqf
@@ -109,7 +109,7 @@ allUAVTerminals = allUAVTerminals select {
 allMagBullet = allMagBullet select { getText (configFile >> "CfgMagazines" >> _x >> "ammo") isNotEqualTo "FakeAmmo"; };
 
 //Remove False NVGs
-allnvgs = Allnvgs select { getarray (configFile >> "CfgWeapons" >> _x >> "visionMode") isnotequalto ["Normal","Normal"]};
+allNVGs = allNVGs select { getarray (configFile >> "CfgWeapons" >> _x >> "visionMode") isnotequalto ["Normal","Normal"]};
 
 private _removableDefaultItems = [
 	[allFirstAidKits,"FirstAidKit","firstAidKits"],


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [x] Enhancement

### What have you changed and why?
Information:
While checking Configs for IFA stuff i noticed there is a Handful of False "NVGs", basicly Gloves, Scarfs etc. using the NVG Slot but not providing any other Vision Modes.

And as it seems all of those "NVGs" have this in Common:
```sqf
visionMode[] = {"Normal","Normal"};
```

This also seems to Apply to RHS NVG Configs, so assuming it should not cause future Problems.

### Please specify which Issue this PR Resolves.
closes nothing, but it might be nice to have

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: Check the Array **AllNVGs** on RHS, there should be no "rhs_6m2_1_nvg", "rhs_6m2_nvg", "rhsusf_Rhino".

********************************************************
Notes:
