### PR TITLE
Reduce capture response delay time

### DIFF
--- a/A3-Antistasi/functions/Base/fn_markerChange.sqf
+++ b/A3-Antistasi/functions/Base/fn_markerChange.sqf
@@ -63,30 +63,14 @@ garrison setVariable [format ["%1_requested", _markerX], [], true];
 if (_winner == teamPlayer) then
 {
 	_super = if (_markerX in airportsX) then {true} else {false};
-    if(_positionX distance2D posHQ > distanceMission) then
-    {
-        [_markerX, _looser, _super] spawn
-        {
-            params ["_marker", "_loser", "_super"];
-            waitUntil
-            {
-                sleep 10;
-                spawner getVariable _marker == 2
-            };
-            if(sidesX getVariable [_marker, sideUnknown] == _loser) exitWith {};
-            [[_marker, _loser, _super], "A3A_fnc_singleAttack"] call A3A_fnc_scheduler;
-        };
-    }
-    else
-    {
-        [_markerX, _looser, _super] spawn
-        {
-            params ["_marker", "_loser", "_super"];
-            sleep (random ((15 - tierWar) * 60));
-            if(sidesX getVariable [_marker, sideUnknown] == _loser) exitWith {};
-            [[_marker, _loser, _super], "A3A_fnc_singleAttack"] call A3A_fnc_scheduler;
-        };
-    };
+	[_markerX, _looser, _super] spawn
+	{
+		params ["_marker", "_loser", "_super"];
+		private _waitTime = (6 - tierWar/2) * (0.5 + random 0.5);
+		sleep (_waitTime * 60);
+		if(sidesX getVariable [_marker, sideUnknown] == _loser) exitWith {};
+		[[_marker, _loser, _super], "A3A_fnc_singleAttack"] call A3A_fnc_scheduler;
+	};
 }
 else
 {


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Approximately halved the maximum capture response delay. See #2146.

Also removed the case where if you captured a marker outside mission radius, the response would be delayed until the marker despawned. Not sure what the purpose of this was, but it feels weird and exploitable.

Not happy with the response + delay mechanic in general as it feels very artificial with the intentional flag flips, but it'll have to do for the moment.

### Please specify which Issue this PR Resolves.
closes #2146

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
