### PR TITLE
Quick fixes for degenerate behaviour in rebelAttack

### DIFF
--- a/A3-Antistasi/functions/Base/fn_rebelAttack.sqf
+++ b/A3-Antistasi/functions/Base/fn_rebelAttack.sqf
@@ -215,7 +215,7 @@ if (count _availableTargets == 0) exitWith
         case (_target in resourcesX): {_targetMultiplier = 0.35};
         case (_target in factories): {_targetMultiplier = 0.5};
         case (_target in seaports): {_targetMultiplier = 0.7};
-        case (_target in citiesX): {_targetMultiplier = 2};
+        case (_target in citiesX): {_targetMultiplier = [2, 0.5] select (side == Invaders)};
         //If I have missed something, multiplier stays the same
         default {_targetMultiplier = 1};
     };

--- a/A3-Antistasi/functions/Base/fn_rebelAttack.sqf
+++ b/A3-Antistasi/functions/Base/fn_rebelAttack.sqf
@@ -167,11 +167,11 @@ private _availableTargets = [];
             _distance = _distance - (300 * (count _nearbyFriendlyMarkers));
             if (_distance < 0) then {_distance = 0};
 
-            if(count _nearbyFriendlyMarkers >= 5 && {!(_target in citiesX)}) then
-            {
-                Debug_1("%1 is surrounded by us, considering easy target", _target);
-                _easyTargets pushBack _target;
-            };
+            //if(count _nearbyFriendlyMarkers >= 5 && {!(_target in citiesX)}) then
+            //{
+            //    Debug_1("%1 is surrounded by us, considering easy target", _target);
+            //    _easyTargets pushBack _target;
+            //};
 
             //If in killzones, double the distance
             if (_target in _killZones) then
@@ -233,12 +233,12 @@ if (count _availableTargets == 0) exitWith
     private _nearbyStatics = staticsToSave select {(_x distance2D (getMarkerPos _target)) < distanceSPWN};
     _targetPoints = _targetPoints + (10 * (count _garrison) + (50 * (count _nearbyStatics)));
 
-    if((count _garrison <= 8) && (_targetSide == teamPlayer) && {(count _nearbyStatics <= 2) && {!(_target in citiesX)}}) then
-    {
+    //if((count _garrison <= 8) && (_targetSide == teamPlayer) && {(count _nearbyStatics <= 2) && {!(_target in citiesX)}}) then
+    //{
         //Only minimal garrison, consider it an easy target
-        Debug_1("%1 has only minimal garrison, considering easy target", _target);
-        _easyTargets pushBackUnique _target;
-    };
+    //    Debug_1("%1 has only minimal garrison, considering easy target", _target);
+    //    _easyTargets pushBackUnique _target;
+    //};
 
     //Apply the new points to the base array
     _baseArray = _baseArray apply {[_x select 0, ((_x select 1) + _targetPoints) * _targetMultiplier]};
@@ -275,6 +275,7 @@ private _fnc_flipMarker =
 };
 
 
+// JJ: Easy targets currently disabled due to overspawning/ineffectiveness
 if(count _easyTargets >= 4) then
 {
     //We got four easy targets, attacking them now
@@ -409,14 +410,15 @@ else
     _finalTarget params ["_attackOrigin", "_attackPoints", "_attackTarget"];
 
     //Select the number of waves based on the points as higher points mean higher difficulty
+    // JJ: Nope, degenerate behaviour with target distance. Revert to a dumb version for the moment.
     private _waves =
-		_attackPoints / 2500
-		+ ([0, 1] select (_attackTarget in airportsX))
-		+ (count allPlayers / 20)
-		+ (tierWar / 5);
+        0.5 + random 1 + 
+        + ([0, 1.5] select (_attackTarget in airportsX))
+        + ([0, 0.5] select (_attackTarget in outposts))
+        + ([0, 0.5] select (_side == Invaders))
+        + (tierWar / 10);
 
-	_waves = round _waves;
-    if(_waves < 1) then {_waves = 1};
+	_waves = 1 max (round _waves);
 
     //Send the actual attacks
     if (sidesX getVariable [_attackOrigin, sideUnknown] == Occupants || {!(_attackTarget in citiesX)}) then


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
The four small attacks against easy targets option and wave count calculation were not working as intended. I've removed the former and simplified the latter to temporarily fix the behaviour. Example cases that now work reasonably:

- Small attacks not spawning due to HC maxUnits limits so the attack does nothing.
- Only one small attack spawning and being less effective than a wavedCA for a higher timer cost.
- Depending on the size and grouping of the singleAttack, captured target will often have a very small garrison afterwards and so be very easy to recapture.
- With 1-3 easy targets, the code would always prefer a non-easy target, often leading to useless attacks on cities.
- Long distance targets having very large wave counts, even if very early game.
- Short distance targets having minimal wave counts, even if heavily defended.

It's not ideal, but I don't think there's any practical downside.

### Please specify which Issue this PR Resolves.
closes #2142

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Difficult because attacks targets are deterministic but target side is random, and there's no function separation. In general, set up various situations with markerChange and garrison functions and then run `[attackerSide] spawn A3A_fnc_rebelAttack`. Using reb vs gov to constrain the target side may be useful.

Not really any new code here though, just removal of paths.
