### PR TITLE
removed the middle man, made the refund synchronous

### DIFF
--- a/A3-Antistasi/Garage/fn_addVehicle.sqf
+++ b/A3-Antistasi/Garage/fn_addVehicle.sqf
@@ -32,10 +32,9 @@ private _class = typeOf _vehicle;
 
 //LTC refund
 if (_class in [NATOSurrenderCrate, CSATSurrenderCrate]) exitWith {
-    _vehicle addMagazineCargoGlobal [unlockedMagazines#0,1];// so fnc_empty will delete the crate
-    [_vehicle] spawn A3A_fnc_empty;
+    [_vehicle,boxX,true] call A3A_fnc_ammunitionTransfer;
     [10] remoteExec ["A3A_fnc_resourcesPlayer", _client];
-    [localize "STR_HR_GRG_Feedback_addVehicle_LTC"]  remoteExec ["HR_GRG_fnc_Hint", _client];
+    [localize "STR_HR_GRG_Feedback_addVehicle_LTC"] remoteExec ["HR_GRG_fnc_Hint", _client];
     true
 };
 


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information: removed the middleman on ltc refunds, this makes it more reliable to transfer and then delete the crates. the transfer is now also synchronous so it should be act faster.
the middleman `A3A_fnc_empty` required the container to be not empty to transfer. hopefully by having a synchronous call to transfere and not have to worry about another function to not bail, the crates will be more leliabilly emptied and deleted.
    

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
