### PR TITLE
Add Ace Food and Drink Items + Parameter

### DIFF
--- a/A3-Antistasi/MissionDescription/params.hpp
+++ b/A3-Antistasi/MissionDescription/params.hpp
@@ -186,6 +186,13 @@ class Params
         texts[] = {"Load from save (Default: Yes)","Yes","No"};
         default = 9999;
     };
+    class aceFood
+    {
+        title = "[ACE] Start with Food Items";
+        values[] = {9999,1,0};
+        texts[] = {"Load from save (Default: No)","Yes","No"};
+        default = 9999;
+    };
     class helmetLossChance
     {
         title = "Chance of helmet loss on headshots";

--- a/A3-Antistasi/functions/Templates/fn_aceModCompat.sqf
+++ b/A3-Antistasi/functions/Templates/fn_aceModCompat.sqf
@@ -66,10 +66,35 @@ katMedItems = [
 	"kat_Painkiller"
 ];
 
+aceCoolingItems = [
+	"ACE_Canteen",
+	"ACE_Canteen_Half",
+	"ACE_Canteen_Empty",
+	"ACE_WaterBottle",
+	"ACE_WaterBottle_Half",
+	"ACE_WaterBottle_Empty",
+	"ACE_Can_Franta",
+	"ACE_Can_RedGull",
+	"ACE_Can_Spirit"
+];
+
+aceFoodItems = [
+	"ACE_MRE_BeefStew",
+	"ACE_MRE_ChickenTikkaMasala",
+	"ACE_MRE_ChickenHerbDumplings",
+	"ACE_MRE_CreamChickenSoup",
+	"ACE_MRE_CreamTomatoSoup",
+	"ACE_MRE_LambCurry",
+	"ACE_MRE_MeatballsPasta",
+	"ACE_MRE_SteakVegetables"
+];
+
 publicVariable "aceItems";
 publicVariable "aceMedItems";
 publicVariable "advItems";
 publicVariable "katMedItems";
+publicVariable "aceCoolingItems";
+publicVariable "aceFoodItems";
 
 ////////////////////////////////////
 //   ACE ITEMS MODIFICATIONS     ///
@@ -88,6 +113,12 @@ if (A3A_hasADV) then {
 
 if (A3A_hasKAT) then {
 	FactionGet(reb,"initialRebelEquipment") append katMedItems;
+};
+
+FactionGet(reb,"initialRebelEquipment") append aceCoolingItems;
+
+if (aceFood) then {
+	FactionGet(reb,"initialRebelEquipment") append aceFoodItems;
 };
 
 if !(A3A_hasVN) then {

--- a/A3-Antistasi/functions/init/fn_initParams.sqf
+++ b/A3-Antistasi/functions/init/fn_initParams.sqf
@@ -61,6 +61,7 @@ A3A_paramTable = [
     ["memberSlots", "memberSlots", ["server"], 20],
 
     ["startWithLongRangeRadio", "startWithLongRangeRadio", [], true],
+    ["aceFood", "aceFood", [], false],
     ["helmetLossChance", "helmetLossChance", [], 33],
     ["minWeaps", "unlockItem", [], 25],
     ["memberOnlyMagLimit", "memberOnlyMagLimit", [], 40],				// dead param


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information:
Adds Ace Drink Items by Default, as they can be used to Cool your Barrel.

Food Items are given at the start if the Parameter is enabled, food is only useful if Ace Field Rations is enabled.

### Please specify which Issue this PR Resolves.
closes nothing

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Start the Mission with and without the Parameter on, Water should always be given, Food only with the Parameter on.
********************************************************
Notes:
