### PR TITLE
Fix allowCrewInImmobile not being applied correctly to convoy vehicles

### DIFF
--- a/A3-Antistasi/functions/Missions/fn_convoy.sqf
+++ b/A3-Antistasi/functions/Missions/fn_convoy.sqf
@@ -156,7 +156,7 @@ private _fnc_spawnConvoyVehicle = {
     deleteWaypoint [_group, 0];													// groups often start with a bogus waypoint
 
     [_veh, _sideX] call A3A_fnc_AIVEHinit;
-    if (_veh in vehArmor) then { _veh allowCrewInImmobile true };			// move this to AIVEHinit at some point?
+    if (_vehType in vehArmor) then { _veh allowCrewInImmobile true };			// move this to AIVEHinit at some point?
     _vehiclesX pushBack _veh;
     _markNames pushBack _markName;
     _veh;

--- a/A3-Antistasi/functions/Missions/fn_convoy.sqf
+++ b/A3-Antistasi/functions/Missions/fn_convoy.sqf
@@ -150,14 +150,13 @@ private _fnc_spawnConvoyVehicle = {
     _veh allowDamage false;
 
     private _group = [_sideX, _veh] call A3A_fnc_createVehicleCrew;
-    // might need to clear waypoints here?
     { [_x] call A3A_fnc_NATOinit; _x allowDamage false; } forEach (units _group);
     _soldiers append (units _group);
     (driver _veh) stop true;
     deleteWaypoint [_group, 0];													// groups often start with a bogus waypoint
 
     [_veh, _sideX] call A3A_fnc_AIVEHinit;
-    if (_veh in vehArmor) then { _vehObj allowCrewInImmobile true };			// move this to AIVEHinit at some point?
+    if (_veh in vehArmor) then { _veh allowCrewInImmobile true };			// move this to AIVEHinit at some point?
     _vehiclesX pushBack _veh;
     _markNames pushBack _markName;
     _veh;

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -671,7 +671,7 @@ DECLARE_SERVER_VAR(vehAA, _vehAA);
 private _vehMRLS = [vehCSATMRLS, vehNATOMRLS];
 DECLARE_SERVER_VAR(vehMRLS, _vehMRLS);
 
-private _vehArmor = [vehTanks,vehAA,vehMRLS] + vehAPCs;
+private _vehArmor = vehTanks + vehAA + vehMRLS + vehAPCs;
 DECLARE_SERVER_VAR(vehArmor, _vehArmor);
 
 private _vehTransportAir = vehNATOTransportHelis + vehCSATTransportHelis + vehNATOTransportPlanes + vehCSATTransportPlanes;

--- a/A3-Antistasi/functions/init/fn_initVehClassToCrew.sqf
+++ b/A3-Antistasi/functions/init/fn_initVehClassToCrew.sqf
@@ -46,7 +46,7 @@ private _allVehClassToCrew = [
 // So if "Tank_F" is in both NATOLand and NATOTanks, NATOTanks should be ABOVE NATOLand, as NATOTanks is a specialised child.
 
     [vehFixedWing,[NATOPilot, CSATPilot, staticCrewTeamPlayer, "C_Man_1"]],
-    [flatten vehArmor, [NATOCrew, CSATCrew, staticCrewTeamPlayer, "C_Man_1"]],          // <- vehArmor has nested arrays; therefore, it needs to be flattened.
+    [vehArmor, [NATOCrew, CSATCrew, staticCrewTeamPlayer, "C_Man_1"]],
     [vehHelis, [NATOPilot, CSATPilot, staticCrewTeamPlayer, "C_Man_1"]],
     [vehUAVs, ["B_UAV_AI", "O_UAV_AI", "I_UAV_AI", "C_UAV_AI"]],
     [vehFIA, [FIARifleman, FIARifleman, staticCrewTeamPlayer, "C_Man_1"]],


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
allowCrewInImmobile (command that prevents crew from bailing out of an immobilized vehicle) was being applied to the convoy objective vehicle rather than the armoured vehicles due to a copypaste error. This PR fixes it so armoured vehicles are set correctly to allowCrewInImmobile.

### Please specify which Issue this PR Resolves.
closes #2104

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Easiest at high war level but quite difficult. Spawn a convoy with an armoured vehicle in it (tank, APC, AA, not MRAP) that's not the objective vehicle. Delete the other vehicles with zeus or whatever and then cripple the armoured vehicle. The crew should remain in the vehicle.

Probably not worth the testing effort.