### PR TITLE
Prevent bad unit types being added to garrisons, repair saves

### DIFF
--- a/A3-Antistasi/REINF/addToGarrison.sqf
+++ b/A3-Antistasi/REINF/addToGarrison.sqf
@@ -46,14 +46,19 @@ private _alreadyInGarrison = false;
 } forEach _unitsX;
 if _alreadyInGarrison exitWith {["Garrison", "The units selected already are in a garrison"] call A3A_fnc_customHint};
 
+if ((groupID _groupX == "MineF") or (groupID _groupX == "Watch") or (isPlayer(leader _groupX))) exitWith {["Garrison", "You cannot garrison player led, Watchpost, Roadblocks or Minefield building squads"] call A3A_fnc_customHint;};
+
+{
+	if (isPlayer _x or !alive _x) exitWith {_leave = true};
+} forEach _unitsX;
+if (_leave) exitWith {["Garrison", "Dead or player-controlled units cannot be added to any garrison"] call A3A_fnc_customHint;};
+
 {
 	private _unitType = _x getVariable "unitType";
-	if ((_unitType == staticCrewTeamPlayer) or (_unitType == SDKUnarmed) or (_unitType == typePetros) or (_unitType in arrayCivs) or (!alive _x)) exitWith {_leave = true}
+	if (isNil "_unitType") exitWith {_leave = true};
+	if ((_unitType == staticCrewTeamPlayer) or (_unitType == SDKUnarmed) or (_unitType == typePetros) or (_unitType in arrayCivs)) exitWith {_leave = true}
 } forEach _unitsX;
-
-if (_leave) exitWith {["Garrison", "Static crewman, prisoners, refugees, Petros or dead units cannot be added to any garrison"] call A3A_fnc_customHint;};
-
-if ((groupID _groupX == "MineF") or (groupID _groupX == "Watch") or (isPlayer(leader _groupX))) exitWith {["Garrison", "You cannot garrison player led, Watchpost, Roadblocks or Minefield building squads"] call A3A_fnc_customHint;};
+if (_leave) exitWith {["Garrison", "Static crewmen, prisoners, refugees, Petros or unknown units cannot be added to any garrison"] call A3A_fnc_customHint;};
 
 
 if (isNull _groupX) then

--- a/A3-Antistasi/REINF/addToGarrison.sqf
+++ b/A3-Antistasi/REINF/addToGarrison.sqf
@@ -46,7 +46,7 @@ private _alreadyInGarrison = false;
 } forEach _unitsX;
 if _alreadyInGarrison exitWith {["Garrison", "The units selected already are in a garrison"] call A3A_fnc_customHint};
 
-if ((groupID _groupX == "MineF") or (groupID _groupX == "Watch") or (isPlayer(leader _groupX))) exitWith {["Garrison", "You cannot garrison player led, Watchpost, Roadblocks or Minefield building squads"] call A3A_fnc_customHint;};
+if ((groupID _groupX == "MineF") or (groupID _groupX == "Post") or (isPlayer(leader _groupX))) exitWith {["Garrison", "You cannot garrison player led, Watchpost, Roadblocks or Minefield building squads"] call A3A_fnc_customHint;};
 
 {
 	if (isPlayer _x or !alive _x) exitWith {_leave = true};

--- a/A3-Antistasi/functions/Save/fn_loadStat.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadStat.sqf
@@ -145,12 +145,18 @@ if (_varName in _specialVarLoads) then {
 	};
 	if (_varName == 'garrison') then {
 		{
-			private _garrison = +(_x select 1);
+			private _garrison = [];
 			{
-				// fix for 2.4 -> 2.5 rebel garrison incompatibity
-				if (_x find "loadouts_rebel" != 0) then { continue };
-				_garrison set [_forEachIndex, "loadouts_reb" + (_x select [14])];
-			} forEach _garrison;
+				if !(_x isEqualType "") then { continue };		// skip garbage created by old bugs
+				if (_x isEqualTo "") then { continue };
+				if (_x find "loadouts_rebel" == 0) then {
+					// fix for 2.4 -> 2.5 rebel garrison incompatibility
+					_garrison pushBack ("loadouts_reb" + (_x select [14]));
+				} else {
+					_garrison pushBack _x;
+				};
+			} forEach (_x select 1);
+
 			garrison setVariable [[_x select 0] call _translateMarker, _garrison, true];
 			if (count _x > 2) then { garrison setVariable [(_x select 0) + "_lootCD", _x select 2, true] };
 		} forEach _varvalue;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
- Fix case where players could be added to a garrison (probably as nils).
- Fix case where units without a unitType (eg. Zeus'd units) could be added to a garrison as nils.
- Remove non-string types (including nils) from garrisons on load.
- Remove empty strings from garrisons on load (bug from <2.4).

### Please specify which Issue this PR Resolves.
closes #1927

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
You can test the load checks without saving anything by abusing loadStat with arbitrary data, like this:
```
_garrisonData = [["Zaros", ["", "loadouts_rebel_militia_rifleman", nil, "loadouts_reb_militia_rifleman"]]]; 
["garrison", _garrisonData] call A3A_loadStat;
garrison getVariable "Zaros";
```
