### PR TITLE
true localised garage hints

### DIFF
--- a/A3-Antistasi/Garage/Core/fn_confirm.sqf
+++ b/A3-Antistasi/Garage/Core/fn_confirm.sqf
@@ -18,7 +18,7 @@
     License: Håkon Rydland Garage SHARED SOURCE LICENSE
 */
 HR_GRG_SelectedVehicles params ["_catIndex", "_vehUID", "_class"];
-if (_vehUID isEqualTo -1) exitWith {[localize "STR_HR_GRG_Feedback_confirm_NullSelection"] call HR_GRG_fnc_Hint};
+if (_vehUID isEqualTo -1) exitWith {["STR_HR_GRG_Feedback_confirm_NullSelection"] call HR_GRG_fnc_Hint};
 
 //get mounts state
 HR_GRG_Mounts apply {

--- a/A3-Antistasi/Garage/Extras/fn_findMount.sqf
+++ b/A3-Antistasi/Garage/Extras/fn_findMount.sqf
@@ -28,7 +28,7 @@
 FIX_LINE_NUMBERS()
 params ["_UID", "_vehUID", "_newIconIndex", "_owner", "_player"];
 Trace_4("Finding available mount | UID: %1 | Vehicle ID: %2 | Reserving: %3 | Client: %4", _UID, _vehUID, _newIconIndex, _owner);
-private _failed = { [localize "STR_HR_GRG_Feedback_requestMount_Denied"] remoteExec ["HR_GRG_fnc_Hint", _owner]; [true] remoteExecCall ["HR_GRG_fnc_toggleConfirmBttn", _owner]; false };
+private _failed = { ["STR_HR_GRG_Feedback_requestMount_Denied"] remoteExec ["HR_GRG_fnc_Hint", _owner]; [true] remoteExecCall ["HR_GRG_fnc_toggleConfirmBttn", _owner]; false };
 if (!isServer) exitWith _failed;
 
 private _cat = HR_GRG_vehicles#4;

--- a/A3-Antistasi/Garage/Extras/fn_requestMount.sqf
+++ b/A3-Antistasi/Garage/Extras/fn_requestMount.sqf
@@ -38,7 +38,7 @@ private _nodes = if (_newIconIndex isEqualTo 1) then { //load static
     deleteVehicle _static;
     _nodes;
 } else { [] }; //unload static
-if (_nodes isEqualType 0) exitWith { [localize "STR_HR_GRG_Feedback_requestMount_Denied"] call HR_GRG_fnc_Hint };
+if (_nodes isEqualType 0) exitWith { ["STR_HR_GRG_Feedback_requestMount_Denied"] call HR_GRG_fnc_Hint };
 
 HR_GRG_ReloadMounts = true;
 [false] call HR_GRG_fnc_toggleConfirmBttn;

--- a/A3-Antistasi/Garage/config.inc
+++ b/A3-Antistasi/Garage/config.inc
@@ -60,7 +60,8 @@ HR_GRG_fnc_Hint = {
 };
 HR_GRG_fnc_vehInit = {
     if (_this isKindOf "StaticWeapon") then {staticsToSave pushBack _this; publicVariable "staticsToSave"};
-    [_this, TeamPlayer] call A3A_fnc_AIVEHinit; }; //is passed vehicle as _this
+    [_this, TeamPlayer] call A3A_fnc_AIVEHinit;
+}; //is passed vehicle as _this
 HR_GRG_onOpenEvent = { player setCaptive false; };
 
 //CBA settings

