### PR TITLE
Fix missing return value on actionRevive

### DIFF
--- a/A3-Antistasi/functions/Revive/fn_actionRevive.sqf
+++ b/A3-Antistasi/functions/Revive/fn_actionRevive.sqf
@@ -93,7 +93,7 @@ waitUntil {
     or !(alive _cured)
 };
 
-if (isNull _medic) exitWith {};
+if (isNull _medic) exitWith { false };
 
 _medic removeEventHandler ["AnimDone", _animHandler];
 _medic setVariable ["helping",false];


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
actionRevive needs a return case for when it's used by fn_help. Missed one for the case where the target unit is deleted during the revive. This likely didn't cause any problems (if the target unit is deleted, the medic almost certainly is too) but did throw an RPT error, so may as well clean it up.

Not tested, but the change itself is harmless. If there's a resulting problem further down the line then it's old and almost certainly invisible.

### Please specify which Issue this PR Resolves.
closes #2071

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
