### PR TITLE
Save all vehicle pool entries that are incremented by economicsAI

### DIFF
--- a/A3-Antistasi/functions/Save/fn_saveLoop.sqf
+++ b/A3-Antistasi/functions/Save/fn_saveLoop.sqf
@@ -226,7 +226,7 @@ _dataX = [];
 _dataX = [];
 {
 	_dataX pushBack [_x,timer getVariable _x];
-} forEach (vehAttack + vehNATOAttackHelis + vehPlanes + vehCSATAttackHelis);
+} forEach (vehAttack + vehMRLS + vehAA + vehHelis + vehFixedWing + [vehNATOBoat, vehCSATBoat, staticATOccupants, staticAAOccupants, staticATInvaders, staticAAInvaders]);
 
 ["idleassets",_dataX] call A3A_fnc_setStatVariable;
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The counts for some limited enemy vehicle types weren't being saved. Static AA & AT, artillery, AA tanks and boats, specifically. This PR fixes this for new saves.

### Please specify which Issue this PR Resolves.
closes #2097

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Some logging code to show the vehicle counts for occupant vehicles:

```
_occTypes = [ 
 ["StaticAT", [staticATOccupants]],
 ["StaticAA", [staticAAOccupants]],
 ["AAPlane", [vehNATOPlaneAA]], 
 ["AttackPlane", [vehNATOPlane]], 
 ["AttackHelis", vehNATOAttackHelis], 
 ["TransportPlanes", vehNATOTransportPlanes], 
 ["TransportHelis", vehNATOTransportHelis], 
 ["APCs", vehNATOAPC], 
 ["Tanks", [vehNATOTank]], 
 ["AATanks", [vehNATOAA]], 
 ["Boats", [vehNATOBoat]]
]; 
_occTypes apply {  
    private _total = 0; 
 { _total = _total + (timer getVariable [_x, 0]) } forEach _x#1; 
 [_x#0, _total] 
}; 
```

Start a new game, or use one where vehicles aren't capped. Run one cycle of economicsAI by running this as server:
`[] call economicsAI`

Check the vehicle counts. They should all have fractions in them. Now save the game and reload. Check that the counts have been preserved.
