### PR TITLE
Make hard/easy difficulty changes less extreme for some cases

### DIFF
--- a/A3-Antistasi/functions/CREATE/fn_NATOinit.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_NATOinit.sqf
@@ -75,7 +75,7 @@ else
 };
 
 //Calculates the skill of the given unit
-private _skill = (0.15 + (0.02 * difficultyCoef) + (0.01 * tierWar)) * skillMult;
+private _skill = (0.15 * skillMult) + (0.04 * difficultyCoef) + (0.02 * tierWar);
 if ("militia_" in (_unit getVariable "unitType")) then
 {
     _skill = _skill min (0.2 * skillMult);


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Currently both the war tier and player-count (difficultyCoef) factors in enemy skill are multiplied by the difficulty parameter, which leads to unreasonably high mission skill values in some cases, or permanent potato mode for easy. This PR levels things out a bit, preserving the gap between enemy and friendly AIs.
    
### Please specify which Issue this PR Resolves.
closes #XXXX

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
