### PR TITLE
made custom JIP keys for Logistics system

### DIFF
--- a/A3-Antistasi/functions/Logistics/fn_logistics_addLoadAction.sqf
+++ b/A3-Antistasi/functions/Logistics/fn_logistics_addLoadAction.sqf
@@ -17,9 +17,10 @@
 
     Example: [_object] call A3A_fnc_logistics_addLoadAction;
 */
-params ["_object", ["_action", "load"]];
+params [["_object", objNull, [objNull]], ["_action", "load", [""]]];
 #include "..\..\Includes\common.inc"
 FIX_LINE_NUMBERS()
+if (isNull _object) exitWith {};
 if (isNil "A3A_logistics_vehicleHardpoints") exitWith {
     Error("Logistics nodes not initialized");
     nil
@@ -32,5 +33,9 @@ if (_object isKindOf "StaticWeapon") then {
 };
 if (_nonSupportedStatic) exitWith {nil};
 
-[_object , _action] remoteExec ["A3A_fnc_logistics_addAction", 0, _object];
+private _jipObject = toArray str _vehicle;
+_jipObject deleteAt (_jipObject find 58); //58 is ':'
+private _jipKey = "A3A_Logistics_" + _action + "_" + toString _jipObject;
+[_object , _action, _jipKey] remoteExec ["A3A_fnc_logistics_addAction", 0, _jipKey];
+
 nil

--- a/A3-Antistasi/functions/Logistics/fn_logistics_addLoadAction.sqf
+++ b/A3-Antistasi/functions/Logistics/fn_logistics_addLoadAction.sqf
@@ -33,7 +33,7 @@ if (_object isKindOf "StaticWeapon") then {
 };
 if (_nonSupportedStatic) exitWith {nil};
 
-private _jipObject = toArray str _vehicle;
+private _jipObject = toArray str _object;
 _jipObject deleteAt (_jipObject find 58); //58 is ':'
 private _jipKey = "A3A_Logistics_" + _action + "_" + toString _jipObject;
 [_object , _action, _jipKey] remoteExec ["A3A_fnc_logistics_addAction", 0, _jipKey];

--- a/A3-Antistasi/functions/Logistics/functions/fn_logistics_addAction.sqf
+++ b/A3-Antistasi/functions/Logistics/functions/fn_logistics_addAction.sqf
@@ -17,8 +17,11 @@
 
     Example: [_object , _action] remoteExec ["A3A_fnc_logistics_addAction", 0, _object];
 */
-params [["_object", objNull, [objNull]], "_action"];
-if (isNull _object) exitWith {};
+params [["_object", objNull, [objNull]], "_action", ["_jipKey", "", [""]]];
+if (isNull _object) exitWith {
+    remoteExec ["", 0, _jipKey]; //clear custom JIP
+};
+
 private _actionNames = (actionIDs _object) apply {(_object actionParams _x)#0};
 private _loadText = format ["Load %1 into nearest vehicle", getText (configFile >> "CfgVehicles" >> typeOf _object >> "displayName")];
 

--- a/A3-Antistasi/functions/Logistics/functions/fn_logistics_addAction.sqf
+++ b/A3-Antistasi/functions/Logistics/functions/fn_logistics_addAction.sqf
@@ -19,7 +19,7 @@
 */
 params [["_object", objNull, [objNull]], "_action", ["_jipKey", "", [""]]];
 if (isNull _object) exitWith {
-    remoteExec ["", 0, _jipKey]; //clear custom JIP
+    remoteExec ["", _jipKey]; //clear custom JIP
 };
 
 private _actionNames = (actionIDs _object) apply {(_object actionParams _x)#0};

--- a/A3-Antistasi/functions/Logistics/functions/fn_logistics_addAction.sqf
+++ b/A3-Antistasi/functions/Logistics/functions/fn_logistics_addAction.sqf
@@ -6,6 +6,7 @@
     Arguments:
     0. <Object> Object to add action to
     1. <String> Which action to add ("load"/"unload")
+    2. <String> Custom JIP key to prevent overwriting (usually build with object string of cargo)
 
     Return Value:
     <nil>

--- a/A3-Antistasi/functions/Logistics/functions/fn_logistics_addWeaponAction.sqf
+++ b/A3-Antistasi/functions/Logistics/functions/fn_logistics_addWeaponAction.sqf
@@ -60,7 +60,7 @@ _cargo setVariable ["getInAction", _actionID];
 private _KilledEH = _cargo addEventHandler ["Killed", {
     params ["_cargo"];
     private _vehicle = attachedTo _cargo;
-    [_vehicle, _cargo] remoteExecCall ["A3A_fnc_logistics_removeWeaponAction",0]
+    [_vehicle, _cargo, _jipKey] remoteExecCall ["A3A_fnc_logistics_removeWeaponAction",0]
 }];
 _cargo setVariable ["KilledEH", _KilledEH];
 _cargo enableWeaponDisassembly false;

--- a/A3-Antistasi/functions/Logistics/functions/fn_logistics_addWeaponAction.sqf
+++ b/A3-Antistasi/functions/Logistics/functions/fn_logistics_addWeaponAction.sqf
@@ -6,6 +6,7 @@
     Arguments:
     0. <Object> Weapon that's being attached
     1. <Object> Vehicle weapon is being attached to
+    2. <String> Custom JIP key to prevent overwriting (usually build with object string of cargo)
 
     Return Value:
     <nil>
@@ -15,9 +16,13 @@
     Public: [No]
     Dependencies:
 
-    Example: [_cargo, _vehicle] remoteExec ["A3A_fnc_logistics_addWeaponAction", 0, _cargo];
+    Example: [_cargo, _vehicle, _jipKey] remoteExec ["A3A_fnc_logistics_addWeaponAction", 0, _cargo];
 */
-params ["_cargo", "_vehicle"];
+params [["_cargo", objNull, [objNull]], ["_vehicle", objNull, [objNull]], ["_jipKey", "", [""]]];
+
+if (isNull _cargo || isNull _vehicle) exitWith {
+    remoteExec ["", _jipKey]; //clear custom JIP
+};
 
 //action to get into static
 private _name = getText (configFile >> "CfgVehicles" >> typeOf _cargo >> "displayName");

--- a/A3-Antistasi/functions/Logistics/functions/fn_logistics_load.sqf
+++ b/A3-Antistasi/functions/Logistics/functions/fn_logistics_load.sqf
@@ -120,5 +120,10 @@ if (_weapon) then {
 };
 
 _vehicle setVariable ["LoadingCargo",nil,true];
-[_vehicle, "unload"] remoteExec ["A3A_fnc_logistics_addAction", 0 ,_vehicle];
+
+private _jipObject = toArray str _vehicle;
+_jipObject deleteAt (_jipObject find 58); //58 is ':'
+private _jipKey = "A3A_Logistics_" + _action + "_" + toString _jipObject;
+[_vehicle, "unload", _jipKey] remoteExec ["A3A_fnc_logistics_addAction", 0 , _jipKey];
+
 nil

--- a/A3-Antistasi/functions/Logistics/functions/fn_logistics_load.sqf
+++ b/A3-Antistasi/functions/Logistics/functions/fn_logistics_load.sqf
@@ -26,13 +26,8 @@ if (_vehicle getVariable ["LoadingCargo", false]) exitWith {["Logistics", "Cargo
 _vehicle setVariable ["LoadingCargo",true,true];
 
 //object string for jip
-private _objStringCargo = toArray str _cargo;
-_objStringCargo deleteAt (_objStringCargo find 58); //58 is ':'
-_objStringCargo = toString _objStringCargo;
-
-private _objStringVehicle = toArray str _vehicle;
-_objStringVehicle deleteAt (_objStringVehicle find 58); //58 is ':'
-_objStringVehicle = toString _objStringVehicle;
+private _objStringCargo = str _cargo splitString ":" joinString "";
+private _objStringVehicle = str _vehicle splitString ":" joinString "";
 
 //update list of nodes on vehicle
 _updateList = {

--- a/A3-Antistasi/functions/Logistics/functions/fn_logistics_load.sqf
+++ b/A3-Antistasi/functions/Logistics/functions/fn_logistics_load.sqf
@@ -115,15 +115,19 @@ _vehicle setVariable ["Cargo", _loadedCargo, true];
 //misc
 [_cargo] call A3A_fnc_logistics_toggleAceActions;
 [_vehicle, _cargo, nil, _instant] call A3A_fnc_logistics_addOrRemoveObjectMass;
+
+private _jipObject = toArray str _cargo;
+_jipObject deleteAt (_jipObject find 58); //58 is ':'
+private _jipKey = "A3A_Logistics_weaponAction_" + toString _jipObject;
 if (_weapon) then {
-    [_cargo, _vehicle] remoteExec ["A3A_fnc_logistics_addWeaponAction", 0, _cargo];
+    [_cargo, _vehicle, _jipKey] remoteExec ["A3A_fnc_logistics_addWeaponAction", 0, _jipKey];
 };
 
 _vehicle setVariable ["LoadingCargo",nil,true];
 
-private _jipObject = toArray str _vehicle;
+_jipObject = toArray str _vehicle;
 _jipObject deleteAt (_jipObject find 58); //58 is ':'
-private _jipKey = "A3A_Logistics_" + _action + "_" + toString _jipObject;
+_jipKey = "A3A_Logistics_" + _action + "_" + toString _jipObject;
 [_vehicle, "unload", _jipKey] remoteExec ["A3A_fnc_logistics_addAction", 0 , _jipKey];
 
 nil

--- a/A3-Antistasi/functions/Logistics/functions/fn_logistics_load.sqf
+++ b/A3-Antistasi/functions/Logistics/functions/fn_logistics_load.sqf
@@ -25,6 +25,15 @@ params ["_cargo", "_vehicle", "_node", "_weapon", ["_instant", false, [true]]];
 if (_vehicle getVariable ["LoadingCargo", false]) exitWith {["Logistics", "Cargo is already being loaded into the vehicle"] remoteExec ["A3A_fnc_customHint", remoteExecutedOwner]; nil};
 _vehicle setVariable ["LoadingCargo",true,true];
 
+//object string for jip
+private _objStringCargo = toArray str _cargo;
+_objStringCargo deleteAt (_objStringCargo find 58); //58 is ':'
+_objStringCargo = toString _objStringCargo;
+
+private _objStringVehicle = toArray str _vehicle;
+_objStringVehicle deleteAt (_objStringVehicle find 58); //58 is ':'
+_objStringVehicle = toString _objStringVehicle;
+
 //update list of nodes on vehicle
 _updateList = {
     params ["_vehicle", "_node"];
@@ -77,8 +86,8 @@ private _yEnd = _location#1;
 _cargo setVariable ["AttachmentOffset", _location];
 
 //block seats
-[_cargo, true] remoteExec ["A3A_fnc_logistics_toggleLock", 0, _cargo];
-[_vehicle, true, _seats] remoteExecCall ["A3A_fnc_logistics_toggleLock", 0, _vehicle];
+[_cargo, true] remoteExec ["A3A_fnc_logistics_toggleLock", 0, "A3A_Logistics_toggleLock" + _objStringCargo];
+[_vehicle, true, _seats] remoteExecCall ["A3A_fnc_logistics_toggleLock", 0, "A3A_Logistics_toggleLock" + _objStringVehicle];
 _cargo engineOn false;
 
 //break undercover
@@ -116,18 +125,12 @@ _vehicle setVariable ["Cargo", _loadedCargo, true];
 [_cargo] call A3A_fnc_logistics_toggleAceActions;
 [_vehicle, _cargo, nil, _instant] call A3A_fnc_logistics_addOrRemoveObjectMass;
 
-private _jipObject = toArray str _cargo;
-_jipObject deleteAt (_jipObject find 58); //58 is ':'
-private _jipKey = "A3A_Logistics_weaponAction_" + toString _jipObject;
 if (_weapon) then {
-    [_cargo, _vehicle, _jipKey] remoteExec ["A3A_fnc_logistics_addWeaponAction", 0, _jipKey];
+    [_cargo, _vehicle, _jipKey] remoteExec ["A3A_fnc_logistics_addWeaponAction", 0, "A3A_Logistics_weaponAction_" + _objStringCargo];
 };
 
 _vehicle setVariable ["LoadingCargo",nil,true];
 
-_jipObject = toArray str _vehicle;
-_jipObject deleteAt (_jipObject find 58); //58 is ':'
-_jipKey = "A3A_Logistics_" + _action + "_" + toString _jipObject;
-[_vehicle, "unload", _jipKey] remoteExec ["A3A_fnc_logistics_addAction", 0 , _jipKey];
+[_vehicle, "unload", _jipKey] remoteExec ["A3A_fnc_logistics_addAction", 0 , "A3A_Logistics_unload_" + _objStringVehicle];
 
 nil

--- a/A3-Antistasi/functions/Logistics/functions/fn_logistics_removeWeaponAction.sqf
+++ b/A3-Antistasi/functions/Logistics/functions/fn_logistics_removeWeaponAction.sqf
@@ -17,12 +17,12 @@
 
     Example: [_vehicle, _cargo] remoteExecCall ["A3A_fnc_logistics_removeWeaponAction",0];
 */
-params ["_vehicle", "_cargo"];
+params [["_vehicle", objnull, [objNull]], ["_cargo", objnull, [objNull]], , ["_jipKey", "", [""]]];
 
 //Remove action
 private _id = _cargo getVariable ["getInAction", -1];
 _cargo setVariable ["getInAction", nil];
-remoteExecCall ["", _cargo]; //clear JIP addAction
+remoteExecCall ["", _jipKey]; //clear JIP addAction
 _vehicle removeAction _id;
 
 //remove weapon killed EH

--- a/A3-Antistasi/functions/Logistics/functions/fn_logistics_removeWeaponAction.sqf
+++ b/A3-Antistasi/functions/Logistics/functions/fn_logistics_removeWeaponAction.sqf
@@ -17,7 +17,7 @@
 
     Example: [_vehicle, _cargo] remoteExecCall ["A3A_fnc_logistics_removeWeaponAction",0];
 */
-params [["_vehicle", objnull, [objNull]], ["_cargo", objnull, [objNull]], , ["_jipKey", "", [""]]];
+params [["_vehicle", objnull, [objNull]], ["_cargo", objnull, [objNull]], ["_jipKey", "", [""]]];
 
 //Remove action
 private _id = _cargo getVariable ["getInAction", -1];

--- a/A3-Antistasi/functions/Logistics/functions/fn_logistics_unload.sqf
+++ b/A3-Antistasi/functions/Logistics/functions/fn_logistics_unload.sqf
@@ -37,13 +37,8 @@ if (_vehicle getVariable ["LoadingCargo", false]) exitWith {["Logistics", "Cargo
 _vehicle setVariable ["LoadingCargo",true,true];
 
 //object string for jip
-private _objStringCargo = toArray str _cargo;
-_objStringCargo deleteAt (_objStringCargo find 58); //58 is ':'
-_objStringCargo = toString _objStringCargo;
-
-private _objStringVehicle = toArray str _vehicle;
-_objStringVehicle deleteAt (_objStringVehicle find 58); //58 is ':'
-_objStringVehicle = toString _objStringVehicle;
+private _objStringCargo = str _cargo splitString ":" joinString "";
+private _objStringVehicle = str _vehicle splitString ":" joinString "";
 
 //update list of nodes on vehicle
 _updateList = {

--- a/A3-Antistasi/functions/Logistics/functions/fn_logistics_unload.sqf
+++ b/A3-Antistasi/functions/Logistics/functions/fn_logistics_unload.sqf
@@ -36,6 +36,15 @@ if !(
 if (_vehicle getVariable ["LoadingCargo", false]) exitWith {["Logistics", "Cargo is already being unloaded from the vehicle"] remoteExec ["A3A_fnc_customHint", remoteExecutedOwner]};
 _vehicle setVariable ["LoadingCargo",true,true];
 
+//object string for jip
+private _objStringCargo = toArray str _cargo;
+_objStringCargo deleteAt (_objStringCargo find 58); //58 is ':'
+_objStringCargo = toString _objStringCargo;
+
+private _objStringVehicle = toArray str _vehicle;
+_objStringVehicle deleteAt (_objStringVehicle find 58); //58 is ':'
+_objStringVehicle = toString _objStringVehicle;
+
 //update list of nodes on vehicle
 _updateList = {
     params ["_vehicle", "_node"];
@@ -90,7 +99,7 @@ if !(_cargo isEqualTo objNull) then {//cargo not deleted
     } forEach A3A_logistics_weapons;
 
     if (_weapon) then {
-        [_vehicle, _cargo] remoteExecCall ["A3A_fnc_logistics_removeWeaponAction",0];
+        [_vehicle, _cargo, "A3A_Logistics_weaponAction_" + _objStringCargo] remoteExecCall ["A3A_fnc_logistics_removeWeaponAction",0];
         player setCaptive false; //break undercover for unloading weapon
     };
     _cargo setVariable ["AttachmentOffset", nil, true];
@@ -123,8 +132,8 @@ if !(_cargo isEqualTo objNull) then {//cargo not deleted
 if (isNull _cargo || isNull _vehicle) exitWith {};//vehicle or cargo deleted
 
 //unlock seats
-[_cargo, false] remoteExec ["A3A_fnc_logistics_toggleLock", 0, _cargo];
-[_vehicle, false, _seats] remoteExec ["A3A_fnc_logistics_toggleLock", 0, _vehicle];
+[_cargo, false] remoteExec ["A3A_fnc_logistics_toggleLock", 0, "A3A_Logistics_toggleLock" + _objStringCargo];
+[_vehicle, false, _seats] remoteExec ["A3A_fnc_logistics_toggleLock", 0, "A3A_Logistics_toggleLock" + _objStringVehicle];
 
 //update list
 _loaded deleteAt 0;


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information: due to object based jip keys overwriting each other some actions on statics were being blocked from being added for jip clients,
this fix adds a custom jip key and null object handling to the logistics system as a band aid as currently the only actions that ***we know*** are conflicting are the logistics and garrison static manning actions.
in the future we might want to consider other possibilities to prevent this from happening again.

### Please specify which Issue this PR Resolves.
closes #2072 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
