### PR TITLE
patched fake lanucher magazines being added to loadouts

### DIFF
--- a/A3-Antistasi/functions/Templates/Loadouts/fn_loadout_builder.sqf
+++ b/A3-Antistasi/functions/Templates/Loadouts/fn_loadout_builder.sqf
@@ -4,17 +4,17 @@
     Date: 2020-11-27
     Last Update: 2020-11-27
     Public: No
-    
+
     Description:
         No description added yet.
-    
+
     Parameter(s):
         _template - Template to build [CODE]
 		_data - Loadout data to insert [NAMESPACE]
-    
+
     Returns:
         Function reached the end [BOOL]
-    
+
     Example(s):
         [parameter] call vn_fnc_myFunction
 */
@@ -35,7 +35,7 @@ private _fnc_magClassToEntry = {
 // - A classname - Loads a full magazine into the weapon, uses only that magazine as an available mag.
 // - A normal loadout entry - [classname, bullet count] - remains unchanged.
 // - An array of classnames - Loads the first magazine into the weapon, and uses the whole array as a pool of available mags.
-// - An array of arrays in format [[numberOfMags, magClass]] 
+// - An array of arrays in format [[numberOfMags, magClass]]
 //    - Loads the first magazine into the weapon, and uses the whole array as a pool of available mags.
 //    - When giving magazines to the loadout, gives numberOfMags instead of only a single mag.
 private _fnc_parseWeaponFormat = {
@@ -74,7 +74,16 @@ private _fnc_parseWeaponFormat = {
 
 		// Only for primary slot
 		if (_muzzle == "pri") then {
-			private _defaultMagData = [_class] call A3A_fnc_loadout_defaultWeaponMag; 
+			private _defaultMagData = [_class] call A3A_fnc_loadout_defaultWeaponMag;
+
+            //if it dosnt have any valid mags return nothing
+            if (_defaultMagData isEqualTo []) then {
+                continueWith [
+                    [],
+                    []
+                ];
+            };
+
 			continueWith [
 				_defaultMagData,
 				[_defaultMagData select 0]

--- a/A3-Antistasi/functions/Templates/Loadouts/fn_loadout_defaultWeaponMag.sqf
+++ b/A3-Antistasi/functions/Templates/Loadouts/fn_loadout_defaultWeaponMag.sqf
@@ -14,6 +14,7 @@
 params ["_class"];
 
 private _magazines = getArray (configFile >> "CfgWeapons" >> _class >> "Magazines");
+if ("CBA_FakeLauncherMagazine" in _magazines) exitWith {[]};
 private _magazineType = "";
 
 if (count _magazines > 0) then {


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information: the loadout builder function `A3A_fnc_loadout_defaultWeaponMag` did not have an exception for cba fake magazines and would therefore add it to the loadouts in both weapon mag slot and as spare ammo.

i made it return an empty array if it found the fake mag, and fixed a bug where empty array return from that function would give null magtype used in spare ammo giving.
    

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes: this was a quick fix so there may be better ways to do it, but this will do for now
