### PR TITLE
Fix vehicle kill event handler

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_vehKilledOrCaptured.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_vehKilledOrCaptured.sqf
@@ -17,7 +17,7 @@ private _side = _veh getVariable ["ownerSide", teamPlayer];			// default because
 if (_captured && (_side == _sideEnemy)) exitWith {};
 
 private _act = if (_captured) then {"captured"} else {"destroyed"};
-Debug_4("%1 of %2 %3 by %4", _type, _side, _act, _sideEnemy);
+ServerDebug_4("%1 of %2 %3 by %4", _type, _side, _act, _sideEnemy);
 
 if (_side == Occupants or _side == Invaders) then
 {
@@ -25,13 +25,12 @@ if (_side == Occupants or _side == Invaders) then
 	if (_sideEnemy != teamPlayer) exitWith {};
 
 	private _value = call {
-		if (_type in vehAPCs) exitWith {8};
-		if (_type in vehTanks) exitWith {15};
-		if (_type in vehAA or _type in vehMRLS) exitWith {15};
-		if (_type in vehAttackHelis) exitWith {15};
-		if (_type in vehTransportAir) exitWith {6};
-		if (_type in vehFixedWing) exitWith {15};		// transportAir must be before this
-		if (_type in vehBoats) exitWith {3};
+		if (_type in vehAPCs) exitWith {5};
+		if (_type in vehTanks) exitWith {10};
+		if (_type in vehAA or _type in vehMRLS) exitWith {10};
+		if (_type in vehAttackHelis) exitWith {10};
+		if (_type in vehTransportAir) exitWith {4};
+		if (_type in vehFixedWing) exitWith {10};		// transportAir must be before this
 		if (_type isKindOf "StaticWeapon") exitWith {1};
 		2;		// trucks, light attack, boats, UAV etc
 	};

--- a/A3-Antistasi/functions/init/fn_initServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initServer.sqf
@@ -182,6 +182,18 @@ addMissionEventHandler ["BuildingChanged", {
 	};
 }];
 
+addMissionEventHandler ["EntityKilled", {
+	params ["_victim", "_killer", "_instigator"];
+	private _killerSide = side group (if (isNull _instigator) then {_killer} else {_instigator});
+	Debug_2("%1 killed by %2", typeof _victim, _killerSide);
+
+	if !(isNil {_victim getVariable "ownerSide"}) then {
+		// Antistasi-created vehicle
+		[_victim, _killerSide, false] call A3A_fnc_vehKilledOrCaptured;
+		[_victim] spawn A3A_fnc_postmortem;
+	};
+}];
+
 serverInitDone = true; publicVariable "serverInitDone";
 Info("Setting serverInitDone as true");
 


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Vehicle kill handler got broken in an Arma update, so vehicle kills are not being registered for any purpose. See #2083 for more details.

Switched it over to the EntityKilled mission event handler, seems to work fine. Tested with various vanilla and RHS vehicles.

I cut down the aggro boosts a bit because it's already death spiralling. QRFs and singleAttacks probably shouldn't be adding their own aggro boosts on failure.

### Please specify which Issue this PR Resolves.
closes #2083

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Kill some vehicles, check that vehKilledOrCaptured is triggering in the RPT.
