### PR TITLE
Improve scaling, fix bugs and add logging in economicsAI

### DIFF
--- a/A3-Antistasi/functions/Base/fn_economicsAI.sqf
+++ b/A3-Antistasi/functions/Base/fn_economicsAI.sqf
@@ -42,16 +42,16 @@ private _increase = _balanceScale / 6;      // Because it's called six times per
 
 [[staticATOccupants], 1.0, _groundCap, _increase] call _fnc_economics;
 [[staticAAOccupants], 1.0, _groundCap, _increase] call _fnc_economics;
-[vehNATOAPC, 1.2, _groundCap, _increase] call _fnc_economics;
-[[vehNATOTank], 0.4, _groundCap, _increase] call _fnc_economics;
-[[vehNATOAA], 0.4, _groundCap, _increase] call _fnc_economics;
-[[vehNATOMRLS], 0.2, _groundCap, _increase] call _fnc_economics;           // not used atm?
+[vehNATOAPC, 1.8, _groundCap, _increase] call _fnc_economics;
+[[vehNATOTank], 0.6, _groundCap, _increase] call _fnc_economics;
+[[vehNATOAA], 0.6, _groundCap, _increase] call _fnc_economics;
+[[vehNATOMRLS], 0.3, _groundCap, _increase] call _fnc_economics;           // not used atm?
 [[vehNATOBoat], 1.0, _balanceScale * (1 + _seaports), _increase] call _fnc_economics;
 [[vehNATOPlane], 0.25, _airCap, _increase] call _fnc_economics;             // only used for major attacks
 [[vehNATOPlaneAA], 0.25, _airCap, _increase] call _fnc_economics;           // only used for major attacks
-[vehNATOTransportPlanes, 1.0, _airCap, _increase] call _fnc_economics;
-[vehNATOTransportHelis - [vehNATOPatrolHeli], 1.5, _airCap, _increase] call _fnc_economics;
-[vehNATOAttackHelis, 0.8, _airCap, _increase] call _fnc_economics;
+[vehNATOTransportPlanes, 1.5, _airCap, _increase] call _fnc_economics;
+[vehNATOTransportHelis - [vehNATOPatrolHeli], 2.5, _airCap, _increase] call _fnc_economics;
+[vehNATOAttackHelis, 1.2, _airCap, _increase] call _fnc_economics;
 
 private _natoArray = flatten [staticATOccupants, staticAAOccupants, vehNATOAPC, vehNATOTank, vehNATOAA, vehNATOBoat, vehNATOPlane, vehNATOPlaneAA, vehNATOTransportPlanes, (vehNATOTransportHelis - [vehNATOPatrolHeli]), vehNATOAttackHelis, vehNATOMRLS];
 _natoArray = _natoArray apply { [_x, timer getVariable [_x, 0]] };
@@ -68,16 +68,16 @@ _increase = 1.2 * _balanceScale / 6;            // Invaders get a bit more of ev
 
 [[staticATInvaders], 1.0, _groundCap, _increase] call _fnc_economics;
 [[staticAAInvaders], 1.0, _groundCap, _increase] call _fnc_economics;
-[vehCSATAPC, 1.2, _groundCap, _increase] call _fnc_economics;
-[[vehCSATTank], 0.4, _groundCap, _increase] call _fnc_economics;
-[[vehCSATAA], 0.4, _groundCap, _increase] call _fnc_economics;
-[[vehCSATMRLS], 0.2, _groundCap, _increase] call _fnc_economics;           // not used atm?
+[vehCSATAPC, 1.8, _groundCap, _increase] call _fnc_economics;
+[[vehCSATTank], 0.6, _groundCap, _increase] call _fnc_economics;
+[[vehCSATAA], 0.6, _groundCap, _increase] call _fnc_economics;
+[[vehCSATMRLS], 0.3, _groundCap, _increase] call _fnc_economics;           // not used atm?
 [[vehCSATBoat], 1.0, _balanceScale * (1 + _seaports), _increase] call _fnc_economics;
 [[vehCSATPlane], 0.25, _airCap, _increase] call _fnc_economics;             // only used for major attacks
 [[vehCSATPlaneAA], 0.25, _airCap, _increase] call _fnc_economics;           // only used for major attacks
-[vehCSATTransportPlanes, 1.0, _airCap, _increase] call _fnc_economics;
-[vehCSATTransportHelis - [vehCSATPatrolHeli], 1.5, _airCap, _increase] call _fnc_economics;
-[vehCSATAttackHelis, 0.8, _airCap, _increase] call _fnc_economics;
+[vehCSATTransportPlanes, 1.5, _airCap, _increase] call _fnc_economics;
+[vehCSATTransportHelis - [vehCSATPatrolHeli], 2.5, _airCap, _increase] call _fnc_economics;
+[vehCSATAttackHelis, 1.2, _airCap, _increase] call _fnc_economics;
 
 private _csatArray = flatten [staticATInvaders, staticAAInvaders, vehCSATAPC, vehCSATTank, vehCSATAA, vehCSATBoat, vehCSATPlane, vehCSATPlaneAA, vehCSATTransportPlanes, (vehCSATTransportHelis - [vehCSATPatrolHeli]), vehCSATAttackHelis, vehCSATMRLS];
 _csatArray = _csatArray apply { [_x, timer getVariable [_x, 0]] };

--- a/A3-Antistasi/functions/Base/fn_economicsAI.sqf
+++ b/A3-Antistasi/functions/Base/fn_economicsAI.sqf
@@ -28,7 +28,7 @@ _fnc_economics = {
 // Coeff 1.0 means one vehicle per hour with 9 players @ tierWar 7, or two vehicles per hour for 26 players.
 
 // 9 players @ tierWar 7 => balanceScale 1
-private _playerScale = exp((sqrt(count allPlayers)/3) - 1);
+private _playerScale = (8 + count (allPlayers - entities "HeadlessClient_F")) / 17;
 private _balanceScale = _playerScale * (3 + tierWar) / 10;
 
 //--------------------------------------Occupants--------------------------------------------------

--- a/A3-Antistasi/functions/Base/fn_economicsAI.sqf
+++ b/A3-Antistasi/functions/Base/fn_economicsAI.sqf
@@ -4,26 +4,31 @@
 #include "..\..\Includes\common.inc"
 FIX_LINE_NUMBERS()
 
+params [["_timeInHours", 1/6], ["_occScale", 1], ["_invScale", 1.2]];
+
 // Increase one type by _increase*_typeCoeff, if total of types is lower than _baseCap*_typeCoeff
 _fnc_economics = {
     params ["_types", "_typeCoeff", "_baseCap", "_increase"];
 
     if (_types isEqualTo []) exitWith {};
 
-    private _totalItems = 0;
-    {
-        // fractions don't count towards cap
-        _totalItems = _totalItems + floor (timer getVariable [_x, 0]);
-    } forEach _types;
+    isNil {
+        private _totalItems = 0;
+        {
+            // fractions don't count towards cap
+            _totalItems = _totalItems + floor (timer getVariable [_x, 0]);
+        } forEach _types;
 
-    if (_totalItems < ceil (_typeCoeff * _baseCap)) then {
-        private _type = selectRandom _types;
-        private _currentItems = timer getVariable [_type, 0];
-        timer setVariable [_type, _currentItems + _typeCoeff * _increase, true];
+        if (_totalItems < _typeCoeff * _baseCap) then {
+            private _type = selectRandom _types;
+            private _currentItems = timer getVariable [_type, 0];
+            timer setVariable [_type, _currentItems + _typeCoeff * _increase, true];
+        };
     };
 };
 
 // Community with ~30 players killed roughly 2 APCs per hour, probably similar for attack helis
+// However they weren't spawning QRFs or singleAttacks due to maxUnits bugs, so this is probably low
 // Air vehicles set fairly high because we're using a lot of them since 2.4
 // Coeff 1.0 means one vehicle per hour with 9 players @ tierWar 7, or two vehicles per hour for 26 players.
 
@@ -36,9 +41,9 @@ private _airbases = { sidesX getVariable [_x, sideUnknown] == Occupants } count 
 private _outposts = { sidesX getVariable [_x, sideUnknown] == Occupants } count outposts;
 private _seaports = { sidesX getVariable [_x, sideUnknown] == Occupants } count seaports;
 
-private _airCap = _balanceScale * (4 + _airbases*2);
-private _groundCap = _balanceScale * (4 + _airbases + _outposts*0.5);
-private _increase = _balanceScale / 6;      // Because it's called six times per hour. Could pass in a time instead...
+private _airCap = _occScale * _balanceScale * (4 + _airbases*2);
+private _groundCap = _occScale * _balanceScale * (4 + _airbases + _outposts*0.5);
+private _increase = _occScale * _balanceScale * _timeInHours;
 
 [[staticATOccupants], 1.0, _groundCap, _increase] call _fnc_economics;
 [[staticAAOccupants], 1.0, _groundCap, _increase] call _fnc_economics;
@@ -46,7 +51,7 @@ private _increase = _balanceScale / 6;      // Because it's called six times per
 [[vehNATOTank], 0.6, _groundCap, _increase] call _fnc_economics;
 [[vehNATOAA], 0.6, _groundCap, _increase] call _fnc_economics;
 [[vehNATOMRLS], 0.3, _groundCap, _increase] call _fnc_economics;           // not used atm?
-[[vehNATOBoat], 1.0, _balanceScale * (1 + _seaports), _increase] call _fnc_economics;
+[[vehNATOBoat], 1.0, _balanceScale * (2 + _seaports*2), _increase] call _fnc_economics;
 [[vehNATOPlane], 0.25, _airCap, _increase] call _fnc_economics;             // only used for major attacks
 [[vehNATOPlaneAA], 0.25, _airCap, _increase] call _fnc_economics;           // only used for major attacks
 [vehNATOTransportPlanes, 1.5, _airCap, _increase] call _fnc_economics;
@@ -62,9 +67,9 @@ _airbases = { sidesX getVariable [_x, sideUnknown] == Invaders } count airportsX
 _outposts = { sidesX getVariable [_x, sideUnknown] == Invaders } count outposts;
 _seaports = { sidesX getVariable [_x, sideUnknown] == Invaders } count seaports;
 
-_airCap = 1.2 * _balanceScale * (4 + _airbases*2);
-_groundCap = 1.2 * _balanceScale * (4 + _airbases + _outposts*0.5);
-_increase = 1.2 * _balanceScale / 6;            // Invaders get a bit more of everything
+_airCap = _invScale * _balanceScale * (4 + _airbases*2);
+_groundCap = _invScale * _balanceScale * (4 + _airbases + _outposts*0.5);
+_increase = _invScale * _balanceScale * _timeInHours;
 
 [[staticATInvaders], 1.0, _groundCap, _increase] call _fnc_economics;
 [[staticAAInvaders], 1.0, _groundCap, _increase] call _fnc_economics;
@@ -72,7 +77,7 @@ _increase = 1.2 * _balanceScale / 6;            // Invaders get a bit more of ev
 [[vehCSATTank], 0.6, _groundCap, _increase] call _fnc_economics;
 [[vehCSATAA], 0.6, _groundCap, _increase] call _fnc_economics;
 [[vehCSATMRLS], 0.3, _groundCap, _increase] call _fnc_economics;           // not used atm?
-[[vehCSATBoat], 1.0, _balanceScale * (1 + _seaports), _increase] call _fnc_economics;
+[[vehCSATBoat], 1.0, _balanceScale * (2 + _seaports*2), _increase] call _fnc_economics;
 [[vehCSATPlane], 0.25, _airCap, _increase] call _fnc_economics;             // only used for major attacks
 [[vehCSATPlaneAA], 0.25, _airCap, _increase] call _fnc_economics;           // only used for major attacks
 [vehCSATTransportPlanes, 1.5, _airCap, _increase] call _fnc_economics;

--- a/A3-Antistasi/functions/Base/fn_economicsAI.sqf
+++ b/A3-Antistasi/functions/Base/fn_economicsAI.sqf
@@ -23,7 +23,11 @@ _fnc_economics = {
     };
 };
 
-// General balance calc. 9 players @ tierWar 7 => balanceScale 1
+// Community with ~30 players killed roughly 2 APCs per hour, probably similar for attack helis
+// Air vehicles set fairly high because we're using a lot of them since 2.4
+// Coeff 1.0 means one vehicle per hour with 9 players @ tierWar 7, or two vehicles per hour for 26 players.
+
+// 9 players @ tierWar 7 => balanceScale 1
 private _playerScale = exp((sqrt(count allPlayers)/3) - 1);
 private _balanceScale = _playerScale * (3 + tierWar) / 10;
 
@@ -38,16 +42,16 @@ private _increase = _balanceScale / 6;      // Because it's called six times per
 
 [[staticATOccupants], 1.0, _groundCap, _increase] call _fnc_economics;
 [[staticAAOccupants], 1.0, _groundCap, _increase] call _fnc_economics;
-[vehNATOAPC, 3.0, _groundCap, _increase] call _fnc_economics;
-[[vehNATOTank], 1.0, _groundCap, _increase] call _fnc_economics;
-[[vehNATOAA], 1.0, _groundCap, _increase] call _fnc_economics;
-[[vehNATOMRLS], 0.5, _groundCap, _increase] call _fnc_economics;           // not used atm?
+[vehNATOAPC, 1.2, _groundCap, _increase] call _fnc_economics;
+[[vehNATOTank], 0.4, _groundCap, _increase] call _fnc_economics;
+[[vehNATOAA], 0.4, _groundCap, _increase] call _fnc_economics;
+[[vehNATOMRLS], 0.2, _groundCap, _increase] call _fnc_economics;           // not used atm?
 [[vehNATOBoat], 1.0, _balanceScale * (1 + _seaports), _increase] call _fnc_economics;
-[[vehNATOPlane], 0.5, _airCap, _increase] call _fnc_economics;             // only used for major attacks
-[[vehNATOPlaneAA], 0.5, _airCap, _increase] call _fnc_economics;           // only used for major attacks
-[vehNATOTransportPlanes, 2.0, _airCap, _increase] call _fnc_economics;
-[vehNATOTransportHelis - [vehNATOPatrolHeli], 2.0, _airCap, _increase] call _fnc_economics;
-[vehNATOAttackHelis, 1.5, _airCap, _increase] call _fnc_economics;
+[[vehNATOPlane], 0.25, _airCap, _increase] call _fnc_economics;             // only used for major attacks
+[[vehNATOPlaneAA], 0.25, _airCap, _increase] call _fnc_economics;           // only used for major attacks
+[vehNATOTransportPlanes, 1.0, _airCap, _increase] call _fnc_economics;
+[vehNATOTransportHelis - [vehNATOPatrolHeli], 1.5, _airCap, _increase] call _fnc_economics;
+[vehNATOAttackHelis, 0.8, _airCap, _increase] call _fnc_economics;
 
 private _natoArray = flatten [staticATOccupants, staticAAOccupants, vehNATOAPC, vehNATOTank, vehNATOAA, vehNATOBoat, vehNATOPlane, vehNATOPlaneAA, vehNATOTransportPlanes, (vehNATOTransportHelis - [vehNATOPatrolHeli]), vehNATOAttackHelis, vehNATOMRLS];
 _natoArray = _natoArray apply { [_x, timer getVariable [_x, 0]] };
@@ -58,22 +62,22 @@ _airbases = { sidesX getVariable [_x, sideUnknown] == Invaders } count airportsX
 _outposts = { sidesX getVariable [_x, sideUnknown] == Invaders } count outposts;
 _seaports = { sidesX getVariable [_x, sideUnknown] == Invaders } count seaports;
 
-_airCap = _balanceScale * (4 + _airbases*2);
-_groundCap = _balanceScale * (4 + _airbases + _outposts*0.5);
-_increase = 1.2 * _increase;            // Invaders get a bit more of everything
+_airCap = 1.2 * _balanceScale * (4 + _airbases*2);
+_groundCap = 1.2 * _balanceScale * (4 + _airbases + _outposts*0.5);
+_increase = 1.2 * _balanceScale / 6;            // Invaders get a bit more of everything
 
 [[staticATInvaders], 1.0, _groundCap, _increase] call _fnc_economics;
 [[staticAAInvaders], 1.0, _groundCap, _increase] call _fnc_economics;
-[vehCSATAPC, 3.0, _groundCap, _increase] call _fnc_economics;
-[[vehCSATTank], 1.0, _groundCap, _increase] call _fnc_economics;
-[[vehCSATAA], 1.0, _groundCap, _increase] call _fnc_economics;
-[[vehCSATMRLS], 0.5, _groundCap, _increase] call _fnc_economics;           // not used atm?
+[vehCSATAPC, 1.2, _groundCap, _increase] call _fnc_economics;
+[[vehCSATTank], 0.4, _groundCap, _increase] call _fnc_economics;
+[[vehCSATAA], 0.4, _groundCap, _increase] call _fnc_economics;
+[[vehCSATMRLS], 0.2, _groundCap, _increase] call _fnc_economics;           // not used atm?
 [[vehCSATBoat], 1.0, _balanceScale * (1 + _seaports), _increase] call _fnc_economics;
-[[vehCSATPlane], 0.5, _airCap, _increase] call _fnc_economics;             // only used for major attacks
-[[vehCSATPlaneAA], 0.5, _airCap, _increase] call _fnc_economics;           // only used for major attacks
-[vehCSATTransportPlanes, 2.0, _airCap, _increase] call _fnc_economics;
-[vehCSATTransportHelis - [vehCSATPatrolHeli], 2.0, _airCap, _increase] call _fnc_economics;
-[vehCSATAttackHelis, 1.5, _airCap, _increase] call _fnc_economics;
+[[vehCSATPlane], 0.25, _airCap, _increase] call _fnc_economics;             // only used for major attacks
+[[vehCSATPlaneAA], 0.25, _airCap, _increase] call _fnc_economics;           // only used for major attacks
+[vehCSATTransportPlanes, 1.0, _airCap, _increase] call _fnc_economics;
+[vehCSATTransportHelis - [vehCSATPatrolHeli], 1.5, _airCap, _increase] call _fnc_economics;
+[vehCSATAttackHelis, 0.8, _airCap, _increase] call _fnc_economics;
 
 private _csatArray = flatten [staticATInvaders, staticAAInvaders, vehCSATAPC, vehCSATTank, vehCSATAA, vehCSATBoat, vehCSATPlane, vehCSATPlaneAA, vehCSATTransportPlanes, (vehCSATTransportHelis - [vehCSATPatrolHeli]), vehCSATAttackHelis, vehCSATMRLS];
 _csatArray = _csatArray apply { [_x, timer getVariable [_x, 0]] };

--- a/A3-Antistasi/functions/CREATE/fn_vehKilledOrCaptured.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_vehKilledOrCaptured.sqf
@@ -21,7 +21,7 @@ ServerDebug_4("%1 of %2 %3 by %4", _type, _side, _act, _sideEnemy);
 
 if (_side == Occupants or _side == Invaders) then
 {
-	_type call A3A_fnc_removeVehFromPool;
+	_type remoteExecCall ["A3A_fnc_removeVehFromPool", 2];
 	if (_sideEnemy != teamPlayer) exitWith {};
 
 	private _value = call {


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
- Fixed the increment function so that it caps correctly for array inputs.
- Used linear player scaling that's basically identical to #2079 but less opaque. Fixed for HCs.
- Increased tier scaling because we don't use many fancy vehicles at low tiers.
- Added a bit of constant to the caps so that carrier-only attacks aren't full of junk.
- Balance scale the caps as well as the increment. Otherwise enemies can pile up vehicles with some playstyles.
- Tweaked the important unit type coefficients based on some community server data.
- Added the logging from #2079, reduced code.

It's normalized such that 9 players at 7 wartier gives one vehicle per hour at typeCoeff 1, or two vehicles per hour for 26 players. Compared to the previous code, the rates are similar for ~26 players but substantially lower for low player counts. This fits my other data point where halving the rate was relatively fair for 3-4 players. Note that in the original version, occupants and invaders destroyed each other's vehicles far more frequently due to lack of attack simulation.

Didn't bother thinking about the coeffs for static AA/AT & boats. I doubt they matter much.

### Please specify which Issue this PR Resolves.
closes #1162
supersedes some of #2079

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

It'll do until I scrap it fairly shortly.

### How can the changes be tested?
Run `call A3A_fnc_economicsAI` a few dozen times as server. Check what it throws at the logs.
