### PR TITLE
Rebalance reinforcements, plus related tweaks

### DIFF
--- a/A3-Antistasi/functions/Base/fn_markerChange.sqf
+++ b/A3-Antistasi/functions/Base/fn_markerChange.sqf
@@ -103,11 +103,21 @@ else
 			case (_markerX in citiesX): {_type = "City"};
 	};
 	private _preference = garrison getVariable (format ["%1_preference", _type]);
+	// pre-fill most of the garrison, because otherwise we're spamming a lot of fake reinf 
+	private _indexToReinf = floor (random count _preference);
+	private _garrison = [];
 	private _request = [];
-	for "_i" from 0 to ((count _preference) - 1) do
 	{
-		_request pushBack ([_preference select _i, _winner] call A3A_fnc_createGarrisonLine);
-	};
+		private _line = [_x, _winner] call A3A_fnc_createGarrisonLine;
+		if (_forEachIndex == _indexToReinf) then {
+			_garrison pushBack ["", [], []];		// empty garrison line
+			_request pushBack _line;
+		} else {
+			_garrison pushBack _line;
+			_request pushBack ["", [], []];
+		};
+	} forEach _preference;
+	garrison setVariable [format ["%1_garrison", _markerX], _garrison, true];
 	garrison setVariable [format ["%1_requested", _markerX], _request, true];
 	//End ========================================================================
 };

--- a/A3-Antistasi/functions/CREATE/fn_garrisonSize.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_garrisonSize.sqf
@@ -1,35 +1,33 @@
-private ["_size","_frontierX","_markerX","_nVeh","_buildings"];
-_markerX = _this select 0;
-_size = [_markerX] call A3A_fnc_sizeMarker;
-_frontierX = [_markerX] call A3A_fnc_isFrontline;
+params ["_markerX"];
 
-_nVeh = 0;
+if ("carrier" in _markerX) exitWith { 0 };
 
+private _size = [_markerX] call A3A_fnc_sizeMarker;
+private _frontierX = [_markerX] call A3A_fnc_isFrontline;
+
+private _groups = 0;
 if (_markerX in airportsX) then
-	{
-	_nveh = _nveh + round (_size/60);
-	if (_frontierX) then {_nveh = _nveh * 2};
-	_nVeh = _nVeh + 1;
-	}
+{
+    _groups = 2 + round (_size/30);
+    _groups = _groups min 11;
+    if (_frontierX) then {_groups = _groups + 3};
+}
 else
-	{
-	if (_markerX in outposts) then
-		{
-		_nveh = round (_size/50);
-		_buildings = nearestObjects [getMarkerPos _markerX,(["Land_TTowerBig_1_F","Land_TTowerBig_2_F","Land_Communication_F"]) + listMilBld, _size];
-		if (count _buildings > 0) then
-			{
-			_nveh = _nveh + 1;
-			};
-		}
-	else
-		{
-		_nveh = if (sidesX getVariable [_markerX,sideUnknown] == Occupants) then {round (_size/70)} else {round (_size/50)};
-		};
-	if (_frontierX) then {_nveh = _nveh + 1};
-	};
+{
+    if (_markerX in outposts) then
+    {
+        _groups = 1 + round (_size/30);
+        _buildings = nearestObjects [getMarkerPos _markerX,(["Land_TTowerBig_1_F","Land_TTowerBig_2_F","Land_Communication_F"]) + listMilBld, _size];
+        if (count _buildings > 0) then {_groups = _groups + 2};
+        _groups = _groups min 7;
+        if (_frontierX) then {_groups = _groups + 2};
+    }
+    else
+    {
+        _groups = if (sidesX getVariable [_markerX,sideUnknown] == Occupants) then {1 + round (_size/45)} else {1 + round (_size/30)};
+        _groups = _groups min 5;
+        if (_frontierX) then {_groups = _groups + 1};
+    };
+};
 
-if (_nveh < 1) then {_nVeh = 1};
-_nVeh = 8 * _nVeh;
-
-_nVeh
+4 * (_groups max 2);

--- a/A3-Antistasi/functions/CREATE/fn_garrisonSize.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_garrisonSize.sqf
@@ -1,9 +1,9 @@
-params ["_markerX"];
+params ["_markerX", ["_ignoreFrontier", false]];
 
 if ("carrier" in _markerX) exitWith { 0 };
 
 private _size = [_markerX] call A3A_fnc_sizeMarker;
