### PR TITLE
Quick player-count balance for QRF/singleAttack/wavedCA

### DIFF
--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -67,6 +67,7 @@ class A3A
         class garbageCleaner {};
         class garrisonInfo {};
         class getAggroLevelString {};
+        class getPlayerScale {};
         class getVehiclePoolForAttacks {};
         class getVehiclePoolForQRFs {};
         class vehicleBoxHeal {};

--- a/A3-Antistasi/functions/Base/fn_economicsAI.sqf
+++ b/A3-Antistasi/functions/Base/fn_economicsAI.sqf
@@ -33,7 +33,7 @@ _fnc_economics = {
 // Coeff 1.0 means one vehicle per hour with 9 players @ tierWar 7, or two vehicles per hour for 26 players.
 
 // 9 players @ tierWar 7 => balanceScale 1
-private _playerScale = (8 + count (allPlayers - entities "HeadlessClient_F")) / 17;
+private _playerScale = call A3A_fnc_getPlayerScale;
 private _balanceScale = _playerScale * (3 + tierWar) / 10;
 
 //--------------------------------------Occupants--------------------------------------------------

--- a/A3-Antistasi/functions/Base/fn_getPlayerScale.sqf
+++ b/A3-Antistasi/functions/Base/fn_getPlayerScale.sqf
@@ -1,0 +1,1 @@
+(8 + count (allPlayers - entities "HeadlessClient_F")) / 17;

--- a/A3-Antistasi/functions/CREATE/fn_invaderPunish.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_invaderPunish.sqf
@@ -26,7 +26,7 @@ private _taskId = "invaderPunish" + str A3A_taskCount;
 [_taskId, "invaderPunish", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
 // give smaller player groups a bit more time to respond
-private _playerScale = (8 + count (allPlayers - entities "HeadlessClient_F")) / 17;
+private _playerScale = call A3A_fnc_getPlayerScale;
 [_attackOrigin, (5 / _playerScale) + 10] call A3A_fnc_addTimeForIdle;        // Reserve airbase for this attack
 sleep (60*5 / _playerScale);
 

--- a/A3-Antistasi/functions/CREATE/fn_singleAttack.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_singleAttack.sqf
@@ -59,7 +59,7 @@ private _groups = [];
 private _landPosBlacklist = [];
 
 private _aggression = if (_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
-private _playerScale = (8 + count (allPlayers - entities "HeadlessClient_F")) / 17;
+private _playerScale = call A3A_fnc_getPlayerScale;
 if (sidesX getVariable [_markerDestination, sideUnknown] != teamPlayer) then { _aggression = 100 - _aggression; _playerScale = 1; };
 private _vehicleCount = random 1 + 2*_playerScale + _aggression/33 + ([0, 2] select _super);
 _vehicleCount = (round (_vehicleCount)) max 1;

--- a/A3-Antistasi/functions/CREATE/fn_singleAttack.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_singleAttack.sqf
@@ -59,12 +59,12 @@ private _groups = [];
 private _landPosBlacklist = [];
 
 private _aggression = if (_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
-if (sidesX getVariable [_markerDestination, sideUnknown] != teamPlayer) then {_aggression = 100 - _aggression};
 private _playerScale = (8 + count (allPlayers - entities "HeadlessClient_F")) / 17;
+if (sidesX getVariable [_markerDestination, sideUnknown] != teamPlayer) then { _aggression = 100 - _aggression; _playerScale = 1; };
 private _vehicleCount = random 1 + 2*_playerScale + _aggression/33 + ([0, 2] select _super);
 _vehicleCount = (round (_vehicleCount)) max 1;
 
-ServerDebug_2("Due to %1 aggression, sending %2 vehicles", _aggression, _vehicleCount);
+ServerDebug_3("Due to %1 aggression and %2 player scale, sending %3 vehicles", _aggression, _playerScale, _vehicleCount);
 
 //Set idle times for marker
 if (_markerOrigin in airportsX) then

--- a/A3-Antistasi/functions/CREATE/fn_singleAttack.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_singleAttack.sqf
@@ -57,25 +57,14 @@ if (_markerOrigin == "") exitWith
 private _vehicles = [];
 private _groups = [];
 private _landPosBlacklist = [];
+
 private _aggression = if (_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
 if (sidesX getVariable [_markerDestination, sideUnknown] != teamPlayer) then {_aggression = 100 - _aggression};
-private _vehicleCount = if(_side == Occupants) then
-{
-    1
-    + (_aggression/16)
-    + ([0, 2] select _super)
-    + ([-0.5, 0, 0.5] select (skillMult - 1))
-}
-else
-{
-    1
-    + (_aggression/16)
-    + ([0, 3] select _super)
-    + ([0, 0.5, 1.5] select (skillMult - 1))
-};
+private _playerScale = (8 + count (allPlayers - entities "HeadlessClient_F")) / 17;
+private _vehicleCount = random 1 + 2*_playerScale + _aggression/33 + ([0, 2] select _super);
 _vehicleCount = (round (_vehicleCount)) max 1;
 
-Debug_2("Due to %1 aggression, sending %2 vehicles", (if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders}), _vehicleCount);
+Debug_2("Due to %1 aggression, sending %2 vehicles", _aggression, _vehicleCount);
 
 //Set idle times for marker
 if (_markerOrigin in airportsX) then

--- a/A3-Antistasi/functions/CREATE/fn_wavedCA.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_wavedCA.sqf
@@ -160,11 +160,11 @@ while {(_waves > 0)} do
 {
 	_soldiers = [];
 	private _playerScale = (8 + count (allPlayers - entities "HeadlessClient_F")) / 17;
-	_nVeh = 1.5 + random 1 + 3*_playerScale;
+	if (!_isSDK) then { _playerScale = 1 };			// occ vs inv attacks shouldn't depend on player count
+	_nVeh = round (1.5 + random 1 + 3*_playerScale);
 	if (_firstWave) then { _nVeh = _nVeh + 2 };
-    _nVeh = (round (_nVeh)) max 1;
 
-    Debug_1("Wave will contain %1 vehicles", _nVeh);
+    Debug_2("Due to %1 player scale, wave will contain %2 vehicles", _playerScale, _nVeh);
 
 	_posOriginLand = [];
 	_pos = [];

--- a/A3-Antistasi/functions/CREATE/fn_wavedCA.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_wavedCA.sqf
@@ -61,10 +61,6 @@ private _taskId = "rebelAttack" + str A3A_taskCount;
 [_sideTsk1,_taskId+"B",[format ["We are attacking %2 from the %1. Help the operation if you can",_nameOrigin,_nameDest],format ["%1 Attack",_nameENY],_mrkDestination],getMarkerPos _mrkDestination,false,0,true,"Attack",true] call BIS_fnc_taskCreate;
 [_taskId, "rebelAttack", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
-// Use fixed aggro value for non-rebel targets for the moment
-private _aggro = if (_sideX == Occupants) then {aggressionOccupants} else {aggressionInvaders};
-if !(_isSDK) then {_aggro = 100 - _aggro;};
-
 _timeX = time + 3600;
 
 private _vehPoolLand = [];
@@ -163,8 +159,8 @@ private _uav = objNull;
 while {(_waves > 0)} do
 {
 	_soldiers = [];
-	_nVeh = 2 + random (2) + (_aggro / 25);
-	_nVeh = _nVeh + (skillMult - 2);
+	private _playerScale = (8 + count (allPlayers - entities "HeadlessClient_F")) / 17;
+	_nVeh = 1.5 + random 1 + 3*_playerScale;
 	if (_firstWave) then { _nVeh = _nVeh + 2 };
     _nVeh = (round (_nVeh)) max 1;
 

--- a/A3-Antistasi/functions/CREATE/fn_wavedCA.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_wavedCA.sqf
@@ -159,8 +159,7 @@ private _uav = objNull;
 while {(_waves > 0)} do
 {
 	_soldiers = [];
-	private _playerScale = (8 + count (allPlayers - entities "HeadlessClient_F")) / 17;
-	if (!_isSDK) then { _playerScale = 1 };			// occ vs inv attacks shouldn't depend on player count
+	private _playerScale = if (_isSDK) then { call A3A_fnc_getPlayerScale } else { 1 };			// occ vs inv attacks shouldn't depend on player count
 	_nVeh = round (1.5 + random 1 + 3*_playerScale);
 	if (_firstWave) then { _nVeh = _nVeh + 2 };
 

--- a/A3-Antistasi/functions/Supports/fn_SUP_QRF.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_QRF.sqf
@@ -58,7 +58,7 @@ private _playerScale = (8 + count (allPlayers - entities "HeadlessClient_F")) / 
 private _vehicleCount = random 1 + _playerScale + _aggression/50;
 _vehicleCount = (round (_vehicleCount)) max 1;
 
-Debug_2("Due to %1 aggression, sending %2 vehicles", _aggression, _vehicleCount);
+Debug_3("Due to %1 aggression and %2 player scale, sending %3 vehicles", _aggression, _playerScale, _vehicleCount);
 
 //Set idle times for marker
 if (_markerOrigin in airportsX) then

--- a/A3-Antistasi/functions/Supports/fn_SUP_QRF.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_QRF.sqf
@@ -54,7 +54,7 @@ private _groups = [];
 private _landPosBlacklist = [];
 
 private _aggression = if (_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
-private _playerScale = (8 + count (allPlayers - entities "HeadlessClient_F")) / 17;
+private _playerScale = call A3A_fnc_getPlayerScale;
 private _vehicleCount = random 1 + _playerScale + _aggression/50;
 _vehicleCount = (round (_vehicleCount)) max 1;
 

--- a/A3-Antistasi/functions/Supports/fn_SUP_QRF.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_QRF.sqf
@@ -52,19 +52,13 @@ _targetMarker setMarkerAlpha 0;
 private _vehicles = [];
 private _groups = [];
 private _landPosBlacklist = [];
-private _vehicleCount = if(_side == Occupants) then
-{
-    (aggressionOccupants/25)
-    + ([-0.5, 0, 0.5] select (skillMult - 1))
-}
-else
-{
-    (aggressionInvaders/25)
-    + ([0, 0.5, 1.5] select (skillMult - 1))
-};
+
+private _aggression = if (_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
+private _playerScale = (8 + count (allPlayers - entities "HeadlessClient_F")) / 17;
+private _vehicleCount = random 1 + _playerScale + _aggression/50;
 _vehicleCount = (round (_vehicleCount)) max 1;
 
-Debug_2("Due to %1 aggression, sending %2 vehicles", (if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders}), _vehicleCount);
+Debug_2("Due to %1 aggression, sending %2 vehicles", _aggression, _vehicleCount);
 
 //Set idle times for marker
 if (_markerOrigin in airportsX) then


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Softer version of #2079 based on the principle that aggro is already somewhat player-count dependent, so it should be used additively rather than multiplicatively with direct player count balancing. Uses a bit of randomness to smooth out the boundaries. Typical vehicle counts:

QRF:
1 player, 25 aggro: 1.5 vehicles.
9 players, 50 aggro: 2.5 vehicles.
26 players, 100 aggro: 3.5 vehicles.

singleAttack (typically higher aggro because a marker was just captured):
1 player, 50 aggro: 3 vehicles.
9 players, 75 aggro: 4.8 vehicles.
26 players, 100 aggro: 7.5 vehicles.

wavedCA (+2 vehicles for first wave)
1 player: 5.5 vehicles first wave, 3.5 subsequent
9 players: 7 vehicles first wave, 5 subsequent
26 players: 10 vehicles first wave, 8 subsequent

wavedCA isn't aggro-dependent because it's kinda odd to increase the attack size because you just took a marker elsewhere. It's a bit flatter than the others because the garrisons + statics are more useful.

### Please specify which Issue this PR Resolves.
Supersedes the other half of #2079

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
