### PR TITLE
Remove undercover on setup of ACE explosives

### DIFF
--- a/A3-Antistasi/functions/init/fn_initClient.sqf
+++ b/A3-Antistasi/functions/init/fn_initClient.sqf
@@ -306,6 +306,13 @@ player addEventHandler ["GetInMan", {
 	};
 }];
 
+if (A3A_hasACE) then {
+    ["ace_explosives_place", {
+        params ["_explosive","_dir","_pitch","_unit"];
+		if (_unit == player) then { player setCaptive false };
+    }] call CBA_fnc_addEventHandler;
+};
+
 call A3A_fnc_initUndercover;
 
 if (isMultiplayer) then {


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Added client event handler to remove undercover status when an ACE explosive is set up (note that this is on trigger setup, not placement).

### Please specify which Issue this PR Resolves.
Bob didn't want to publicize the issue.

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
