### PR TITLE
Member leash FF exemption and many improvements!

### DIFF
--- a/A3-Antistasi/MissionDescription/params.hpp
+++ b/A3-Antistasi/MissionDescription/params.hpp
@@ -134,7 +134,7 @@ class Params
     {
         title = "Max distance non members can be from the closest member or HQ (they will be teleported to HQ after some timeout)";
         values[] = {9999,4000,5000,6000,7000,8000,10000,16000,-1};  // 16000 is left as backwards compatibility
-        texts[] = {"Default (5 km)","4 Km","5 Km","6 Km","7 Km","8 Km","10 Km","16 Km","Unlimited"};
+        texts[] = {"Default (5 km)","4 km","5 km","6 km","7 km","8 km","10 km","16 km","Unlimited"};
         default = 9999;
     };
     class allowFT

--- a/A3-Antistasi/MissionDescription/params.hpp
+++ b/A3-Antistasi/MissionDescription/params.hpp
@@ -133,8 +133,8 @@ class Params
     class memberDistance
     {
         title = "Max distance non members can be from the closest member or HQ (they will be teleported to HQ after some timeout)";
-        values[] = {9999,4000,5000,6000,7000,8000,16000};
-        texts[] = {"Default (5km)","4 Kmts","5 Kmts","6 Kmts","7 Kmts","8 Kmts","Unlimited"};
+        values[] = {9999,4000,5000,6000,7000,8000,10000,16000,-1};  // 16000 is left as backwards compatibility
+        texts[] = {"Default (5 km)","4 Km","5 Km","6 Km","7 Km","8 Km","10 Km","16 Km","Unlimited"};
         default = 9999;
     };
     class allowFT

--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -471,6 +471,8 @@ class A3A
         class memberAdd {};
         class membersList {};
         class playerLeash {};
+        class playerLeashRefresh {};
+        class playerLeashCheckPosition {};
         class playerScoreAdd {};
         class promotePlayer {};
         class ranksMP {};

--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -470,6 +470,7 @@ class A3A
         class makePlayerBossIfEligible {};
         class memberAdd {};
         class membersList {};
+        class playerLeash {};
         class playerScoreAdd {};
         class promotePlayer {};
         class ranksMP {};

--- a/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -55,7 +55,7 @@ if (count _positionTel > 0) then
 	//if (_base in outpostsFIA) exitWith {hint "You cannot Fast Travel to roadblocks and watchposts"; openMap [false,false]};
 
 	if ([getMarkerPos _base,500] call A3A_fnc_enemyNearCheck) exitWith {["Fast Travel", "You cannot Fast Travel to an area under attack or with enemies in the surrounding"] call A3A_fnc_customHint; openMap [false,false]};
