### PR TITLE
Added missing parenthesis around sleep expression

### DIFF
--- a/A3-Antistasi/functions/AI/fn_AIreactOnKill.sqf
+++ b/A3-Antistasi/functions/AI/fn_AIreactOnKill.sqf
@@ -133,5 +133,5 @@ if(_group getVariable ["canCallSupportAt", -1] < dateToNumber date) then
             };
 		};
 	};
-    sleep 1 + (random 1);
+    sleep (1 + random 1);
 } forEach _aliveGroupMembers;

--- a/A3-Antistasi/functions/AI/fn_artillery.sqf
+++ b/A3-Antistasi/functions/AI/fn_artillery.sqf
@@ -66,7 +66,7 @@ if (_posDestination inRangeOfArtillery [[_veh], ((getArtilleryAmmo [_veh]) selec
 			{
 			_veh commandArtilleryFire [position _objectiveX,_typeAmmunition,_roundsX];
 			_timeX = _veh getArtilleryETA [position _objectiveX, ((getArtilleryAmmo [_veh]) select 0)];
-			sleep 9 + ((_roundsX - 1) * 3);
+			sleep (9 + (_roundsX - 1) * 3);
 			}
 		else
 			{

--- a/A3-Antistasi/functions/init/fn_initServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initServer.sqf
@@ -84,7 +84,8 @@ _nul = call A3A_fnc_initVar;
 call A3A_fnc_logistics_initNodes;
 
 savingServer = true;
-Info_2("%1 server version: %2", ["SP","MP"] select isMultiplayer, localize "STR_antistasi_credits_generic_version_text");
+#define MODE_ARRAY ["SP","MP"]
+Info_2("%1 server version: %2", MODE_ARRAY select isMultiplayer, localize "STR_antistasi_credits_generic_version_text");
 bookedSlots = floor ((memberSlots/100) * (playableSlotsNumber teamPlayer)); publicVariable "bookedSlots";
 if (A3A_hasACEMedical) then { call A3A_fnc_initACEUnconsciousHandler };
 call A3A_fnc_loadNavGrid;


### PR DESCRIPTION


## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
`sleep` is a unary command which has a higher precedence than the binary + command, thus 
```sqf
sleep 1 + (random 1);
// parses as
(sleep 1) + (random 1);
```
Which is not a valid expression (as sleep returns nothing), what was probably intended is:
```sqf
sleep (1 + (random 1));
```
which can be written simpler like this:
```sqf
sleep (1 + random 1);
```

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
