### PR TITLE
add a time stamp to the locked name for the tool tip

### DIFF
--- a/A3-Antistasi/JeroenArsenal/JNG/fn_garage.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNG/fn_garage.sqf
@@ -455,6 +455,14 @@ switch _mode do {
 		_beingChangedUpdate = _this select 2;
 		_lockedUpdate = _this select 3;
 		_lockedNameUpdate = _this select 4;
+
+		// add a time stamp in UTC to the name
+		private _tempSystemTime = systemTimeUTC;  
+
+		// day(2), hour(3), minute(3)	-> name date hour:min										
+		_lockedNameUpdate = _lockedNameUpdate + format[" %1 %2:%3", _tempSystemTime select 2, _tempSystemTime select 3, _tempSystemTime select 4];
+
+
 		_display =  uiNamespace getVariable ["arsanalDisplay","No display"];
 
 		if (typeName _display == "STRING") exitWith {};

--- a/A3-Antistasi/JeroenArsenal/JNG/fn_garage_getVehicleData.sqf
+++ b/A3-Antistasi/JeroenArsenal/JNG/fn_garage_getVehicleData.sqf
@@ -113,6 +113,14 @@ private _beingChanged = "";
 private _locked = getPlayerUID player;
 private _lockedName = name player;
 
+// add a time stamp in UTC to the name
+private _tempSystemTime = systemTimeUTC;  
+
+// day(2), hour(3), minute(3)	-> name date hour:min										
+_lockedName = _lockedName + format[" %1 %2:%3", _tempSystemTime select 2, _tempSystemTime select 3, _tempSystemTime select 4];
+
+
+
 //return
 COMPILE_SAVE
 


### PR DESCRIPTION
## What type of PR is this.
3. [x ] Enhancement

### What have you changed and why?
Information:
Added a timestamp in day hour minute in UTC.
Allows the commander to make a better decision on unlocking a vehicle by looking at how long the vehicle has been locked.
    


### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
1) Start Game
2) add vehicle to garage
3) lock vehicle
4) verify that tooltip has a timestamp in UTC


********************************************************
Notes:
Foremost apologies as this is my first pull request for Antistasi.
