### PR TITLE
Change civ detection to city+house detection

### DIFF
--- a/A3-Antistasi/functions/AI/fn_chooseSupport.sqf
+++ b/A3-Antistasi/functions/AI/fn_chooseSupport.sqf
@@ -203,10 +203,7 @@ private _maxFriendlies = if (side _group == Invaders) then { random [1, 2, 10] }
 private _nearHouses = call {
 	if (side _group == Invaders) exitWith { 0 };		// invaders are fine with bombing towns
 	// many buildings within military facilities also count as HOUSE, so first check if we're inside a town radius
-	private _cityIndex = citiesX findIf {
-		private _dist = getMarkerPos _x distance2d getpos _enemy;
-		_dist < markerSize _x # 0;
-	};
+	private _cityIndex = citiesX findIf { _enemy inArea _x };
 	if (_cityIndex == -1) exitWith { 0 };
 	count nearestTerrainObjects [getpos _enemy, ["HOUSE"], 100, false];
 };

--- a/A3-Antistasi/functions/AI/fn_chooseSupport.sqf
+++ b/A3-Antistasi/functions/AI/fn_chooseSupport.sqf
@@ -196,13 +196,25 @@ switch (true) do
     };
 };
 
-// Avoid making area attacks against friendlies, although "mistakes" can be made
-private _friendlyUnits = if (side _group == Invaders) then { units Invaders } else { units Occupants + units civilian };
-private _friendlyCount = count (_friendlyUnits inAreaArray [getpos _enemy, 200, 200]);
+// Avoid making area attacks against friendlies or groups of houses, although "mistakes" can be made
+private _friendlyCount = count (units side _group inAreaArray [getpos _enemy, 150, 150]);
 private _maxFriendlies = if (side _group == Invaders) then { random [1, 2, 10] } else { random [0, 0, 5] };
 
-if (_friendlyCount > _maxFriendlies) then
+private _nearHouses = call {
+	if (side _group == Invaders) exitWith { 0 };		// invaders are fine with bombing towns
+	// many buildings within military facilities also count as HOUSE, so first check if we're inside a town radius
+	private _cityIndex = citiesX findIf {
+		private _dist = getMarkerPos _x distance2d getpos _enemy;
+		_dist < markerSize _x # 0;
+	};
+	if (_cityIndex == -1) exitWith { 0 };
+	count nearestTerrainObjects [getpos _enemy, ["HOUSE"], 100, false];
+};
+private _maxHouses = (1 + random 5) ^ 2;
+
+if (_friendlyCount > _maxFriendlies or _nearHouses > _maxHouses) then
 {
+	ServerDebug_3("Area attacks blocked at %1 due to %2 friendlies and %3 houses", getpos _enemy, _friendlyCount, _nearHouses);
     _supportTypes = _supportTypes - ["MORTAR", "AIRSTRIKE", "CARPETBOMB", "MISSILE", "ORBSTRIKE"];
 };
 


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
The civ proximity check used for occupant support selection was overly sensitive due to civs spawning near any building with players nearby, and Arma/UPSMON civs being too dumb to run away from a firefight.

This PR switches it to a city marker radius + nearby house check. Results seem reasonably sensible if the expectation is that occupants don't bomb cities.

### Please specify which Issue this PR Resolves.
closes #2099 

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Bit tricky due to the caller + target requirements. There's a debug log line added for the denial case though, so you can just drive around shooting policemen.
