### PR TITLE
Magazines getter

### DIFF
--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -438,6 +438,7 @@ class A3A
     class Ammunition
     {
         class ACEpvpReDress {};
+        class allMagazines {};
         class ammunitionTransfer {};
         class arsenalManage {};
         class categoryOverrides {};

--- a/A3-Antistasi/functions/Ammunition/fn_allMagazines.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_allMagazines.sqf
@@ -1,0 +1,54 @@
+/*
+Author: Håkon
+Description:
+    Retrives all magazines compatible with the passed config
+
+Arguments:
+0. <Config> Config of whatever you want to get the magazines for
+1. <Bool>   Perform only a shallow search (optional) (Default: false)
+
+Return Value: <Array> compatible magazines
+
+Scope: Any
+Environment: Any
+Public: Yes
+Dependencies:
+
+Example:
+    [configFile/"cfgVehicles"/"B_MBT_01_base_F"] call A3A_fnc_allMagazines;
+    [configFile/"cfgWeapons"/"arifle_MX_GL_F"] call A3A_fnc_allMagazines;
+
+Note: None shallow search can take several millisecond, use it sparingly.
+
+License: MIT License
+*/
+#include "..\..\Includes\common.inc"
+params ["_config", ["_shallow", false, [true]]];
+if (!isClass _config) exitWith { Error_1("Not a config: ", _config); [] };
+
+//data store
+private _magazines = [];
+private _magazineWells = [];
+private _classes = [_config];
+
+//process
+while {_config isNotEqualTo []} do {
+    private _curClass = _classes#0;
+    if (isNil "_curClass") exitWith {};
+    if (!isClass _curClass) exitWith {};
+
+    if (isArray (_curClass/"magazines")) then {_magazines append getArray (_curClass/"magazines")};
+    if (isArray (_curClass/"magazineWell")) then {_magazineWells append getArray (_curClass/"magazineWell")};
+
+    if (_shallow) exitWith {};
+    _classes append (configProperties [_curClass, "isClass _x"]);
+    _classes deleteAt (_classes find _curClass);
+};
+
+{
+    {
+        if (isArray _x) then { _magazines append getArray _x };
+    } forEach configProperties [configFile/"cfgMagazineWells"/_x];
+} forEach _magazineWells;
+
+_magazines arrayIntersect _magazines;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information: recent comments and experience has shown a lack of complete compatible magazine info, as well as the complexity of getting this information.

as how compatible magazines can be included in a weapon or vehicle config this requires a bit of brute force.
therefore the default behavior is to do a full config search, but as this can be some what slow (example numbers bellow) i also added a the option to perform a shallow search.

This checks both magazines and magazineWells

**Test output**
```json
{
    "arifle_MX_GL_F_shallow": {
        "class": "arifle_MX_GL_F",
        "time-ms": 0.0464,
        "Shallow": true,
        "Output": [
            "30Rnd_65x39_caseless_mag",
            "30Rnd_65x39_caseless_khaki_mag",
            "30Rnd_65x39_caseless_black_mag",
            "30Rnd_65x39_caseless_mag_Tracer",
            "30Rnd_65x39_caseless_khaki_mag_Tracer",
            "30Rnd_65x39_caseless_black_mag_Tracer",
            "ACE_30Rnd_65x39_caseless_mag_Tracer_Dim",
            "ACE_30Rnd_65x47_Scenar_mag",
            "ACE_30Rnd_65_Creedmor_mag",
            "100Rnd_65x39_caseless_mag",
            "100Rnd_65x39_caseless_khaki_mag",
            "100Rnd_65x39_caseless_black_mag",
            "100Rnd_65x39_caseless_mag_tracer",
            "100Rnd_65x39_caseless_khaki_mag_tracer",
            "100Rnd_65x39_caseless_black_mag_tracer",
            "ACE_100Rnd_65x39_caseless_mag_Tracer_Dim",
            "100Rnd_65x39_caseless_mag_Tracer",
            "100Rnd_65x39_caseless_khaki_mag_Tracer",
            "100Rnd_65x39_caseless_black_mag_Tracer"
        ]
    },
    "arifle_MX_GL_F": {
        "class": "arifle_MX_GL_F",
        "time-ms": 1.25,
        "Shallow": false,
        "Output": [
            "30Rnd_65x39_caseless_mag",
            "1Rnd_HE_Grenade_shell",
            "UGL_FlareWhite_F",
            "UGL_FlareGreen_F",
            "UGL_FlareRed_F",
            "UGL_FlareYellow_F",
            "UGL_FlareCIR_F",
            "1Rnd_Smoke_Grenade_shell",
            "1Rnd_SmokeRed_Grenade_shell",
            "1Rnd_SmokeGreen_Grenade_shell",
            "1Rnd_SmokeYellow_Grenade_shell",
            "1Rnd_SmokePurple_Grenade_shell",
            "1Rnd_SmokeBlue_Grenade_shell",
            "1Rnd_SmokeOrange_Grenade_shell",
            "3Rnd_HE_Grenade_shell",
            "3Rnd_UGL_FlareWhite_F",
            "3Rnd_UGL_FlareGreen_F",
            "3Rnd_UGL_FlareRed_F",
            "3Rnd_UGL_FlareYellow_F",
            "3Rnd_UGL_FlareCIR_F",
            "3Rnd_Smoke_Grenade_shell",
            "3Rnd_SmokeRed_Grenade_shell",
            "3Rnd_SmokeGreen_Grenade_shell",
            "3Rnd_SmokeYellow_Grenade_shell",
            "3Rnd_SmokePurple_Grenade_shell",
            "3Rnd_SmokeBlue_Grenade_shell",
            "3Rnd_SmokeOrange_Grenade_shell",
            "ACE_HuntIR_M203",
            "30Rnd_65x39_caseless_khaki_mag",
            "30Rnd_65x39_caseless_black_mag",
            "30Rnd_65x39_caseless_mag_Tracer",
            "30Rnd_65x39_caseless_khaki_mag_Tracer",
            "30Rnd_65x39_caseless_black_mag_Tracer",
            "ACE_30Rnd_65x39_caseless_mag_Tracer_Dim",
            "ACE_30Rnd_65x47_Scenar_mag",
            "ACE_30Rnd_65_Creedmor_mag",
            "100Rnd_65x39_caseless_mag",
            "100Rnd_65x39_caseless_khaki_mag",
            "100Rnd_65x39_caseless_black_mag",
            "100Rnd_65x39_caseless_mag_tracer",
            "100Rnd_65x39_caseless_khaki_mag_tracer",
            "100Rnd_65x39_caseless_black_mag_tracer",
            "ACE_100Rnd_65x39_caseless_mag_Tracer_Dim",
            "100Rnd_65x39_caseless_mag_Tracer",
            "100Rnd_65x39_caseless_khaki_mag_Tracer",
            "100Rnd_65x39_caseless_black_mag_Tracer",
            "rhs_mag_M441_HE",
            "rhs_mag_M433_HEDP",
            "rhs_mag_M397_HET",
            "rhs_mag_m576",
            "rhs_mag_M4009",
            "rhs_mag_M583A1_white",
            "rhs_mag_M585_white",
            "rhs_mag_M661_green",
            "rhs_mag_M662_red",
            "rhs_mag_M585_white_cluster",
            "rhs_mag_M663_green_cluster",
            "rhs_mag_M664_red_cluster",
            "rhs_mag_M713_red",
            "rhs_mag_M714_white",
            "rhs_mag_M715_green",
            "rhs_mag_M716_yellow",
            "rhs_mag_M781_Practice",
            "ACE_40mm_flare_white",
            "ACE_40mm_flare_red",
            "ACE_40mm_flare_green",
            "ACE_40mm_flare_ir"
        ]
    },
    "B_MBT_01_base_F_shallow" : {
        "class": "B_MBT_01_base_F",
        "time-ms": 0.011,
        "Shallow": true,
        "Output": []
    },
    "B_MBT_01_base_F": {
        "class": "B_MBT_01_base_F",
        "time-ms": 4.82,
        "Shallow": true,
        "Output": [
            "24Rnd_120mm_APFSDS_shells_Tracer_Red",
            "12Rnd_120mm_HE_shells_Tracer_Red",
            "12Rnd_120mm_HEAT_MP_T_Red",
            "200Rnd_762x51_Belt_Red",
            "SmokeLauncherMag"
        ]
    }
}
```

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes: i plan on having this be used for compatible magazine checking for the arsenal and maybe other things as well
