### PR TITLE
Make singleAttack and patrolReinf log to server

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_createAttackVehicle.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAttackVehicle.sqf
@@ -69,7 +69,7 @@ if (_expectedCargo > 0) then
 };
 
 _landPosBlacklist = [_vehicle, _crewGroup, _cargoGroup, _posDestination, _markerOrigin, _landPosBlacklist] call A3A_fnc_createVehicleQRFBehaviour;
-Debug_2("Spawn Performed: Created vehicle %1 with %2 soldiers", typeof _vehicle, count crew _vehicle);
+ServerDebug_2("Spawn Performed: Created vehicle %1 with %2 soldiers", typeof _vehicle, count crew _vehicle);
 
 private _vehicleData = [_vehicle, _crewGroup, _cargoGroup, _landPosBlacklist];
 _vehicleData;

--- a/A3-Antistasi/functions/CREATE/fn_patrolReinf.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_patrolReinf.sqf
@@ -6,7 +6,7 @@ _mrkDestination = _this select 0;
 _mrkOrigin = _this select 1;
 _numberX = _this select 2;
 _sideX = _this select 3;
-Info_4("Spawning PatrolReinf. Dest:%1, Orig:%2, Size:%3, Side: %4",_mrkDestination,_mrkOrigin,_numberX,_sideX);
+ServerInfo_4("Spawning PatrolReinf. Dest:%1, Orig:%2, Size:%3, Side: %4",_mrkDestination,_mrkOrigin,_numberX,_sideX);
 _posDestination = getMarkerPos _mrkDestination;
 _posOrigin = getMarkerPos _mrkOrigin;
 
@@ -145,7 +145,7 @@ else
 	};
 };
 
-Info_2("Spawn performed: Vehicle type %1 with %2 troops", _typeVehX, count units _groupX);
+ServerInfo_2("Spawn performed: Vehicle type %1 with %2 troops", _typeVehX, count units _groupX);
 
 
 // Allow the convoy a generous time to arrive
@@ -185,10 +185,10 @@ if (count _units == 0 || time > _timeout || _sideX != (sidesX getVariable _mrkDe
 		killZones setVariable [_mrkOrigin,_killzones,true];
 	};
 
-    Info_2("Reinf on %1 failed, returning with %2 units", _mrkDestination, count units _groupX);
+    ServerInfo_2("Reinf on %1 failed, returning with %2 units", _mrkDestination, count units _groupX);
 };
 
-Info_2("Reinf on %1 successful, adding %2 units", _mrkDestination, count units _groupX);
+ServerInfo_2("Reinf on %1 successful, adding %2 units", _mrkDestination, count units _groupX);
 
 // Arrived successfully, add units to garrison and despawn with it
 [_units, _sideX, _mrkDestination, 0] remoteExec ["A3A_fnc_garrisonUpdate", 2];

--- a/A3-Antistasi/functions/CREATE/fn_singleAttack.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_singleAttack.sqf
@@ -17,7 +17,7 @@ params ["_markerDestination", "_side", "_super"];
 #include "..\..\Includes\common.inc"
 FIX_LINE_NUMBERS()
 
-Info_1("Starting single attack with parameters %1", _this);
+ServerInfo_1("Starting single attack with parameters %1", _this);
 
 private _markerOrigin = "";
 private _posOrigin = [];
@@ -30,12 +30,12 @@ if(_side isEqualType "") then
     _markerOrigin = _side;
     _posOrigin = getMarkerPos _markerOrigin;
     _side = sidesX getVariable [_markerOrigin, sideUnknown];
-    Info_2("Adapting attack params, side is %1, start base is %2", _side, _markerOrigin);
+    ServerInfo_2("Adapting attack params, side is %1, start base is %2", _side, _markerOrigin);
 };
 
 if(_side == sideUnknown) exitWith
 {
-    Error_1("Could not retrieve side for %1", _markerOrigin);
+    ServerError_1("Could not retrieve side for %1", _markerOrigin);
 };
 
 private _typeOfAttack = [_posDestination, _side] call A3A_fnc_chooseAttackType;
@@ -50,7 +50,7 @@ if(_markerOrigin == "") then
 
 if (_markerOrigin == "") exitWith
 {
-    Info_1("Small attack to %1 cancelled because no usable bases in vicinity",_markerDestination);
+    ServerInfo_1("Small attack to %1 cancelled because no usable bases in vicinity",_markerDestination);
 };
 
 //Base selected, select units now
@@ -75,7 +75,7 @@ else
 };
 _vehicleCount = (round (_vehicleCount)) max 1;
 
-Debug_2("Due to %1 aggression, sending %2 vehicles", (if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders}), _vehicleCount);
+ServerDebug_2("Due to %1 aggression, sending %2 vehicles", (if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders}), _vehicleCount);
 
 //Set idle times for marker
 if (_markerOrigin in airportsX) then
@@ -113,7 +113,7 @@ if(_vehPool isEqualTo []) then
 for "_i" from 1 to _vehicleCount do
 {
     if ([_side] call A3A_fnc_remUnitCount < 4) exitWith {
-        Info("Cancelling because maxUnits exceeded");
+        ServerInfo("Cancelling because maxUnits exceeded");
     };
 
     private _vehicleType = selectRandomWeighted _vehPool;
@@ -130,7 +130,7 @@ for "_i" from 1 to _vehicleCount do
         sleep 5;
     };
 };
-Info_2("Spawn Performed: Small %1 attack sent with %2 vehicles", _typeOfAttack, count _vehicles);
+ServerInfo_2("Spawn Performed: Small %1 attack sent with %2 vehicles", _typeOfAttack, count _vehicles);
 
 //Prepare despawn conditions
 private _endTime = time + 2700;
@@ -143,11 +143,10 @@ while {true} do
 
     if(_markerSide == _side) exitWith
     {
-        Info_1("Small attack to %1 captured the marker, starting despawn routines", _markerDestination);
+        ServerInfo_1("Small attack to %1 captured the marker, starting despawn routines", _markerDestination);
     };
 
     //Trying to flip marker
-    Debug("Checking whether small attack took marker");
     [_markerDestination, _markerSide] remoteExec ["A3A_fnc_zoneCheck", 2];
 
     private _groupAlive = false;
@@ -161,13 +160,13 @@ while {true} do
 
     if !(_groupAlive) exitWith
     {
-        Info_1("Small attack to %1 has been eliminated, starting despawn routines", _markerDestination);
+        ServerInfo_1("Small attack to %1 has been eliminated, starting despawn routines", _markerDestination);
     };
 
     sleep 60;
     if(_endTime < time) exitWith
     {
-        Info_1("Small attack to %1 timed out without winning or loosing, starting despawn routines", _markerDestination);
+        ServerInfo_1("Small attack to %1 timed out without winning or loosing, starting despawn routines", _markerDestination);
     };
 };
 


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
As they typically run on HCs, singleAttack and patrolReinf lost their log-to-server behaviour in the define switchover. This is bad because it means most vehicle spawns are no longer logged. This PR restores the log-to-server behaviour.    

### Please specify which Issue this PR Resolves.
closes #2101

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Hold this PR until 2.5.3 in case I remember any other functions that needed server logging.