### PR TITLE
ACE water items for cooling

### DIFF
--- a/A3-Antistasi/functions/Templates/fn_aceModCompat.sqf
+++ b/A3-Antistasi/functions/Templates/fn_aceModCompat.sqf
@@ -22,7 +22,9 @@ aceItems = [
 	"ACE_UAVBattery",
 	"ACE_SpareBarrel",
 	"ACE_Flashlight_XL50",
-	"ACE_HandFlare_White"
+	"ACE_HandFlare_White",
+	"ACE_Canteen",
+	"ACE_WaterBottle"
 ];
 
 aceMedItems = [


### PR DESCRIPTION
adds ACE_Canteen and ACE_WaterBottle to initial ACE items in arsenal

## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
adds wurdur-items to cool down barrels    


### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
