### PR TITLE
Added Time Span Since Last GC

### DIFF
--- a/A3-Antistasi/functions/Base/fn_garbageCleaner.sqf
+++ b/A3-Antistasi/functions/Base/fn_garbageCleaner.sqf
@@ -1,6 +1,8 @@
 #include "..\..\Includes\common.inc"
 FIX_LINE_NUMBERS()
-[petros,"hint","Deleting Garbage. Please wait", "Garbage Cleaner"] remoteExec ["A3A_fnc_commsMP", 0];
+// Do not localise timeSpan, it is broadcast to all connected clients.
+private _timeSinceLastGC = [[serverTime-A3A_lastGarbageCleanTime] call A3A_fnc_secondsToTimeSpan,0,0,false,2] call A3A_fnc_timeSpan_format;
+["Garbage Cleaner","Please wait for GC to finish.<br/>Last GC was " + _timeSinceLastGC + " ago."] remoteExec ["A3A_fnc_customHint", 0];
 Info("Cleaning garbage...");
 
 private _rebelSpawners = allUnits select { side group _x == teamPlayer && {_x getVariable ["spawner",false]} };
@@ -49,5 +51,7 @@ if (A3A_hasRHS) then {
 
 };
 
-[petros,"hint","Garbage deleted", "Garbage Cleaner"] remoteExec ["A3A_fnc_commsMP", 0];
+// Do not localise timeSpan, it is broadcast to all connected clients.
+["Garbage Cleaner","Garbage Deleted.<br/>Last GC was " + _timeSinceLastGC + " ago."] remoteExec ["A3A_fnc_customHint", 0];
+missionNamespace setVariable ["A3A_lastGarbageCleanTime",serverTime,true];
 Info("Garbage clean completed");

--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -440,7 +440,8 @@ mapX addAction ["Game Options", {
 		"<br/>Limited Fast Travel: "+ (["No","Yes"] select limitedFT) +
 		"<br/>AI Limit: "+ str maxUnits +
 		"<br/>Spawn Distance: "+ str distanceSPWN + "m" +
-		"<br/>Civilian Limit: "+ str civPerc
+		"<br/>Civilian Limit: "+ str civPerc +
+		"<br/>Time since GC: " + ([[serverTime-A3A_lastGarbageCleanTime] call A3A_fnc_secondsToTimeSpan,1,0,false,2,false,true] call A3A_fnc_timeSpan_format)
 	] call A3A_fnc_customHint;
 	CreateDialog "game_options";
 	nil;

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -112,6 +112,8 @@ DECLARE_SERVER_VAR(reportedVehs, []);
 server setVariable ["hr",8,true];
 //Initial faction money pool
 server setVariable ["resourcesFIA",1000,true];
+// Time of last garbage clean. Note: serverTime may not reset to zero if server was not restarted. Therefore, it should capture the time at start of mission.
+DECLARE_SERVER_VAR(A3A_lastGarbageCleanTime, serverTime);
 
 ////////////////////////////////////
 //     SERVER ONLY VARIABLES     ///


### PR DESCRIPTION
## What type of PR is this.
* Bug
* Change
3. [x] Enhancement

### What have you changed and why?
* Now, using the power of timeSpan, a one-line addition can format the time since last GC.
* This time is visible in `Game Options` (for Commanders and Admins) and `Garbage Cleaner`(For all players when in progress or finished.)
* Commanders want to know the time of the last GC to determine whether they should perform one or restart the server. There was no in-game Info/Feedback about when the last GC happened.
### Please specify which Issue this PR Resolves.
closes https://github.com/official-antistasi-community/A3-Antistasi/issues/1991

### Please verify the following and ensure all checks are completed.
1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
* Yes (Please provide further detail below.)

### How can the changes be tested?
1. Start Game
2. Check time since the last GC in `Game Options`.
3. Check again in `Game Options` to confirm that it is increasing.
4. Run a GC and confirm that the displayed number is still larger.
5. Check game options and see that number is much smaller.
6. Run GC and check that number is still much smaller.

![Game Options And Garbage Cleaner](https://user-images.githubusercontent.com/31820984/127169839-723529c2-e15a-436d-9226-7b6a7679876a.png)