### PR TITLE
[Garage] Add Static Weapons to staticsToSave

### DIFF
--- a/A3-Antistasi/Garage/config.inc
+++ b/A3-Antistasi/Garage/config.inc
@@ -53,7 +53,9 @@ HR_GRG_blackListCamo = ["IDAP"];
 
 //proxies
 HR_GRG_fnc_Hint = { ["Garage",_this#0] call A3A_fnc_customHint };
-HR_GRG_fnc_vehInit = { [_this, TeamPlayer] call A3A_fnc_AIVEHinit; }; //is passed vehicle as _this
+HR_GRG_fnc_vehInit = { 
+    if (_this isKindOf "StaticWeapon") then {staticsToSave pushBack _this; publicVariable "staticsToSave"};
+    [_this, TeamPlayer] call A3A_fnc_AIVEHinit; }; //is passed vehicle as _this
 HR_GRG_onOpenEvent = { player setCaptive false; };
 
 //CBA settings


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
This is missing from the Garage currently.
This is already in #1998 but that will be Merged later, so to make sure Statics will still work this is for Unstable.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Buy/Place a Static weapon, Check StaticsToSave in the console, it should return the Statics.
********************************************************
Notes:
