### PR TITLE
Change zoneCheck to use marker-size based capture radius

### DIFF
--- a/A3-Antistasi/functions/Base/fn_markerChange.sqf
+++ b/A3-Antistasi/functions/Base/fn_markerChange.sqf
@@ -305,11 +305,13 @@ if (_winner == teamPlayer) then
 	};
     ([Occupants] + _prestigeOccupants) spawn A3A_fnc_addAggression;
     ([Invaders] + _prestigeInvaders) spawn A3A_fnc_addAggression;
-	waitUntil {sleep 1; ((spawner getVariable _markerX == 2)) or ({((side group _x) in [_looser,_other]) and (_x getVariable ["spawner",false]) and ([_x,_markerX] call A3A_fnc_canConquer)} count allUnits > 3*({(side _x == teamPlayer) and ([_x,_markerX] call A3A_fnc_canConquer)} count allUnits))};
-	if (spawner getVariable _markerX != 2) then
-	{
-		sleep 10;
-		[_markerX,teamPlayer] remoteExec ["A3A_fnc_zoneCheck",2];
+	[_markerX] spawn {
+		params ["_markerX"];
+		// This allows enemies to retake rebel markers with random junk until the marker is despawned
+		while { spawner getVariable _markerX != 2 and sidesX getVariable _markerX == teamPlayer } do {
+			sleep 60;
+			[_markerX,teamPlayer] remoteExec ["A3A_fnc_zoneCheck",2];
+		};
 	};
 }
 else

--- a/A3-Antistasi/functions/Base/fn_mrkWIN.sqf
+++ b/A3-Antistasi/functions/Base/fn_mrkWIN.sqf
@@ -1,25 +1,21 @@
-private ["_flagX","_pos","_markerX","_positionX","_size","_powerpl","_revealX"];
 #include "..\..\Includes\common.inc"
 FIX_LINE_NUMBERS()
 
-//Variable Setup.
-_flagX = _this select 0;
-_playerX = _this select 1;
-_revealX = [];
-_pos = getPos _flagX;
-_markerX = [markersX,_pos] call BIS_fnc_nearestPosition;
+params ["_flagX", "_playerX"];
+
+private _markerX = [markersX, getPos _flagX] call BIS_fnc_nearestPosition;
+private _markerPos = getMarkerPos _markerX;
 
 if (sidesX getVariable [_markerX,sideUnknown] == teamPlayer) exitWith {};
-_positionX = getMarkerPos _markerX;
-_size = [_markerX] call A3A_fnc_sizeMarker;
 
-if ((!isNull _playerX) and (captive _playerX)) exitWith {["Capture", "You cannot Capture the Flag while Undercover"] call A3A_fnc_customHint;};
+if !(_playerX call A3A_fnc_canFight) exitWith { ServerError_1("Action somehow used by dead or unconscious player?") };
+if (captive _playerX) exitWith {["Capture", "You cannot Capture the Flag while Undercover"] call A3A_fnc_customHint;};
 if ((_markerX in airportsX) and (tierWar < 3)) exitWith {["Capture", "You cannot capture Airports until you reach War Level 3"] call A3A_fnc_customHint;};
 
 //Check if the flag is locked
 if(_flagX getVariable ["isGettingCaptured", false]) exitWith
 {
-	["Capture", "This flag pole is locked, try again in 30 seconds!"] call A3A_fnc_customHint;
+    ["Capture", "This flag pole is locked, try again in 30 seconds!"] call A3A_fnc_customHint;
 };
 
 //Lock the flag
@@ -28,52 +24,53 @@ _flagX setVariable ["isGettingCaptured", true, true];
 //Unlock the flag after 30 seconds
 _flagX spawn
 {
-	sleep 30;
-	_this setVariable ["isGettingCaptured", nil, true];
+    sleep 30;
+    _this setVariable ["isGettingCaptured", nil, true];
 };
 
