### PR TITLE
Fix rare case when player rank wouldn't save correctly when dead

### DIFF
--- a/A3-Antistasi/functions/Save/fn_savePlayer.sqf
+++ b/A3-Antistasi/functions/Save/fn_savePlayer.sqf
@@ -53,11 +53,13 @@ if (_shouldStripLoadout) then {
 
 if (isMultiplayer) then
 {
-	[_playerId, "scorePlayer", _playerUnit getVariable "score"] call A3A_fnc_savePlayerStat;
-	[_playerId, "rankPlayer", rank _playerUnit] call A3A_fnc_savePlayerStat;
-	[_playerId, "personalGarage", []] call A3A_fnc_savePlayerStat;
+	private _scorePlayer = _playerUnit getVariable ["score", 0];
+	private _rankPlayer = _playerUnit getVariable ["rankX", "PRIVATE"];		// rank _unit fails on corpses
+	[_playerId, "scorePlayer", _scorePlayer] call A3A_fnc_savePlayerStat;
+	[_playerId, "rankPlayer", _rankPlayer] call A3A_fnc_savePlayerStat;
+	[_playerId, "personalGarage", []] call A3A_fnc_savePlayerStat;			// legacy variable
 
-	_totalMoney = _playerUnit getVariable ["moneyX", 0];
+	private _totalMoney = _playerUnit getVariable ["moneyX", 0];
 	if (_shouldStripLoadout) then { _totalMoney = round (_totalMoney * 0.85) };
 
 	if (_globalSave) then
@@ -84,7 +86,7 @@ if (isMultiplayer) then
 	};
 	[_playerId, "moneyX", _totalMoney] call A3A_fnc_savePlayerStat;
 
-    Info_3("Saved player %1: %2 rank, %3 money, %4 vehicles", _playerId, rank _playerUnit, _totalMoney);
+    Info_3("Saved player %1: %2 rank, %3 money", _playerId, _rankPlayer, _totalMoney);
 };
 
 if (!_globalSave) then { saveProfileNamespace };


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
`rank _playerUnit` returns empty string on dead players after respawning, which is possible on save if timed precisely. Switched to using the mirrored rankX variable on the player unit, which should always return a real rank.

### Please specify which Issue this PR Resolves.
closes #1285

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
