### PR TITLE
VN Template Update

### DIFF
--- a/A3-Antistasi/Templates/NewTemplates/FactionDefaults/RebelDefaults.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/FactionDefaults/RebelDefaults.sqf
@@ -10,8 +10,6 @@
 
 ["diveGear", ["U_I_Wetsuit","V_RebreatherIA","G_Diving"]] call _fnc_saveToTemplate;
 
-["diveBP", []] call _fnc_saveToTemplate;
-
 ["flyGear", ["U_I_pilotCoveralls"]] call _fnc_saveToTemplate;
 
 ["vehicleLightSource", "Land_LampShabby_F"] call _fnc_saveToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/FactionDefaults/RebelDefaults.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/FactionDefaults/RebelDefaults.sqf
@@ -8,8 +8,10 @@
 ["toolKits", ["ToolKit"]] call _fnc_saveToTemplate;  // Relies on autodetection.
 ["itemMaps", ["ItemMap"]] call _fnc_saveToTemplate;  // Relies on autodetection.
 
-// This should be replaced by static loot lists.
-["addDiveGear",true] call _fnc_saveToTemplate;
-["addFlightGear",true] call _fnc_saveToTemplate;
+["diveGear", ["U_I_Wetsuit","V_RebreatherIA","G_Diving"]] call _fnc_saveToTemplate;
+
+["diveBP", []] call _fnc_saveToTemplate;
+
+["flyGear", ["U_I_pilotCoveralls"]] call _fnc_saveToTemplate;
 
 ["vehicleLightSource", "Land_LampShabby_F"] call _fnc_saveToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/VN/VN_CIV.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/VN/VN_CIV.sqf
@@ -32,22 +32,26 @@
 //////////////////////////
 
 ["vehiclesCivCar", [
-	"vn_c_wheeled_m151_02", 2
-	,"vn_c_wheeled_m151_01", 2
-	,"vn_c_bicycle_01", 0.2
-						]] call _fnc_saveToTemplate;
-["vehiclesCivIndustrial", ["vn_b_wheeled_m54_01_airport", 1]] call _fnc_saveToTemplate; 			//this line determines civilian trucks -- Example: ["vehiclesCivIndustrial", ["C_Truck_02_transport_F"]] -- Array, can contain multiple assets
+    "vn_c_wheeled_m151_02", 1.8
+    ,"vn_c_wheeled_m151_01", 1.8
+    ,"vn_c_car_02_01", 1.5
+    ,"vn_c_car_03_01", 1
+    ,"vn_c_car_01_01", 0.8
+    ,"vn_c_bicycle_01", 0.2]] call _fnc_saveToTemplate;
 
-["vehiclesCivHeli", []] call _fnc_saveToTemplate; 			//this line determines civilian helis -- Example: ["vehiclesCivHeli", ["C_Heli_Light_01_civil_F"]] -- Array, can contain multiple assets
+["vehiclesCivIndustrial", [
+    "vn_b_wheeled_m54_01_airport", 0.2
+    ,"vn_c_car_04_01", 1]] call _fnc_saveToTemplate;
+
+["vehiclesCivHeli", []] call _fnc_saveToTemplate;
 
 ["vehiclesCivBoat", [
-	"vn_c_boat_02_02", 1
-	,"vn_c_boat_07_01", 0.6
-	,"vn_c_boat_08_01", 0.3
-]] call _fnc_saveToTemplate; 			//this line determines civilian boats -- Example: ["vehiclesCivBoat", ["C_Boat_Civil_01_F"]] -- Array, can contain multiple assets
+    "vn_c_boat_02_02", 1
+    ,"vn_c_boat_07_01", 0.6
+    ,"vn_c_boat_08_01", 0.3]] call _fnc_saveToTemplate;
 
-["vehiclesCivRepair", ["vn_b_wheeled_m54_repair_airport", 0.3]] call _fnc_saveToTemplate;			//this line determines civilian repair vehicles
+["vehiclesCivRepair", ["vn_b_wheeled_m54_repair_airport", 0.3]] call _fnc_saveToTemplate;
 
-["vehiclesCivMedical", []] call _fnc_saveToTemplate;		//this line determines civilian medic vehicles
+["vehiclesCivMedical", []] call _fnc_saveToTemplate;
 
-["vehiclesCivFuel", ["vn_b_wheeled_m54_fuel_airport", 0.2]] call _fnc_saveToTemplate;			//this line determines civilian fuel vehicles
+["vehiclesCivFuel", ["vn_b_wheeled_m54_fuel_airport", 0.2]] call _fnc_saveToTemplate;

--- a/A3-Antistasi/Templates/NewTemplates/VN/VN_Logistics_Nodes.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/VN/VN_Logistics_Nodes.sqf
@@ -29,7 +29,7 @@ A3A_logistics_attachmentOffset append [
     ,["\vn\static_f_vietnam\m2\vn_static_m2_high.p3d",[0.2,0,1.63],[0,1,0],4,100]
     ,["\vn\static_f_vietnam\m1919\vn_static_m1919a4_low.p3d",[-0.2,0,1.2],[0,-1,0],4,100]
     ,["\vn\static_f_vietnam\m1919\vn_static_m1919a4_high.p3d",[0.2,0,1.66],[0,1,0],4,100]
-    ,["\vn\static_f_vietnam\tow\vn_static_tow.p3d",[0.2,0,1.48],[-1,0,0],4,250]
+    ,["\vn\static_f_vietnam\tow\vn_static_tow.p3d",[0.2,0,1.19],[-1,0,0],4,250]
     ,["\vn\static_f_vietnam\m1919\vn_static_m1919a6.p3d",[0,0,1.15],[0,-1,0],5,100]
     ,["\vn\static_f_vietnam\mortar_m29\vn_static_mortar_m29",[-0.2,0,0.69],[0,-1,0],3,2000]
     ,["\vn\static_f_vietnam\mortar_m2\vn_static_mortar_m2",[-0.3,0,0.7],[0,-1,0],2,1500]

--- a/A3-Antistasi/Templates/NewTemplates/VN/VN_Logistics_Nodes.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/VN/VN_Logistics_Nodes.sqf
@@ -46,6 +46,7 @@ A3A_logistics_attachmentOffset append [
     ,["\vn\static_f_vietnam\PK\vn_static_PK_low.p3d",[-0.3,0,1.21],[0,-1,0],2,100]
     ,["\vn\static_f_vietnam_02\l70mk2\vn_static_l70mk2.p3d",[0.2,0,1.58],[0,0,0],4,1500]
     ,["\vn\static_f_vietnam_02\l60mk3\vn_static_l60mk3.p3d",[0,0,1.77],[0,0,0],7,3000]
+    ,["\vn\static_f_vietnam_02\type56rr\vn_o_static_type56rr.p3d",[-0.55,0,1.48],[0,-1,0],4,250]
 ];
 A3A_logistics_coveredVehicles append [
     "vn_b_wheeled_m54_03"

--- a/A3-Antistasi/Templates/NewTemplates/VN/VN_Logistics_Nodes.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/VN/VN_Logistics_Nodes.sqf
@@ -74,7 +74,7 @@ A3A_logistics_coveredVehicles append [
 ];
 A3A_logistics_weapons append [
     ["\vn\static_f_vietnam\zpu4\vn_static_zpu4_01.p3d",[]]
-    ,["\vn\static_f_vietnam\m45\vn_static_m45.p3d",[]]
+    ,["\vn\static_f_vietnam\m45\vn_static_m45.p3d",["vn\wheeled_f_vietnam\z157\vn_wheeled_z157_01.p3d","vn\wheeled_f_vietnam\m54\vn_wheeled_m54_01.p3d"]]
     ,["\vn\static_f_vietnam\m60\vn_static_m60_high.p3d",[]]
     ,["\vn\static_f_vietnam\m2\vn_static_m2_high.p3d",[]]
     ,["\vn\static_f_vietnam\m1919\vn_static_m1919a4_low.p3d",[]]

--- a/A3-Antistasi/Templates/NewTemplates/VN/VN_Logistics_Nodes.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/VN/VN_Logistics_Nodes.sqf
@@ -16,6 +16,8 @@ A3A_logistics_vehicleHardpoints append [
     ,["vn\boat_f_vietnam\ptf\vn_boat_05.p3d",[[1,[1.2,-9.9,-0.3],[]],[1,[1.2,-10.7,-0.3],[]]]] // PTF Nasty Boat (Mortar/ Black)
     ,["vn\boat_f_vietnam\gunboat\vn_boat_04.p3d",[[1,[1,-10.4,-1.63],[]],[1,[1,-11.2,-1.63],[]]]] // Shantou Gunboat (ZPU-4/ Green)
     ,["vn\boat_f_vietnam\gunboat\vn_boat_03.p3d",[[1,[1,-10.4,-1.63],[]],[1,[1,-11.2,-1.63],[]]]] // Shantou Gunboat (V-11M/ Green)
+    ,["vn\wheeled_f_vietnam_02\car\vn_wheeled_car_04.p3d",[[1,[0,0.4,-0.62],[1]],[1,[0,-0.4,-0.62],[2]],[1,[0,-1.2,-0.62],[3,4]]]]
+    ,["vn\wheeled_f_vietnam_02\car\vn_wheeled_car_02.p3d",[[1,[0,-0.02,0.22],[]],[1,[0,-0.82,0.22],[]]]]
 ];
 A3A_logistics_attachmentOffset append [
     //Boxes
@@ -42,6 +44,8 @@ A3A_logistics_attachmentOffset append [
     ,["\vn\static_f_vietnam\rpd\vn_static_rpd_high.p3d",[-0.15,1,1.67],[0,-1,0],4,100]
     ,["\vn\static_f_vietnam\dshkm\vn_static_dshkm_low_01.p3d",[-0.3,0.8,1.21],[0,-1,0],4,150]
     ,["\vn\static_f_vietnam\PK\vn_static_PK_low.p3d",[-0.3,0,1.21],[0,-1,0],2,100]
+    ,["\vn\static_f_vietnam_02\l70mk2\vn_static_l70mk2.p3d",[0.2,0,1.58],[0,0,0],4,1500]
+    ,["\vn\static_f_vietnam_02\l60mk3\vn_static_l60mk3.p3d",[0,0,1.77],[0,0,0],7,3000]
 ];
 A3A_logistics_coveredVehicles append [
     "vn_b_wheeled_m54_03"
@@ -65,6 +69,8 @@ A3A_logistics_coveredVehicles append [
     ,"vn_i_wheeled_m54_repair"
     ,"vn_i_wheeled_m54_02"
     ,"vn_c_wheeled_m151_02"
+    ,"vn\wheeled_f_vietnam_02\car\vn_wheeled_car_02.p3d"
+    ,"vn\wheeled_f_vietnam_02\car\vn_wheeled_car_04.p3d"
 ];
 A3A_logistics_weapons append [
     ["\vn\static_f_vietnam\zpu4\vn_static_zpu4_01.p3d",[]]
@@ -97,4 +103,6 @@ A3A_logistics_weapons append [
     ,["\vn\static_f_vietnam\rpd\vn_static_rpd_high.p3d",[]]
     ,["\vn\static_f_vietnam\dshkm\vn_static_dshkm_low_01.p3d",[]]
     ,["\vn\static_f_vietnam\PK\vn_static_PK_low.p3d",[]]
+    ,["\vn\static_f_vietnam_02\l70mk2\vn_static_l70mk2.p3d",[]]
+    ,["\vn\static_f_vietnam_02\l60mk3\vn_static_l60mk3.p3d",[]]
 ];

--- a/A3-Antistasi/Templates/NewTemplates/VN/VN_MACV.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/VN/VN_MACV.sqf
@@ -25,7 +25,7 @@
 //////////////////////////
 
 ["ammobox", "B_supplyCrate_F"] call _fnc_saveToTemplate;
-["surrenderCrate", "Box_IND_Wps_F"] call _fnc_saveToTemplate; //Changeing this from default will require you to define logistics attachement offset for the box type
+["surrenderCrate", "vn_o_ammobox_04"] call _fnc_saveToTemplate; //Changeing this from default will require you to define logistics attachement offset for the box type
 ["equipmentBox", "Box_NATO_Equip_F"] call _fnc_saveToTemplate; //Changeing this from default will require you to define logistics attachement offset for the box type
 
 // All fo bellow are optional overrides
@@ -42,7 +42,7 @@
 
 ["vehiclesBasic", ["vn_b_wheeled_m151_01"]] call _fnc_saveToTemplate;
 ["vehiclesLightUnarmed", ["vn_b_wheeled_m151_01","vn_b_wheeled_m151_02"]] call _fnc_saveToTemplate;
-["vehiclesLightArmed",["vn_b_wheeled_m151_mg_02","vn_b_wheeled_m151_mg_03","vn_b_wheeled_m151_mg_04"]] call _fnc_saveToTemplate;
+["vehiclesLightArmed",["vn_b_wheeled_m151_mg_02","vn_b_wheeled_m151_mg_03","vn_b_wheeled_m151_mg_04","vn_b_wheeled_m151_mg_05"]] call _fnc_saveToTemplate;
 ["vehiclesTrucks", ["vn_b_wheeled_m54_01","vn_b_wheeled_m54_02"]] call _fnc_saveToTemplate;
 ["vehiclesCargoTrucks", []] call _fnc_saveToTemplate;
 ["vehiclesAmmoTrucks", ["vn_b_wheeled_m54_ammo"]] call _fnc_saveToTemplate;
@@ -235,7 +235,9 @@ _sfLoadoutData setVariable ["grenadeLaunchers", [
 _sfLoadoutData setVariable ["machineGuns", [
 ["vn_m60", "", "", "", [], [], ""],
 ["vn_m60_shorty_camo", "", "", "", [], [], ""],
-["vn_rpd", "", "", "", [], [], ""]
+["vn_rpd", "", "", "", [], [], ""],
+["vn_m63a_cdo", "", "", "", ["vn_m63a_150_mag", "vn_m63a_150_mag", "vn_m63a_150_t_mag"], [], ""],
+["vn_m63a_lmg", "", "", "", ["vn_m63a_100_mag", "vn_m63a_100_mag", "vn_m63a_100_t_mag"], [], ""]
 ]];
 _sfLoadoutData setVariable ["marksmanRifles", [
 ["vn_m16_camo", "vn_s_m16", "", "vn_o_9x_m16", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], [], ""],
@@ -766,7 +768,7 @@ private _crewTemplate = {
 	["vests"] call _fnc_setVest;
 	["uniforms"] call _fnc_setUniform;
 
-	["smgs"] call _fnc_setPrimary;
+	["SMGs"] call _fnc_setPrimary;
 	["primary", 3] call _fnc_addMagazines;
 
 	["sidearms"] call _fnc_setHandgun;

--- a/A3-Antistasi/Templates/NewTemplates/VN/VN_PAVN.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/VN/VN_PAVN.sqf
@@ -14,7 +14,7 @@
 //////////////////////////
 
 ["ammobox", "B_supplyCrate_F"] call _fnc_saveToTemplate;
-["surrenderCrate", "Box_IND_Wps_F"] call _fnc_saveToTemplate; //Changeing this from default will require you to define logistics attachement offset for the box type
+["surrenderCrate", "vn_o_ammobox_04"] call _fnc_saveToTemplate; //Changeing this from default will require you to define logistics attachement offset for the box type
 ["equipmentBox", "Box_NATO_Equip_F"] call _fnc_saveToTemplate; //Changeing this from default will require you to define logistics attachement offset for the box type
 
 // All fo bellow are optional overrides
@@ -69,7 +69,7 @@
 ["vehiclesPolice", ["vn_i_wheeled_m151_02_mp"]] call _fnc_saveToTemplate;
 
 ["staticMGs", ["vn_o_nva_static_dshkm_high_01"]] call _fnc_saveToTemplate;
-["staticAT", ["vn_o_nva_static_at3"]] call _fnc_saveToTemplate;
+["staticAT", ["vn_o_vc_static_type56rr"]] call _fnc_saveToTemplate;
 ["staticAA", ["vn_o_nva_static_zpu4"]] call _fnc_saveToTemplate;
 ["staticMortars", ["vn_o_nva_65_static_mortar_type63"]] call _fnc_saveToTemplate;
 
@@ -81,7 +81,7 @@
 
 //Bagged weapon definitions
 ["baggedMGs", [["vn_o_pack_static_base_01", "vn_o_pack_static_dshkm_high_01"]]] call _fnc_saveToTemplate;
-["baggedAT", [["vn_o_pack_static_base_01", "vn_o_pack_static_at3_01"]]] call _fnc_saveToTemplate;
+["baggedAT", [["vn_o_pack_static_base_01", "vn_o_pack_static_type56rr_01"]]] call _fnc_saveToTemplate;
 ["baggedAA", [[]]] call _fnc_saveToTemplate;
 ["baggedMortars", [["vn_o_pack_static_base_01", "vn_o_pack_static_type63_01"]]] call _fnc_saveToTemplate;
 

--- a/A3-Antistasi/Templates/NewTemplates/VN/VN_Reb_POF.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/VN/VN_Reb_POF.sqf
@@ -17,9 +17,11 @@
 ["toolKits", ["vn_b_item_toolkit"]] call _fnc_saveToTemplate;  // Relies on autodetection.
 ["itemMaps", ["vn_b_item_map"]] call _fnc_saveToTemplate;  // Relies on autodetection.
 
-// This should be replaced by static loot lists.
-["addDiveGear",false] call _fnc_saveToTemplate;
-["addFlightGear",false] call _fnc_saveToTemplate;
+["diveGear", ["vn_b_uniform_seal_09_01", "vn_b_acc_seal_01"]] call _fnc_saveToTemplate;
+
+["diveBP", ["vn_b_pack_seal_01"]] call _fnc_saveToTemplate;
+
+["flyGear", ["vn_b_uniform_heli_01_01"]] call _fnc_saveToTemplate;
 
 //////////////////////////
 //       Vehicles       //
@@ -27,7 +29,7 @@
 
 ["vehicleBasic", "vn_c_bicycle_01"] call _fnc_saveToTemplate; 			//this line determines basic vehicles, the lightest kind available. -- Example: ["vehiclesBasic", ["B_Quadbike_01_F"]] -- Array, can contain multiple assets
 ["vehicleLightUnarmed", "vn_i_wheeled_m151_02"] call _fnc_saveToTemplate; 		//this line determines light and unarmed vehicles. -- Example: ["vehiclesLightUnarmed", ["B_MRAP_01_F"]] -- Array, can contain multiple assets
-["vehicleLightArmed", "vn_i_wheeled_m151_mg_01"] call _fnc_saveToTemplate; 		//this line determines light and armed vehicles -- Example: ["vehiclesLightArmed",["B_MRAP_01_hmg_F","B_MRAP_01_gmg_F"]] -- Array, can contain multiple assets
+["vehicleLightArmed", "vn_o_car_04_mg_01"] call _fnc_saveToTemplate; 		//this line determines light and armed vehicles -- Example: ["vehiclesLightArmed",["B_MRAP_01_hmg_F","B_MRAP_01_gmg_F"]] -- Array, can contain multiple assets
 ["vehicleTruck", "vn_i_wheeled_m54_01"] call _fnc_saveToTemplate; 			//this line determines the trucks -- Example: ["vehiclesTrucks", ["B_Truck_01_transport_F","B_Truck_01_covered_F"]] -- Array, can contain multiple assets
 ["vehicleAT", "not_supported"] call _fnc_saveToTemplate; 		//this line determines AT vehicle -- Example: ["vehiclesCargoTrucks", ["B_Truck_01_transport_F","B_Truck_01_covered_F"]] -- Array, can contain multiple assets
 ["vehicleAA", "vn_b_wheeled_m54_mg_02"] call _fnc_saveToTemplate; 		//this line determines AA vehicle -- Example: ["vehiclesCargoTrucks", ["B_Truck_01_transport_F","B_Truck_01_covered_F"]] -- Array, can contain multiple assets
@@ -38,13 +40,13 @@
 ["vehiclePlane", "vn_o_air_mi2_01_02"] call _fnc_saveToTemplate; 		//this line determines CAS planes -- Example: ["vehiclesPlanesCAS", ["B_Plane_CAS_01_dynamicLoadout_F"]] -- Array, can contain multiple assets
 ["vehicleHeli", "not_supported"] call _fnc_saveToTemplate; 		//this line determines light helis -- Example: ["vehiclesHelisLight", ["B_Heli_Light_01_F"]] -- Array, can contain multiple assets
 
-["vehicleCivCar", "vn_c_wheeled_m151_02"] call _fnc_saveToTemplate;
+["vehicleCivCar", "vn_c_car_02_01"] call _fnc_saveToTemplate;
 ["vehicleCivTruck", "vn_b_wheeled_m54_01_airport"] call _fnc_saveToTemplate;
 ["vehicleCivHeli", "not_supported"] call _fnc_saveToTemplate;
 ["vehicleCivBoat", "vn_c_boat_08_01"] call _fnc_saveToTemplate;
 
 ["staticMG", "vn_i_static_m60_high"] call _fnc_saveToTemplate; 					//this line determines static MGs -- Example: ["staticMG", ["B_HMG_01_high_F"]] -- Array, can contain multiple assets
-["staticAT", "vn_i_static_tow"] call _fnc_saveToTemplate; 					//this line determinesstatic ATs -- Example: ["staticAT", ["B_static_AT_F"]] -- Array, can contain multiple assets
+["staticAT", "vn_o_vc_static_type56rr"] call _fnc_saveToTemplate; 					//this line determinesstatic ATs -- Example: ["staticAT", ["B_static_AT_F"]] -- Array, can contain multiple assets
 ["staticAA", "vn_i_static_m45"] call _fnc_saveToTemplate; 					//this line determines static AAs -- Example: ["staticAA", ["B_static_AA_F"]] -- Array, can contain multiple assets
 ["staticMortar", "vn_i_static_mortar_m2"] call _fnc_saveToTemplate; 				//this line determines static mortars -- Example: ["staticMortar", ["B_Mortar_01_F"]] -- Array, can contain multiple assets
 ["staticMortarMagHE", "vn_mortar_m2_mag_he_x8"] call _fnc_saveToTemplate;
@@ -52,7 +54,7 @@
 
 //Static weapon definitions
 ["baggedMGs", [["vn_b_pack_static_base_01","vn_b_pack_static_m60_high_01"]]] call _fnc_saveToTemplate; 				//this line determines bagged static MGs -- Example: ["baggedMGs", [["B_HMG_01_high_F", "B_HMG_01_support_high_F"]]] -- Array, can contain multiple assets
-["baggedAT", [["vn_b_pack_static_base_01","vn_b_pack_static_tow"]]] call _fnc_saveToTemplate; 					//this line determines bagged static ATs -- Example: ["baggedAT", [["B_AT_01_weapon_F", "B_HMG_01_support_F"]]] -- Array, can contain multiple assets
+["baggedAT", [["vn_o_pack_static_base_01","vn_o_pack_static_type56rr_01"]]] call _fnc_saveToTemplate; 					//this line determines bagged static ATs -- Example: ["baggedAT", [["B_AT_01_weapon_F", "B_HMG_01_support_F"]]] -- Array, can contain multiple assets
 ["baggedAA", [["not_supported", "not_supported"]]] call _fnc_saveToTemplate; 					//this line determines bagged static AAs -- Example: ["baggedAA", [["B_AA_01_weapon_F", "B_HMG_01_support_F"]]] -- Array, can contain multiple assets
 ["baggedMortars", [["vn_b_pack_static_base_01","vn_b_pack_static_m2_01"]]] call _fnc_saveToTemplate; 			//this line determines bagged static mortars -- Example: ["baggedMortars", [["B_Mortar_01_F", "B_Mortar_01_weapon_F"]]] -- Array, can contain multiple assets
 

--- a/A3-Antistasi/Templates/NewTemplates/VN/VN_Reb_POF.sqf
+++ b/A3-Antistasi/Templates/NewTemplates/VN/VN_Reb_POF.sqf
@@ -17,9 +17,7 @@
 ["toolKits", ["vn_b_item_toolkit"]] call _fnc_saveToTemplate;  // Relies on autodetection.
 ["itemMaps", ["vn_b_item_map"]] call _fnc_saveToTemplate;  // Relies on autodetection.
 
-["diveGear", ["vn_b_uniform_seal_09_01", "vn_b_acc_seal_01"]] call _fnc_saveToTemplate;
-
-["diveBP", ["vn_b_pack_seal_01"]] call _fnc_saveToTemplate;
+["diveGear", ["vn_b_uniform_seal_09_01", "vn_b_acc_seal_01", "vn_b_vest_seal_01"]] call _fnc_saveToTemplate;
 
 ["flyGear", ["vn_b_uniform_heli_01_01"]] call _fnc_saveToTemplate;
 

--- a/A3-Antistasi/functions/Ammunition/fn_equipmentSort.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentSort.sqf
@@ -51,6 +51,7 @@ allCivilianVests = allVests - allArmoredVests;
 allCivilianVests deleteAt (allCivilianVests find "V_RebreatherB");
 allCivilianVests deleteAt (allCivilianVests find "V_RebreatherIR");
 allCivilianVests deleteAt (allCivilianVests find "V_RebreatherIA");
+allCivilianVests deleteAt (allCivilianVests find "vn_b_vest_seal_01");
 
 ////////////////////////////////////
 //   ARMORED HELMETS LIST        ///

--- a/A3-Antistasi/functions/Ammunition/fn_equipmentSort.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_equipmentSort.sqf
@@ -70,6 +70,7 @@ allCosmeticGlasses deleteAt (allCosmeticGlasses find "G_I_Diving");
 allCosmeticGlasses deleteAt (allCosmeticGlasses find "G_O_Diving");
 allCosmeticGlasses deleteAt (allCosmeticGlasses find "G_B_Diving");
 allCosmeticGlasses deleteAt (allCosmeticGlasses find "LIB_Glasses");
+allCosmeticGlasses deleteAt (allCosmeticGlasses find "vn_b_acc_seal_01");
 
 ////////////////
 //   Radios   //

--- a/A3-Antistasi/functions/Ammunition/fn_itemSort.sqf
+++ b/A3-Antistasi/functions/Ammunition/fn_itemSort.sqf
@@ -1,10 +1,3 @@
-if (A3A_faction_reb getVariable "addDiveGear") then {
-	diveGear append ["U_I_Wetsuit","V_RebreatherIA","G_Diving"];
-};
-
-if (A3A_faction_reb getVariable "addFlightGear") then {
-	flyGear pushBack "U_I_pilotCoveralls"
-};
 //Lights Vs Laser ID
 {
 if (isClass(configfile >> "CfgWeapons" >> _x >> "ItemInfo" >> "FlashLight" >> "Attenuation")) then

--- a/A3-Antistasi/functions/CREATE/fn_createAIAirplane.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAIAirplane.sqf
@@ -249,7 +249,7 @@ private _ammoBox = if (garrison getVariable [_markerX + "_lootCD", 0] == 0) then
 		sleep 1;    //make sure fillLootCrate finished clearing the crate
 		{
 			_this#0 addItemCargoGlobal [_x, round random [5,15,15]];
-		} forEach flyGear;
+		} forEach (A3A_faction_reb getVariable "flyGear");
 	};
 	_ammoBox;
 };

--- a/A3-Antistasi/functions/CREATE/fn_createAIOutposts.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAIOutposts.sqf
@@ -148,12 +148,15 @@ private _ammoBox = if (garrison getVariable [_markerX + "_lootCD", 0] == 0) then
 	[_ammoBox] spawn A3A_fnc_fillLootCrate;
 	[_ammoBox] call A3A_fnc_logistics_addLoadAction;
 
-	if ((_markerX in seaports) and !A3A_hasIFA) then {
+	if (_markerX in seaports) then {
 		[_ammoBox] spawn {
 			sleep 1;    //make sure fillLootCrate finished clearing the crate
 			{
 				_this#0 addItemCargoGlobal [_x, round random [2,6,8]];
-			} forEach diveGear;
+			} forEach (A3A_faction_reb getVariable "diveGear");
+			{
+				_this#0 addBackpackCargoGlobal [_x, round random [2,6,8]];
+			} forEach (A3A_faction_reb getVariable "diveBP");
 		};
 	};
 	_ammoBox;

--- a/A3-Antistasi/functions/CREATE/fn_createAIOutposts.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAIOutposts.sqf
@@ -154,9 +154,6 @@ private _ammoBox = if (garrison getVariable [_markerX + "_lootCD", 0] == 0) then
 			{
 				_this#0 addItemCargoGlobal [_x, round random [2,6,8]];
 			} forEach (A3A_faction_reb getVariable "diveGear");
-			{
-				_this#0 addBackpackCargoGlobal [_x, round random [2,6,8]];
-			} forEach (A3A_faction_reb getVariable "diveBP");
 		};
 	};
 	_ammoBox;

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -185,9 +185,7 @@ private _otherEquipmentArrayNames = [
 	"invaderBackpackDevice",
 	"occupantBackpackDevice",
 	"rebelBackpackDevice",
-	"civilianBackpackDevice",
-	"diveGear",
-	"flyGear"
+	"civilianBackpackDevice"
 ];
 
 DECLARE_SERVER_VAR(otherEquipmentArrayNames, _otherEquipmentArrayNames);


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Don't Merge before the VN Update.

Changed Rebell Defaults for DiveGear and FlyGear to use arrays instead of being a True/False,
Added DiveBP due to VN using a Backpack as Rebreather,
changed CreateAiAirplane and CreateAiOutpost to use whats set in the Templates/Rebell Defaults.
Remove the IFA check for Seaports as that can be solved within the Templates.
Removed DiveGear and FlyGear in ItemSort.
Removed the Vars for them in InitVarServer,
Added Back the VN Surrender boxes as the Maximumload issue has been resolved,
Added the new Civ Vehicles added by the Update,
Added the New MGs for MACV,
Added TOW M151A1 for MACV,
changed the Static AT for Rebell and PAVN to an Unguided AT Launcher,
Added Logistic nodes for new Weapons and Civ Vehicles.
Added Type 56.
Blacklisted Quadmount for M54 and Z-157 (clipping).

### Please specify which Issue this PR Resolves.
closes nothing it just updates the VN Templates and other stuff needed for it.

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
FlyGear/DiveGear:
Teleport to a Seaport/Airbase and check the Inventory of the Box, it should have FlightSuits/DiveGear.

Check fitment on new Vehicles/Weapons
********************************************************
Notes:
One of the New Small Trucks always spawns with Vases in the Back, these can be removed via Garage, it has 3 Logistic nodes so it can load a few things, but the Vases are annoying.