### PR TITLE
Added player scaling for the most important things

### DIFF
--- a/A3-Antistasi/functions/Base/fn_economicsAI.sqf
+++ b/A3-Antistasi/functions/Base/fn_economicsAI.sqf
@@ -8,7 +8,7 @@ _fnc_economics = {
     if (_typeX isEqualType "") then {
         _typeX  = [_typeX];
     };
-	
+
 	if (_typeX isEqualTo []) exitWith {};
 
     if (_random == "random") then {
@@ -33,35 +33,38 @@ private _airbases = { sidesX getVariable [_x, sideUnknown] == Occupants } count 
 private _outposts = { sidesX getVariable [_x, sideUnknown] == Occupants } count outposts;
 private _seaports = { sidesX getVariable [_x, sideUnknown] == Occupants } count seaports;
 private _accelerator = [1 + (tierWar + difficultyCoef) / 20, 0] select (tierWar == 1);
+private _capBalance = tierWar + 5;
+private _playerScale = exp((sqrt(count allPlayers)/3) - 1);
 
-[0.2, "", staticATOccupants, _outposts * 0.2 + _airbases * 0.5, _accelerator] spawn _fnc_economics;
-[0.1, "", staticAAOccupants, _airbases * 2, _accelerator] spawn _fnc_economics;
-[0.2, "random", vehNATOAPC, _outposts * 0.3 + _airbases * 2, _accelerator] spawn _fnc_economics;
-[0.1, "", vehNATOTank, _outposts * 0.5 + _airbases * 2, _accelerator] spawn _fnc_economics;
-[0.1, "", vehNATOAA, _airbases, _accelerator] spawn _fnc_economics;
-[0.3, "", vehNATOBoat, _seaports, _accelerator] spawn _fnc_economics;
-[0.2, "", vehNATOPlane, _airbases * 4, _accelerator] spawn _fnc_economics;
-[0.2, "", vehNATOPlaneAA, _airbases * 4, _accelerator] spawn _fnc_economics;
-[0.2, "random", vehNATOTransportPlanes, _airbases * 4, _accelerator] spawn _fnc_economics;
-[0.2, "random", vehNATOTransportHelis - [vehNATOPatrolHeli], _airbases * 4, _accelerator] spawn _fnc_economics;
-[0.2, "random", vehNATOAttackHelis, _airbases * 4, _accelerator] spawn _fnc_economics;
-[0.2, "", vehNATOMRLS, _airbases + _outposts * 0.2, _accelerator] spawn _fnc_economics;
+[0.2 * _playerScale, "", staticATOccupants, _capBalance + _outposts * 0.2 + _airbases * 0.5, _accelerator] spawn _fnc_economics;
+[0.1 * _playerScale, "", staticAAOccupants, _capBalance + _airbases * 2, _accelerator] spawn _fnc_economics;
+[0.2 * _playerScale, "random", vehNATOAPC, _capBalance + _outposts * 0.3 + _airbases * 2, _accelerator] spawn _fnc_economics;
+[0.1 * _playerScale, "", vehNATOTank, _capBalance + _outposts * 0.5 + _airbases * 2, _accelerator] spawn _fnc_economics;
+[0.1 * _playerScale, "", vehNATOAA, _capBalance + _airbases, _accelerator] spawn _fnc_economics;
+[0.3 * _playerScale, "", vehNATOBoat, _capBalance + _seaports, _accelerator] spawn _fnc_economics; //Why on earth do they get as many boats but we cheat AA tanks????
+[0.2 * _playerScale, "", vehNATOPlane, _capBalance + _airbases * 4, _accelerator] spawn _fnc_economics;
+[0.2 * _playerScale, "", vehNATOPlaneAA, _capBalance + _airbases * 4, _accelerator] spawn _fnc_economics;
+[0.2 * _playerScale, "random", vehNATOTransportPlanes, _capBalance + _airbases * 4, _accelerator] spawn _fnc_economics;
+[0.2 * _playerScale, "random", vehNATOTransportHelis - [vehNATOPatrolHeli], _capBalance + _airbases * 4, _accelerator] spawn _fnc_economics;
+[0.2 * _playerScale, "random", vehNATOAttackHelis, _capBalance + _airbases * 4, _accelerator] spawn _fnc_economics;
+[0.2 * _playerScale, "", vehNATOMRLS, _capBalance + _airbases + _outposts * 0.2, _accelerator] spawn _fnc_economics;
 
 //--------------------------------------Invaders---------------------------------------------------
 _airbases = { sidesX getVariable [_x, sideUnknown] == Invaders } count airportsX;
 _outposts = { sidesX getVariable [_x, sideUnknown] == Invaders } count outposts;
 _seaports = { sidesX getVariable [_x, sideUnknown] == Invaders } count seaports;
 _accelerator = 1.2 + (tierWar + difficultyCoef) / 20;
+_capBalance = tierWar * 2 + 10;
 
-[0.2, "", staticATInvaders, _outposts * 0.2 + _airbases * 0.5, _accelerator] spawn _fnc_economics;
-[0.1, "", staticAAInvaders, _airbases * 2, _accelerator] spawn _fnc_economics;
-[0.2, "random", vehCSATAPC, _outposts * 0.3 + _airbases * 2, _accelerator] spawn _fnc_economics;
-[0.1, "", vehCSATTank, _outposts * 0.5 + _airbases * 2, _accelerator] spawn _fnc_economics;
-[0.1, "", vehCSATAA, _airbases, _accelerator] spawn _fnc_economics;
-[0.3, "", vehCSATBoat, _seaports, _accelerator] spawn _fnc_economics;
-[0.2, "", vehCSATPlane, _airbases * 4, _accelerator] spawn _fnc_economics;
-[0.2, "", vehCSATPlaneAA, _airbases * 4, _accelerator] spawn _fnc_economics;
-[0.2, "random", vehCSATTransportPlanes, _airbases * 4, _accelerator] spawn _fnc_economics;
-[0.2, "random", vehCSATTransportHelis - [vehCSATPatrolHeli], _airbases * 4, _accelerator] spawn _fnc_economics;
-[0.2, "random", vehCSATAttackHelis, _airbases * 4, _accelerator] spawn _fnc_economics;
-[0.2, "", vehCSATMRLS, _airbases + _outposts * 0.2, _accelerator] spawn _fnc_economics;
+[0.2 * _playerScale, "", staticATInvaders, _capBalance + _outposts * 0.2 + _airbases * 0.5, _accelerator] spawn _fnc_economics;
+[0.1 * _playerScale, "", staticAAInvaders, _capBalance + _airbases * 2, _accelerator] spawn _fnc_economics;
+[0.2 * _playerScale, "random", vehCSATAPC, _capBalance + _outposts * 0.3 + _airbases * 2, _accelerator] spawn _fnc_economics;
+[0.1 * _playerScale, "", vehCSATTank, _capBalance + _outposts * 0.5 + _airbases * 2, _accelerator] spawn _fnc_economics;
+[0.1 * _playerScale, "", vehCSATAA, _capBalance + _airbases, _accelerator] spawn _fnc_economics;
+[0.3 * _playerScale, "", vehCSATBoat, _capBalance + _seaports, _accelerator] spawn _fnc_economics;
+[0.2 * _playerScale, "", vehCSATPlane, _capBalance + _airbases * 4, _accelerator] spawn _fnc_economics;
+[0.2 * _playerScale, "", vehCSATPlaneAA, _capBalance + _airbases * 4, _accelerator] spawn _fnc_economics;
+[0.2 * _playerScale, "random", vehCSATTransportPlanes, _airbases * 4, _accelerator] spawn _fnc_economics;
+[0.2 * _playerScale, "random", vehCSATTransportHelis - [vehCSATPatrolHeli], _capBalance + _airbases * 4, _accelerator] spawn _fnc_economics;
+[0.2 * _playerScale, "random", vehCSATAttackHelis, _capBalance + _airbases * 4, _accelerator] spawn _fnc_economics;
+[0.2 * _playerScale, "", vehCSATMRLS, _capBalance + _airbases + _outposts * 0.2, _accelerator] spawn _fnc_economics;

--- a/A3-Antistasi/functions/Base/fn_economicsAI.sqf
+++ b/A3-Antistasi/functions/Base/fn_economicsAI.sqf
@@ -114,4 +114,4 @@ _natoArray = [];
         _natoArray append (_array apply {[_x, timer getVariable [_x, 0]]});
     };
 } forEach [staticATInvaders, staticAAInvaders, vehCSATAPC, vehCSATTank, vehCSATAA, vehCSATBoat, vehCSATPlane, vehCSATPlaneAA, vehCSATTransportPlanes, (vehCSATTransportHelis - [vehCSATPatrolHeli]), vehCSATAttackHelis, vehCSATMRLS];
