### PR TITLE
fixed wrong var name being used as target

### DIFF
--- a/A3-Antistasi/functions/Supports/fn_SUP_CASRoutine.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_CASRoutine.sqf
@@ -19,7 +19,7 @@ while {_sleepTime > 0} do
 //150 is more likely to be in the actual viewcone of a player
 private _spawnPos = (getMarkerPos _airport);
 private _strikePlane = createVehicle [_plane, _spawnPos, [], 0, "FLY"];
-_strikePlane setDir (_spawnPos getDir _supportObj);
+_strikePlane setDir (_spawnPos getDir _setupPos);
 
 //Put it in the sky
 _strikePlane setPosATL (_spawnPos vectorAdd [0, 0, 1000]);


### PR DESCRIPTION
when setting plane dir

## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    Fixed wrong var name used as target when setting cas plane direction

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
