### PR TITLE
Minor mortar fixes

### DIFF
--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -296,6 +296,7 @@ class A3A
 
     class EventHandler
     {
+        class addArtilleryDetectionEH {};
         class addArtilleryTrailEH {};
     };
 

--- a/A3-Antistasi/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_AIVEHinit.sqf
@@ -112,46 +112,6 @@ else
 				[_veh, "static"] remoteExec ["A3A_fnc_flagAction", [teamPlayer,civilian], _veh];
 				if (_side == teamPlayer && !isNil {serverInitDone}) then { [_veh] remoteExec ["A3A_fnc_updateRebelStatics", 2] };
 			};
-
-			// TODO: fix this shit so it's dependent on occupancy rather than type
-			if (_typeX == SDKMortar) then
-			{
-				_veh addEventHandler ["Fired",
-				{
-					_mortarX = _this select 0;
-					_dataX = _mortarX getVariable ["detection",[position _mortarX,0]];
-					_positionX = position _mortarX;
-					_chance = _dataX select 1;
-					if ((_positionX distance (_dataX select 0)) < 300) then
-					{
-						_chance = _chance + 2;
-					}
-					else
-					{
-						_chance = 0;
-					};
-					if (random 100 < _chance) then
-					{
-						{if ((side _x == Occupants) or (side _x == Invaders)) then {_x reveal [_mortarX,4]}} forEach allUnits;
-						if (_mortarX distance posHQ < 300) then
-						{
-							if !("DEF_HQ" in A3A_activeTasks) then
-							{
-								_LeaderX = leader (gunner _mortarX);
-								if (!isPlayer _LeaderX) then
-								{
-									[[],"A3A_fnc_attackHQ"] remoteExec ["A3A_fnc_scheduler",2];
-								}
-								else
-								{
-									if ([_LeaderX] call A3A_fnc_isMember) then {[[],"A3A_fnc_attackHQ"] remoteExec ["A3A_fnc_scheduler",2]};
-								};
-							};
-						};
-					};
-					_mortarX setVariable ["detection",[_positionX,_chance]];
-				}];
-			};
 		};
 	};
 };
@@ -170,9 +130,10 @@ if (_side == civilian) then
 	}];
 };
 
-if(_typeX in vehMRLS + [CSATMortar, NATOMortar, SDKMortar]) then
+if(_typeX in vehMRLS + vehMortars) then
 {
     [_veh] call A3A_fnc_addArtilleryTrailEH;
+	[_veh] remoteExec ["A3A_fnc_addArtilleryDetectionEH", 2];
 };
 
 // EH behaviour:

--- a/A3-Antistasi/functions/CREATE/fn_createSDKgarrisons.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createSDKgarrisons.sqf
@@ -96,7 +96,7 @@ if (staticCrewTeamPlayer in _garrison) then
 	private _index = _garrison findIf {_x in SDKMil};
 	if (_index == -1) exitWith {};
 	private _unit = objNull;
-	if (typeOf _x == SDKMortar) then
+	if (typeOf _x in vehMortars) then
 	{
 		if (isNull _groupMortars) then { _groupMortars = createGroup teamPlayer };
 		_unit = [_groupMortars, (_garrison select _index), _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;

--- a/A3-Antistasi/functions/EventHandler/fn_addArtilleryDetectionEH.sqf
+++ b/A3-Antistasi/functions/EventHandler/fn_addArtilleryDetectionEH.sqf
@@ -1,0 +1,47 @@
+/*
+    Adds event handler to trigger enemy responses when rebels fire artillery/mortars
+
+Arguments:
+    <OBJECT> The artillery vehicle object
+
+Environment:
+    Should be added on server so that it works when vehicle changes locality
+
+Example:
+    [_myMortar] remoteExec ["A3A_fnc_artilleryDetectionEH", 2];
+*/
+
+params ["_artillery"];
+
+_artillery addEventHandler ["Fired", {
+    _mortarX = _this select 0;
+    if (side group _mortarX != teamPlayer) exitWith {};
+    _dataX = _mortarX getVariable ["detection",[position _mortarX,0]];
+    _positionX = position _mortarX;
+    _chance = _dataX select 1;
+    if ((_positionX distance (_dataX select 0)) < 300) then
+    {
+        _chance = _chance + 2;
+    }
+    else
+    {
+        _chance = 0;
+    };
+    if (random 100 < _chance) then
+    {
+        {
+            if !(side _x in [Occupants, Invaders]) then { continue };
+            [leader _x, [_mortarX, 4]] remoteExec ["reveal", leader _x];
+        } forEach allGroups;
+        if (_mortarX distance posHQ < 300 and !("DEF_HQ" in A3A_activeTasks)) then
+        {
+            _LeaderX = leader (gunner _mortarX);
+            if (!isPlayer _LeaderX or [_LeaderX] call A3A_fnc_isMember) then
+            {
+                [[],"A3A_fnc_attackHQ"] remoteExec ["A3A_fnc_scheduler",2];
+            };
+        };
+        _chance = 0;        // reduce spamming
+    };
+    _mortarX setVariable ["detection",[_positionX,_chance]];
+}];

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -671,6 +671,9 @@ DECLARE_SERVER_VAR(vehAA, _vehAA);
 private _vehMRLS = [vehCSATMRLS, vehNATOMRLS];
 DECLARE_SERVER_VAR(vehMRLS, _vehMRLS);
 
+private _vehMortars = [SDKMortar, NATOMortar, CSATMortar];
+DECLARE_SERVER_VAR(vehMortars, _vehMortars);
+
 private _vehArmor = [vehTanks,vehAA,vehMRLS] + vehAPCs;
 DECLARE_SERVER_VAR(vehArmor, _vehArmor);
 


### PR DESCRIPTION

### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Various fixes related to mortar type checking and locality issues:
- Fixed exploit where the mortar detection routine wasn't used on captured mortars.
- Fixed locality bug where the mortar detection routine wouldn't fire on captured mortars.
- Fixed locality bug where the reveal wasn't necessarily applied.
- Moved artillery detection EH out into separate file.
- Fixed issue where captured mortars used by rebel garrisons didn't fire.

addArtilleryDetectionEH is mostly ripped from AIVEHinit so it's not fantastic quality.

### Please specify which Issue this PR Resolves.
closes #2096

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

It's not thoroughly tested but it won't be any worse. Checked that HQ attacks still trigger appropriately.
