### PR TITLE
Fix attackHQ transport planes

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_spawnVehicle.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_spawnVehicle.sqf
@@ -57,6 +57,7 @@ private _sim = getText(configFile >> "CfgVehicles" >> _type >> "simulation");
 private _velocity = 0;
 private _veh = objNull;
 switch (toLower _sim) do {
+    case "airplane";
     case "airplanex";
     case "helicopterrtd";
     case "helicopterx": {

--- a/A3-Antistasi/functions/Missions/fn_attackHQ.sqf
+++ b/A3-Antistasi/functions/Missions/fn_attackHQ.sqf
@@ -64,7 +64,7 @@ for "_i" from 0 to (round random 2) do
 	_groups pushBack _groupX;
 	//[_heli,"Air Transport"] spawn A3A_fnc_inmuneConvoy;
 	if (_typeVehX isKindOf "Plane") then {
-		[_heli,_groupX,_positionX,_posOrigin] spawn A3A_fnc_paradrop;
+		[_heli,_groupX,_positionX,_airportX] spawn A3A_fnc_paradrop;
 	} else {
 		[_heli,_groupX,_positionX,_posOrigin,_groupHeli] spawn A3A_fnc_fastrope;
 	};


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
A couple of fixes related to the use of IFA transport planes:
1. Fixed a bad parameter to paradrop in attackHQ.
2. Added an aircraft config simulation used by IFA to spawnVehicle.

### Please specify which Issue this PR Resolves.
closes #2054

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