-DebugArray("Occupants arsenal", _natoArray);
+DebugArray("Invaders arsenal", _natoArray);

--- a/A3-Antistasi/functions/Base/fn_economicsAI.sqf
+++ b/A3-Antistasi/functions/Base/fn_economicsAI.sqf
@@ -1,30 +1,50 @@
+#include "..\..\Includes\common.inc"
+FIX_LINE_NUMBERS()
+
 //Original Author: Barbolani
 //Edited and updated by the Antstasi Community Development Team
 
-_fnc_economics = {
-    params ["_coefficient", "_random", "_typeX", "_maxItems", "_accelerator"];
-    private ["_currentItems"];
+_fnc_economics =
+{
+    params
+    [
+        ["_coefficient", 0, [0]],
+        ["_isRandom", false, [false]],
+        ["_types", [], ["", []]],
+        ["_itemCap", 0, [0]],
+        ["_accelerator", 0, [0]]
+    ];
 
-    if (_typeX isEqualType "") then {
-        _typeX  = [_typeX];
+    if (_types isEqualType "") then
+    {
+        _types  = [_types];
     };
 
-	if (_typeX isEqualTo []) exitWith {};
+	if (_types isEqualTo []) exitWith {};
 
-    if (_random == "random") then {
-        private _selectedType = selectRandom _typeX;
+    private _currentItems = 0;
+    private _selectedType = "";
+    if (_isRandom) then
+    {
+        _selectedType = selectRandom _types;
         _currentItems = timer getVariable [_selectedType, 0];
-        if (_currentItems < _maxItems) then {
-            timer setVariable [_selectedType, _currentItems + _coefficient * _accelerator, true];
-        };
-    } else {
-        _currentItems = 0;
+        if (_currentItems < _itemCap) then
         {
-            _currentItems = _currentItems + (timer getVariable [_x, 0]);
-        } forEach _typeX;
-        if (_currentItems < _maxItems) then {
-            timer setVariable [selectRandom _typeX, _currentItems + _coefficient * _accelerator, true];
+            timer setVariable [_selectedType, _currentItems + _coefficient * _accelerator, true];
+            Debug_3("Out of the array %1, increased %2 by %3", str _types, _selectedType, _coefficient * _accelerator);
         };
+    }
+    else
+    {
+        {
+            _selectedType = _x;
+            _currentItems = _currentItems + (timer getVariable [_selectedType, 0]);
+            if (_currentItems < _itemCap) then
+            {
+                timer setVariable [_selectedType, _currentItems + _coefficient * _accelerator, true];
+                Debug_2("Increasing single entry %1 by %2", _selectedType, _coefficient * _accelerator);
+            };
+        } forEach _types;
     };
 };
 
@@ -36,19 +56,32 @@ private _accelerator = [1 + (tierWar + difficultyCoef) / 20, 0] select (tierWar 
 private _capBalance = tierWar + 5;
 private _playerScale = exp((sqrt(count allPlayers)/3) - 1);
 
-[0.2 * _playerScale, "", staticATOccupants, _capBalance + _outposts * 0.2 + _airbases * 0.5, _accelerator] spawn _fnc_economics;
-[0.1 * _playerScale, "", staticAAOccupants, _capBalance + _airbases * 2, _accelerator] spawn _fnc_economics;
-[0.2 * _playerScale, "random", vehNATOAPC, _capBalance + _outposts * 0.3 + _airbases * 2, _accelerator] spawn _fnc_economics;
-[0.1 * _playerScale, "", vehNATOTank, _capBalance + _outposts * 0.5 + _airbases * 2, _accelerator] spawn _fnc_economics;
-[0.1 * _playerScale, "", vehNATOAA, _capBalance + _airbases, _accelerator] spawn _fnc_economics;
-[0.3 * _playerScale, "", vehNATOBoat, _capBalance + _seaports, _accelerator] spawn _fnc_economics; //Why on earth do they get as many boats but we cheat AA tanks????
-[0.2 * _playerScale, "", vehNATOPlane, _capBalance + _airbases * 4, _accelerator] spawn _fnc_economics;
-[0.2 * _playerScale, "", vehNATOPlaneAA, _capBalance + _airbases * 4, _accelerator] spawn _fnc_economics;
-[0.2 * _playerScale, "random", vehNATOTransportPlanes, _capBalance + _airbases * 4, _accelerator] spawn _fnc_economics;
-[0.2 * _playerScale, "random", vehNATOTransportHelis - [vehNATOPatrolHeli], _capBalance + _airbases * 4, _accelerator] spawn _fnc_economics;
-[0.2 * _playerScale, "random", vehNATOAttackHelis, _capBalance + _airbases * 4, _accelerator] spawn _fnc_economics;
-[0.2 * _playerScale, "", vehNATOMRLS, _capBalance + _airbases + _outposts * 0.2, _accelerator] spawn _fnc_economics;
+[0.2 * _playerScale, false, staticATOccupants, _capBalance + _outposts * 0.2 + _airbases * 0.5, _accelerator] call _fnc_economics;
+[0.1 * _playerScale, false, staticAAOccupants, _capBalance + _airbases * 2, _accelerator] call _fnc_economics;
+[0.2 * _playerScale, true, vehNATOAPC, _capBalance + _outposts * 0.3 + _airbases * 2, _accelerator] call _fnc_economics;
+[0.1 * _playerScale, false, vehNATOTank, _capBalance + _outposts * 0.5 + _airbases * 2, _accelerator] call _fnc_economics;
+[0.1 * _playerScale, false, vehNATOAA, _capBalance + _airbases, _accelerator] call _fnc_economics;
+[0.3 * _playerScale, false, vehNATOBoat, _capBalance + _seaports, _accelerator] call _fnc_economics; //Why on earth do they get as many boats but we cheat AA tanks????
+[0.2 * _playerScale, false, vehNATOPlane, _capBalance + _airbases * 4, _accelerator] call _fnc_economics;
+[0.2 * _playerScale, false, vehNATOPlaneAA, _capBalance + _airbases * 4, _accelerator] call _fnc_economics;
+[0.2 * _playerScale, true, vehNATOTransportPlanes, _capBalance + _airbases * 4, _accelerator] call _fnc_economics;
+[0.2 * _playerScale, true, vehNATOTransportHelis - [vehNATOPatrolHeli], _capBalance + _airbases * 4, _accelerator] call _fnc_economics;
+[0.2 * _playerScale, true, vehNATOAttackHelis, _capBalance + _airbases * 4, _accelerator] call _fnc_economics;
+[0.2 * _playerScale, false, vehNATOMRLS, _capBalance + _airbases + _outposts * 0.2, _accelerator] call _fnc_economics;
 
+private _natoArray = [];
+{
+    if(_x isEqualType "") then
+    {
+        _natoArray pushBack [_x, timer getVariable [_x, 0]];
+    }
+    else
+    {
+        private _array = _x;
+        _natoArray append (_array apply {[_x, timer getVariable [_x, 0]]});
+    };
+} forEach [staticATOccupants, staticAAOccupants, vehNATOAPC, vehNATOTank, vehNATOAA, vehNATOBoat, vehNATOPlane, vehNATOPlaneAA, vehNATOTransportPlanes, (vehNATOTransportHelis - [vehNATOPatrolHeli]), vehNATOAttackHelis, vehNATOMRLS];
+DebugArray("Occupants arsenal", _natoArray);
 //--------------------------------------Invaders---------------------------------------------------
 _airbases = { sidesX getVariable [_x, sideUnknown] == Invaders } count airportsX;
 _outposts = { sidesX getVariable [_x, sideUnknown] == Invaders } count outposts;
@@ -56,15 +89,29 @@ _seaports = { sidesX getVariable [_x, sideUnknown] == Invaders } count seaports;
 _accelerator = 1.2 + (tierWar + difficultyCoef) / 20;
 _capBalance = tierWar * 2 + 10;
 
-[0.2 * _playerScale, "", staticATInvaders, _capBalance + _outposts * 0.2 + _airbases * 0.5, _accelerator] spawn _fnc_economics;
-[0.1 * _playerScale, "", staticAAInvaders, _capBalance + _airbases * 2, _accelerator] spawn _fnc_economics;
-[0.2 * _playerScale, "random", vehCSATAPC, _capBalance + _outposts * 0.3 + _airbases * 2, _accelerator] spawn _fnc_economics;
-[0.1 * _playerScale, "", vehCSATTank, _capBalance + _outposts * 0.5 + _airbases * 2, _accelerator] spawn _fnc_economics;
-[0.1 * _playerScale, "", vehCSATAA, _capBalance + _airbases, _accelerator] spawn _fnc_economics;
-[0.3 * _playerScale, "", vehCSATBoat, _capBalance + _seaports, _accelerator] spawn _fnc_economics;
-[0.2 * _playerScale, "", vehCSATPlane, _capBalance + _airbases * 4, _accelerator] spawn _fnc_economics;
-[0.2 * _playerScale, "", vehCSATPlaneAA, _capBalance + _airbases * 4, _accelerator] spawn _fnc_economics;
-[0.2 * _playerScale, "random", vehCSATTransportPlanes, _airbases * 4, _accelerator] spawn _fnc_economics;
-[0.2 * _playerScale, "random", vehCSATTransportHelis - [vehCSATPatrolHeli], _capBalance + _airbases * 4, _accelerator] spawn _fnc_economics;
-[0.2 * _playerScale, "random", vehCSATAttackHelis, _capBalance + _airbases * 4, _accelerator] spawn _fnc_economics;
-[0.2 * _playerScale, "", vehCSATMRLS, _capBalance + _airbases + _outposts * 0.2, _accelerator] spawn _fnc_economics;
+[0.2 * _playerScale, false, staticATInvaders, _capBalance + _outposts * 0.2 + _airbases * 0.5, _accelerator] call _fnc_economics;
+[0.1 * _playerScale, false, staticAAInvaders, _capBalance + _airbases * 2, _accelerator] call _fnc_economics;
+[0.2 * _playerScale, true, vehCSATAPC, _capBalance + _outposts * 0.3 + _airbases * 2, _accelerator] call _fnc_economics;
+[0.1 * _playerScale, false, vehCSATTank, _capBalance + _outposts * 0.5 + _airbases * 2, _accelerator] call _fnc_economics;
+[0.1 * _playerScale, false, vehCSATAA, _capBalance + _airbases, _accelerator] call _fnc_economics;
+[0.3 * _playerScale, false, vehCSATBoat, _capBalance + _seaports, _accelerator] call _fnc_economics;
+[0.2 * _playerScale, false, vehCSATPlane, _capBalance + _airbases * 4, _accelerator] call _fnc_economics;
+[0.2 * _playerScale, false, vehCSATPlaneAA, _capBalance + _airbases * 4, _accelerator] call _fnc_economics;
+[0.2 * _playerScale, true, vehCSATTransportPlanes, _airbases * 4, _accelerator] call _fnc_economics;
+[0.2 * _playerScale, true, vehCSATTransportHelis - [vehCSATPatrolHeli], _capBalance + _airbases * 4, _accelerator] call _fnc_economics;
+[0.2 * _playerScale, true, vehCSATAttackHelis, _capBalance + _airbases * 4, _accelerator] call _fnc_economics;
+[0.2 * _playerScale, false, vehCSATMRLS, _capBalance + _airbases + _outposts * 0.2, _accelerator] call _fnc_economics;
+
+_natoArray = [];
+{
+    if(_x isEqualType "") then
+    {
+        _natoArray pushBack [_x, timer getVariable [_x, 0]];
+    }
+    else
+    {
+        private _array = _x;
+        _natoArray append (_array apply {[_x, timer getVariable [_x, 0]]});
+    };
+} forEach [staticATInvaders, staticAAInvaders, vehCSATAPC, vehCSATTank, vehCSATAA, vehCSATBoat, vehCSATPlane, vehCSATPlaneAA, vehCSATTransportPlanes, (vehCSATTransportHelis - [vehCSATPatrolHeli]), vehCSATAttackHelis, vehCSATMRLS];
+DebugArray("Occupants arsenal", _natoArray);

--- a/A3-Antistasi/functions/CREATE/fn_singleAttack.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_singleAttack.sqf
@@ -73,7 +73,8 @@ else
     + ([0, 3] select _super)
     + ([0, 0.5, 1.5] select (skillMult - 1))
 };
-_vehicleCount = (round (_vehicleCount)) max 1;
+private _playerScale = exp((sqrt(count allPlayers)/3) - 1);
+_vehicleCount = (round (_vehicleCount * _playerScale)) max 1;
 
 Debug_2("Due to %1 aggression, sending %2 vehicles", (if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders}), _vehicleCount);
 

--- a/A3-Antistasi/functions/CREATE/fn_wavedCA.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_wavedCA.sqf
@@ -166,7 +166,8 @@ while {(_waves > 0)} do
 	_nVeh = 2 + random (2) + (_aggro / 25);
 	_nVeh = _nVeh + (skillMult - 2);
 	if (_firstWave) then { _nVeh = _nVeh + 2 };
-    _nVeh = (round (_nVeh)) max 1;
+    private _playerScale = exp((sqrt(count allPlayers)/3) - 1);
+    _nVeh = (round (_nVeh * _playerScale)) max 1;
 
     Debug_1("Wave will contain %1 vehicles", _nVeh);
 

--- a/A3-Antistasi/functions/Supports/fn_SUP_QRF.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_QRF.sqf
@@ -62,7 +62,8 @@ else
     (aggressionInvaders/25)
     + ([0, 0.5, 1.5] select (skillMult - 1))
 };
-_vehicleCount = (round (_vehicleCount)) max 1;
+private _playerScale = exp((sqrt(count allPlayers)/3) - 1);
+_vehicleCount = (round (_vehicleCount * _playerScale)) max 1;
 
 Debug_2("Due to %1 aggression, sending %2 vehicles", (if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders}), _vehicleCount);
 


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [X] Enhancement

