### PR TITLE
Patch for bugs  in unstable found during Testing Tuesday 29.jun

### DIFF
--- a/A3-Antistasi/Garage/Core/fn_confirm.sqf
+++ b/A3-Antistasi/Garage/Core/fn_confirm.sqf
@@ -18,6 +18,7 @@
     License: Håkon Rydland Garage SHARED SOURCE LICENSE
 */
 HR_GRG_SelectedVehicles params ["_catIndex", "_vehUID", "_class"];
+if (_vehUID isEqualTo -1) exitWith {[localize "STR_HR_GRG_Feedback_confirm_NullSelection"] call HR_GRG_fnc_Hint};
 
 //get mounts state
 HR_GRG_Mounts apply {

--- a/A3-Antistasi/Garage/Core/fn_getCatIndex.sqf
+++ b/A3-Antistasi/Garage/Core/fn_getCatIndex.sqf
@@ -42,5 +42,11 @@ switch (true) do {
     //cup
     case (_editorCat in ["CUP_EdSubcat_Bikes","CUP_EdSubCat_Cars_Woodland","CUP_EdSubCat_UpHMMWV_Cars_Desert","CUP_EdSubCat_Cars_Winter"]): { 0 };
 
+    //Fallback
+    case (_class isKindOf "Car"): { 0 };
+    case (_class isKindOf "Tank"): { 1 };
+    case (_class isKindOf "Air"): { 2 };
+    case (_class isKindOf "Ship"): { 3 };
+
     default { -1 };
 };

--- a/A3-Antistasi/Garage/Core/fn_onLoad.sqf
+++ b/A3-Antistasi/Garage/Core/fn_onLoad.sqf
@@ -54,6 +54,7 @@ HR_GRG_previewCam = "camera" camCreate [10,0,100000];
 HR_GRG_previewCam enableSimulation false;
 HR_GRG_previewCam cameraEffect ["Internal", "Back"];
 showCinemaBorder false;
+enableEnvironment false; //wind sound
 HR_GRG_previewCam camCommit 0;
 HR_GRG_camDist = 1.3;
 HR_GRG_camDirX = 30;

--- a/A3-Antistasi/Garage/Core/fn_onUnload.sqf
+++ b/A3-Antistasi/Garage/Core/fn_onUnload.sqf
@@ -34,6 +34,7 @@ lightDetachObject HR_GRG_previewLight;
 deleteVehicle HR_GRG_previewLight;
 
 //destroy preview camera
+enableEnvironment true;
 HR_GRG_previewCam cameraEffect ["terminate","back"];
 camDestroy HR_GRG_previewCam;
 

--- a/A3-Antistasi/Garage/Core/fn_reciveBroadcast.sqf
+++ b/A3-Antistasi/Garage/Core/fn_reciveBroadcast.sqf
@@ -33,16 +33,18 @@ private _vehicle = _cat get _vehUID;
 
 //set the new data
 if (_switch) then { [getPlayerUID _player] call HR_GRG_fnc_releaseAllVehicles };
+
 if (!isNil "_lockUID") then {
     _vehicle set [2, _lockUID];
+    _vehicle set [5, if (_lockUID isEqualTo "") then { "" } else { name _player }];
 };
+
 if (!isNil "_checkoutUID") then {
     _vehicle set [3, _checkoutUID];
 };
 
-private _isPlayer = _player isEqualTo player;
-
 //handle refreshing preview and extras
+private _isPlayer = _player isEqualTo player;
 if (_isPlayer) then {
     if (_switch) then {
         Trace_3("Setting selected vehicle | Cat: %1 | UID: %2 | Class: %3", _catIndex, _vehUID, _vehicles#1);

--- a/A3-Antistasi/Garage/Core/fn_releaseAllVehicles.sqf
+++ b/A3-Antistasi/Garage/Core/fn_releaseAllVehicles.sqf
@@ -26,11 +26,9 @@ Trace_1("Releasing all vehicles with UID: %1", _UID);
 
 //release all vehicles in all HR_GRG_categories
 {
-    private _hash = _x;
     {
-        _veh = _hash get _x;
-        if ( (_veh#3) isEqualTo _UID) then {_veh set [3, ""] };
-    } forEach (keys _x);
+        if ( (_y#3) isEqualTo _UID) then {_y set [3, ""] };
+    } forEach _x;
 } forEach HR_GRG_Vehicles;
 
 //refresh category if client

--- a/A3-Antistasi/Garage/Core/fn_reloadCategory.sqf
+++ b/A3-Antistasi/Garage/Core/fn_reloadCategory.sqf
@@ -56,7 +56,7 @@ private _HR_GRG_SelectedVehicles = [-1,-1,""];
         _ctrl lbSetPictureRightColor [_index, _color];
         _tooltipText = _tooltipText + ( localize "STR_HR_GRG_Feedback_LockedToolTip" )+" "+ _lockName;
     };
-    _ctrl lbSetTooltip [_index, _tooltipText]; //for some reason dosnt apply
+    _ctrl lbSetTooltip [_index, _tooltipText];
     _ctrl lbSetPictureRightColorSelected [_index, [0.85,0.85,0.55,1]];
 
 } forEach (keys (HR_GRG_Vehicles#_catIndex));

--- a/A3-Antistasi/Garage/Core/fn_reloadCategory.sqf
+++ b/A3-Antistasi/Garage/Core/fn_reloadCategory.sqf
@@ -29,8 +29,7 @@ lbClear _ctrl;
 private _selected = -1;
 private _HR_GRG_SelectedVehicles = [-1,-1,""];
 {
-    private _veh = (HR_GRG_Vehicles#_catIndex) get _x;
-    _veh params ["_displayName", "_class", "_lockedUID", "_checkedOut", "", ["_lockName", ""]];
+    _y params ["_displayName", "_class", "_lockedUID", "_checkedOut", "", ["_lockName", ""]];
     private _index = _ctrl lbAdd _displayName;
     _ctrl lbSetData [_index, str _x];
     _ctrl lbSetValue [_index, _x];
@@ -59,5 +58,5 @@ private _HR_GRG_SelectedVehicles = [-1,-1,""];
     _ctrl lbSetTooltip [_index, _tooltipText];
     _ctrl lbSetPictureRightColorSelected [_index, [0.85,0.85,0.55,1]];
 
-} forEach (keys (HR_GRG_Vehicles#_catIndex));
+} forEach (HR_GRG_Vehicles#_catIndex);
 _ctrl lbSetCurSel _selected;

--- a/A3-Antistasi/Garage/Core/fn_reloadCategory.sqf
+++ b/A3-Antistasi/Garage/Core/fn_reloadCategory.sqf
@@ -30,7 +30,7 @@ private _selected = -1;
 private _HR_GRG_SelectedVehicles = [-1,-1,""];
 {
     private _veh = (HR_GRG_Vehicles#_catIndex) get _x;
-    _veh params ["_displayName", "_class", "_lockedUID", "_checkedOut"];
+    _veh params ["_displayName", "_class", "_lockedUID", "_checkedOut", "", ["_lockName", ""]]; //ToDo: remove default after test (only needed for backwards compat)
     private _index = _ctrl lbAdd _displayName;
     _ctrl lbSetData [_index, str _x];
     _ctrl lbSetValue [_index, _x];
@@ -38,6 +38,7 @@ private _HR_GRG_SelectedVehicles = [-1,-1,""];
     _ctrl lbSetPictureColor [_index, [1, 1, 1, 1]];
     _ctrl lbSetPictureColorSelected [_index, [0.85, 0.85, 0.55, 1]];
 
+    private _tooltipText = "";
     if !( _checkedOut isEqualTo "" ) then {
         private _color = [1,0.1,0.1,1];
         if ( (HR_GRG_SelectedVehicles#1) isEqualTo _x ) then {
@@ -46,15 +47,16 @@ private _HR_GRG_SelectedVehicles = [-1,-1,""];
         };
         _ctrl lbSetPictureRight [_index, CheckOutIcon];
         _ctrl lbSetPictureRightColor [_index, _color];
+        _tooltipText = name (_checkedOut call BIS_fnc_getUnitByUID) +" "+( localize "STR_HR_GRG_Feedback_checkedOutToolTip" )+" ";
     };
 
     if !( _lockedUID isEqualTo "" ) then {
         private _color = if ( _lockedUID isEqualTo HR_GRG_PlayerUID ) then { [1,1,1,1] } else { [1,0.1,0.1,1] }; //white, red
-        private _toolTip = if ( _lockedUID isEqualTo HR_GRG_PlayerUID ) then { "" } else { localize "STR_HR_GRG_Feedback_LockedToolTip" };
         _ctrl lbSetPictureRight [_index, LockIcon];
         _ctrl lbSetPictureRightColor [_index, _color];
-        _ctrl lbSetTooltip [_index, _toolTip]; //for some reason dosnt apply
+        _tooltipText = _tooltipText + ( localize "STR_HR_GRG_Feedback_LockedToolTip" )+" "+ _lockName;
     };
+    _ctrl lbSetTooltip [_index, _tooltipText]; //for some reason dosnt apply
     _ctrl lbSetPictureRightColorSelected [_index, [0.85,0.85,0.55,1]];
 
 } forEach (keys (HR_GRG_Vehicles#_catIndex));

--- a/A3-Antistasi/Garage/Core/fn_reloadCategory.sqf
+++ b/A3-Antistasi/Garage/Core/fn_reloadCategory.sqf
@@ -30,7 +30,7 @@ private _selected = -1;
 private _HR_GRG_SelectedVehicles = [-1,-1,""];
 {
     private _veh = (HR_GRG_Vehicles#_catIndex) get _x;
-    _veh params ["_displayName", "_class", "_lockedUID", "_checkedOut", "", ["_lockName", ""]]; //ToDo: remove default after test (only needed for backwards compat)
+    _veh params ["_displayName", "_class", "_lockedUID", "_checkedOut", "", ["_lockName", ""]];
     private _index = _ctrl lbAdd _displayName;
     _ctrl lbSetData [_index, str _x];
     _ctrl lbSetValue [_index, _x];

--- a/A3-Antistasi/Garage/Core/fn_reloadPreview.sqf
+++ b/A3-Antistasi/Garage/Core/fn_reloadPreview.sqf
@@ -48,8 +48,8 @@ HR_GRG_previewVehState = _veh#4;
 HR_GRG_previewVeh allowDamage false;
 
 //set customisation
-private _customisation = _veh param [6, [false,false]]; //ToDo: remove after test, for backwards compat
-([HR_GRG_previewVeh]+_customisation) call BIS_fnc_initVehicle; //if texture and anim is stored restore from it
+private _customisation = _veh param [6, [false,false]];
+([HR_GRG_previewVeh]+_customisation) call BIS_fnc_initVehicle;
 
 //set up camera
 HR_GRG_previewVeh setPosASL [0,0,100000];

--- a/A3-Antistasi/Garage/Core/fn_reloadPreview.sqf
+++ b/A3-Antistasi/Garage/Core/fn_reloadPreview.sqf
@@ -22,6 +22,8 @@
 FIX_LINE_NUMBERS()
 Trace("Reloading preview");
 HR_GRG_SelectedVehicles params ["_catIndex", "_vehUID", "_class"];
+
+//delete old vehicle
 if (!isNull HR_GRG_previewVeh) then {
     {
         if !(_x isEqualTo HR_GRG_previewCam) then {detach _x; deleteVehicle _x};
@@ -29,15 +31,27 @@ if (!isNull HR_GRG_previewVeh) then {
     deleteVehicle HR_GRG_previewVeh;
 };
 if (!isClass (configFile >> "CfgVehicles" >> _class)) exitWith {};
+
+//create new preview vehicle
 HR_GRG_previewVeh = _class createVehicleLocal [0,0,100000];
 HR_GRG_previewVeh enableSimulation false;
+
+//get vehicle data
 private _cat = HR_GRG_Vehicles#_catIndex;
 private _veh = _cat get _vehUID;
 Trace_1("ReloadPreview - Veh: %1", _veh);
+
+//set state
 Trace_1("Preview vehicle State: %1", _veh#4);
 HR_GRG_previewVehState = _veh#4;
 [HR_GRG_previewVeh, HR_GRG_previewVehState] call HR_GRG_fnc_setState;
 HR_GRG_previewVeh allowDamage false;
+
+//set customisation
+private _customisation = _veh param [6, [false,false]]; //ToDo: remove after test, for backwards compat
+([HR_GRG_previewVeh]+_customisation) call BIS_fnc_initVehicle; //if texture and anim is stored restore from it
+
+//set up camera
 HR_GRG_previewVeh setPosASL [0,0,100000];
 HR_GRG_previewVeh setVectorUp [0,0,1];
 [nil,0,0] call HR_GRG_fnc_updateCamPos;

--- a/A3-Antistasi/Garage/Core/fn_requestSelectionChange.sqf
+++ b/A3-Antistasi/Garage/Core/fn_requestSelectionChange.sqf
@@ -25,7 +25,7 @@
 #include "defines.inc"
 FIX_LINE_NUMBERS()
 params ["_UID", "_catIndex", "_vehUID", "_player", "_client"];
-Trace_3("Vehicle change requested | UID: %1 | Cat: %2 | vehUID: %3", _UID, _catIndex, _vehUID);
+Trace_3("Vehicle change requested | UID: %1 | Cat: %2 | Vehicle ID: %3", _UID, _catIndex, _vehUID);
 private _exit = { [true] remoteExecCall ["HR_GRG_fnc_toggleConfirmBttn", _client]; false};
 if (!isServer) exitWith _exit;
 if (_UID isEqualTo "") exitWith _exit;
@@ -40,6 +40,6 @@ if !((_vehicle#3) in ["", _UID] ) exitWith _exit;
 [_UID] call HR_GRG_fnc_releaseAllVehicles;
 _vehicle set [3, _UID];
 
-Trace_4("Vehicle at | Cat: %1 | vehUID: %2 | At Index: %3 | checked out by UID: %4", _catIndex, _vehUID, _UID);
+Trace_4("Vehicle at | Cat: %1 | Vehicle ID: %2 | At Index: %3 | checked out by UID: %4", _catIndex, _vehUID, _UID);
 [nil,_UID, _catIndex, _vehUID, _player, true] call HR_GRG_fnc_broadcast;
 true

--- a/A3-Antistasi/Garage/Core/fn_toggleLock.sqf
+++ b/A3-Antistasi/Garage/Core/fn_toggleLock.sqf
@@ -31,10 +31,11 @@ Trace_2("Attempting to toggle lock for vehicle at cat: %1 | Vehicle ID: %2", _ca
 private _cat = HR_GRG_Vehicles#_catIndex;
 private _veh = _cat get _vehUID;
 private _lock = _veh#2;
+private _owner = _veh#5;
 _succes = call {
     if ( _lock isEqualTo "" ) exitWith { true };
     if ( _lock isEqualTo _UID) exitWith { _UID = ""; true };
-    if (_player isEqualTo (_player call HR_GRG_cmdClient)) exitWith { _UID = ""; Info_4("Commander unlock | Vehicle ID: %1 | Owner: %2 | Commander: %3[%4]", _vehUID, _lock, name _player, _UID); true };
+    if (_player isEqualTo (_player call HR_GRG_cmdClient)) exitWith { _UID = ""; Info_4("Commander unlock | Vehicle ID: %1 | Owner: %2 [%3] | Commander: %4[%5]", _vehUID, _owner, _lock, name _player, _UID); true };
     false
 };
 

--- a/A3-Antistasi/Garage/Core/fn_toggleLock.sqf
+++ b/A3-Antistasi/Garage/Core/fn_toggleLock.sqf
@@ -41,6 +41,6 @@ _succes = call {
 if (_succes) exitWith {
     _veh set [2, _UID];
     [_UID, nil, _catIndex, _vehUID, _player, false] call HR_GRG_fnc_broadcast;
-    Trace("Lock state toggled");
+    Info_3("Lock state toggled for VehUID: %1 | By: %2 | Locked: %3", _vehUID, name _player, (_UID isNotEqualTo ""));
 };
 Trace("Failed to toggle lock");

--- a/A3-Antistasi/Garage/Core/fn_toggleLock.sqf
+++ b/A3-Antistasi/Garage/Core/fn_toggleLock.sqf
@@ -40,6 +40,7 @@ _succes = call {
 
 if (_succes) exitWith {
     _veh set [2, _UID];
+    _veh set [5, [name _player, ""] select (_UID isEqualTo "")];
     [_UID, nil, _catIndex, _vehUID, _player, false] call HR_GRG_fnc_broadcast;
     Info_3("Lock state toggled for VehUID: %1 | By: %2 | Locked: %3", _vehUID, name _player, (_UID isNotEqualTo ""));
 };

--- a/A3-Antistasi/Garage/Core/fn_toggleLock.sqf
+++ b/A3-Antistasi/Garage/Core/fn_toggleLock.sqf
@@ -26,7 +26,7 @@ params ["_UID", "_player", "_selectedVehicle"];
 if (!isServer) exitWith {};
 _selectedVehicle params [["_catIndex", -1], ["_vehUID", -1]];
 if ( (_catIndex isEqualTo -1) || (_vehUID isEqualTo -1) ) exitWith {};
-Trace_2("Attempting to toggle lock for vehicle at cat: %1 | vehUID: %2", _catIndex, _vehUID);
+Trace_2("Attempting to toggle lock for vehicle at cat: %1 | Vehicle ID: %2", _catIndex, _vehUID);
 
 private _cat = HR_GRG_Vehicles#_catIndex;
 private _veh = _cat get _vehUID;
@@ -34,7 +34,7 @@ private _lock = _veh#2;
 _succes = call {
     if ( _lock isEqualTo "" ) exitWith { true };
     if ( _lock isEqualTo _UID) exitWith { _UID = ""; true };
-    if (_player isEqualTo (_player call HR_GRG_cmdClient)) exitWith { _UID = ""; Info_4("Commander unlock | VehUID: %1 | Owner: %2 | Commander: %3[%4]", _vehUID, _lock, name _player, _UID); true };
+    if (_player isEqualTo (_player call HR_GRG_cmdClient)) exitWith { _UID = ""; Info_4("Commander unlock | Vehicle ID: %1 | Owner: %2 | Commander: %3[%4]", _vehUID, _lock, name _player, _UID); true };
     false
 };
 
@@ -42,6 +42,6 @@ if (_succes) exitWith {
     _veh set [2, _UID];
     _veh set [5, [name _player, ""] select (_UID isEqualTo "")];
     [_UID, nil, _catIndex, _vehUID, _player, false] call HR_GRG_fnc_broadcast;
-    Info_3("Lock state toggled for VehUID: %1 | By: %2 | Locked: %3", _vehUID, name _player, (_UID isNotEqualTo ""));
+    Info_3("Lock state toggled for Vehicle ID: %1 | By: %2 | Locked: %3", _vehUID, name _player, (_UID isNotEqualTo ""));
 };
 Trace("Failed to toggle lock");

--- a/A3-Antistasi/Garage/Core/fn_validateGarage.sqf
+++ b/A3-Antistasi/Garage/Core/fn_validateGarage.sqf
@@ -25,10 +25,9 @@ private _cfg = (configFile >> "CfgVehicles");
     private _cat = _x;
     private _catIndex = _forEachIndex;
     {
-        private _veh = _cat get _x;
-        private _class = _veh#1;
+        private _class = _y#1;
         if !(isClass (_cfg >> _class)) then {_invalidentries pushBack [_catIndex, _x]};
-    } forEach (keys _x);
+    } forEach _x;
 } forEach HR_GRG_Vehicles;
 
 {

--- a/A3-Antistasi/Garage/Extras/fn_findMount.sqf
+++ b/A3-Antistasi/Garage/Extras/fn_findMount.sqf
@@ -27,7 +27,7 @@
 #include "defines.inc"
 FIX_LINE_NUMBERS()
 params ["_UID", "_vehUID", "_newIconIndex", "_owner", "_player"];
-Trace_4("Finding available mount | UID: %1 | vehUID: %2 | Reserving: %3 | Client: %4", _UID, _vehUID, _newIconIndex, _owner);
+Trace_4("Finding available mount | UID: %1 | Vehicle ID: %2 | Reserving: %3 | Client: %4", _UID, _vehUID, _newIconIndex, _owner);
 private _failed = { [localize "STR_HR_GRG_Feedback_requestMount_Denied"] remoteExec ["HR_GRG_fnc_Hint", _owner]; [true] remoteExecCall ["HR_GRG_fnc_toggleConfirmBttn", _owner]; false };
 if (!isServer) exitWith _failed;
 

--- a/A3-Antistasi/Garage/Extras/fn_isAmmoSource.sqf
+++ b/A3-Antistasi/Garage/Extras/fn_isAmmoSource.sqf
@@ -12,7 +12,7 @@
     Scope: Any
     Environment: Any
     Public: Yes
-    Dependencies: <Bool>hasAce
+    Dependencies: <Bool> A3A_hasAce
 
     Example: [_veh] call HR_GRG_fnc_isAmmoSource;
 
@@ -21,7 +21,7 @@
 params [ ["_vehicle", objNull, [objNull]] ];
 if (isNull _vehicle) exitWith {false};
 
-if (hasAce) then { //Ace
+if (A3A_hasAce) then { //Ace
     private _aceCurrent = _vehicle getVariable ["ace_rearm_currentSupply", 0];
     if (_aceCurrent < 0) exitWith {false};
 

--- a/A3-Antistasi/Garage/Extras/fn_isFuelSource.sqf
+++ b/A3-Antistasi/Garage/Extras/fn_isFuelSource.sqf
@@ -12,7 +12,7 @@
     Scope: Any
     Environment: Any
     Public: Yes
-    Dependencies: <Bool>hasAce
+    Dependencies: <Bool> A3A_hasAce
 
     Example: [_veh] call HR_GRG_fnc_isFuelSource;
 
@@ -21,7 +21,7 @@
 params [ ["_vehicle", objNull, [objNull]] ];
 if (isNull _vehicle) exitWith {false};
 
-if (hasAce) then { //Ace
+if (A3A_hasAce) then { //Ace
     private _vehCfg = configFile >> "CfgVehicles" >> typeOf _vehicle;
     _vehicle getVariable ["ace_refuel_currentFuelCargo", getNumber (_vehCfg >> "ace_refuel_fuelCargo")] > 0;
 } else { //Vanilla

--- a/A3-Antistasi/Garage/Extras/fn_isRepairSource.sqf
+++ b/A3-Antistasi/Garage/Extras/fn_isRepairSource.sqf
@@ -12,7 +12,7 @@
     Scope: Any
     Environment: Any
     Public: Yes
-    Dependencies: <Bool>hasAce
+    Dependencies: <Bool> A3A_hasAce
 
     Example: [_veh] call HR_GRG_fnc_isRepairSource;
 
@@ -21,7 +21,7 @@
 params [ ["_vehicle", objNull, [objNull]] ];
 if (isNull _vehicle) exitWith {false};
 
-if (hasAce) then {
+if (A3A_hasAce) then {
     private _value = _vehicle getVariable ["ACE_isRepairVehicle", getNumber (configFile >> "CfgVehicles" >> typeOf _vehicle >> "ace_repair_canRepair")];
     _value in [1, true];
 } else {

--- a/A3-Antistasi/Garage/Extras/fn_reloadExtras.sqf
+++ b/A3-Antistasi/Garage/Extras/fn_reloadExtras.sqf
@@ -92,7 +92,6 @@ lbSort _ctrl;
 
 //animations
 private _ctrl = _disp displayCtrl HR_GRG_IDC_ExtraAnim;
-private _anims = _customisation#1;
 lbClear _ctrl;
 {
     _configName = configname _x;
@@ -106,8 +105,8 @@ lbClear _ctrl;
     };
 } foreach (configProperties [(configfile >> "CfgVehicles" >> _class >> "animationSources"),"isclass _x",true]);
 lbSort _ctrl;
-HR_GRG_curAnims = _anims;
 
+HR_GRG_curAnims = _customisation#1;
 [HR_GRG_previewVeh, HR_GRG_curTexture, HR_GRG_curAnims] call BIS_fnc_initVehicle;
 
 //update source panel

--- a/A3-Antistasi/Garage/Extras/fn_reloadExtras.sqf
+++ b/A3-Antistasi/Garage/Extras/fn_reloadExtras.sqf
@@ -112,25 +112,28 @@ HR_GRG_curAnims = _anims;
 
 //update source panel
 private _ctrl = _disp displayCtrl HR_GRG_IDC_SourcePanelAmmo;
-_ctrl ctrlSetStructuredText composeText ["   ", image RearmIcon, " ", image (checkboxTextures select HR_GRG_hasAmmoSource)];
+_ctrl ctrlSetStructuredText composeText ["   ", image RearmIcon, " ", image (checkboxTextures select (HR_GRG_hasAmmoSource && !HR_GRG_ServiceDisabled_Rearm))];
 _ctrl ctrlSetTooltip ([
     localize "STR_HR_GRG_SourcePanel_toolTip_Ammo_Unavailable"
     , localize "STR_HR_GRG_SourcePanel_toolTip_Ammo_Available"
-] select HR_GRG_hasAmmoSource);
+    , localize "STR_HR_GRG_SourcePanel_toolTip_Ammo_Disabled"
+] select (if (HR_GRG_ServiceDisabled_Rearm) then {2} else {HR_GRG_hasAmmoSource}));
 
 private _ctrl = _disp displayCtrl HR_GRG_IDC_SourcePanelFuel;
-_ctrl ctrlSetStructuredText composeText ["   ", image RefuelIcon, " ", image (checkboxTextures select HR_GRG_hasFuelSource)];
+_ctrl ctrlSetStructuredText composeText ["   ", image RefuelIcon, " ", image (checkboxTextures select (HR_GRG_hasFuelSource && !HR_GRG_ServiceDisabled_Refuel))];
 _ctrl ctrlSetTooltip ([
     localize "STR_HR_GRG_SourcePanel_toolTip_Fuel_Unavailable"
     , localize "STR_HR_GRG_SourcePanel_toolTip_Fuel_Available"
-] select HR_GRG_hasFuelSource);
+    , localize "STR_HR_GRG_SourcePanel_toolTip_Fuel_Disabled"
+] select (if (HR_GRG_ServiceDisabled_Refuel) then {2} else {HR_GRG_hasFuelSource}));
 
 private _ctrl = _disp displayCtrl HR_GRG_IDC_SourcePanelRepair;
-_ctrl ctrlSetStructuredText composeText ["   ", image RepairIcon, " ", image (checkboxTextures select HR_GRG_hasRepairSource)];
+_ctrl ctrlSetStructuredText composeText ["   ", image RepairIcon, " ", image (checkboxTextures select (HR_GRG_hasRepairSource && !HR_GRG_ServiceDisabled_Repair))];
 _ctrl ctrlSetTooltip ([
     localize "STR_HR_GRG_SourcePanel_toolTip_Repair_Unavailable"
     , localize "STR_HR_GRG_SourcePanel_toolTip_Repair_Available"
-] select HR_GRG_hasRepairSource);
+    , localize "STR_HR_GRG_SourcePanel_toolTip_Repair_Disabled"
+] select (if (HR_GRG_ServiceDisabled_Repair) then {2} else {HR_GRG_hasRepairSource}));
 
 if (isNull HR_GRG_previewVeh) exitWith {};
 //update info panel

--- a/A3-Antistasi/Garage/Extras/fn_reloadExtras.sqf
+++ b/A3-Antistasi/Garage/Extras/fn_reloadExtras.sqf
@@ -12,7 +12,7 @@
     Scope: Clients
     Environment: Any
     Public: [No]
-    Dependencies:
+    Dependencies: A3A_hasAce
 
     Example: [true] call HR_GRG_fnc_reloadExtras;
 
@@ -192,7 +192,7 @@ if (isNil "_nodes") then {
 if (_nodes isEqualType 0) then {_nodes = []};
 private _cargoCapacity = count _nodes;
 private _availableCapacity = _cargoCapacity - HR_GRG_usedCapacity;
-private _aceCargo = if (hasAce) then {
+private _aceCargo = if (A3A_hasAce) then {
     composeText [lineBreak, "    ", localize "STR_HR_GRG_InfoPanel_AceCargo"," ", str cfgAceCargo(_class)]
 } else {""};
 

--- a/A3-Antistasi/Garage/Extras/fn_reloadExtras.sqf
+++ b/A3-Antistasi/Garage/Extras/fn_reloadExtras.sqf
@@ -31,8 +31,7 @@ private _vehNodes = [HR_GRG_previewVeh] call A3A_fnc_logistics_getVehicleNodes;
 if (_vehNodes isEqualType []) then {
     private _capacity = count _vehNodes;
     {
-        _static = (HR_GRG_Vehicles#4) get _x;
-        _static params ["_displayName", "_staticClass", "_lockedUID", "_checkedOut"];
+        _y params ["_displayName", "_staticClass", "_lockedUID", "_checkedOut"];
 
         private _block =false;
         if !(_lockedUID in ["", HR_GRG_PlayerUID]) then {_block = true};
@@ -65,7 +64,7 @@ if (_vehNodes isEqualType []) then {
             _ctrl lbSetTextRight [_index, format ["Size: %1", _type]];
             Trace_4("Mount Added to list | Class: %1 | UID: %2 | Checked: %3 | Size: %4", _staticClass, _x, (_checkedOut isEqualTo HR_GRG_PlayerUID), _type);
         };
-    } forEach (keys (HR_GRG_Vehicles#4));//statics
+    } forEach (HR_GRG_Vehicles#4);//statics
 };
 if (_reloadMounts) then { [] call HR_GRG_fnc_reloadMounts };
 

--- a/A3-Antistasi/Garage/StatePreservation/fn_setAmmoData.sqf
+++ b/A3-Antistasi/Garage/StatePreservation/fn_setAmmoData.sqf
@@ -41,7 +41,7 @@
 */
 params ["_vehicle", "_ammoData"];
 if !(local _vehicle) exitWith {};
-if (HR_GRG_hasAmmoSource) exitWith {};
+if (HR_GRG_hasAmmoSource && !HR_GRG_ServiceDisabled_Rearm) exitWith {};
 private _weaponData = _ammoData select {!(_x#0)};
 private _pylonData = _ammoData - _weaponData;
 

--- a/A3-Antistasi/Garage/StatePreservation/fn_setDamage.sqf
+++ b/A3-Antistasi/Garage/StatePreservation/fn_setDamage.sqf
@@ -25,10 +25,10 @@
 params ["_vehicle", "_dmgStats"];
 if !(local _vehicle) exitWith {};
 _dmgStats params [["_dmg",0,[0]], ["_hitDmg", [[],[]], [[]]], ["_repairCargo", -1, [0]]];
-_vehicle setDamage ([_dmg,0] select HR_GRG_hasRepairSource);
+_vehicle setDamage ([_dmg,0] select (HR_GRG_hasRepairSource && !HR_GRG_ServiceDisabled_Repair));
 for "_i" from 0 to count (_hitDmg#1) - 1 do {
     private _hit = _hitDmg#0#_i;
     private _dmg = _hitDmg#1#_i;
-    _vehicle setHit [_hit, [_dmg, 0] select HR_GRG_hasRepairSource, false];
+    _vehicle setHit [_hit, [_dmg, 0] select (HR_GRG_hasRepairSource && !HR_GRG_ServiceDisabled_Repair), false];
 };
 _vehicle setRepairCargo _repairCargo;

--- a/A3-Antistasi/Garage/StatePreservation/fn_setFuel.sqf
+++ b/A3-Antistasi/Garage/StatePreservation/fn_setFuel.sqf
@@ -25,7 +25,7 @@
 params ["_vehicle", "_fuelStats"];
 if !(local _vehicle) exitWith {};
 _fuelStats params [["_fuel",0, [0]], ["_fuelCargo",-1,[0]], ["_aceFuel",-2,[0]]];
-_vehicle setFuel ([_fuel, 1] select HR_GRG_hasFuelSource);
+_vehicle setFuel ([_fuel, 1] select (HR_GRG_hasFuelSource && !HR_GRG_ServiceDisabled_Refuel));
 _vehicle setFuelCargo _fuelCargo;
 if (_aceFuel > -2) then { // my nill indicator
     _vehicle setVariable ["ace_refuel_currentFuelCargo", _aceFuel, true];

--- a/A3-Antistasi/Garage/config.inc
+++ b/A3-Antistasi/Garage/config.inc
@@ -44,6 +44,9 @@ HR_GRG_VehCap = { HR_GRG_PoolBase + warTier * HR_GRG_PoolIncr };
 
 //Pylon config
 if (isNil "HR_GRG_Pylons_Enabled") then { HR_GRG_Pylons_Enabled = true }; //can be overwritten by CBA settings
+if (isNil "HR_GRG_ServiceDisabled_Rearm") then {HR_GRG_ServiceDisabled_Rearm = false};
+if (isNil "HR_GRG_ServiceDisabled_Refuel") then {HR_GRG_ServiceDisabled_Refuel = false};
+if (isNil "HR_GRG_ServiceDisabled_Repair") then {HR_GRG_ServiceDisabled_Repair = false};
 
 //camo blacklist (display name, case sensitive)
 HR_GRG_blackListCamo = ["IDAP"];
@@ -62,6 +65,17 @@ if (isClass (configfile >> "CBA_Extended_EventHandlers")) then {
 
     ["HR_GRG_Pylons_Enabled", "CHECKBOX", ["Allow pylon editing", "Allows player to configure pylons in the garage"], [HR_GRG_Prefix,"Garage"], true, true, {
         HR_GRG_Pylons_Enabled = _this;
+    }] call CBA_fnc_addSetting;
+
+    //Service disablers
+    ["HR_GRG_ServiceDisabled_Rearm", "CHECKBOX", ["Disable garage rearm feature", "Prevent vehicles from being rearmed on ungarage"], [HR_GRG_Prefix,"Garage"], false, true, {
+        HR_GRG_ServiceDisabled_Rearm = _this;
+    }] call CBA_fnc_addSetting;
+    ["HR_GRG_ServiceDisabled_Refuel", "CHECKBOX", ["Disable garage refuel feature", "Prevent vehicles from being refueled on ungarage"], [HR_GRG_Prefix,"Garage"], false, true, {
+        HR_GRG_ServiceDisabled_Refuel = _this;
+    }] call CBA_fnc_addSetting;
+    ["HR_GRG_ServiceDisabled_Repair", "CHECKBOX", ["Disable garage repair feature", "Prevent vehicles from being repaired on ungarage"], [HR_GRG_Prefix,"Garage"], false, true, {
+        HR_GRG_ServiceDisabled_Repair = _this;
     }] call CBA_fnc_addSetting;
 
     ["HR_GRG_PoolBase", "SLIDER", ["Base Capacity", "Garage base capacity"], [HR_GRG_Prefix,"Garage"], [0, 50, HR_GRG_PoolBase, 0], true, {

--- a/A3-Antistasi/Garage/fn_addVehicle.sqf
+++ b/A3-Antistasi/Garage/fn_addVehicle.sqf
@@ -92,10 +92,11 @@ private _lockName = if (_locking) then { name _player } else { "" };
     detach _x;
     if (_x isKindOf "StaticWeapon") then {
         private _stateData = [_x] call HR_GRG_fnc_getState;
+        private _customisation = [_x] call BIS_fnc_getVehicleCustomization;
         if (_x in staticsToSave) then {staticsToSave = staticsToSave - [_x]; publicVariable "staticsToSave"};
         deleteVehicle _x;
         private _vehUID = [] call HR_GRG_fnc_genVehUID;
-        (HR_GRG_Vehicles#4) set [_vehUID, [cfgDispName(typeOf _x), typeOf _x, _lockUID, "", _stateData, _lockName]];
+        (HR_GRG_Vehicles#4) set [_vehUID, [cfgDispName(typeOf _x), typeOf _x, _lockUID, "", _stateData, _lockName, _customisation]];
         Info_5("By: %1 [%2] | Type: %3 | Vehicle ID: %4 | Lock: %5", name _player, getPlayerUID _player, cfgDispName(typeOf _x), _vehUID, _locking );
     };
 } forEach attachedObjects _vehicle;
@@ -107,6 +108,7 @@ private _source = [
 ];
 private _sourceIndex = _source find true;
 private _stateData = [_vehicle] call HR_GRG_fnc_getState;
+private _customisation = [_vehicle] call BIS_fnc_getVehicleCustomization;
 
 [_vehicle,true] call A3A_fnc_empty;
 if (_vehicle in staticsToSave) then {staticsToSave = staticsToSave - [_vehicle]; publicVariable "staticsToSave"};
@@ -114,7 +116,7 @@ if (_vehicle in reportedVehs) then {reportedVehs = reportedVehs - [_vehicle]; pu
 
 deleteVehicle _vehicle;
 private _vehUID = [] call HR_GRG_fnc_genVehUID;
-(HR_GRG_Vehicles#_cat) set [_vehUID, [cfgDispName(_class), _class, _lockUID, "", _stateData, _lockName]];
+(HR_GRG_Vehicles#_cat) set [_vehUID, [cfgDispName(_class), _class, _lockUID, "", _stateData, _lockName, _customisation]];
 if (_sourceIndex != -1) then {
     (HR_GRG_Sources#_sourceIndex) pushBack _vehUID;
     [_sourceIndex] call HR_GRG_fnc_declairSources;

--- a/A3-Antistasi/Garage/fn_addVehicle.sqf
+++ b/A3-Antistasi/Garage/fn_addVehicle.sqf
@@ -28,9 +28,7 @@ FIX_LINE_NUMBERS()
 if (isNil "HR_GRG_Vehicles") then {
     if (isServer) then {[] call HR_GRG_fnc_initServer} else {[] remoteExec ["HR_GRG_fnc_initServer", 2]};
 };
-
 private _class = typeOf _vehicle;
-private _cat = [_class] call HR_GRG_fnc_getCatIndex;
 
 //LTC refund
 if (_class in [NATOSurrenderCrate, CSATSurrenderCrate]) exitWith {
@@ -45,6 +43,7 @@ if (_class in [NATOSurrenderCrate, CSATSurrenderCrate]) exitWith {
 if (isNull _vehicle) exitWith { [localize "STR_HR_GRG_Feedback_addVehicle_Null"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
 if (!alive _vehicle) exitWith { [localize "STR_HR_GRG_Feedback_addVehicle_Destroyed"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
 if (locked _vehicle > 1) exitWith { [localize "STR_HR_GRG_Feedback_addVehicle_Locked"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
+private _cat = [_class] call HR_GRG_fnc_getCatIndex;
 if (_cat isEqualTo -1) exitWith { [localize "STR_HR_GRG_Feedback_addVehicle_GenericFail"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
 
     //Towing

--- a/A3-Antistasi/Garage/fn_addVehicle.sqf
+++ b/A3-Antistasi/Garage/fn_addVehicle.sqf
@@ -87,6 +87,7 @@ if (
 
 //add vehicle
 private _locking = if (_lockUID isEqualTo "") then {false} else {true};
+private _lockName = if (_locking) then { name _player } else { "" };
 {
     detach _x;
     if (_x isKindOf "StaticWeapon") then {
@@ -94,7 +95,7 @@ private _locking = if (_lockUID isEqualTo "") then {false} else {true};
         if (_x in staticsToSave) then {staticsToSave = staticsToSave - [_x]; publicVariable "staticsToSave"};
         deleteVehicle _x;
         private _vehUID = [] call HR_GRG_fnc_genVehUID;
-        (HR_GRG_Vehicles#4) set [_vehUID, [cfgDispName(typeOf _x), typeOf _x, _lockUID, "", _stateData]];
+        (HR_GRG_Vehicles#4) set [_vehUID, [cfgDispName(typeOf _x), typeOf _x, _lockUID, "", _stateData, _lockName]];
         Info_5("By: %1 [%2] | Type: %3 | Vehicle ID: %4 | Lock: %5", name _player, getPlayerUID _player, cfgDispName(typeOf _x), _vehUID, _locking );
     };
 } forEach attachedObjects _vehicle;
@@ -113,7 +114,7 @@ if (_vehicle in reportedVehs) then {reportedVehs = reportedVehs - [_vehicle]; pu
 
 deleteVehicle _vehicle;
 private _vehUID = [] call HR_GRG_fnc_genVehUID;
-(HR_GRG_Vehicles#_cat) set [_vehUID, [cfgDispName(_class), _class, _lockUID, "", _stateData]];
+(HR_GRG_Vehicles#_cat) set [_vehUID, [cfgDispName(_class), _class, _lockUID, "", _stateData, _lockName]];
 if (_sourceIndex != -1) then {
     (HR_GRG_Sources#_sourceIndex) pushBack _vehUID;
     [_sourceIndex] call HR_GRG_fnc_declairSources;

--- a/A3-Antistasi/Garage/fn_addVehiclesByClass.sqf
+++ b/A3-Antistasi/Garage/fn_addVehiclesByClass.sqf
@@ -31,7 +31,7 @@ private _cfg = configFile >> "CfgVehicles";
     private _cat = [_x] call HR_GRG_fnc_getCatIndex;
     if (_cat < 0) then {Info_1("Unsoported category: %1", str _x); continue};
     private _vehUID = [] call HR_GRG_fnc_genVehUID;
-    (HR_GRG_Vehicles#_cat) set [_vehUID, [cfgDispName(_x), _x, _lockUID, "", [[1,-1,nil],[0,[[],[]],-1],[]]]];
+    (HR_GRG_Vehicles#_cat) set [_vehUID, [cfgDispName(_x), _x, _lockUID, "", [[1,-1,nil],[0,[[],[]],-1],[]], ""]];
     Info_2("Vehicle added to garage: %1 | Lock UID: %2", str _x, str _lockUID);
 } forEach _vehicles;
 true

--- a/A3-Antistasi/Garage/fn_addVehiclesByClass.sqf
+++ b/A3-Antistasi/Garage/fn_addVehiclesByClass.sqf
@@ -31,7 +31,7 @@ private _cfg = configFile >> "CfgVehicles";
     private _cat = [_x] call HR_GRG_fnc_getCatIndex;
     if (_cat < 0) then {Info_1("Unsoported category: %1", str _x); continue};
     private _vehUID = [] call HR_GRG_fnc_genVehUID;
-    (HR_GRG_Vehicles#_cat) set [_vehUID, [cfgDispName(_x), _x, _lockUID, "", [[1,-1,nil],[0,[[],[]],-1],[]], ""]];
+    (HR_GRG_Vehicles#_cat) set [_vehUID, [cfgDispName(_x), _x, _lockUID, "", [[1,-1,nil],[0,[[],[]],-1],[]], "", [false, false]]];
     Info_2("Vehicle added to garage: %1 | Lock UID: %2", str _x, str _lockUID);
 } forEach _vehicles;
 true

--- a/A3-Antistasi/Garage/fn_getSaveData.sqf
+++ b/A3-Antistasi/Garage/fn_getSaveData.sqf
@@ -48,11 +48,9 @@ private _sources = [+(HR_GRG_Sources#0),+(HR_GRG_Sources#1),+(HR_GRG_Sources#2)]
 
 //correct some data to savable state
 {
-    private _cat = _x;
     {
-        private _veh = _cat get _x;
-        _veh set [3, ""]; //remove checkouts
-    } forEach (keys _cat);
+        _y set [3, ""]; //remove checkouts
+    } forEach _x;
 } forEach _garage;
 
 Trace("Save data generated");

--- a/A3-Antistasi/Garage/fn_initServer.sqf
+++ b/A3-Antistasi/Garage/fn_initServer.sqf
@@ -30,6 +30,20 @@ if (isNil "HR_GRG_Vehicles") then {[] call HR_GRG_fnc_loadSaveData};
 if (isNil "HR_GRG_Users") then {HR_GRG_Users = []};
 [] call HR_GRG_fnc_validateGarage;
 
+//Handle improper exit of garage (crash)
+addMissionEventHandler ["PlayerDisconnected", {
+    private _owner = param [4, -1];
+    if (_owner isNotEqualTo -1) then {
+        private _UID = param [1,""];
+        Error_2("User disconnected while in garage: %1 [%2]", _this select 2, _UID); //name, UID
+        [_owner] call HR_GRG_fnc_removeUser;
+
+        private _recipients = +HR_GRG_Users;
+        _recipients pushBackUnique 2;
+        [_UID] remoteExecCall ["HR_GRG_fnc_releaseAllVehicles",_recipients];
+    };
+}];
+
 //mark init complete
 HR_GRG_Init = true;
 publicVariable "HR_GRG_Init";

--- a/A3-Antistasi/Garage/fn_initServer.sqf
+++ b/A3-Antistasi/Garage/fn_initServer.sqf
@@ -35,7 +35,6 @@ addMissionEventHandler ["PlayerDisconnected", {
     private _owner = param [4, -1];
     if (_owner isNotEqualTo -1) then {
         private _UID = param [1,""];
-        Error_2("User disconnected while in garage: %1 [%2]", _this select 2, _UID); //name, UID
         [_owner] call HR_GRG_fnc_removeUser;
 
         private _recipients = +HR_GRG_Users;

--- a/A3-Antistasi/Stringtable.xml
+++ b/A3-Antistasi/Stringtable.xml
@@ -3831,9 +3831,15 @@
             <Original>Cant mount static</Original>
             <English>Cant mount static</English>
         </Key>
+        <Key ID="STR_HR_GRG_Feedback_checkedOutToolTip">
+            <!-- name is appended on at the start with a spcae in between-->
+            <Original>is looking at this vehicle.</Original>
+            <English>is looking at this vehicle.</English>
+        </Key>
         <Key ID="STR_HR_GRG_Feedback_LockedToolTip">
-            <Original>This vehicle is locked by another player</Original>
-            <English>This vehicle is locked by another player</English>
+            <!-- name is appended on at the end with a spcae in between-->
+            <Original>Vehicle is locked by</Original>
+            <English>Vehicle is locked by</English>
         </Key>
         <Key ID="STR_HR_GRG_Feedback_CP_Rotation">
             <!--Keybinds are hardcoded to key DIK codes: DIK_E, DIK_Q, DIK_ESCAPE, DIK_RETURN, and DIK_SPACE-->

--- a/A3-Antistasi/Stringtable.xml
+++ b/A3-Antistasi/Stringtable.xml
@@ -3680,24 +3680,36 @@
             <English>Vehicles will be rearmed when ungaraged</English>
         </Key>
         <Key ID="STR_HR_GRG_SourcePanel_toolTip_Ammo_Unavailable">
-            <Original>Vehicles won't be rearmed when ungaraged</Original>
-            <English>Vehicles won't be rearmed when ungaraged</English>
+            <Original>Vehicles won't be rearmed when ungaraged as the garage lacks a ammo source</Original>
+            <English>Vehicles won't be rearmed when ungaraged as the garage lacks a ammo source</English>
+        </Key>
+        <Key ID="STR_HR_GRG_SourcePanel_toolTip_Ammo_Disabled">
+            <Original>Rearm disabled by server</Original>
+            <English>Rearm disabled by server</English>
         </Key>
         <Key ID="STR_HR_GRG_SourcePanel_toolTip_Fuel_Available">
             <Original>Vehicles will be refueled when ungaraged</Original>
             <English>Vehicles will be refueled when ungaraged</English>
         </Key>
         <Key ID="STR_HR_GRG_SourcePanel_toolTip_Fuel_Unavailable">
-            <Original>Vehicles won't be refueled when ungaraged</Original>
-            <English>Vehicles won't be refueled when ungaraged</English>
+            <Original>Vehicles won't be refueled when ungaraged as the garage lacks a fuel source</Original>
+            <English>Vehicles won't be refueled when ungaraged as the garage lacks a fuel source</English>
+        </Key>
+        <Key ID="STR_HR_GRG_SourcePanel_toolTip_Fuel_Disabled">
+            <Original>Refuel disabled by server settings</Original>
+            <English>Refuel disabled by server settings</English>
         </Key>
         <Key ID="STR_HR_GRG_SourcePanel_toolTip_Repair_Available">
             <Original>Vehicles will be repaired when ungaraged</Original>
             <English>Vehicles will be repaired when ungaraged</English>
         </Key>
         <Key ID="STR_HR_GRG_SourcePanel_toolTip_Repair_Unavailable">
-            <Original>Vehicles won't be repaired when ungaraged</Original>
-            <English>Vehicles won't be repaired when ungaraged</English>
+            <Original>Vehicles won't be repaired when ungaraged as the garage lacks a repair source</Original>
+            <English>Vehicles won't be repaired when ungaraged as the garage lacks a repair source</English>
+        </Key>
+        <Key ID="STR_HR_GRG_SourcePanel_toolTip_Repair_Disabled">
+            <Original>Repair disabled by server settings</Original>
+            <English>Repair disabled by server settings</English>
         </Key>
         <Key ID="STR_HR_GRG_InfoPanel_isAmmoSource">
             <Original>Vehicle is an ammo source</Original>

--- a/A3-Antistasi/Stringtable.xml
+++ b/A3-Antistasi/Stringtable.xml
@@ -3772,6 +3772,10 @@
             <Original>You are not looking at a vehicle</Original>
             <English>You are not looking at a vehicle</English>
         </Key>
+        <Key ID="STR_HR_GRG_Feedback_confirm_NullSelection">
+            <Original>No vehicle selected</Original>
+            <English>No vehicle selected</English>
+        </Key>
         <Key ID="STR_HR_GRG_Feedback_addVehicle_SATow">
             <Original>You can't garage a Vehicle with your Tow Rope out or a Vehicle attached</Original>
             <English>You can't garage a Vehicle with your Tow Rope out or a Vehicle attached</English>

--- a/A3-Antistasi/Templates/NewTemplates/RHS/RHS_Logistics_Nodes.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/RHS/RHS_Logistics_Nodes.sqf
@@ -249,6 +249,8 @@ A3A_logistics_coveredVehicles append [
     , "rhsusf_M1078A1P2_B_WD_fmtv_usarmy" call A3A_fnc_classNameToModel
     , "rhsusf_M1078A1P2_B_M2_WD_fmtv_usarmy" call A3A_fnc_classNameToModel
     , "rhsusf_M1083A1P2_WD_fmtv_usarmy" call A3A_fnc_classNameToModel
+    , "rhsusf_M1083A1P2_B_WD_fmtv_usarmy" call A3A_fnc_classNameToModel
+    , "rhsusf_M1083A1P2_B_M2_WD_fmtv_usarmy" call A3A_fnc_classNameToModel
 ];
 
 //if you want a weapon to be loadable you need to add it to this as a array of [model, [blacklist specific vehicles]],

--- a/A3-Antistasi/functions/AI/fn_chooseSupport.sqf
+++ b/A3-Antistasi/functions/AI/fn_chooseSupport.sqf
@@ -197,9 +197,9 @@ switch (true) do
 };
 
 // Avoid making area attacks against friendlies, although "mistakes" can be made
-private _friendlyUnits = if (_side == Invaders) then { units Invaders } else { units Occupants + units civilian };
+private _friendlyUnits = if (side _group == Invaders) then { units Invaders } else { units Occupants + units civilian };
 private _friendlyCount = count (_friendlyUnits inAreaArray [getpos _enemy, 200, 200]);
-private _maxFriendlies = if (_side == Invaders) then { random [1, 2, 10] } else { random [0, 0, 5] };
+private _maxFriendlies = if (side _group == Invaders) then { random [1, 2, 10] } else { random [0, 0, 5] };
 
 if (_friendlyCount > _maxFriendlies) then
 {


### PR DESCRIPTION
Fixed `hasAce` missing the new prefix in new garage

## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information: Current bugs fixed:
- Wrong variable used in chooseSuport breaking support selection #1986 
- missing A3A_ prefix for hasAce var in new garage, breaking source detection and ace cargo info entry
- Added 2 Trucks to CoveredVehicles blacklist to prevent loading static weapons into them.

### Please specify which Issue this PR Resolves.
closes #1986 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes: Should not be merged before end of Testing Tuesday, and a chance to fix remaining bugs found before it is over.
