### PR TITLE
fix addVehicleByClass lacking source detection

### DIFF
--- a/A3-Antistasi/Garage/Extras/fn_isAmmoSource.sqf
+++ b/A3-Antistasi/Garage/Extras/fn_isAmmoSource.sqf
@@ -18,18 +18,29 @@
 
     License: APL-ND
 */
-params [ ["_vehicle", objNull, [objNull]] ];
-if (isNull _vehicle) exitWith {false};
+params [ ["_vehicle", objNull, [objNull,""]] ];
 
+//handle obj input and class input
+private _vehType = if (_vehicle isEqualType objNull) then {typeOf _vehicle} else {_vehicle};
+if (_vehicle isEqualType "") then {_vehicle = objNull};
+
+if (_vehType isEqualTo "") exitWith {false}; //null obj passed
+private _vehCfg = configFile/"CfgVehicles"/_vehType;
+if (!isClass _vehCfg) exitWith {false}; //invalid class string passed
+
+//check if is source
 if (A3A_hasAce) then { //Ace
     private _aceCurrent = _vehicle getVariable ["ace_rearm_currentSupply", 0];
     if (_aceCurrent < 0) exitWith {false};
 
-    private _vehCfg = configFile >> "CfgVehicles" >> typeOf _vehicle;
     private _ammoCap = getNumber (_vehCfg >> "transportAmmo");
     private _aceDefault = getNumber (_vehCfg >> "ace_rearm_defaultSupply");
     private _aceIsSupply = _vehicle getVariable ["ace_rearm_isSupplyVehicle", false];
     (_aceDefault > 0) || {_aceIsSupply} || {_ammoCap > 0}
 } else { //Vanilla
-    getAmmoCargo _vehicle > 0
+    if (isNull _vehicle) then {
+        getNumber (_vehCfg/"transportAmmo") > 0
+    } else {
+        getAmmoCargo _vehicle > 0
+    };
 };

--- a/A3-Antistasi/Garage/Extras/fn_isFuelSource.sqf
+++ b/A3-Antistasi/Garage/Extras/fn_isFuelSource.sqf
@@ -18,12 +18,22 @@
 
     License: APL-ND
 */
-params [ ["_vehicle", objNull, [objNull]] ];
-if (isNull _vehicle) exitWith {false};
+params [ ["_vehicle", objNull, [objNull,""]] ];
+
+//handle obj input and class input
+private _vehType = if (_vehicle isEqualType objNull) then {typeOf _vehicle} else {_vehicle};
+if (_vehicle isEqualType "") then {_vehicle = objNull};
+
+if (_vehType isEqualTo "") exitWith {false}; //null obj passed
+private _vehCfg = configFile/"CfgVehicles"/_vehType;
+if (!isClass _vehCfg) exitWith {false}; //invalid class string passed
 
 if (A3A_hasAce) then { //Ace
-    private _vehCfg = configFile >> "CfgVehicles" >> typeOf _vehicle;
     _vehicle getVariable ["ace_refuel_currentFuelCargo", getNumber (_vehCfg >> "ace_refuel_fuelCargo")] > 0;
 } else { //Vanilla
-    getFuelCargo _vehicle > 0
+    if (isNull _vehicle) then {
+        getNumber (_vehCfg/"transportFuel") > 0
+    } else {
+        getFuelCargo _vehicle > 0
+    };
 };

--- a/A3-Antistasi/Garage/Extras/fn_isRepairSource.sqf
+++ b/A3-Antistasi/Garage/Extras/fn_isRepairSource.sqf
@@ -18,12 +18,23 @@
 
     License: APL-ND
 */
-params [ ["_vehicle", objNull, [objNull]] ];
-if (isNull _vehicle) exitWith {false};
+params [ ["_vehicle", objNull, [objNull,""]] ];
+
+//handle obj input and class input
+private _vehType = if (_vehicle isEqualType objNull) then {typeOf _vehicle} else {_vehicle};
+if (_vehicle isEqualType "") then {_vehicle = objNull};
+
+if (_vehType isEqualTo "") exitWith {false}; //null obj passed
+private _vehCfg = configFile/"CfgVehicles"/_vehType;
+if (!isClass _vehCfg) exitWith {false}; //invalid class string passed
 
 if (A3A_hasAce) then {
-    private _value = _vehicle getVariable ["ACE_isRepairVehicle", getNumber (configFile >> "CfgVehicles" >> typeOf _vehicle >> "ace_repair_canRepair")];
+    private _value = _vehicle getVariable ["ACE_isRepairVehicle", getNumber (_vehCfg/"ace_repair_canRepair")];
     _value in [1, true];
 } else {
-    getRepairCargo _vehicle > 0
+    if (isNull _vehicle) then {
+        getNumber (_vehCfg/"transportRepair") > 0
+    } else {
+        getRepairCargo _vehicle > 0
+    };
 };

--- a/A3-Antistasi/Garage/fn_addVehicle.sqf
+++ b/A3-Antistasi/Garage/fn_addVehicle.sqf
@@ -127,7 +127,7 @@ private _vehUID = [] call HR_GRG_fnc_genVehUID;
 if (_sourceIndex != -1) then {
     (HR_GRG_Sources#_sourceIndex) pushBack _vehUID;
     [_sourceIndex] call HR_GRG_fnc_declairSources;
-    }; //register vehicle as a source
+}; //register vehicle as a source
 Info_6("By: %1 [%2] | Type: %3 | Vehicle ID: %4 | Lock: %5 | Source: %6", name _player, getPlayerUID _player, cfgDispName(_class), _vehUID, _locking, _sourceIndex);
 
 //refresh category for active users

--- a/A3-Antistasi/Garage/fn_addVehiclesByClass.sqf
+++ b/A3-Antistasi/Garage/fn_addVehiclesByClass.sqf
@@ -32,6 +32,18 @@ private _cfg = configFile >> "CfgVehicles";
     if (_cat < 0) then {Info_1("Unsoported category: %1", str _x); continue};
     private _vehUID = [] call HR_GRG_fnc_genVehUID;
     (HR_GRG_Vehicles#_cat) set [_vehUID, [cfgDispName(_x), _x, _lockUID, "", [[1,-1,nil],[0,[[],[]],-1],[]], "", [false, false]]];
+
+    private _source = [
+        [_x] call HR_GRG_fnc_isAmmoSource
+        ,[_x] call HR_GRG_fnc_isFuelSource
+        ,[_x] call HR_GRG_fnc_isRepairSource
+    ];
+    private _sourceIndex = _source find true;
+    if (_sourceIndex != -1) then {
+        (HR_GRG_Sources#_sourceIndex) pushBack _vehUID;
+        [_sourceIndex] call HR_GRG_fnc_declairSources;
+    }; //register vehicle as a source
+
     Info_2("Vehicle added to garage: %1 | Lock UID: %2", str _x, str _lockUID);
 } forEach _vehicles;
 true


### PR DESCRIPTION
added it to addVehicleByClass

## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    old saves loaded into the new version would not have source vehicles detected and registered to the garage, resulting in sources having to be re-garaged to be able to use the vehicle services

### Please specify which Issue this PR Resolves.
closes #2051 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
