### PR TITLE
Disable Problematic Ace Settings

### DIFF
--- a/A3-Antistasi/cba_settings.sqf
+++ b/A3-Antistasi/cba_settings.sqf
@@ -15,3 +15,9 @@ force TFAR_givePersonalRadioToRegularSoldier = false;
 force TFAR_SameLRFrequenciesForSide = false;
 force TFAR_SameSRFrequenciesForSide = false;
 
+// ACE Crew Served Weapons
+force ace_csw_defaultAssemblyMode = false;
+force ace_csw_handleExtraMagazines = false;
+
+// ACE User Interface
+force ace_ui_groupBar = true;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information:
ACE CSW has 2 settings that can cause problems with the Mission, to avoid this they should be forced off.

**ace_csw_defaultAssemblyMode** "Store extra Magazines next to Static Weapon"
-----> This will spawn Ammo next to any Static Weapon that spawns within the Mission, which can be bad for performance.

**ace_csw_defaultAssemblyMode** "Use ace for Assemble/Disassemble of supported static weapons. Loaded ammo is reduced to a Single Magazine".
-----> All Static Weapons will only have one Magazine, Ai can't deal with that, so Ai Mortars and MGs and AA Weapons will run out very quickly.

**ace_ui_groupBar** this is turned of by default and causes people to be incapable of using AI, this might help new people since they might have default Settings.

### Please specify which Issue this PR Resolves.
closes nothing

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
