### PR TITLE
Fix fastrope spawning corpses underground after heli crash

### DIFF
--- a/A3-Antistasi/functions/AI/fn_fastrope.sqf
+++ b/A3-Antistasi/functions/AI/fn_fastrope.sqf
@@ -45,7 +45,7 @@ _veh flyInHeight 15;
 waitUntil {sleep 1; (not alive _veh) or ((speed _veh < 1) and (speed _veh > -1)) or !(canMove _veh)};
 
 if (alive _veh) then
-	{
+{
 	[_veh] call A3A_fnc_smokeCoverAuto;
 
 	{
@@ -60,6 +60,7 @@ if (alive _veh) then
 		_d = -1;
 		unassignVehicle _unit;
 		moveOut _unit;
+		if (!(alive _veh) or (getPos _veh)#2 < 5) exitWith {};			// Avoid placing dead units underground after vehicle crashes
 		[_unit,"gunner_standup01"] remoteExec ["switchmove"];
 		_unit attachTo [_veh, [_xRef,_yRef,_d]];
 		while {((getposATL _unit select 2) > 1) and (alive _veh) and (alive _unit) and (speed _veh < 10) and (speed _veh > -10)} do
@@ -74,7 +75,7 @@ if (alive _veh) then
 		};
 	sleep 5 + random 2;
 	} forEach units _groupX;
-	};
+};
 
 waitUntil {sleep 1; (not alive _veh) or ((count assignedCargo _veh == 0) and (([_veh] call A3A_fnc_countAttachedObjects) == 0))};
 
@@ -105,3 +106,4 @@ _wp3 setWaypointSpeed "NORMAL";
 _wp3 setWaypointBehaviour "CARELESS";
 _wp3 setWaypointStatements ["true", "if !(local this) exitWith {}; deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
 {_x setBehaviour "CARELESS";} forEach units _heli;
+


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Once units have started fastroping from a heli, the whole cargo will continue spawning in the fastrope position (below the heli) regardless of whether it's above the ground. This causes it to spawn corpses underground, wasting performance and annoying players when they can't find the bodies to loot.

This PR fixes the problem by not performing the fastrope process if the heli is destroyed or close to the ground.

This doesn't fix the heli/pilots despawning issue (#1487) which often coincides. That one's much harder.

### Please specify which Issue this PR Resolves.
closes #2093

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Easiest in vanilla with a MAAWS because the patrol helis are consistently destroyed by one shot. Get a rocket launcher and a good oversight position on HQ and summon an HQ attack ( `[[],"A3A_fnc_attackHQ"] remoteExec ["A3A_fnc_scheduler",2]`). Wait until units start fastroping and then nuke their heli. Go check for corpses.