-	if !([_positionTel] call A3A_fnc_playerLeashCheckPosition) exitWith {systemChat "issued: noMembersNearbyWarning";["Fast Travel", format ["There are no members nearby the target location. You need to be within %1 km of HQ or a member.", ceil (memberDistance/1e3)]] call A3A_fnc_customHint;};
+	if !([_positionTel] call A3A_fnc_playerLeashCheckPosition) exitWith {["Fast Travel", format ["There are no members nearby the target location. You need to be within %1 km of HQ or a member.", ceil (memberDistance/1e3)]] call A3A_fnc_customHint;};
 
 	if (_positionTel distance getMarkerPos _base < 50) then
 		{

--- a/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -16,7 +16,7 @@ if (({isPlayer _x} count units _groupX > 1) and (_esHC)) exitWith {["Fast Travel
 
 if (player != player getVariable ["owner",player]) exitWith {["Fast Travel", "You cannot Fast Travel while you are controlling AI"] call A3A_fnc_customHint;};
 
-if (!isNil "A3A_FFPun_Jailed" && {(getPlayerUID player) in A3A_FFPun_Jailed}) exitWith {["Fast Travel", "Nope. Not happening."] call A3A_fnc_customHint;};
+if (!isNil "A3A_FFPun_Jailed" && {(getPlayerUID player) in A3A_FFPun_Jailed}) exitWith {["Fast Travel", "You cannot fast travel while being FF Punished."] call A3A_fnc_customHint;};
 
 _checkX = false;
 //_distanceX = 500 - (([_boss,false] call A3A_fnc_fogCheck) * 450);
@@ -55,6 +55,7 @@ if (count _positionTel > 0) then
 	//if (_base in outpostsFIA) exitWith {hint "You cannot Fast Travel to roadblocks and watchposts"; openMap [false,false]};
 
 	if ([getMarkerPos _base,500] call A3A_fnc_enemyNearCheck) exitWith {["Fast Travel", "You cannot Fast Travel to an area under attack or with enemies in the surrounding"] call A3A_fnc_customHint; openMap [false,false]};
+	if !([_positionTel] call A3A_fnc_playerLeashCheckPosition) exitWith {systemChat "issued: noMembersNearbyWarning";["Fast Travel", format ["There are no members nearby the target location. You need to be within %1 km of HQ or a member.", ceil (memberDistance/1e3)]] call A3A_fnc_customHint;};
 
 	if (_positionTel distance getMarkerPos _base < 50) then
 		{
@@ -132,6 +133,7 @@ if (count _positionTel > 0) then
 		//if (!_esHC) then {sleep _distanceX};
 		if (!_esHC) then {disableUserInput false;cutText ["You arrived to destination","BLACK IN",1]} else {["Fast Travel", format ["Group %1 arrived to destination",groupID _groupX]] call A3A_fnc_customHint;};
 		if (_forcedX) then {forcedSpawn = forcedSpawn - [_base]};
+		[] call A3A_fnc_playerLeashRefresh;
 		sleep 5;
 		{_x allowDamage true} forEach units _groupX;
 		}

--- a/A3-Antistasi/functions/OrgPlayers/fn_playerLeash.sqf
+++ b/A3-Antistasi/functions/OrgPlayers/fn_playerLeash.sqf
@@ -19,61 +19,76 @@ Example:
 
     // Following snippet is used to debug after the game has initialised:
     membershipEnabled = true;
-    memberDistance = 100;
+    memberDistance = 1000;
     membersX deleteAt (membersX find getPlayerUID player);
     A3A_DEV_playerLeash_debug = true;
     [] spawn A3A_fnc_playerLeash;
 */
 
 #define INITIAL_COUNT_TIME 61
+private _countDown = INITIAL_COUNT_TIME;
 private _debugMode = !isNil "A3A_DEV_playerLeash_debug";
 
 // -1 is used to represent unlimited distance.
 if (memberDistance <= 0) exitWith {};
 
-_countX = INITIAL_COUNT_TIME;
+
+
 // Membership is rechecked in the case that a temporary membership is granted.
 while {!([player] call A3A_fnc_isMember) || _debugMode} do {
+    private _nearestLeashCentre = getPos player;  // Only 2D pos is evaluated. Default to player position when no members or ff punishment is the exemption.
+
     // A switch statement would require all the variables and lists used in the comparison to always be calculated.
     // By using sequential if-exits, the cheaper and frequently true checks can be done first.
     private _withinLeash = call {
-        // Check distance to HQ flag.
-        if (player distance2D getMarkerPos respawnTeamPlayer <= memberDistance) exitWith {true};
-
-        // If there are no members online, allow unlimited distance.
-        private _playerMembers = (call A3A_fnc_playableUnits) select {([_x] call A3A_fnc_isMember) and (side group _x == teamPlayer)};
-        if (count _playerMembers == 0 && !_debugMode) exitWith {true};
-
-        // Else find the closest member and check the distance.
-        _closestMember = [_playerMembers,player] call BIS_fnc_nearestPosition;
-        if (player distance2D _closestMember <= memberDistance) exitWith {true};
-
         // The player is being FF punished.
         if (!isNil "A3A_FFPun_Jailed" && {(getPlayerUID player) in A3A_FFPun_Jailed}) exitWith {true};
 
-        // No leash exemptions were found.
-        false;
+        // If there are no members online, allow unlimited distance.
+        private _playerMembers = call A3A_fnc_playableUnits select {[_x] call A3A_fnc_isMember};
+        if (count _playerMembers == 0 && !_debugMode) exitWith {true};
+
+
+        // By this point no leash exemptions were found.
+
+        private _leashCentres = [];
+        _leashCentres pushBack getMarkerPos respawnTeamPlayer;
+        _leashCentres append _playerMembers;
+
+        _nearestLeashCentre = [_leashCentres,player] call BIS_fnc_nearestPosition;
+        player distance2D _nearestLeashCentre <= memberDistance;  // Final return of whether the player is within leash
     };
 
     if (_withinLeash) then {
         // Reset timer.
-        _countX = INITIAL_COUNT_TIME;
+        _countDown = INITIAL_COUNT_TIME;
+        // Calculates the time of the next check based on radius and velocity in any direction.
+        private _distanceToEdge =  (memberDistance - (player distance2D _nearestLeashCentre));
+        // 100km/h is an offroads' top speed on average terrain.
+        private _velocity = (speed player max 100) / 3.6;  // Convert Km/h to m/s
+        private _nextLeashCheck = 0.75 * _distanceToEdge / _velocity;  // Distance is checked at 75% to accommodate deviation from expected velocity and position.
+
         if (_debugMode) then {
-            [serverTime + 60] spawn {
-                while {_this#0 - serverTime > 0} do {
-                    systemChat ("Next player leash check in " + ((_this#0 - serverTime) toFixed 0) + " sec");
+            [_nextLeashCheck] spawn {
+                private _checkTime = serverTime + _this#0;
+                while {_checkTime - serverTime > 0} do {
+                    systemChat ("Leash check every " + (_this#0 toFixed 0) + " s; Next in " + ((_checkTime - serverTime) toFixed 0) + " s");
                     uiSleep 5;
                 };
             }
         };
-        uiSleep 60;
+        uiSleep _nextLeashCheck;
     } else {
         // Decrement timer.
-        _countX = _countX - 1;
+        _countDown = _countDown - 1;
         // Show player a countdown warning.
-        ["Maximum Distance", format ["You must be within %1 Km of the HQ marker or a member. <br/><br/> After <t color='#f0d498'>%2</t> seconds you will be teleported to your HQ. Driven vehicle will be included.", (memberDistance/1e3) toFixed 1, _countX]] call A3A_fnc_customHint;
+        private _retreatDistance = (player distance2D _nearestLeashCentre) - memberDistance;
+        private _compassDirections = ["N","NE","E","SE","S","SW","W","NW"];
+        private _retreatDirection = _compassDirections # ((player getDir _nearestLeashCentre) / 360 * count _compassDirections);
+
+        ["Comrade, we're losing contact!", format ["Retreat <t color='#f0d498'>%1 m %2</t>, within <t color='#f0d498'>%3 s</t>.<br/>Stay within %4 km of HQ or a member. Failure to comply will re-insert you at HQ.", ceil _retreatDistance, _retreatDirection, _countDown, ceil (memberDistance/1e3)]] call A3A_fnc_customHint;
         uiSleep 1;
-        if (_countX <= 0) then {
+        if (_countDown <= 0) then {
             // Teleport the vehicle as well to avoid it becoming stranded and unobtainable by the player.
             private _possibleVehicle = vehicle player;
             if (_possibleVehicle != player && (driver _possibleVehicle) == player) then {

--- a/A3-Antistasi/functions/OrgPlayers/fn_playerLeash.sqf
+++ b/A3-Antistasi/functions/OrgPlayers/fn_playerLeash.sqf
@@ -1,3 +1,23 @@
+/*
+Maintainer: Caleb Serafin
+    If the current player is not a member, it will loop every 60 seconds to check the distance from the player to HQ or any member.
+    However, if there are no members online, it will allow the player unlimited distance from HQ.
+    If there is a member online, it will warn the player and begin a 61 second countdown
+
+Return Value:
+    <ANY> Undefined
+
+Scope: Clients, Global Effect
+Environment: Scheduled
+Public: No (Only spawned once in initClient)
+Dependencies:
+    <SCALAR> memberDistance
+    <SIDE> teamPlayer
+
+Example:
+    [] spawn A3A_fnc_memberLeash;
+*/
+
 #define INITIAL_COUNT_TIME 61
 
 _countX = INITIAL_COUNT_TIME;

--- a/A3-Antistasi/functions/OrgPlayers/fn_playerLeash.sqf
+++ b/A3-Antistasi/functions/OrgPlayers/fn_playerLeash.sqf
@@ -15,54 +15,71 @@ Dependencies:
     <SIDE> teamPlayer
 
 Example:
-    [] spawn A3A_fnc_memberLeash;
+    [] spawn A3A_fnc_playerLeash;
+
+    // Following snippet is used to debug after the game has initialised:
+    membershipEnabled = true;
+    memberDistance = 100;
+    membersX deleteAt (membersX find getPlayerUID player);
+    A3A_DEV_playerLeash_debug = true;
+    [] spawn A3A_fnc_playerLeash;
 */
 
 #define INITIAL_COUNT_TIME 61
+private _debugMode = !isNil "A3A_DEV_playerLeash_debug";
+
+// -1 is used to represent unlimited distance.
+if (memberDistance <= 0) exitWith {};
 
 _countX = INITIAL_COUNT_TIME;
-while {!([player] call A3A_fnc_isMember)} do
-	{
-	_playerMembers = (call A3A_fnc_playableUnits) select {([_x] call A3A_fnc_isMember) and (side group _x == teamPlayer)};
-	if !(_playerMembers isEqualTo []) then
-		{
-		if (player distance2D (getMarkerPos respawnTeamPlayer) > memberDistance) then
-			{
-			_closestMember = [_playerMembers,player] call BIS_fnc_nearestPosition;
-			if (player distance2d _closestMember > memberDistance) then
-				{
-				_countX = _countX - 1;
-				}
-			else
-				{
-				_countX = INITIAL_COUNT_TIME;
-				};
-			}
-		else
-			{
-			_countX = INITIAL_COUNT_TIME;
-			};
-		}
-	else
-		{
-		_countX = INITIAL_COUNT_TIME;
-		};
-	if (_countX != INITIAL_COUNT_TIME) then
-		{
-		["Member Distance", format ["You have to get closer to the HQ or the closest server member in %1 seconds. <br/><br/> After this timeout you will be teleported to your HQ", _countX]] call A3A_fnc_customHint;
-		sleep 1;
-		if (_countX == 0) then
-			{
-			private _possibleVehicle = vehicle player;
-			if (_possibleVehicle != player && (driver _possibleVehicle) == player) then
-				{
-				[_possibleVehicle] call A3A_fnc_teleportVehicleToBase;
-				};
-			player setPos (getMarkerPos respawnTeamPlayer);
-			};
-		}
-	else
-		{
-		sleep 60;
-		};
-	};
+// Membership is rechecked in the case that a temporary membership is granted.
+while {!([player] call A3A_fnc_isMember) || _debugMode} do {
+    // A switch statement would require all the variables and lists used in the comparison to always be calculated.
+    // By using sequential if-exits, the cheaper and frequently true checks can be done first.
+    private _withinLeash = call {
+        // Check distance to HQ flag.
+        if (player distance2D getMarkerPos respawnTeamPlayer <= memberDistance) exitWith {true};
+
+        // If there are no members online, allow unlimited distance.
+        private _playerMembers = (call A3A_fnc_playableUnits) select {([_x] call A3A_fnc_isMember) and (side group _x == teamPlayer)};
+        if (count _playerMembers == 0 && !_debugMode) exitWith {true};
+
+        // Else find the closest member and check the distance.
+        _closestMember = [_playerMembers,player] call BIS_fnc_nearestPosition;
+        if (player distance2D _closestMember <= memberDistance) exitWith {true};
+
+        // The player is being FF punished.
+        if (!isNil "A3A_FFPun_Jailed" && {(getPlayerUID player) in A3A_FFPun_Jailed}) exitWith {true};
+
+        // No leash exemptions were found.
+        false;
+    };
+
+    if (_withinLeash) then {
+        // Reset timer.
+        _countX = INITIAL_COUNT_TIME;
+        if (_debugMode) then {
+            [serverTime + 60] spawn {
+                while {_this#0 - serverTime > 0} do {
+                    systemChat ("Next player leash check in " + ((_this#0 - serverTime) toFixed 0) + " sec");
+                    uiSleep 5;
+                };
+            }
+        };
+        uiSleep 60;
+    } else {
+        // Decrement timer.
+        _countX = _countX - 1;
+        // Show player a countdown warning.
+        ["Maximum Distance", format ["You must be within %1 Km of the HQ marker or a member. <br/><br/> After <t color='#f0d498'>%2</t> seconds you will be teleported to your HQ. Driven vehicle will be included.", (memberDistance/1e3) toFixed 1, _countX]] call A3A_fnc_customHint;
+        uiSleep 1;
+        if (_countX <= 0) then {
+            // Teleport the vehicle as well to avoid it becoming stranded and unobtainable by the player.
+            private _possibleVehicle = vehicle player;
+            if (_possibleVehicle != player && (driver _possibleVehicle) == player) then {
+                [_possibleVehicle] call A3A_fnc_teleportVehicleToBase;
+            };
+            player setPos (getMarkerPos respawnTeamPlayer);
+        };
+    };
+};

--- a/A3-Antistasi/functions/OrgPlayers/fn_playerLeashCheckPosition.sqf
+++ b/A3-Antistasi/functions/OrgPlayers/fn_playerLeashCheckPosition.sqf
@@ -1,0 +1,49 @@
+/*
+Maintainer: Caleb Serafin
+    Will check if the provided position is within a member leash.
+    It is recommended to use this before teleporting.
+
+Arguments:
+    <POS2D | POS3D> Position to check for player leash. Z-axis is ignored.
+    <POS2D | POS3D> The nearest leash center found (OPTIONAL). [DEFAULT = [0,0]]
+
+Return Value:
+    <BOOL> If the target zone is within a player leash.
+
+Scope: Any, Global Arguments
+Environment: Any
+Public: Yes
+Dependencies:
+    <SCALAR> memberDistance
+    <STRING> respawnTeamPlayer
+
+Example:
+    [_airport1] call A3A_fnc_playerLeashCheckPosition; // false
+
+    _nearestLeashCentre = [0,0];
+    [_coolMission,_nearestLeashCentre] call A3A_fnc_playerLeashCheckPosition;
+    _member = (_nearestLeashCentre nearEntities 99999) #0;
+    hint format ["You could ask %1 to support you at the mission.",name _member];
+*/
+params [
+    ["_targetPos", [0,0] ,[ [] ], [2,3]],
+    ["_out_nearestLeashCentre", [0,0], [ [] ], [2,3]]
+];
+private _debugMode = !isNil "A3A_DEV_playerLeash_debug";
+
+// -1 is used to represent unlimited distance.
+if (memberDistance <= 0 || !membershipEnabled) exitWith {true};
+
+private _leashCentres = [];
+_leashCentres pushBack getMarkerPos respawnTeamPlayer;
+private _memberPositions = (call A3A_fnc_playableUnits select {[_x] call A3A_fnc_isMember}) apply {getPos _x};
+_leashCentres append _memberPositions;
+
+_nearestLeashCentre = [_leashCentres,_targetPos] call BIS_fnc_nearestPosition;
+_out_nearestLeashCentre set [0,_nearestLeashCentre #0];
+_out_nearestLeashCentre set [1,_nearestLeashCentre #1];
+
+// If there are no members online, allow unlimited distance.
+if (count _memberPositions == 0 && !_debugMode) exitWith {true};
+// By this point no leash exemptions were found.
+_targetPos distance2D _nearestLeashCentre <= memberDistance;  // Final return of whether the player is within leash

--- a/A3-Antistasi/functions/OrgPlayers/fn_playerLeashRefresh.sqf
+++ b/A3-Antistasi/functions/OrgPlayers/fn_playerLeashRefresh.sqf
@@ -1,0 +1,13 @@
+/*
+Maintainer: Caleb Serafin
+    Forces playerLeash to re-evaluate from the player's current position.
+    This is NEEDED when fast travelling or teleporting.
+
+Scope: Clients, Local Effect
+Environment: Any
+Public: Yes
+
+Example:
+    [] remoteExec ["A3A_fnc_playerLeashRefresh",_teleportedPlayer];
+*/
+A3A_playerLeash_refresh = true;

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -327,7 +327,7 @@ if (isMultiplayer) then {
 			} else {
 				_nonMembers = {(side group _x == teamPlayer) and !([_x] call A3A_fnc_isMember)} count (call A3A_fnc_playableUnits);
 				if (_nonMembers >= (playableSlotsNumber teamPlayer) - bookedSlots) then {["memberSlots",false,1,false,false] call BIS_fnc_endMission};
-				if (memberDistance != 16000) then {[] spawn A3A_fnc_playerLeash};
+				[] spawn A3A_fnc_playerLeash;
 
 				["General Info", "Welcome Guest<br/><br/>You have joined this server as guest"] call A3A_fnc_customHint;
 			};

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -327,7 +327,7 @@ if (isMultiplayer) then {
 			} else {
 				_nonMembers = {(side group _x == teamPlayer) and !([_x] call A3A_fnc_isMember)} count (call A3A_fnc_playableUnits);
 				if (_nonMembers >= (playableSlotsNumber teamPlayer) - bookedSlots) then {["memberSlots",false,1,false,false] call BIS_fnc_endMission};
-				if (memberDistance != 16000) then {[] execVM "orgPlayers\nonMemberDistance.sqf"};
+				if (memberDistance != 16000) then {[] spawn A3A_fnc_playerLeash};
 
 				["General Info", "Welcome Guest<br/><br/>You have joined this server as guest"] call A3A_fnc_customHint;
 			};


### PR DESCRIPTION
## What type of PR is this.
* [x] Bug
* Change
* [x] Enhancement
### Changes
* Prevents players from getting too far away from leash before noticing. Reduces desk bangs and rage quites by 200%.
* Player leash provides immersive info. No more teleport magic and non member distance! Now comrade has to within contact range or else he will be "re-inserted" to HQ.
* Player leash no longer uses a 60 second refresh period. Rather it estimates how long the player could get out of the leash and bases the refresh time off that. This saves performace when near members and HQ; And provides fine accuracy when near the leash border.
* Player leash provides more info. Such as distance to HQ or member leash and what direction to retreat to. 
* Moved, renamed, and headered fn_playerLeash.
* Member leash exemption for FF Punishment.
* Player leash fast travel compatibility. Prevents fast travel if no members nearby. After successful fast travel, will rescan to set an appropriate rescan period.

### Please specify which Issue this PR Resolves.
closes https://github.com/official-antistasi-community/A3-Antistasi/issues/2003

### Please verify the following and ensure all checks are completed.

* [x] Have you loaded the mission in LAN host?
* [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
* Yes

### How can the changes be tested?
Either create a multiplay server with membership and atleast one member and non-member.

Or test locally with debug commands
```sqf
// Following snippet is used to debug as non-member after the game has initialised:
memberDistance = 1000;
membershipEnabled = true;
membersX deleteAt (membersX find getPlayerUID player);
A3A_DEV_playerLeash_debug = true;
[] spawn A3A_fnc_playerLeash;
```
Test Objectives
1. Player leash works when near HQ.
2. Playerleash works when near member.
3. Player leash does not pull players in FF punishment.
4. Player leash acts accuratly on the leash border. 
5. Player leash prevents Fast Travel to non member near zones.
6. Player leash still works accuratly immediatly after fast travel.