-if (!isNull _playerX) then
+
+ServerInfo_2("Flag capture at %1 initiated by %2", _markerX, str _playerX);
+
+private _capRadius = ((markerSize _markerX select 0) + (markerSize _markerX select 1)) / 2;
+_capRadius = _capRadius max 50;
+
+private _rebelValue = 0;
+private _enemyValue = 0;
 {
-    Info_2("Flag capture at %1 initiated by %2", _markerX, str _playerX);
-	if (_size > 300) then
-	{
-		_size = 300
-	};
-	{
-		if (((side _x == Occupants) or (side _x == Invaders)) and ([_x,_markerX] call A3A_fnc_canConquer)) then
-		{
-			_revealX pushBack _x
-		};
-	} forEach allUnits;
-	if (player == _playerX) then
-	{
-		_playerX playMove "MountSide";
-		sleep 8;
-		_playerX playMove "";
-		{
-			player reveal _x
-		} forEach _revealX;
-	};
+    if !(_x call A3A_fnc_canFight) then { continue };
+    private _value = linearConversion [_capRadius/2, _capRadius, _markerPos distance2d _x, 1, 0, true];
+    if (side _x == teamPlayer) then {
+        _rebelValue = _rebelValue + _value;
+        continue;
+    };
+    if (side _x == Occupants or side _x == Invaders) then {
+        _enemyValue = _enemyValue + _value;
+        _playerX reveal _x;
+    };
+} forEach (allUnits inAreaArray [_markerPos, _capRadius, _capRadius]);
+
+ServerDebug_2("Rebel value %1, enemy value %2", _rebelValue, _enemyValue);
+
+if (_enemyValue > 2*_rebelValue) exitWith
+{
+    ServerInfo_1("Flag capture by %1 abandoned due to outnumbering", str _playerX);
+    ["Capture", "The enemy still outnumber us, check the map and clear the rest of the area"] call A3A_fnc_customHint;
 };
 
-if ((count _revealX) > 2*({([_x,_markerX] call A3A_fnc_canConquer) and (side _x == teamPlayer)} count allUnits)) exitWith
-{
-    Debug_1("Markers left to be conquered: %1 ", _revealX);
-    Info_1("Flag capture by %1 abandoned due to outnumbering", str _playerX);
-	["Capture", "The enemy still outnumber us, check the map and clear the rest of the area"] call A3A_fnc_customHint;
-};
+_playerX playMove "MountSide";
+sleep 8;
+_playerX playMove "";
 
 {
-	if (isPlayer _x) then
-	{
-		[5,_x] remoteExec ["A3A_fnc_playerScoreAdd",_x];
-		if (captive _x) then
-		{
-			[_x,false] remoteExec ["setCaptive",0,_x];
-			_x setCaptive false;
-		};
-	}
-} forEach ([_size,0,_positionX,teamPlayer] call A3A_fnc_distanceUnits);
+    if (isPlayer _x) then
+    {
+        [5,_x] remoteExec ["A3A_fnc_playerScoreAdd",_x];
+        if (captive _x) then
+        {
+            [_x,false] remoteExec ["setCaptive",_x];
+        };
+    }
+} forEach ([_capRadius,0,_markerPos,teamPlayer] call A3A_fnc_distanceUnits);
 
-Info_1("Flag capture by %1 rewarded", str _playerX);
+ServerInfo_1("Flag capture by %1 rewarded", str _playerX);
 [teamPlayer,_markerX] remoteExec ["A3A_fnc_markerChange",2];

--- a/A3-Antistasi/functions/Base/fn_zoneCheck.sqf
+++ b/A3-Antistasi/functions/Base/fn_zoneCheck.sqf
@@ -49,18 +49,22 @@ switch (_side) do
 
 [0,0,0] params ["_defenderUnitCount", "_enemy1UnitCount", "_enemy2UnitCount"];
 