--- a/A3-Antistasi/Garage/config.inc
+++ b/A3-Antistasi/Garage/config.inc
@@ -54,7 +54,9 @@ HR_GRG_blackListCamo = ["IDAP"];
 //proxies
 HR_GRG_fnc_Hint = {
     params ["_key", ["_arguments", []]];
-    ["Garage",format ( [localize _key] + _arguments ) ] call A3A_fnc_customHint;
+    ["Garage",
+        if (_arguments isEqualTo []) then {localize _key} else {format ( [localize _key] + _arguments )}
+    ] call A3A_fnc_customHint;
 };
 HR_GRG_fnc_vehInit = {
     if (_this isKindOf "StaticWeapon") then {staticsToSave pushBack _this; publicVariable "staticsToSave"};

--- a/A3-Antistasi/Garage/config.inc
+++ b/A3-Antistasi/Garage/config.inc
@@ -52,8 +52,11 @@ if (isNil "HR_GRG_ServiceDisabled_Repair") then {HR_GRG_ServiceDisabled_Repair =
 HR_GRG_blackListCamo = ["IDAP"];
 
 //proxies
-HR_GRG_fnc_Hint = { ["Garage",_this#0] call A3A_fnc_customHint };
-HR_GRG_fnc_vehInit = { 
+HR_GRG_fnc_Hint = {
+    params ["_key", ["_arguments", []]];
+    ["Garage",format ( [localize _key] + _arguments ) ] call A3A_fnc_customHint;
+};
+HR_GRG_fnc_vehInit = {
     if (_this isKindOf "StaticWeapon") then {staticsToSave pushBack _this; publicVariable "staticsToSave"};
     [_this, TeamPlayer] call A3A_fnc_AIVEHinit; }; //is passed vehicle as _this
 HR_GRG_onOpenEvent = { player setCaptive false; };

--- a/A3-Antistasi/Garage/fn_addVehicle.sqf
+++ b/A3-Antistasi/Garage/fn_addVehicle.sqf
@@ -35,54 +35,54 @@ if (_class in [NATOSurrenderCrate, CSATSurrenderCrate]) exitWith {
     _vehicle addMagazineCargoGlobal [unlockedMagazines#0,1];// so fnc_empty will delete the crate
     [_vehicle] spawn A3A_fnc_empty;
     [10] remoteExec ["A3A_fnc_resourcesPlayer", _client];
-    [localize "STR_HR_GRG_Feedback_addVehicle_LTC"]  remoteExec ["HR_GRG_fnc_Hint", _client];
+    ["STR_HR_GRG_Feedback_addVehicle_LTC"] remoteExec ["HR_GRG_fnc_Hint", _client];
     true
 };
 
 //validate input
-if (isNull _vehicle) exitWith { [localize "STR_HR_GRG_Feedback_addVehicle_Null"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
-if (!alive _vehicle) exitWith { [localize "STR_HR_GRG_Feedback_addVehicle_Destroyed"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
-if (locked _vehicle > 1) exitWith { [localize "STR_HR_GRG_Feedback_addVehicle_Locked"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
+if (isNull _vehicle) exitWith { ["STR_HR_GRG_Feedback_addVehicle_Null"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
+if (!alive _vehicle) exitWith { ["STR_HR_GRG_Feedback_addVehicle_Destroyed"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
+if (locked _vehicle > 1) exitWith { ["STR_HR_GRG_Feedback_addVehicle_Locked"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
 private _cat = [_class] call HR_GRG_fnc_getCatIndex;
-if (_cat isEqualTo -1) exitWith { [localize "STR_HR_GRG_Feedback_addVehicle_GenericFail"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
+if (_cat isEqualTo -1) exitWith { ["STR_HR_GRG_Feedback_addVehicle_GenericFail"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
 
     //Towing
-if !((_vehicle getVariable ["SA_Tow_Ropes",objNull]) isEqualTo objNull) exitWith {[localize "STR_HR_GRG_Feedback_addVehicle_SATow"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
+if !((_vehicle getVariable ["SA_Tow_Ropes",objNull]) isEqualTo objNull) exitWith {["STR_HR_GRG_Feedback_addVehicle_SATow"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
 
     //distance
-if (_player distance _vehicle > 25) exitWith {[localize "STR_HR_GRG_Feedback_addVehicle_Distance"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
+if (_player distance _vehicle > 25) exitWith {["STR_HR_GRG_Feedback_addVehicle_Distance"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
 
     //crewed
 private _exit = false;
 if ( ( {alive _x} count (crew _vehicle) ) > 0) then { _exit = true };
 { if ( ( {alive _x} count (crew _x) ) > 0) exitWith {_exit = true} } forEach attachedObjects _vehicle;
-if (_exit) exitWith { [localize "STR_HR_GRG_Feedback_addVehicle_Crewed"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
+if (_exit) exitWith { ["STR_HR_GRG_Feedback_addVehicle_Crewed"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
 
     //Valid area
 private _friendlyMarkers = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
 private _inArea = _friendlyMarkers findIf { count ([_player, _vehicle] inAreaArray _x) > 1 };
-if !(_inArea > -1) exitWith {[format [localize "STR_HR_GRG_Feedback_addVehicle_badLocation",nameTeamPlayer]] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
+if !(_inArea > -1) exitWith {["STR_HR_GRG_Feedback_addVehicle_badLocation",[nameTeamPlayer]] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
 
     //No hostiles near
 private _units = (_player nearEntities ["Man",300]) select {([_x] call A3A_fnc_CanFight) && (side _x isEqualTo Occupants || side _x isEqualTo Invaders)};
 if (_units findIf {_unit = _x; _players = allPlayers select {(side _x isEqualTo teamPlayer) && (_player distance _x < 300)}; _players findIf {_x in (_unit targets [true, 300])} != -1} != -1) exitWith {
-    [localize "STR_HR_GRG_Feedback_addVehicle_enemiesEngaging"] remoteExec ["HR_GRG_fnc_Hint", _client];
+    ["STR_HR_GRG_Feedback_addVehicle_enemiesEngaging"] remoteExec ["HR_GRG_fnc_Hint", _client];
     false;
 };
-if (_units findIf{_player distance _x < 100} != -1) exitWith {[localize "STR_HR_GRG_Feedback_addVehicle_enemiesNear"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
+if (_units findIf{_player distance _x < 100} != -1) exitWith {["STR_HR_GRG_Feedback_addVehicle_enemiesNear"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
 
     //cap block
 private _capacity = 0;
 { _capacity = _capacity + count _x } forEach HR_GRG_Vehicles;
 
 private _countStatics = {_x isKindOf "StaticWeapon"} count (attachedObjects _vehicle);
-if ((call HR_GRG_VehCap - _capacity) < (_countStatics + 1)) exitWith { [localize "STR_HR_GRG_Feedback_addVehicle_Capacity"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };//HR_GRG_VehCap is defined in config.inc
+if ((call HR_GRG_VehCap - _capacity) < (_countStatics + 1)) exitWith { ["STR_HR_GRG_Feedback_addVehicle_Capacity"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };//HR_GRG_VehCap is defined in config.inc
 
 //Block air garage outside of airbase
 if (
     (_class isKindOf "Air")
     && {count (airportsX select {(sidesX getVariable [_x,sideUnknown] == teamPlayer) and (_player inArea _x)}) < 1} //no airports
-) exitWith {[format [localize "STR_HR_GRG_Feedback_addVehicle_airBlocked",nameTeamPlayer]] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
+) exitWith {["STR_HR_GRG_Feedback_addVehicle_airBlocked", [nameTeamPlayer]] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
 
 //add vehicle
 private _locking = if (_lockUID isEqualTo "") then {false} else {true};
@@ -137,5 +137,5 @@ private _refreshCode = {
 };
 [ _catToRefresh, _refreshCode ] remoteExecCall ["call", HR_GRG_Users];
 
-[format [localize "STR_HR_GRG_Feedback_addVehicle_Success", cfgDispName(_class)] ] remoteExec ["HR_GRG_fnc_Hint", _client];
+["STR_HR_GRG_Feedback_addVehicle_Success", [cfgDispName(_class)] ] remoteExec ["HR_GRG_fnc_Hint", _client];
 true;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information: The proxy hint function for the garage now handles localisation, as this function is run on client we now have truly localised hints in the garage.
the garage hint function now takes a stringtable key and optional arguments for string formatting, when no arguments are supplied simply localises and then hints with A3A_fnc_customHint.
this can be used as a inspiration for the A3A localised hint
    

### Please specify which Issue this PR Resolves.
closes none

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes: garage stringtable entries are only in english for the moment, we should add in some translations to already supported languages, maybe we should even just google translate it?