-private _frontierX = [_markerX] call A3A_fnc_isFrontline;
+private _frontierX = if (_ignoreFrontier) then { false } else { [_markerX] call A3A_fnc_isFrontline };
 
 private _groups = 0;
 if (_markerX in airportsX) then

--- a/A3-Antistasi/functions/CREATE/fn_reinforcementsAI.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_reinforcementsAI.sqf
@@ -27,7 +27,7 @@ while {killZoneRemove >= 1} do
 
 // Handle the old reinforcements
 
-private _playerScale = (8 + count (allPlayers - entities "HeadlessClient_F")) / 17;
+private _playerScale = call A3A_fnc_getPlayerScale;
 private _totalReinf = 4 * round (3 * (1 + tierWar/10) * _playerScale * (0.5 + random 1));
 Debug_1("Sending %1 total troops to reinforce", _totalReinf);
 

--- a/A3-Antistasi/functions/CREATE/fn_reinforcementsAI.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_reinforcementsAI.sqf
@@ -27,84 +27,87 @@ while {killZoneRemove >= 1} do
 
 // Handle the old reinforcements
 
-private ["_airportsX","_reinfPlaces","_airportX","_numberX","_numGarr","_numReal","_sideX","_potentials","_countX","_siteX","_positionX"];
-_airportsX = airportsX select {(sidesX getVariable [_x,sideUnknown] != teamPlayer) and (spawner getVariable _x == 2)};
-if (count _airportsX == 0) exitWith {};
-_reinfPlaces = [];
+private _playerScale = (8 + count (allPlayers - entities "HeadlessClient_F")) / 17;
+private _totalReinf = 4 * round (3 * (1 + tierWar/10) * _playerScale * (0.5 + random 1));
+Debug_1("Sending %1 total troops to reinforce", _totalReinf);
+
+private _airportsX = airportsX select {(sidesX getVariable [_x,sideUnknown] != teamPlayer) and (spawner getVariable _x != 0)};
+if (gameMode == 3) then { _airportsX pushBack "NATO_carrier" } else { _airportsX append ["NATO_carrier", "CSAT_carrier"] };
+
+// build list of markers that need reinforcement
+private _reinfTargets = [];			// elements are [troopsNeeded, marker]
 {
-	_airportX = _x;
-	_numberX = 8;
-	_numGarr = [_airportX] call A3A_fnc_garrisonSize;
-	_numReal = count (garrison getVariable [_airportX, []]);
-	_sideX = sidesX getVariable [_airportX,sideUnknown];
+	private _site = _x;
+	private _troopsNeeded = ([_site] call A3A_fnc_garrisonSize) - count (garrison getVariable [_site, []]);
+	if (_troopsNeeded <= 0) then { continue };
+	if (_site in forcedSpawn) then { continue };
+
+	// Don't reinforce if marker has enemy-controlled airfields within spawn distance
+	private _siteSide = sidesX getVariable [_site, sideUnknown];
+	if ({(getMarkerPos _x distance2d getMarkerPos _site < distanceSPWN) and (sidesX getVariable [_x,sideUnknown] != _siteSide)} count airportsX > 0) then { continue };
+
+	_reinfTargets pushBack [_troopsNeeded, _site];
+} forEach (outposts + seaports + resourcesX + factories);
+
+// prioritize bases with most troops needed
+_reinfTargets sort false;
+
+private _fnc_pickSquadType = {
+	params ["_count", "_side"];
+	if (_numTroops == 8) exitWith { selectRandom ([groupsNATOSquad, groupsCSATSquad] select (_side == Invaders))};
+	selectRandom ([groupsNATOmid, groupsCSATmid] select (_side == Invaders));
+};
+
+while {_totalReinf > 0} do
+{
+	if (_airportsX isEqualTo [] or _reinfTargets isEqualTo []) exitWith {};
+	private _airport = selectRandom _airportsX;
+	private _side = sidesX getVariable [_airport, sideUnknown];
 
 	//Self reinforce the airport if needed
-	if (_numReal + 4 <= _numGarr) then
-	{
-		if (_numReal + 8 <= _numGarr) then
-		{
-			if (_sideX == Occupants) then {[selectRandom groupsNATOSquad,_sideX,_airportX,0] remoteExec ["A3A_fnc_garrisonUpdate",2]} else {[selectRandom groupsCSATSquad,_sideX,_airportX,0] remoteExec ["A3A_fnc_garrisonUpdate",2]};
-			_numberX = 0;
-		}
-		else
-		{
-			if (_sideX == Occupants) then {[selectRandom groupsNATOmid,_sideX,_airportX,0] remoteExec ["A3A_fnc_garrisonUpdate",2]} else {[selectRandom groupsCSATmid,_sideX,_airportX,0] remoteExec ["A3A_fnc_garrisonUpdate",2]};
-			_numberX = 4;
-		};
+	if !("carrier" in _airport) then {
+		private _numNeeded = ([_airport] call A3A_fnc_garrisonSize) - count (garrison getVariable [_airport, []]);
+		if (_numNeeded <= 0) exitWith {};
+
+		private _numTroops = [4, 8] select (_numNeeded > 4 and _totalReinf >= 8 and random 1 > 0.3);
+		[[_numTroops, _side] call _fnc_pickSquadType, _side, _airport, 0] remoteExec ["A3A_fnc_garrisonUpdate",2];
+		Debug_2("Airport %1 self-reinforced with %2 troops", _airport, _numTroops);
+		_totalReinf = _totalReinf - _numTroops;
+		continue;
 	};
-	//Self reinforce done
 
-	//Reinforce nearby sides
-	if (_numberX >= 4) then
-	{
-		_potentials = (outposts + seaports - _reinfPlaces - (killZones getVariable [_airportX,[]])) select {sidesX getVariable [_x,sideUnknown] == _sideX};
-		if (_potentials isEqualTo []) then
-		{
-			_potentials = (resourcesX + factories - _reinfPlaces - (killZones getVariable [_airportX,[]])) select {sidesX getVariable [_x,sideUnknown] == _sideX};
-		};
-		_positionX = getMarkerPos _airportX;
-		_potentials = _potentials select {((getMarkerPos _x distance2D _positionX) < distanceForAirAttack) and !(_x in forcedSpawn)};
-		if (count _potentials > 0) then
-		{
-			_countX = 0;
-			_siteX = "";
-			{
-				_numGarr = [_x] call A3A_fnc_garrisonSize;
-				_numReal = count (garrison getVariable [_x, []]);
-				if (_numGarr - _numReal > _countX) then
-				{
-					_countX = _numGarr - _numReal;
-					_siteX = _x;
-				};
-			} forEach _potentials;
-			if (_siteX != "") then
-			{
-				if ({(getMarkerPos _x distance2d getMarkerPos _siteX < distanceSPWN) and (sidesX getVariable [_x,sideUnknown] != _sideX)} count airportsX == 0) then
-				{
-					if ({(_x distance2D _positionX < (2*distanceSPWN)) or (_x distance2D (getMarkerPos _siteX) < (2*distanceSPWN))} count allPlayers == 0) then
-					{
-						_typeGroup = if (_sideX == Occupants) then {if (_numberX == 4) then {selectRandom groupsNATOmid} else {selectRandom groupsNATOSquad}} else {if (_numberX == 4) then {selectRandom groupsCSATmid} else {selectRandom groupsCSATSquad}};
-						[_typeGroup,_sideX,_siteX,2] remoteExec ["A3A_fnc_garrisonUpdate",2];
-
-						//This line send a virtual convoy, execute [] execVM "Convoy\convoyDebug.sqf" as admin to see it
-						//If it breaks, it doesn't change anything
-						//If it works, it will not add any troups
-						//[_siteX, "Reinforce", _sideX, [(_numberX == 4)]] remoteExec ["A3A_fnc_createAIAction", 2];
-					}
-					else
-					{
-						_reinfPlaces pushBack _siteX;
-						[[_siteX,_airportX,_numberX,_sideX],"A3A_fnc_patrolReinf"] call A3A_fnc_scheduler;
-					};
-				};
-			};
-		};
+	//Find a suitable site to reinforce
+	private _killZones = killzones getVariable [_airport, []];
+	private _targIndex = _reinfTargets findIf {
+		(getMarkerPos (_x#1) distance2d getMarkerPos _airport < distanceForAirAttack)
+		and (sidesX getVariable [_x#1, sideUnknown] == _side)
+		and !((_x#1) in _killZones)
 	};
-	if (count _reinfPlaces > 3) exitWith {};
-} forEach _airportsX;
+	if (_targIndex == -1) then {
+		// Airport has nothing to do, remove it from the list
+		_airportsX deleteAt (_airportsX find _airport);
+		continue;
+	};
 
-if ((count _reinfPlaces == 0) and (AAFpatrols <= 3)) then {[] spawn A3A_fnc_AAFroadPatrol};
+	(_reinfTargets deleteAt _targIndex) params ["_numNeeded", "_target"];
+	private _numTroops = [4, 8] select (_numNeeded > 4 and _totalReinf >= 8 and random 1 > 0.3);
+	_totalReinf = _totalReinf - _numTroops;
 
+	Debug_3("Reinforcing garrison %1 from %2 with %3 troops", _target, _airport, _numTroops);
+	if ([distanceSPWN1, 1, getMarkerPos _target, teamPlayer] call A3A_fnc_distanceUnits) then {
+		// If rebels are near the target, send a real reinforcement
+		[[_target, _airport, _numTroops, _side], "A3A_fnc_patrolReinf"] call A3A_fnc_scheduler;
+		sleep 10;		// Might re-use this marker shortly, avoid collisions
+	} else {
+		// Otherwise just add troops directly
+		[[_numTroops, _side] call _fnc_pickSquadType, _side, _target, 2] remoteExec ["A3A_fnc_garrisonUpdate", 2];
+	};
+};
+
+// If there aren't too many road patrols around already, generate about 1.5 * playerScale per hour
+if (AAFpatrols < round (3 * _playerScale) and (random 4 < _playerScale)) then {
+	[] spawn A3A_fnc_AAFroadPatrol;
+};
 
 // Reduce loot crate cooldown if garrison is complete
 {

--- a/A3-Antistasi/functions/CREATE/fn_reinforcementsAI.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_reinforcementsAI.sqf
@@ -44,7 +44,7 @@ private _reinfTargets = [];			// elements are [troopsNeeded, marker]
 
 	// Don't reinforce if marker has enemy-controlled airfields within spawn distance
 	private _siteSide = sidesX getVariable [_site, sideUnknown];
-	if ({(getMarkerPos _x distance2d getMarkerPos _site < distanceSPWN) and (sidesX getVariable [_x,sideUnknown] != _siteSide)} count airportsX > 0) then { continue };
+	if (-1 != airportsX findIf {(markerPos _x distance2d markerPos _site < distanceSPWN) and (sidesX getVariable [_x,sideUnknown] != _siteSide)}) then { continue };
 
 	_reinfTargets pushBack [_troopsNeeded, _site];
 } forEach (outposts + seaports + resourcesX + factories);

--- a/A3-Antistasi/functions/Templates/fn_compatibilityLoadFaction.sqf
+++ b/A3-Antistasi/functions/Templates/fn_compatibilityLoadFaction.sqf
@@ -102,11 +102,13 @@ if (_side isEqualTo east) then {
 	//TODO Add ammobearers
 	groupsCSATAA = [
 		"loadouts_inv_military_SquadLeader",
+		"loadouts_inv_military_Rifleman",
 		"loadouts_inv_military_AA",
 		"loadouts_inv_military_AA"
 	];
 	groupsCSATAT = [
 		"loadouts_inv_military_SquadLeader",
+		"loadouts_inv_military_Rifleman",
 		"loadouts_inv_military_AT",
 		"loadouts_inv_military_AT"
 	];
@@ -170,7 +172,6 @@ if (_side isEqualTo east) then {
 				"loadouts_inv_militia_Grenadier",
 				"loadouts_inv_militia_Rifleman",
 				selectRandomWeighted ["loadouts_inv_militia_Rifleman", 1, "loadouts_inv_militia_Marksman", 1],
-				selectRandomWeighted ["loadouts_inv_militia_Rifleman", 2, "loadouts_inv_militia_Marksman", 1],
 				selectRandomWeighted ["loadouts_inv_militia_Rifleman", 1, "loadouts_inv_militia_ExplosivesExpert", 1],
 				"loadouts_inv_militia_LAT",
 				"loadouts_inv_militia_Medic"
@@ -293,11 +294,13 @@ if (_side isEqualTo west) then {
 	//TODO Add ammobearers
 	groupsNATOAA = [
 		"loadouts_occ_military_SquadLeader",
+		"loadouts_occ_military_Rifleman",
 		"loadouts_occ_military_AA",
 		"loadouts_occ_military_AA"
 	];
 	groupsNATOAT = [
 		"loadouts_occ_military_SquadLeader",
+		"loadouts_occ_military_Rifleman",
 		"loadouts_occ_military_AT",
 		"loadouts_occ_military_AT"
 	];
@@ -361,7 +364,6 @@ if (_side isEqualTo west) then {
 				"loadouts_occ_militia_Grenadier",
 				"loadouts_occ_militia_Rifleman",
 				selectRandomWeighted ["loadouts_occ_militia_Rifleman", 1, "loadouts_occ_militia_Marksman", 1],
-				selectRandomWeighted ["loadouts_occ_militia_Rifleman", 2, "loadouts_occ_militia_Marksman", 1],
 				selectRandomWeighted ["loadouts_occ_militia_Rifleman", 1, "loadouts_occ_militia_ExplosivesExpert", 1],
 				"loadouts_occ_militia_LAT",
 				"loadouts_occ_militia_Medic"

--- a/A3-Antistasi/functions/init/fn_initGarrisons.sqf
+++ b/A3-Antistasi/functions/init/fn_initGarrisons.sqf
@@ -68,7 +68,7 @@ _fnc_initGarrison =
 		}
 		else
 		{
-			if(_type != "Airport" && {_type != "Outpost"}) then
+			if !(_type in ["Airport", "Outpost"]) then
 			{
 				_groupsRandom = groupsFIASquad + groupsFIAMid;
 			}

--- a/A3-Antistasi/functions/init/fn_initGarrisons.sqf
+++ b/A3-Antistasi/functions/init/fn_initGarrisons.sqf
@@ -57,36 +57,34 @@ _fnc_initMarker =
 _fnc_initGarrison =
 {
 	params ["_markerArray", "_type"];
-	private ["_side", "_groupsRandom", "_garrNum", "_garrisonOld", "_marker"];
+	private ["_side", "_groupsRandom", "_garrNum", "_garrison", "_marker"];
 	{
 	    _marker = _x;
-			_garrNum = ([_marker] call A3A_fnc_garrisonSize) / 8;
-			_side = sidesX getVariable [_marker, sideUnknown];
-			if(_side != Occupants) then
+		_garrNum = [_marker] call A3A_fnc_garrisonSize;
+		_side = sidesX getVariable [_marker, sideUnknown];
+		if(_side != Occupants) then
+		{
+			_groupsRandom = groupsCSATSquad + groupsCSATMid;
+		}
+		else
+		{
+			if(_type != "Airport" && {_type != "Outpost"}) then
 			{
-				_groupsRandom = [groupsCSATSquad, groupsFIASquad] select ((_marker in outposts) && (gameMode == 4));
+				_groupsRandom = groupsFIASquad + groupsFIAMid;
 			}
 			else
 			{
-				if(_type != "Airport" && {_type != "Outpost"}) then
-				{
-					_groupsRandom = groupsFIASquad;
-				}
-				else
-				{
-	 				_groupsRandom = groupsNATOSquad;
-				};
+ 				_groupsRandom = groupsNATOSquad + groupsNATOMid;
 			};
-			//Old system, keeping it intact for the moment
-			_garrisonOld = [];
-			for "_i" from 1 to _garrNum do
-			{
-				_garrisonOld append (selectRandom _groupsRandom);
-			};
-			//
+		};
 
-			//Old system, keeping it runing for now
-			garrison setVariable [_marker, _garrisonOld, true];
+		_garrison = [];
+		while {count _garrison < _garrNum} do
+		{
+			_garrison append (selectRandom _groupsRandom);
+		};
+		_garrison resize _garrNum;
+		garrison setVariable [_marker, _garrison, true];
 
 	} forEach _markerArray;
 };


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
- Balance reinforcement system for player count.
- Enable reinforcing from "carriers".
- Separate road patrol generation from reinforcements and rebalance.
- Sanitize garrison sizes (fewer giant and tiny garrisons, units of 4 rather than 8).
- Use more 4-man teams in garrisons for both init and reinf.
- Prevent new reinf convoys spamming after a recapture.
- Fill out the AA & AT squads with a fourth soldier, cap militia squads to 8.

The rebalanced reinforcements generate an average of around 16 troops per 10 minute tick for nine players at war level 3, or about half that for a single player. For comparison, the previous version generated 8 troops per airport (not carrier) in range. The new version is not particularly dependent on airfield count or positioning.

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Checking max garrison sizes:
`outposts apply { [_x, [_x] call A3A_fnc_garrisonSize] };`

Checking reinforcements:
`[] spawn A3A_fnc_reinforcementsAI`
Check the RPT after each call, there is logging for the total troops and for each reinforcement sent.
