### PR TITLE
Prevent simulated attacks from massively overfilling garrisons

### DIFF
--- a/A3-Antistasi/functions/Base/fn_markerChange.sqf
+++ b/A3-Antistasi/functions/Base/fn_markerChange.sqf
@@ -349,6 +349,7 @@ else
 		if ((random 10 < ((tierWar + difficultyCoef)/4)) and !("DEF_HQ" in A3A_activeTasks) and (isPlayer theBoss)) then {[[],"A3A_fnc_attackHQ"] remoteExec ["A3A_fnc_scheduler",2]};
 		};
 	};
+/*
 if ((_winner != teamPlayer) and (_looser != teamPlayer)) then
 	{
 	if (_markerX in outposts) then
@@ -368,6 +369,7 @@ if ((_winner != teamPlayer) and (_looser != teamPlayer)) then
 			};
 		};
 	};
+*/
 markersChanging = markersChanging - [_markerX];
 
 Debug_1("Finished marker change at %1", _markerX);

--- a/A3-Antistasi/functions/Base/fn_rebelAttack.sqf
+++ b/A3-Antistasi/functions/Base/fn_rebelAttack.sqf
@@ -228,7 +228,7 @@ if (count _availableTargets == 0) exitWith
     private _nearbyStatics = staticsToSave select {(_x distance2D (getMarkerPos _target)) < distanceSPWN};
     _targetPoints = _targetPoints + (10 * (count _garrison) + (50 * (count _nearbyStatics)));
 
-    if((count _garrison <= 8) && {(count _nearbyStatics <= 2) && {!(_target in citiesX)}}) then
+    if((count _garrison <= 8) && (_targetSide == teamPlayer) && {(count _nearbyStatics <= 2) && {!(_target in citiesX)}}) then
     {
         //Only minimal garrison, consider it an easy target
         Debug_1("%1 has only minimal garrison, considering easy target", _target);
@@ -248,13 +248,13 @@ to attack from which airport
 
 private _fnc_flipMarker =
 {
-    params ["_side", "_marker", "_minTroops", "_randomTroops"];
+    params ["_side", "_marker"];
     Info_2("Autowin %1 for side %2 to avoid unnecessary calculations", _marker, _side);
     [_side, _marker] spawn A3A_fnc_markerChange;
     sleep 10;
-    private _squads = _minTroops + round (random _randomTroops);
+    private _maxTroops = 12 max round ((0.5 + random 0.5) * ([_marker] call A3A_fnc_garrisonSize));
     private _soldiers = [];
-    for "_i" from 0 to _squads do
+    while {count _soldiers < _maxTroops} do
     {
         if (_side == Occupants) then
         {
@@ -265,6 +265,7 @@ private _fnc_flipMarker =
             _soldiers append (selectRandom (groupsCSATSquad + groupsCSATmid));
         };
     };
+    _soldiers resize _maxTroops;
     [_soldiers,_side,_marker,0] remoteExec ["A3A_fnc_garrisonUpdate",2];
 };
 
@@ -328,7 +329,7 @@ if(count _easyTargets >= 4) then
         else
         {
             private _side = sidesX getVariable (_x select 0);
-            [_side, _target, 2, 2] spawn _fnc_flipMarker;
+            [_side, _target] spawn _fnc_flipMarker;
         };
         sleep 15;
     } forEach _attackList;
@@ -424,7 +425,7 @@ else
         }
         else
         {
-            [_side, _attackTarget, 4, 3] spawn _fnc_flipMarker;
+            [_side, _attackTarget] spawn _fnc_flipMarker;
             [3600, _side] call A3A_fnc_timingCA;
         };
     }


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
The simulated attack routine in rebelAttack randomly fills the target garrison after a capture. This fill wasn't based on the garrison size at all, instead adding up to 56 troops, potentially within a very small area.

This PR bases the fill based on garrison size, with a minimum of 12 units. It also disables adding non-rebel targets as easy targets based on garrison size, because there were some weird early-game cases with mass flips.

### Please specify which Issue this PR Resolves.
closes #2115

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

Found some fairly weird stuff with squad sizes along the way, but it doesn't really matter for this PR.

### How can the changes be tested?
In a fresh game, set occupant aggro high with `[Occupants, 100, 120] spawn A3A_fnc_addAggression` (this disables the counterattack randomization), then run `[Invaders] spawn A3A_fnc_rebelAttack` a few times. Teleport over to the flipped locations and check that there aren't any excessive garrisons.

Alternatively you can check the garrison sizes with `count (garrison getVariable "markerName")` if you know the names. 