### PR TITLE
Make QRFs and singleAttacks behave semi-reasonably with maxUnits

### DIFF
--- a/A3-Antistasi/functions/Base/fn_chooseAttackType.sqf
+++ b/A3-Antistasi/functions/Base/fn_chooseAttackType.sqf
@@ -17,30 +17,6 @@ params ["_posDestination", "_side", ["_supportName", "Small attack"]];
 #include "..\..\Includes\common.inc"
 FIX_LINE_NUMBERS()
 
-//Check if unit count isnt reached
-//There might be an exploit here with spawning alot of rebel units to prevent qrfs from happening
-private _allAIUnits = {(alive _x) && {!(isPlayer _x)}} count allUnits;
-private _allUnitsSide = 0;
-private _maxUnitsSide = maxUnits;
-
-if (gameMode <3) then
-{
-	_allUnitsSide = {(alive _x) && {(side group _x == _side) && {!(isPlayer _x)}}} count allUnits;
-	_maxUnitsSide = round (maxUnits * 0.7);
-};
-if ((_allAIUnits + 4 > maxUnits) || (_allUnitsSide + 4 > _maxUnitsSide)) exitWith
-{
-    Info_2("%1 to %2 cancelled because maximum unit count reached", _supportName, _posDestination);
-    ""
-};
-
-//If too foggy for anything abort here
-if ([_posDestination,false] call A3A_fnc_fogCheck < 0.3) exitWith
-{
-    Info_2("%1 to %1 cancelled due to heavy fog", _supportName, _posDestination);
-    ""
-};
-
 //Search for nearby enemies
 private _enemyGroups = allGroups select
 {

--- a/A3-Antistasi/functions/CREATE/fn_singleAttack.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_singleAttack.sqf
@@ -24,6 +24,17 @@ private _posOrigin = [];
 
 private _posDestination = getMarkerPos _markerDestination;
 
+//Don't attempt unless we have enough units spare on this machine to make a worthwhile attack
+if ([_side] call A3A_fnc_remUnitCount < 16) exitWith
+{
+    Info_1("SingleAttack to %1 cancelled because maximum unit count reached", _markerDestination);
+};
+
+if ([_posDestination,false] call A3A_fnc_fogCheck < 0.3) exitWith
+{
+    Info_1("SingleAttack to %1 cancelled due to heavy fog", _markerDestination);
+};
+
 //Parameter is the starting base
 if(_side isEqualType "") then
 {

--- a/A3-Antistasi/functions/Supports/fn_SUP_QRFAvailable.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_QRFAvailable.sqf
@@ -2,7 +2,7 @@ params ["_side", "_position"];
 
 /*  Checks if the QRF support is available
 
-    Execution on: HC or Server
+    Execution on: Server
 
     Scope: Internal
 
@@ -13,6 +13,22 @@ params ["_side", "_position"];
     Returns:
         0 if QRF is possible, -1 otherwise
 */
+
+#include "..\..\Includes\common.inc"
+FIX_LINE_NUMBERS()
+
+//QRFs always run on the server at the moment, so leave a buffer for wavedCAs
+if ([_side] call A3A_fnc_remUnitCount < 40) exitWith
+{
+    Debug("Blocked QRF because unit count on server is too high");
+    -1;
+};
+
+if ([_position,false] call A3A_fnc_fogCheck < 0.3) exitWith
+{
+    Debug("Blocked QRF to %1 due to heavy fog", _position);
+    -1;
+};
 
 //Do a quick check for at least one available airport
 private _index = airportsX findIf


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Support QRFs and singleAttack (marker recapture counterattack) were using a maxUnits check (through chooseAttackType) that didn't account for unit locality. In Antistasi, maxUnits applies per machine rather than globally, so the permitted unit count scales up with the number of headless clients. As a result, QRFs and singleAttacks will have been much rarer or smaller than intended when headless clients were used.

This PR fixes the maxUnits checks so that they ignore units on other machines. A buffer is left for QRFs so that wavedCA doesn't get completely crippled by running on the same machine.

### Please specify which Issue this PR Resolves.
closes #2098

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

maxUnits behaviour is generally terrible but that's a bigger problem to be addressed later.

More problematic is that singleAttacks and QRFs likely didn't spawn at all on the community servers, so that would invalidate any balance data. Might need to buff up economicsAI again, for example, and the upper-end vehicle counts in singleAttacks and QRFs are likely far too high, as that end hasn't been tested in an appropriate case.

### How can the changes be tested?
WIP
