### PR TITLE
Fix lamp drop action after respawn and some related things

### DIFF
--- a/A3-Antistasi/functions/Base/fn_flagaction.sqf
+++ b/A3-Antistasi/functions/Base/fn_flagaction.sqf
@@ -77,7 +77,7 @@ switch _typeX do
             {
                 removeAllActions _flag;
                 if (player == player getVariable ["owner",player]) then {[] call SA_Add_Player_Tow_Actions};
-                call A3A_fnc_initLootToCrate;
+                if (lootToCrateEnabled) then {call A3A_fnc_initLootToCrate};
                 call A3A_fnc_dropObject;
             }
             else
@@ -122,7 +122,7 @@ switch _typeX do
         fireX addAction ["Rest for 8 Hours", A3A_fnc_skiptime,nil,0,false,true,"","(_this == theBoss)",4];
         fireX addAction ["Clear Nearby Forest", A3A_fnc_clearForest,nil,0,false,true,"","(_this == theBoss)",4];
         fireX addAction ["I hate the fog", { [10,[0,0,0]] remoteExec ["setFog",2]; },nil,0,false,true,"","(_this == theBoss)",4];
-        fireX addAction ["Rain rain go away", { [10,0] remoteExec ["setRain",2]; },nil,0,false,true,"","(_this == theBoss)",4];
+        fireX addAction ["Rain rain go away", { [10,0] remoteExec ["setRain",2]; [60,0.25] remoteExec ["setOvercast",2] },nil,0,false,true,"","(_this == theBoss)",4];
         fireX addAction ["Move this asset", A3A_fnc_moveHQObject,nil,0,false,true,"","(_this == theBoss)",4];
     };
     case "SDKFlag":

--- a/A3-Antistasi/onPlayerRespawn.sqf
+++ b/A3-Antistasi/onPlayerRespawn.sqf
@@ -19,6 +19,7 @@ if (isServer) then {
 	} ];
 };
 
+removeAllActions _oldUnit;
 _nul = [_oldUnit] spawn A3A_fnc_postmortem;
 
 _oldUnit setVariable ["incapacitated",false,true];
@@ -233,6 +234,7 @@ if (side group player == teamPlayer) then
 	[] execVM "OrgPlayers\unitTraits.sqf";
 	[] spawn A3A_fnc_statistics;
 	if (LootToCrateEnabled) then {call A3A_fnc_initLootToCrate};
+	call A3A_fnc_dropObject;
 	}
 else
 	{


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
- Fix bug where drop object action (for dropping lamps) wasn't added to player after respawn.
- Fix bug where actions were left on a dead player object.
- Fix bug where LTC actions could be added when disabled by params.

Also accidentally added the setOvercast functionality that solidifies the rain-removal tent option. Can't be bothered to unfuck git and separate it. Note that the overcast state changes very slowly, but it should prevent the rain from coming back.

### Please specify which Issue this PR Resolves.
closes #2154
closes #1992

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
