### PR TITLE
Fix bad exitWith in resourceCheck causing incorrect losses

### DIFF
--- a/A3-Antistasi/functions/init/fn_resourcecheck.sqf
+++ b/A3-Antistasi/functions/init/fn_resourcecheck.sqf
@@ -29,7 +29,7 @@ while {true} do
 		_cityData params ["_numCiv", "_numVeh", "_supportGov", "_supportReb"];
 
 		_popTotal = _popTotal + _numCiv;
-		if (_city in destroyedSites) exitWith { _popKilled = _popKilled + _numCiv };
+		if (_city in destroyedSites) then { _popKilled = _popKilled + _numCiv; continue };
 
 		_popReb = _popReb + (_numCiv * (_supportReb / 100));
 		_popGov = _popGov + (_numCiv * (_supportGov / 100));


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Bad exitWith caused the city-processing loop in resourceCheck to early-out incorrectly on destroyed cities, potentially causing cities not to update and miscalculation of the loss condition.

### Please specify which Issue this PR Resolves.
closes #2140

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Add the first city in the list to destroyed sites (won't black it, but whatever):
`destroyedSites pushBack (citiesX#0); publicVariable "destroyedSites"`

Then to force a tick: `nextTick = time`, run as server