### What have you changed and why?
Information:
I added a formular to calculate a player scaling multiplier for the most important things.

The formular is 
`e ^ (sqrt(playerCount)/3 - 1)`

Initial approach to that formular was the idea that my group of up to 6 experience and relatively well coordinated players with my knowledge can fight of everything that is not a big attack. Giving that this knowledge (especially around the support system) is roughly worth three more players, so 9 players should be able to win the current balance while having a challange and fun.

Going from that was the idea that a lineary scale is not sufficient and singleplayers with AI should be able to get half the units and win with their AI. So with f(1) ~0.5 and f(9) = 1 in a non lineary formular, resulted to the formular givin above.

Interesting points are:
f(1) = 0.5134
f(2) = 0.5894
f(3) = 0.6553
f(4) = 0.7165
f(5) = 0.7751
f(9) = 1
f(10) = 1.0555
f(15) = 1.3377
f(20) = 1.6334
f(25) = 1.9477
f(32) = 2,4244 (Max slots)

It is a nearly lineary run in the lower numbers, but the exponential parts wins more in the higher player numbers

An interesting other formular would be
`e ^ (playerCount/16 - 1)`

f(1) = 0.392
f(5) = 0.503
f(10) = 0.687
f(16) = 1
f(20) = 1.284
f(32) = 2.718

