### PR TITLE
[Garage] Blacklist ADE Camos

### DIFF
--- a/A3-Antistasi/Garage/config.inc
+++ b/A3-Antistasi/Garage/config.inc
@@ -49,8 +49,7 @@ if (isNil "HR_GRG_ServiceDisabled_Refuel") then {HR_GRG_ServiceDisabled_Refuel =
 if (isNil "HR_GRG_ServiceDisabled_Repair") then {HR_GRG_ServiceDisabled_Repair = false};
 
 //camo blacklist (display name, case sensitive)
-HR_GRG_blackListCamo = ["IDAP"];
-
+HR_GRG_blackListCamo = ["IDAP", "African Desert Extremists", "African Desert Extremists 01", "African Desert Extremists 02", "African Desert Extremists Alt"];
 //proxies
 HR_GRG_fnc_Hint = { ["Garage",_this#0] call A3A_fnc_customHint };
 HR_GRG_fnc_vehInit = { 


### PR DESCRIPTION
## What type of PR is this.
1. [] Bug
2. [x] Change
3. [] Enhancement

### What have you changed and why?
Information:
Removed ADE Camos from Garage due to having a "jihadist flag" on their Camos, which could encourage stuff we don't want,

### Please specify which Issue this PR Resolves.
closes nothing, can be seen as Additions to Garage

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Start the Mission with 3CB Factions,
Spawn and Garage Vehicles,
Open the Garage and check if you can apply Camos that could be problematic.

```sqf
//Garages Vehicles so you don't have to place them.
_vehicle1 = "UK3CB_I_G_Hilux_Spg9" createVehicle getpos (Player);
_vehicle2 = "UK3CB_TKM_I_LR_M2" createVehicle getpos (Player);
_vehicle3 = "UK3CB_CCM_I_Datsun_Open" createVehicle getpos (Player);
_vehicle4 = "UK3CB_ADC_C_Pickup" createVehicle getpos (Player);
_vehicle5 = "UK3CB_ADE_I_BTR40" createVehicle getpos (Player); //These are from ADE they come with the Evil Camo by default
_vehicle6 = "UK3CB_ADE_I_T34" createVehicle getpos (Player);
_vehicle7 = "UK3CB_AAF_I_Offroad" createVehicle getpos (Player);



[_vehicle1, clientOwner, call HR_GRG_dLock, player] remoteExecCall ['HR_GRG_fnc_addVehicle',2];
[_vehicle2, clientOwner, call HR_GRG_dLock, player] remoteExecCall ['HR_GRG_fnc_addVehicle',2];
[_vehicle3, clientOwner, call HR_GRG_dLock, player] remoteExecCall ['HR_GRG_fnc_addVehicle',2];
[_vehicle4, clientOwner, call HR_GRG_dLock, player] remoteExecCall ['HR_GRG_fnc_addVehicle',2];
[_vehicle5, clientOwner, call HR_GRG_dLock, player] remoteExecCall ['HR_GRG_fnc_addVehicle',2];
[_vehicle6, clientOwner, call HR_GRG_dLock, player] remoteExecCall ['HR_GRG_fnc_addVehicle',2];
[_vehicle7, clientOwner, call HR_GRG_dLock, player] remoteExecCall ['HR_GRG_fnc_addVehicle',2];
```
********************************************************
Notes:
