### PR TITLE
fix incorrect remoteExec target in AILoadInfo

### DIFF
--- a/A3-Antistasi/functions/Base/fn_AILoadInfo.sqf
+++ b/A3-Antistasi/functions/Base/fn_AILoadInfo.sqf
@@ -1,5 +1,5 @@
 if (!isServer) exitWith {};
-if (count hcArray == 0) exitWith {[petros,"hint","No Headless Client Detected","AI Load Information"] remoteExec ["A3A_fnc_commsMP",theBoss]};
+if (count hcArray == 0) exitWith {[petros,"hint","No Headless Client Detected","AI Load Information"] remoteExec ["A3A_fnc_commsMP",remoteExecutedOwner]};
 _textX = "";
 
 for "_i" from 0 to (count hcArray) - 1 do
@@ -24,6 +24,6 @@ for "_i" from 0 to (count hcArray) - 1 do
 			};
 		};
 	} forEach allUnits select {alive _x};
-	_textX = format ["%1SDK: %2<br/>West:%3<br/>East:%4<br/>Civ:%5<br/>TOTAL:%6<br/><br/>",_textX,_indep,_west,_east,_civ,_total];
+	_textX = format ["%1Reb: %2<br/>Occ:%3<br/>Inv:%4<br/>Civ:%5<br/>TOTAL:%6<br/><br/>",_textX,_indep,_west,_east,_civ,_total];
 	};
-[petros, "hint", _textX, "AI Load Information"] remoteExec ["A3A_fnc_commsMP",theBoss];
+[petros, "hint", _textX, "AI Load Information"] remoteExec ["A3A_fnc_commsMP",remoteExecutedOwner];


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    Fixed AI load info always remoteExec the stats to the commander, when its available to more than just commander (commander & logged in admin)

### Please specify which Issue this PR Resolves.
closes #1990 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
