### PR TITLE
🔫 ADR DLC Funnies 🔫

### DIFF
--- a/A3-Antistasi/MissionDescription/params.hpp
+++ b/A3-Antistasi/MissionDescription/params.hpp
@@ -277,13 +277,6 @@ class Params
         texts[] = {"Default (No)","Yes","No"};
         default = 9999;
     };
-    class OfficialMod
-    {
-        title = "Allow ADR-97 DLC?";
-        values[] = {9999,1,0};
-        texts[] = {"Default (No)","Yes","No"};
-        default = 9999;
-    };
     class AoW
     {
         title = "Allow Art of War DLC?";

--- a/A3-Antistasi/functions/ModsAndDLC/fn_initDisabledMods.sqf
+++ b/A3-Antistasi/functions/ModsAndDLC/fn_initDisabledMods.sqf
@@ -12,7 +12,6 @@ if (!allowDLCOrange) then {_disabledMods pushBack "orange"};
 if (!allowDLCTanks) then {_disabledMods pushBack "tanks"};
 if (!allowDLCGlobMob) then {_disabledMods pushBack "gm"};
 if (!allowDLCEnoch) then {_disabledMods pushBack "enoch"};
-if (!allowDLCOfficialMod) then {_disabledMods pushBack "officialmod"};
 if (!allowDLCAoW) then {_disabledMods pushBack "aow"};
 if (!allowDLCVN) then {_disabledMods pushBack "vn"};
 

--- a/A3-Antistasi/functions/ModsAndDLC/fn_isModNameVanilla.sqf
+++ b/A3-Antistasi/functions/ModsAndDLC/fn_isModNameVanilla.sqf
@@ -10,4 +10,4 @@
 
 params ["_modName"];
 
-_modName == "" || { toLower _modName in (allDLCMods apply {toLower (_x#1)}) };
+_modName == "" || _modName == toLower "officialmod" || { toLower _modName in (allDLCMods apply {toLower (_x#1)}) };

--- a/A3-Antistasi/functions/init/fn_initParams.sqf
+++ b/A3-Antistasi/functions/init/fn_initParams.sqf
@@ -46,7 +46,6 @@ A3A_paramTable = [
     ["allowDLCTanks", "Tanks", ["server"], false],
     ["allowDLCGlobMob", "GlobMob", ["server"], false],
     ["allowDLCEnoch", "Enoch", ["server"], false],
-    ["allowDLCOfficialMod", "OfficialMod", ["server"], false],
     ["allowDLCAoW", "AoW", ["server"], false],
     ["allowDLCVN", "VN", [], true],
 


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
As it seems getLoadedModsInfo doesent find "officialmod" so the Weapons it adds can apear in non vanilla games if the DLC is enabled.

As the "DLC" is free Content. there is no reason to have a Parameter for it.
-----> Removed the Parameter and made sure that it will count as part of _itemIsVanilla

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Load the Mission with RHS,

```sqf
"SMG_03C_hex" in allweapons
```
This should be false, and True in Vanilla.
********************************************************
Notes:
