### PR TITLE
Fast Travel checks membership before leashCheck.

### DIFF
--- a/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -55,7 +55,7 @@ if (count _positionTel > 0) then
 	//if (_base in outpostsFIA) exitWith {hint "You cannot Fast Travel to roadblocks and watchposts"; openMap [false,false]};
 
 	if ([getMarkerPos _base,500] call A3A_fnc_enemyNearCheck) exitWith {["Fast Travel", "You cannot Fast Travel to an area under attack or with enemies in the surrounding"] call A3A_fnc_customHint; openMap [false,false]};
-	if !([_positionTel] call A3A_fnc_playerLeashCheckPosition) exitWith {["Fast Travel", format ["There are no members nearby the target location. You need to be within %1 km of HQ or a member.", ceil (memberDistance/1e3)]] call A3A_fnc_customHint;};
+	if (!([player] call A3A_fnc_isMember) && {![_positionTel] call A3A_fnc_playerLeashCheckPosition}) exitWith {["Fast Travel", format ["There are no members nearby the target location. You need to be within %1 km of HQ or a member.", ceil (memberDistance/1e3)]] call A3A_fnc_customHint;};
 
 	if (_positionTel distance getMarkerPos _base < 50) then
 		{

--- a/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3-Antistasi/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -55,7 +55,7 @@ if (count _positionTel > 0) then
 	//if (_base in outpostsFIA) exitWith {hint "You cannot Fast Travel to roadblocks and watchposts"; openMap [false,false]};
 
 	if ([getMarkerPos _base,500] call A3A_fnc_enemyNearCheck) exitWith {["Fast Travel", "You cannot Fast Travel to an area under attack or with enemies in the surrounding"] call A3A_fnc_customHint; openMap [false,false]};
-	if (!([player] call A3A_fnc_isMember) && {![_positionTel] call A3A_fnc_playerLeashCheckPosition}) exitWith {["Fast Travel", format ["There are no members nearby the target location. You need to be within %1 km of HQ or a member.", ceil (memberDistance/1e3)]] call A3A_fnc_customHint;};
+	if (!([player] call A3A_fnc_isMember) && {!([_positionTel] call A3A_fnc_playerLeashCheckPosition)}) exitWith {["Fast Travel", format ["There are no members nearby the target location. You need to be within %1 km of HQ or a member.", ceil (memberDistance/1e3)]] call A3A_fnc_customHint;};
 
 	if (_positionTel distance getMarkerPos _base < 50) then
 		{


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
* Change
* Enhancement

### What have you changed and why?
Information:
* Fast Travel checks membership. If the player is a member, it skips the leash check.
* If this did not occur, members would be unable to fast travel to airports and HQ.

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
* Yes (Please provide further detail below.)

## How can the changes be tested?
### Debug Mode to test.
1. Without debug mode, you can FT to an airport as an alone player.
2. With debug  mode
```sqf
// Following snippet is used to debug as non-member after the game has initialised:
    memberDistance = 1000;
    membershipEnabled = true;
    membersX deleteAt (membersX find getPlayerUID player);
    A3A_DEV_playerLeash_debug = true;
    [] spawn A3A_fnc_playerLeash;
```
3. You cannot FT to the airport. The hintis sent to you that "There are no members nearby the 4. target location. You need to be within %1 km of HQ or a member."

### Long: 
1. Enable Member.
2. Be not a member.
3. Have a member join game.
4. Try FT to captured airport, no luck.
5. Member can FT to captured airport.
