### PR TITLE
Fix damage preservation and ltc refund

### DIFF
--- a/A3-Antistasi/Garage/StatePreservation/fn_getDamage.sqf
+++ b/A3-Antistasi/Garage/StatePreservation/fn_getDamage.sqf
@@ -25,10 +25,8 @@
 params ["_vehicle"];
 private _dmg = damage _vehicle min 0.89;
 private _hitPointDamage = getAllHitPointsDamage _vehicle;
-if (_hitPointDamage isEqualTo []) then {
-    _hitPointDamage = [[],[]];
-} else {
-    _hitPointDamage = [_hitPointDamage#1, _hitPointDamage#2];
+if !(_hitPointDamage isEqualTo []) then { //ensure it has hitpoints
+    _hitPointDamage = _hitPointDamage#2
 };
 private _repairCargo = getRepairCargo _vehicle;
 

--- a/A3-Antistasi/Garage/StatePreservation/fn_setDamage.sqf
+++ b/A3-Antistasi/Garage/StatePreservation/fn_setDamage.sqf
@@ -24,11 +24,12 @@
 */
 params ["_vehicle", "_dmgStats"];
 if !(local _vehicle) exitWith {};
-_dmgStats params [["_dmg",0,[0]], ["_hitDmg", [[],[]], [[]]], ["_repairCargo", -1, [0]]];
+_dmgStats params [["_dmg",0,[0]], ["_hitDmg", [], [[]]], ["_repairCargo", -1, [0]]];
 _vehicle setDamage ([_dmg,0] select (HR_GRG_hasRepairSource && !HR_GRG_ServiceDisabled_Repair));
-for "_i" from 0 to count (_hitDmg#1) - 1 do {
-    private _hit = _hitDmg#0#_i;
-    private _dmg = _hitDmg#1#_i;
-    _vehicle setHit [_hit, [_dmg, 0] select (HR_GRG_hasRepairSource && !HR_GRG_ServiceDisabled_Repair), false];
-};
+
+if (_hitDmg#0 isEqualTo []) then {_hitDmg = _hitDmg#1}; //temp compat while testing, old had selection names we no longer care about those
+{
+    _vehicle setHitIndex [_forEachIndex, [_dmg, 0] select (HR_GRG_hasRepairSource && !HR_GRG_ServiceDisabled_Repair), false];
+} forEach _hitDmg;
+
 _vehicle setRepairCargo _repairCargo;

--- a/A3-Antistasi/Garage/StatePreservation/fn_setDamage.sqf
+++ b/A3-Antistasi/Garage/StatePreservation/fn_setDamage.sqf
@@ -25,11 +25,12 @@
 params ["_vehicle", "_dmgStats"];
 if !(local _vehicle) exitWith {};
 _dmgStats params [["_dmg",0,[0]], ["_hitDmg", [], [[]]], ["_repairCargo", -1, [0]]];
-_vehicle setDamage ([_dmg,0] select (HR_GRG_hasRepairSource && !HR_GRG_ServiceDisabled_Repair));
+private _restoreState = [0,1] select (HR_GRG_hasRepairSource && !HR_GRG_ServiceDisabled_Repair);
+_vehicle setDamage ([_dmg, 0] # _restoreState);
 
 if (_hitDmg#0 isEqualTo []) then {_hitDmg = _hitDmg#1}; //temp compat while testing, old had selection names we no longer care about those
 {
-    _vehicle setHitIndex [_forEachIndex, [_dmg, 0] select (HR_GRG_hasRepairSource && !HR_GRG_ServiceDisabled_Repair), false];
+    _vehicle setHitIndex [_forEachIndex, [_x, 0] # _restoreState , false];
 } forEach _hitDmg;
 
 _vehicle setRepairCargo _repairCargo;

--- a/A3-Antistasi/Garage/fn_addVehicle.sqf
+++ b/A3-Antistasi/Garage/fn_addVehicle.sqf
@@ -34,7 +34,7 @@ private _class = typeOf _vehicle;
 if (_class in [NATOSurrenderCrate, CSATSurrenderCrate]) exitWith {
     _vehicle addMagazineCargoGlobal [unlockedMagazines#0,1];// so fnc_empty will delete the crate
     [_vehicle] spawn A3A_fnc_empty;
-    [10] call A3A_fnc_resourcesPlayer;
+    [10] remoteExec ["A3A_fnc_resourcesPlayer", _client];
     [localize "STR_HR_GRG_Feedback_addVehicle_LTC"]  remoteExec ["HR_GRG_fnc_Hint", _client];
     true
 };


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Fixed two bugs in new garage
1) vehicle preservation was slightly inaccurate due to lacking of selectionNames for each hit point.
- Fixed by changing from setHit to setHitIndex.

2) LTC refund would not give player back their money.
- Fixed by correcting resourcePlayer exec from  server to client.
    

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
