### PR TITLE
Prevent airborne troops from counting towards zoneCheck captures

### DIFF
--- a/A3-Antistasi/functions/Base/fn_zoneCheck.sqf
+++ b/A3-Antistasi/functions/Base/fn_zoneCheck.sqf
@@ -57,6 +57,7 @@ private _markerPos = getMarkerPos _marker;
 private _units = allUnits inAreaArray [_markerPos, _capRadius, _capRadius];
 {
     if !(_x call A3A_fnc_canFight) then { continue };
+    if (vehicle _x isKindOf "Air") then { continue };
     private _value = linearConversion [_capRadius/2, _capRadius, _markerPos distance2d _x, 1, 0, true];
     switch (side _x) do				// Not side group because we don't count undercover
     {


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Airborne troops, for example overflying in transport helis, counted towards flag recapture checks. This caused some very weird marker flips. This PR prevents airborne troops from counting towards the capture check.

wavedCA probably has a similar issue but it's harder to fix.

### Please specify which Issue this PR Resolves.
closes #2145

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