+// Use average marker size to force reasonable behaviour with highly rectangular targets
+private _capRadius = ((markerSize _marker select 0) + (markerSize _marker select 1)) / 2;
+_capRadius = _capRadius max 50;
+
 private _markerPos = getMarkerPos _marker;
+private _units = allUnits inAreaArray [_markerPos, _capRadius, _capRadius];
 {
-    if((_markerPos distance2D _x < 300) && {[_x] call A3A_fnc_canFight}) then
+    if !(_x call A3A_fnc_canFight) then { continue };
+    private _value = linearConversion [_capRadius/2, _capRadius, _markerPos distance2d _x, 1, 0, true];
+    switch (side (group _x)) do
     {
-        switch (side (group _x)) do
-        {
-            case (_side): {_defenderUnitCount = _defenderUnitCount + 1};
-            case (_enemy1): {_enemy1UnitCount = _enemy1UnitCount + 1};
-            case (_enemy2): {_enemy2UnitCount = _enemy2UnitCount + 1};
-        };
-    }
-} forEach allUnits;
+        case (_side): {_defenderUnitCount = _defenderUnitCount + _value};
+        case (_enemy1): {_enemy1UnitCount = _enemy1UnitCount + _value};
+        case (_enemy2): {_enemy2UnitCount = _enemy2UnitCount + _value};
+    };
+} forEach _units;
 
 Debug_7("ZoneCheck at %1 found %2 friendly %5 units, %3 enemy %6 units and %4 enemy %7 units", _marker, _defenderUnitCount, _enemy1UnitCount, _enemy2UnitCount, _side, _enemy1, _enemy2);
 

--- a/A3-Antistasi/functions/Base/fn_zoneCheck.sqf
+++ b/A3-Antistasi/functions/Base/fn_zoneCheck.sqf
@@ -58,7 +58,7 @@ private _units = allUnits inAreaArray [_markerPos, _capRadius, _capRadius];
 {
     if !(_x call A3A_fnc_canFight) then { continue };
     private _value = linearConversion [_capRadius/2, _capRadius, _markerPos distance2d _x, 1, 0, true];
-    switch (side (group _x)) do
+    switch (side _x) do				// Not side group because we don't count undercover
     {
         case (_side): {_defenderUnitCount = _defenderUnitCount + _value};
         case (_enemy1): {_enemy1UnitCount = _enemy1UnitCount + _value};


### PR DESCRIPTION

### What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
1. Changed zoneCheck to use an average marker radius with some mild proximity falloff, as opposed to the previous flat 300m count. What would often happen otherwise is that markers occupied by small teams could potentially be flipped very easily by singleAttacks, especially for small markers with a lot of surrounding tree cover.

2. Changed the mrkWIN calc similarly to the zoneCheck calc. This one was already marker-size based so previously you could often flip the flag back immediately after a zoneCheck recapture (without killing any enemies), causing stacked singleAttacks. Also cleared up a lot of weird shit in mrkWIN while I was there.

3. Fixed some old broken code in markerChange that was used to allow enemies to re-flip rebel-captured locations with any units in the vicinity. I assume this is there to prevent rebels speed-capping a location, leaving it empty and it remaining in their hands despite incoming QRFs/patrols. Because markerChange has a lockout (markersIsChanging) and it wasn't running as a spawn and had slightly different conditions to zoneCheck or wavedCA, there were cases where it would block or stall future marker changes causing broken behaviour. I simplified the code and changed it to run as a spawn. Could have just removed it due to marginal utility, but it's fairly harmless now.

Note that zoneCheck is primarily used by singleAttack (the capture response "QRFs"). wavedCA (major attack routine) has its own capture detection. This should be sanitized at some point, but there's less potential harm in leaving it for the moment.

### Please specify which Issue this PR Resolves.
Very partial fix of #1976.

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

Should probably get a test run on a server before it hits release though. Mission doesn't work very well if capturing breaks.