### PR TITLE
Fixed carry object carrying an object that is not the object you want to carry.

### DIFF
--- a/A3-Antistasi/functions/UtilityItems/fn_carryItem.sqf
+++ b/A3-Antistasi/functions/UtilityItems/fn_carryItem.sqf
@@ -2,7 +2,7 @@
 Author: Killerswin2,
     trys to carry an object to a place
 Arguments:
-    0.<String>  netId of the object that will be carried
+    0.<Object>  object that will be carried
     1.<Bool>    bool that determines if the object will be picked up
     2.<Object>  player that calls or holds object (optional)
 Return Value:
@@ -14,13 +14,12 @@ Public: yes
 Dependencies: 
 
 Example:
-    [cursorObject call BIS_fnc_netId] call A3A_fnc_carryItem; 
+    [cursorObject] call A3A_fnc_carryItem; 
 
 */
 
 
-params [["_netId", ""], "_pickUp", ["_player", player]];
-private _item = _netId call BIS_fnc_objectFromNetId;
+params [["_item", objNull], "_pickUp", ["_player", player]];
 
 if (_pickUp) then {
     if (([_player] call A3A_fnc_countAttachedObjects) > 0) exitWith {[localize "STR_A3A_Utility_Title", localize "STR_A3A_Utility_Items_Feedback_Normal"] call A3A_fnc_customHint};

--- a/A3-Antistasi/functions/UtilityItems/fn_carryItem.sqf
+++ b/A3-Antistasi/functions/UtilityItems/fn_carryItem.sqf
@@ -2,7 +2,7 @@
 Author: Killerswin2,
     trys to carry an object to a place
 Arguments:
-    0.<Object>  object that will carried;
+    0.<String>  netId of object that will be carried
     1.<Bool>    bool that determines if the object will be picked up
     2.<Object>  player that calls or holds object (optional)
 Return Value:
@@ -14,12 +14,13 @@ Public: yes
 Dependencies: 
 
 Example:
-    [cursorObject] call A3A_fnc_carryItem; 
+    [cursorObject call BIS_fnc_netId] call A3A_fnc_carryItem; 
 
 */
 
 
-params [["_item", objNull], "_pickUp", ["_player", player]];
+params [["_netId", ""], "_pickUp", ["_player", player]];
+private _item = _netId call BIS_fnc_objectFromNetId;
 
 if (_pickUp) then {
     if (([_player] call A3A_fnc_countAttachedObjects) > 0) exitWith {[localize "STR_A3A_Utility_Title", localize "STR_A3A_Utility_Items_Feedback_Normal"] call A3A_fnc_customHint};

--- a/A3-Antistasi/functions/UtilityItems/fn_carryItem.sqf
+++ b/A3-Antistasi/functions/UtilityItems/fn_carryItem.sqf
@@ -19,7 +19,7 @@ Example:
 */
 
 
-params [["_item", objNull], "_pickUp", ["_player", player]];
+params [["_item", objNull, [objNull]], "_pickUp", ["_player", player]];
 
 if (_pickUp) then {
     if (([_player] call A3A_fnc_countAttachedObjects) > 0) exitWith {[localize "STR_A3A_Utility_Title", localize "STR_A3A_Utility_Items_Feedback_Normal"] call A3A_fnc_customHint};

--- a/A3-Antistasi/functions/UtilityItems/fn_carryItem.sqf
+++ b/A3-Antistasi/functions/UtilityItems/fn_carryItem.sqf
@@ -2,7 +2,7 @@
 Author: Killerswin2,
     trys to carry an object to a place
 Arguments:
-    0.<String>  netId of object that will be carried
+    0.<String>  netId of the object that will be carried
     1.<Bool>    bool that determines if the object will be picked up
     2.<Object>  player that calls or holds object (optional)
 Return Value:

--- a/A3-Antistasi/functions/UtilityItems/fn_initMovableObject.sqf
+++ b/A3-Antistasi/functions/UtilityItems/fn_initMovableObject.sqf
@@ -20,13 +20,14 @@ Example:
 params[["_object", objNull, [objNull]],["_jipKey", "", [""]]];
 
 if (isNil "_object") exitwith {remoteExec ["", _jipKey];};
-    
+private _netId = _object call BIS_fnc_netId;
+
 _object addAction [
     "Carry object",
     {
-        [_this select 3,true] call A3A_fnc_carryItem;
+        [_this select 3, true] call A3A_fnc_carryItem;
     },
-    _object call BIS_fnc_netId,
+    _netId,
     1.5,
     true,
     true,
@@ -41,9 +42,9 @@ _object addAction [
 _object addAction [
     "Rotate object",
     {
-        [cursorObject] call A3A_fnc_rotateItem;
+        [_this select 3] call A3A_fnc_rotateItem;
     },
-    nil,
+    _netId,
     1.5,
     true,
     true,

--- a/A3-Antistasi/functions/UtilityItems/fn_initMovableObject.sqf
+++ b/A3-Antistasi/functions/UtilityItems/fn_initMovableObject.sqf
@@ -24,9 +24,9 @@ if (isNil "_object") exitwith {remoteExec ["", _jipKey];};
 _object addAction [
     "Carry object",
     {
-        [cursorObject, true] call A3A_fnc_carryItem;
+        [_this select 3,true] call A3A_fnc_carryItem;
     },
-    nil,
+    _object call BIS_fnc_netId,
     1.5,
     true,
     true,

--- a/A3-Antistasi/functions/UtilityItems/fn_initMovableObject.sqf
+++ b/A3-Antistasi/functions/UtilityItems/fn_initMovableObject.sqf
@@ -20,14 +20,13 @@ Example:
 params[["_object", objNull, [objNull]],["_jipKey", "", [""]]];
 
 if (isNil "_object") exitwith {remoteExec ["", _jipKey];};
-private _netId = _object call BIS_fnc_netId;
 
 _object addAction [
     "Carry object",
     {
-        [_this select 3, true] call A3A_fnc_carryItem;
+        [_this#3, true] call A3A_fnc_carryItem;
     },
-    _netId,
+    _object,
     1.5,
     true,
     true,
@@ -42,9 +41,9 @@ _object addAction [
 _object addAction [
     "Rotate object",
     {
-        [_this select 3] call A3A_fnc_rotateItem;
+        [_this#3] call A3A_fnc_rotateItem;
     },
-    _netId,
+    _object,
     1.5,
     true,
     true,

--- a/A3-Antistasi/functions/UtilityItems/fn_initMovableObject.sqf
+++ b/A3-Antistasi/functions/UtilityItems/fn_initMovableObject.sqf
@@ -19,7 +19,7 @@ Example:
 
 params[["_object", objNull, [objNull]],["_jipKey", "", [""]]];
 
-if (isNil "_object") exitwith {remoteExec ["", _jipKey];};
+if (isNil _object) exitwith {remoteExec ["", _jipKey];};
 
 _object addAction [
     "Carry object",

--- a/A3-Antistasi/functions/UtilityItems/fn_initMovableObject.sqf
+++ b/A3-Antistasi/functions/UtilityItems/fn_initMovableObject.sqf
@@ -19,7 +19,7 @@ Example:
 
 params[["_object", objNull, [objNull]],["_jipKey", "", [""]]];
 
-if (isNil _object) exitwith {remoteExec ["", _jipKey];};
+if (isNull _object) exitwith {remoteExec ["", _jipKey];};
 
 _object addAction [
     "Carry object",

--- a/A3-Antistasi/functions/UtilityItems/fn_rotateItem.sqf
+++ b/A3-Antistasi/functions/UtilityItems/fn_rotateItem.sqf
@@ -18,7 +18,7 @@ Note:
 */
 
 #include "\a3\ui_f\hpp\definedikcodes.inc"
-params[["_netId", "", [objNull]]];
+params[["_netId", ""]];
 private _object = _netId call BIS_fnc_objectFromNetId;
 
 #define E_PRESSED 0

--- a/A3-Antistasi/functions/UtilityItems/fn_rotateItem.sqf
+++ b/A3-Antistasi/functions/UtilityItems/fn_rotateItem.sqf
@@ -2,7 +2,7 @@
 Author: Killerswin2, Hakon
     rotates an item
 Arguments:
-    0.<Object> object that will be carried
+    0.<Object> object that will be rotated
 Return Value:
     <nil>
 

--- a/A3-Antistasi/functions/UtilityItems/fn_rotateItem.sqf
+++ b/A3-Antistasi/functions/UtilityItems/fn_rotateItem.sqf
@@ -2,7 +2,7 @@
 Author: Killerswin2, Hakon
     rotates an item
 Arguments:
-    0.<String> netId of the object that will be carried
+    0.<Object> object that will be carried
 Return Value:
     <nil>
 
@@ -12,14 +12,13 @@ Public: No
 Dependencies: 
 
 Example:
-    [cursorObject call BIS_fnc_netId] call A3A_fnc_rotateItem; 
+    [cursorObject] call A3A_fnc_rotateItem; 
 
 Note: 
 */
 
 #include "\a3\ui_f\hpp\definedikcodes.inc"
-params[["_netId", ""]];
-private _object = _netId call BIS_fnc_objectFromNetId;
+params[["_object", objNull]];
 
 #define E_PRESSED 0
 #define Q_PRESSED 1

--- a/A3-Antistasi/functions/UtilityItems/fn_rotateItem.sqf
+++ b/A3-Antistasi/functions/UtilityItems/fn_rotateItem.sqf
@@ -2,7 +2,7 @@
 Author: Killerswin2, Hakon
     rotates an item
 Arguments:
-    0.<object> object that will be rotated;
+    0.<String> netId of the object that will be carried
 Return Value:
     <nil>
 
@@ -18,7 +18,8 @@ Note:
 */
 
 #include "\a3\ui_f\hpp\definedikcodes.inc"
-params[["_object", objNull, [objNull]]];
+params[["_netId", "", [objNull]]];
+private _object = _netId call BIS_fnc_objectFromNetId;
 
 #define E_PRESSED 0
 #define Q_PRESSED 1

--- a/A3-Antistasi/functions/UtilityItems/fn_rotateItem.sqf
+++ b/A3-Antistasi/functions/UtilityItems/fn_rotateItem.sqf
@@ -18,7 +18,7 @@ Note:
 */
 
 #include "\a3\ui_f\hpp\definedikcodes.inc"
-params[["_object", objNull]];
+params[["_object", objNull, [objNull]]];
 
 #define E_PRESSED 0
 #define Q_PRESSED 1

--- a/A3-Antistasi/functions/UtilityItems/fn_rotateItem.sqf
+++ b/A3-Antistasi/functions/UtilityItems/fn_rotateItem.sqf
@@ -12,7 +12,7 @@ Public: No
 Dependencies: 
 
 Example:
-    [cursorObject] call A3A_fnc_rotateItem; 
+    [cursorObject call BIS_fnc_netId] call A3A_fnc_rotateItem; 
 
 Note: 
 */


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information: fn_initMovableObject uses cursorObject for addAction. With small objects it is possible for cursorObject to retrieve a different object. If netId is used this shouldn't be possible.
    

### Please specify which Issue this PR Resolves.
was not posted, here is a video of the issue: https://youtu.be/-N96s0wBq5M

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
  Buy a light from vehicle box.
  Hit carry object while looking at another object.
  (I already did some tests myself but i checked yes just to make sure someone else tests it too)

********************************************************
Notes: