### PR TITLE
Fix multiple rebel squad/vehicle price bugs

### DIFF
--- a/A3-Antistasi/REINF/dismissSquad.sqf
+++ b/A3-Antistasi/REINF/dismissSquad.sqf
@@ -65,15 +65,14 @@ private _assignedVehicles =	[];
 
 {
 	private _veh = _x;
-	if ((typeOf _veh) in vehFIA) then
+	if !(typeOf _veh in vehFIA) then { continue };
+	_resourcesFIA = _resourcesFIA + ([typeOf _veh] call A3A_fnc_vehiclePrice);
 	{
-		_resourcesFIA = _resourcesFIA + ([typeOf _veh] call A3A_fnc_vehiclePrice);
-		{
-			_resourcesFIA = _resourcesFIA + ([typeOf _x] call A3A_fnc_vehiclePrice);
-			deleteVehicle _x;
-		} forEach attachedObjects _veh;
-		deleteVehicle _veh;
-	};
+		if !(typeOf _x in vehFIA) then { continue };
+		_resourcesFIA = _resourcesFIA + ([typeOf _x] call A3A_fnc_vehiclePrice);
+		deleteVehicle _x;
+	} forEach attachedObjects _veh;
+	deleteVehicle _veh;
 } forEach _assignedVehicles;
 
 _nul = [_hr,_resourcesFIA] remoteExec ["A3A_fnc_resourcesFIA",2];

--- a/A3-Antistasi/REINF/dismissSquad.sqf
+++ b/A3-Antistasi/REINF/dismissSquad.sqf
@@ -42,7 +42,7 @@ private _assignedVehicles =	[];
 		{
 			_hr = _hr + 1;
 			_resourcesFIA = _resourcesFIA + (server getVariable [_x getVariable "unitType",0]);
-			if (!isNull (assignedVehicle _x)) then
+			if (!isNull (assignedVehicle _x) and {isNull attachedTo (assignedVehicle _x)}) then
 			{
 				_assignedVehicles pushBackUnique (assignedVehicle _x);
 			};
@@ -67,13 +67,11 @@ private _assignedVehicles =	[];
 	private _veh = _x;
 	if ((typeOf _veh) in vehFIA) then
 	{
-		_resourcesFIA = _resourcesFIA + ([(typeOf _veh)] call A3A_fnc_vehiclePrice);
-		if (count attachedObjects _veh > 0) then
+		_resourcesFIA = _resourcesFIA + ([typeOf _veh] call A3A_fnc_vehiclePrice);
 		{
-			_subVeh = (attachedObjects _veh) select 0;
-			_resourcesFIA = _resourcesFIA + ([(typeOf _subVeh)] call A3A_fnc_vehiclePrice);
-			deleteVehicle _subVeh;
-		};
+			_resourcesFIA = _resourcesFIA + ([typeOf _x] call A3A_fnc_vehiclePrice);
+			deleteVehicle _x;
+		} forEach attachedObjects _veh;
 		deleteVehicle _veh;
 	};
 } forEach _assignedVehicles;

--- a/A3-Antistasi/functions/REINF/fn_addFIAsquadHC.sqf
+++ b/A3-Antistasi/functions/REINF/fn_addFIAsquadHC.sqf
@@ -39,11 +39,11 @@ if (_typeGroup isEqualType []) then {
 
 } else {
 	_costs = _costs + (2*(server getVariable staticCrewTeamPlayer)) + ([_typeGroup] call A3A_fnc_vehiclePrice);
+	if (_typeGroup == staticAAteamPlayer) then { _costs = _costs + ([vehSDKTruck] call A3A_fnc_vehiclePrice) };
     _formatX = [staticCrewTeamPlayer,staticCrewTeamPlayer];
 	_costHR = 2;
 
 	if ((_typeGroup == SDKMortar) or (_typeGroup == SDKMGStatic)) exitWith { _isInfantry = true };
-	_costs = _costs + ([vehSDKTruck] call A3A_fnc_vehiclePrice)
 };
 
 if ((_withBackpck != "") and A3A_hasIFA) exitWith {["Recruit Squad", "Your current modset doesn't support packing/unpacking static weapons."] call A3A_fnc_customHint;};
