### PR TITLE
Make vehicles shit again

### DIFF
--- a/A3-Antistasi/MissionDescription/params.hpp
+++ b/A3-Antistasi/MissionDescription/params.hpp
@@ -102,6 +102,13 @@ class Params
         texts[] = {"Default (Normal)","Easy","Normal","Hard"};
         default = 9999;
     };
+    class VehicleNerf
+    {
+        title = "Vehicle Accuracy";
+        values[] = {9999,0,250,1000,2500,5000};
+        texts[] = {"Default (Godmode)", "Godmode - No changes to accuracy", "Slight nerf - Might be windy", "Infantry balanced - Spray and pray", "Heavy nerf - No intention to hit anyways","Noobmode - Vehicles are useless"};
+        default = 9999;
+    };
     class unlockItem
     {
         title = "Number of the same item required to unlock";

--- a/A3-Antistasi/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_AIVEHinit.sqf
@@ -37,6 +37,28 @@ if (_side == teamPlayer) then
 // Sync the vehicle textures if necessary
 _veh call A3A_fnc_vehicleTextureSync;
 
+Info_2("Adding accuracy change to vehicle %1 (Factor %2)", typeOf _veh, accuracyMult);
+_veh addEventHandler
+[
+    "Fired",
+    {
+        params ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile", "_gunner"];
+
+        private _dispersion = getNumber(configFile >> "CfgWeapons" >> _weapon >> "dispersion");
+        private _caliber = getNumber(configFile >> "CfgAmmo" >> _ammo >> "caliber");
+        private _yeetBullet = [sin(random 360), sin(random 360)] vectorMultiply (accuracyMult * _dispersion * 5/_caliber);
+
+        private _forward = vectorDir _projectile;
+        private _up = vectorUp _projectile;
+        private _side = _forward vectorCrossProduct _up;
+
+        private _velocity = velocity _projectile;
+        _velocity = _velocity vectorAdd (_up vectorMultiply _yeetBullet#0) vectorAdd (_side vectorMultiply _yeetBullet#1);
+        _projectile setVelocity _velocity;
+        _projectile setVectorDir _velocity;
+    }
+];
+
 private _typeX = typeOf _veh;
 if ((_typeX in vehNormal) or (_typeX in vehAttack) or (_typeX in vehBoats) or (_typeX in vehAA)) then
 {

--- a/A3-Antistasi/functions/init/fn_initParams.sqf
+++ b/A3-Antistasi/functions/init/fn_initParams.sqf
@@ -30,6 +30,7 @@ A3A_paramTable = [
     ["autoSaveInterval", "autoSaveInterval", [], 3600],
     ["distanceMission", "mRadius", [], 4000],
     ["skillMult", "AISkill", [], 2],
+    ["accuracyMult", "VehicleNerf", [], 0],
     ["civTraffic", "civTraffic", [], 2],
     ["limitedFT", "allowFT", [], true],									// backwards naming...
     ["napalmEnabled", "napalmEnabled", [], false],


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Information:
Added a parameter which can add inaccuracy to all vehicles, making them less pinpoint godmode. There is also the option to not add any inaccuracy. This nerf works for both sidess and is based on the technical data of the weapon.

Technical detail
Weapon spread is added based on the dispersion of the weapon and the caliber of the ammo. 

High caliber ammo in a precise weapon, for example a tank gun, will still be mostly precise in all options.
Low caliber ammo in unprecise weapon, such as statics, can get a drastical sway.

I tested mostly the "Infantry balanced" option, which favors player infantry over AI vehicles and player vehicles over AI infantry. I also know that the higher values are heavily throwing ammo around. The middle ground option is just a guess.    

### Please specify which Issue this PR Resolves.
None

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Running into enemy vehicles, firing own vehicle weapons, every vehicle is has the code and gets applied to the ammo.

********************************************************
Notes:
The exact values might need to be tested, the code itself does work.