### PR TITLE
Block exploit where commander could become permanently undercover

### DIFF
--- a/A3-Antistasi/REINF/controlHCsquad.sqf
+++ b/A3-Antistasi/REINF/controlHCsquad.sqf
@@ -1,4 +1,5 @@
 if (player != theBoss) exitWith {["Control Squad", "Only Commander has the ability to control HC units."] call A3A_fnc_customHint;};
+if (captive player) exitWith {["Control Squad", "You cannot control squads while undercover."] call A3A_fnc_customHint;};
 if (!isNil "A3A_FFPun_Jailed" && {(getPlayerUID player) in A3A_FFPun_Jailed}) exitWith {["Control Squad", "Nope. Not happening."] call A3A_fnc_customHint;};
 
 _groups = _this select 0;

--- a/A3-Antistasi/REINF/controlunit.sqf
+++ b/A3-Antistasi/REINF/controlunit.sqf
@@ -5,7 +5,7 @@ _units = _this select 0;
 _unit = _units select 0;
 
 if (_unit == Petros) exitWith {["Control Unit", "You cannot control Petros."] call A3A_fnc_customHint;};
-//if (captive player) exitWith {hint "You cannot control AI while on Undercover"};
+if (captive player) exitWith {["Control Unit", "You cannot control AI while undercover."] call A3A_fnc_customHint;};
 if (player != leader group player) exitWith {["Control Unit", "You cannot control AI if you are not the squad leader."] call A3A_fnc_customHint;};
 if (isPlayer _unit) exitWith {["Control Unit", "You cannot control another player."] call A3A_fnc_customHint;};
 if (!(alive _unit) or (_unit getVariable ["incapacitated",false]))  exitWith {["Control Unit", "You cannot control an unconscious, a dead unit."] call A3A_fnc_customHint;};


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
#1818 introduced a bug (_player -> player switch) where the commander could become permanently undercover by remote controlling a high command squad.

I've just blocked it for the moment by preventing use of remote control while undercover, as that seemed to fit better with other design decisions. If we want to bring back undercover RC then goUndercover will need changes to support that.

### Please specify which Issue this PR Resolves.
closes #2133

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