@@ -110,8 +110,8 @@ private _vehiclePlacementMethod = if (getMarkerPos respawnTeamPlayer distance pl
 if (!_isInfantry) exitWith { [_vehType, "HCSquadVehicle", [_formatX, _idFormat, _special], _mounts] call _vehiclePlacementMethod };
 
 private _vehCost = [_vehType] call A3A_fnc_vehiclePrice;
-if ((_costs + _vehCost) > server getVariable "resourcesFIA") exitWith {
-    ["Recruit Squad", format ["You do not have enough money for this request (%1 € required).",_vehCost]] call A3A_fnc_customHint;
+if (_isInfantry and (_costs + _vehCost) > server getVariable "resourcesFIA") exitWith {
+    ["Recruit Squad", format ["No money left to buy a transport vehicle (%1 € required), creating barefoot squad.",_vehCost]] call A3A_fnc_customHint;
     [_formatX, _idFormat, _special, objNull] spawn A3A_fnc_spawnHCGroup;
 };
 

--- a/A3-Antistasi/functions/REINF/fn_addFIAsquadHC.sqf
+++ b/A3-Antistasi/functions/REINF/fn_addFIAsquadHC.sqf
@@ -122,7 +122,7 @@ private _display = findDisplay 100;
 
 if (str (_display) != "no display") then {
 	private _ChildControl = _display displayCtrl 104;
-	_ChildControl  ctrlSetTooltip format ["Buy a vehicle for this squad for %1 €.",_costs];
+	_ChildControl  ctrlSetTooltip format ["Buy a vehicle for this squad for %1 €.", _vehCost];
 	_ChildControl = _display displayCtrl 105;
 	_ChildControl  ctrlSetTooltip "Barefoot Infantry";
 };

--- a/A3-Antistasi/functions/REINF/fn_spawnHCGroup.sqf
+++ b/A3-Antistasi/functions/REINF/fn_spawnHCGroup.sqf
@@ -28,16 +28,12 @@ params [
     , ["_vehicle", objNull, [objNull]]
 ];
 
-//calculate cost
-private _cost = if (isNull _vehicle) then { 0 } else {
-    if (_special == "BuildAA" or typeOf _vehicle == vehSDKAA) exitWith { ([vehSDKTruck] call A3A_fnc_vehiclePrice) + ([staticAAteamPlayer] call A3A_fnc_vehiclePrice) }; 
-    [typeOf _vehicle] call A3A_fnc_vehiclePrice
-};
+//calculate base cost
+private _cost = if (isNull _vehicle) then { 0 } else { [typeOf _vehicle] call A3A_fnc_vehiclePrice };
 private _costHR = 0;
 {
     _cost = _cost + (server getVariable _x); _costHR = _costHR +1
 } forEach _unitTypes;
-[- _costHR, - _cost] remoteExec ["A3A_fnc_resourcesFIA", 2];
 
 //spawn group
 private _pos = [(getMarkerPos respawnTeamPlayer), 30, random 360] call BIS_Fnc_relPos;
@@ -85,6 +81,7 @@ switch _special do {
         call _initInfVeh;
         _group setVariable ["staticAutoT",false,true];
         [_group, _staticType] spawn A3A_fnc_MortyAI;
+        _cost = _cost + ([_staticType] call A3A_fnc_vehiclePrice);
     };
 
     //vehicle squad
@@ -93,6 +90,8 @@ switch _special do {
         (_units # (_countUnits -1)) assignAsDriver _vehicle;
         (_units # _countUnits) assignAsGunner _static;
         call _initVeh;
+        _cost = _cost + ([staticAAteamPlayer] call A3A_fnc_vehiclePrice);
+
     };
     case "VehicleSquad": {
         (_units # (_countUnits -1)) assignAsDriver _vehicle;
@@ -106,12 +105,16 @@ switch _special do {
     case "MG": {
         (_units # (_countUnits - 1)) addBackpackGlobal supportStaticsSDKB2;
         (_units # _countUnits) addBackpackGlobal MGStaticSDKB;
+        _cost = _cost + ([SDKMGStatic] call A3A_fnc_vehiclePrice);
     };
     case "Mortar": {
         (_units # (_countUnits - 1)) addBackpackGlobal supportStaticsSDKB3;
         (_units # _countUnits) addBackpackGlobal MortStaticSDKB;
+        _cost = _cost + ([SDKMortar] call A3A_fnc_vehiclePrice);
     };
 };
+
+[- _costHR, - _cost] remoteExec ["A3A_fnc_resourcesFIA", 2];
 
 if !(_bypassAI) then {_group spawn A3A_fnc_attackDrillAI};
 

--- a/A3-Antistasi/functions/REINF/fn_spawnHCGroup.sqf
+++ b/A3-Antistasi/functions/REINF/fn_spawnHCGroup.sqf
@@ -29,7 +29,10 @@ params [
 ];
 
 //calculate cost
-private _cost = if (isNull _vehicle) then { 0 } else { [typeOf _vehicle] call A3A_fnc_vehiclePrice };
+private _cost = if (isNull _vehicle) then { 0 } else {
+    if (_special == "BuildAA" or typeOf _vehicle == vehSDKAA) exitWith { ([vehSDKTruck] call A3A_fnc_vehiclePrice) + ([staticAAteamPlayer] call A3A_fnc_vehiclePrice) }; 
+    [typeOf _vehicle] call A3A_fnc_vehiclePrice
+};
 private _costHR = 0;
 {
     _cost = _cost + (server getVariable _x); _costHR = _costHR +1

--- a/A3-Antistasi/functions/init/fn_initVarServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initVarServer.sqf
@@ -687,6 +687,7 @@ private _vehUnlimited = vehNATONormal + vehCSATNormal + [vehNATORBoat,vehNATOPat
 DECLARE_SERVER_VAR(vehUnlimited, _vehUnlimited);
 
 private _vehFIA = [vehSDKBike,vehSDKAT,vehSDKLightArmed,SDKMGStatic,vehSDKLightUnarmed,vehSDKTruck,vehSDKBoat,SDKMortar,staticATteamPlayer,staticAAteamPlayer,vehSDKRepair];
+if (vehSDKAA != "not_supported") then { _vehFIA pushBack vehSDKAA };
 DECLARE_SERVER_VAR(vehFIA, _vehFIA);
 
 private _vehCargoTrucks = (vehTrucks + vehNATOCargoTrucks) select { [_x] call A3A_fnc_logistics_getVehCapacity > 1 };
@@ -758,6 +759,7 @@ server setVariable [vehSDKTruck,300,true];											//300
 {server setVariable [_x,700,true]} forEach [vehSDKLightArmed,vehSDKAT];
 {server setVariable [_x,400,true]} forEach [SDKMGStatic,vehSDKBoat,vehSDKRepair];			//400
 {server setVariable [_x,800,true]} forEach [SDKMortar,staticATteamPlayer,staticAAteamPlayer];			//800
+server setVariable [vehSDKAA,1100,true];				// should be vehSDKTruck + staticAAteamPlayer otherwise things will break
 
 ///////////////////////
 //     GARRISONS    ///


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Both constructed and single-vehicle AA trucks were being underpriced on purchase due to not calculating truck + static AA costs as the other code did. This PR fixes this for both cases with a horrible hack.    

**Edit:** Additional vehicle price bugs fixed:
- Fixed doubled check price for AA and AT vehicles (missing isInfantry check).
- Fixed AT car check price adding SDKTruck price.
- Fixed ancient bug where zu-23 rebel AA trucks were not refunded on dismissal.
- Fixed bug where vanilla AA trucks were double-refunded.
- Fixed misleading error message when you didn't have enough money to purchase a transport vehicle.
- Fixed wrong price shown for transport vehicle.
- Fixed squad mortars and MGs not being charged for.

### Please specify which Issue this PR Resolves.
closes #2150
closes #2152

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
