### PR TITLE
Fix 2.4 -> 2.5 rebel garrison compatibility

### DIFF
--- a/A3-Antistasi/functions/Save/fn_loadStat.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadStat.sqf
@@ -11,6 +11,7 @@
 */
 #include "..\..\Includes\common.inc"
 FIX_LINE_NUMBERS()
+
 private _translateMarker = {
 	params ["_mrk"];
 	if (_mrk find "puesto" == 0) exitWith { "outpost" + (_mrk select [6]) };
@@ -142,15 +143,21 @@ if (_varName in _specialVarLoads) then {
 	};
 	if (_varName == 'garrison') then {
 		{
-			garrison setVariable [[_x select 0] call _translateMarker, _x select 1, true];
+			private _garrison = +(_x select 1);
+			{
+				// fix for 2.4 -> 2.5 rebel garrison incompatibity
+				if (_x find "loadouts_rebel" != 0) then { continue };
+				_garrison set [_forEachIndex, "loadouts_reb" + (_x select [14])];
+			} forEach _garrison;
+			garrison setVariable [[_x select 0] call _translateMarker, _garrison, true];
 			if (count _x > 2) then { garrison setVariable [(_x select 0) + "_lootCD", _x select 2, true] };
 		} forEach _varvalue;
 	};
 	if (_varName == 'wurzelGarrison') then {
 		{
-			garrison setVariable [format ["%1_garrison", (_x select 0)], _x select 1, true];
-			garrison setVariable [format ["%1_requested", (_x select 0)], _x select 2, true];
-			garrison setVariable [format ["%1_over", (_x select 0)], _x select 3, true];
+			garrison setVariable [format ["%1_garrison", (_x select 0)], +(_x select 1), true];
+			garrison setVariable [format ["%1_requested", (_x select 0)], +(_x select 2), true];
+			garrison setVariable [format ["%1_over", (_x select 0)], +(_x select 3), true];
 			[(_x select 0)] call A3A_fnc_updateReinfState;
 		} forEach _varvalue;
 	};


### PR DESCRIPTION

### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Translated saved garrison data from loadouts_rebel to loadouts_reb so that 2.4(.1) saved games work correctly.

Also fixed some dangerous shallow copies on load from the profileNamespace.

### Please specify which Issue this PR Resolves.
closes #2058

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
