### PR TITLE
Protect players from themselves with fog params sanitization

### DIFF
--- a/A3-Antistasi/functions/Base/fn_flagaction.sqf
+++ b/A3-Antistasi/functions/Base/fn_flagaction.sqf
@@ -120,7 +120,7 @@ switch _typeX do
     {
         fireX addAction ["Rest for 8 Hours", A3A_fnc_skiptime,nil,0,false,true,"","(_this == theBoss)",4];
         fireX addAction ["Clear Nearby Forest", A3A_fnc_clearForest,nil,0,false,true,"","(_this == theBoss)",4];
-        fireX addAction ["I hate the fog", { [10,0] remoteExec ["setFog",2]; },nil,0,false,true,"","(_this == theBoss)",4];
+        fireX addAction ["I hate the fog", { [10,[0,0,0]] remoteExec ["setFog",2]; },nil,0,false,true,"","(_this == theBoss)",4];
         fireX addAction ["Rain rain go away", { [10,0] remoteExec ["setRain",2]; },nil,0,false,true,"","(_this == theBoss)",4];
         fireX addAction ["Move this asset", A3A_fnc_moveHQObject,nil,0,false,true,"","(_this == theBoss)",4];
     };

--- a/A3-Antistasi/functions/Save/fn_loadStat.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadStat.sqf
@@ -76,7 +76,9 @@ if (_varName in _specialVarLoads) then {
 	if (_varName == 'hr') then {server setVariable ["HR",_varValue,true]};
 	if (_varName == 'dateX') then {setDate _varValue};
 	if (_varName == 'weather') then {
-		0 setFog (_varValue select 0);
+		// Avoid persisting potentially-broken fog values
+		private _fogParams = _varValue select 0;
+		0 setFog [_fogParams#0, (_fogParams#1) max 0, (_fogParams#2) max 0];
 		0 setRain (_varValue select 1);
 		forceWeatherChange
 	};


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
1. Cap the second and third params of fogParams to min zero on Antistasi load. Arma itself doesn't use negative values here, and they're usually set accidentally with Zeus, with serious consequences including random whiteouts, launchers failing to lock and AIs not spotting correctly.

2. Set all three fog params to 0 with the "I hate the fog" option, so that players aren't tempted to use Zeus to clear the last bit.

### Please specify which Issue this PR Resolves.
closes #2060

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