Its is less punishing for solo players, but harder for larger groups, but without real data it is extremely hard to guess that correctly.

To break down potential complains about it:

- The value for X players is way too high/low
Really? Thats an interesting conclusion on something we have literally zero data on (if we have, please let me know). I have no clue if this formular is even close to good, but I am 100% sure its not perfect. Its just how I feel it could be right, it is not how I say it is! If you feel different, that is fine, but if reject this PR based on your personal feeling about it without any data backup, we two have a problem.

- The community might ...
I literally couldnt care less. I have stated my opinion about them on official servers in closed chats multiple times, but as this here is public I will refrain from repeating what I have said. Send me a DM if you wanna know.

- Are you sure it should go over 1
No! I am not, I think it should, as the current amount surely cant stop 32 players. But maybe it needs to be balanced for 32 players and then a formular that goes from 0.2 to 1 or something. Again, there is no data to back any of this, so I say lets try this.

- The AI limiter will become a problem
It will, but I have three possible solutions for that, there might be more tho

> Link slot count and AI limiter and remove rebel AI from the counter. 
 If you only have 8 slots 100 AI should be more than enough as enemies. If you want more players, you automatically adjust the AI limit up (you need some better hardware anyways), so 32 slots result in 300 AI (random numbers, can be adjusted)
 
> Make QRFs and single Attacks waved too
 Just like large attacks, these two could send multiple waves with a specific time between them. Could simulate readyness and so on.
 
> Give them a point/money pool, which is scaled
 Bigger player groups will not necessary get more units, but better ones, where the AI can grab better vehicles with a higher money/point pool 

### Please specify which Issue this PR Resolves.
Solves so many issues and complains, but none on this github

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?
3. [X] Too angry at all this to even fire up the code right now

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:
Have different sizes of playergroups play with this scaling, then evaluate their experiences and logs. Adjust the formular and try again 

********************************************************
Notes: Economics AI is a mess out of magic numbers, which all make no sense to me (30 minutes to regain a useless boat vs 2.5 hours to get an AA tanks, which we otherwise just cheat in???). Would be worth throwing in logs there and see how these actually behave with different player numbers. Would heavily recommend doing that and then redoing the values in there!
