### PR TITLE
🔧🛠 equipRebell give back their Tools 🛠🔧

### DIFF
--- a/A3-Antistasi/functions/REINF/fn_equipRebel.sqf
+++ b/A3-Antistasi/functions/REINF/fn_equipRebel.sqf
@@ -71,10 +71,13 @@ switch (true) do {
 		if (count unlockedAA > 0) then {
 			[_unit, selectRandom unlockedAA, 1] call _addWeaponAndMags;
 		};
+			_unit addItemToBackpack (selectRandom unlockedToolkits);
+			_unit addItemToBackpack (selectRandom unlockedMineDetectors);
 		// TODO: explosives. Not that they know what to do with them.
 	};
 	case (_unitClass in SDKEng): {
 		[_unit,unlockedRifles] call A3A_fnc_randomRifle;
+		_unit addItemToBackpack (selectRandom unlockedToolkits);
 	};
 	case (_unitClass in SDKMedic): {
 		[_unit,unlockedSMGs] call A3A_fnc_randomRifle;


### PR DESCRIPTION
Added UnlockedToolkits and MineDetectors to Engineers and Explosive Experts.

## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Due to my changes in https://github.com/official-antistasi-community/A3-Antistasi/commit/dd00cc782b804492b89388917e48e9a02e563401 Rebell Ai lost Toolkits and Medical Equipment.
This PR returns to Previous behaivior of EquipRebell with the difference that it uses UnlockedToolKits and UnlockedMineDetectors instead of the direct classes now.

### Please specify which Issue this PR Resolves.
closes #1929 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Buy Engineers and Explosive Specialists,
They should now get their Equipment if its unlocked (ToolKits are always unlocked).

```
//Resource and Money
[2000] call A3A_fnc_resourcesPlayer; 
[2000,25000] remoteExec ["A3A_fnc_resourcesFIA",2];
```

********************************************************
Notes:
