### PR TITLE
Prevent converted Explosives from Unlocking

### DIFF
--- a/A3-Antistasi/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_categoryOverrides.sqf
@@ -111,6 +111,8 @@ private _categoryOverrideTable = [
 ["LIB_PTRD", ["Unknown", "Weapons"]],
 ["LIB_M2_Flamethrower", ["Unknown", "Weapons"]],			// don't want these two being chosen randomly by AIs
 ["LIB_Bagpipes", ["Unknown","Weapons"]],					// wat
+["ACE_SatchelCharge_Remote_Mag_Throwable", ["Unknown", "Explosives", "Items"]],
+["ACE_DemoCharge_Remote_Mag_Throwable", ["Unknown", "Explosives", "Items"]],
 //Flashlights
 ["vn_mx991", ["Unknown","Weapons"]],
 ["vn_mx991_red", ["Unknown","Weapons"]],


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Ace Grenades allows cojnversion of Explosives to Grenades,
These Grenades can be unlocked and be converted back.
Currently only 2 charges use this function, hopefully it stays that way.

I added them to Unknown which will prevent them from Unlocking.

### Please specify which Issue this PR Resolves.
closes #1466 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Try unlocking the converted Explosives
```sqf
boxx addItemCargoGlobal ["ACE_SatchelCharge_Remote_Mag_Throwable", 500];
boxx addItemCargoGlobal ["ACE_DemoCharge_Remote_Mag_Throwable", 500];
```
********************************************************
Notes:
