### PR TITLE
Fix zero-divisor bug in minefield saving

### DIFF
--- a/A3-Antistasi/functions/Save/fn_saveLoop.sqf
+++ b/A3-Antistasi/functions/Save/fn_saveLoop.sqf
@@ -177,7 +177,7 @@ _wurzelGarrison = [];
 ["usesWurzelGarrison", true] call A3A_fnc_setStatVariable;
 
 _arrayMines = [];
-private _mineChance = 500 / count allMines;
+private _mineChance = 500 / (500 max count allMines);
 {
 	// randomly discard mines down to ~500 to avoid ballooning saves
 	if (random 1 > _mineChance) then { continue };


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed the case where the game is saved with zero mines causing a zero divisor error on the save-chance calculation.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Start new game, ensuring that the HQ isn't placed within spawn distance of a specops control point. Check allMines to make sure. Then save.
