### PR TITLE
Fixed various incorrect usages of defined macros

### DIFF
--- a/A3-Antistasi/Garage/Core/fn_requestSelectionChange.sqf
+++ b/A3-Antistasi/Garage/Core/fn_requestSelectionChange.sqf
@@ -40,6 +40,6 @@ if !((_vehicle#3) in ["", _UID] ) exitWith _exit;
 [_UID] call HR_GRG_fnc_releaseAllVehicles;
 _vehicle set [3, _UID];
 
-Trace_4("Vehicle at | Cat: %1 | Vehicle ID: %2 | At Index: %3 | checked out by UID: %4", _catIndex, _vehUID, _UID);
+Trace_3("Vehicle at | Cat: %1 | Vehicle ID: %2 | checked out by UID: %3", _catIndex, _vehUID, _UID);
 [nil,_UID, _catIndex, _vehUID, _player, true] call HR_GRG_fnc_broadcast;
 true

--- a/A3-Antistasi/Garage/Core/fn_toggleLock.sqf
+++ b/A3-Antistasi/Garage/Core/fn_toggleLock.sqf
@@ -35,7 +35,7 @@ private _owner = _veh#5;
 _succes = call {
     if ( _lock isEqualTo "" ) exitWith { true };
     if ( _lock isEqualTo _UID) exitWith { _UID = ""; true };
-    if (_player isEqualTo (_player call HR_GRG_cmdClient)) exitWith { _UID = ""; Info_4("Commander unlock | Vehicle ID: %1 | Owner: %2 [%3] | Commander: %4[%5]", _vehUID, _owner, _lock, name _player, _UID); true };
+    if (_player isEqualTo (_player call HR_GRG_cmdClient)) exitWith { _UID = ""; Info_5("Commander unlock | Vehicle ID: %1 | Owner: %2 [%3] | Commander: %4 [%5]", _vehUID, _owner, _lock, name _player, _UID); true };
     false
 };
 

--- a/A3-Antistasi/Garage/Pylons/fn_pylonsTurretToggle.sqf
+++ b/A3-Antistasi/Garage/Pylons/fn_pylonsTurretToggle.sqf
@@ -52,7 +52,7 @@ if (_turret isEqualTo [0]) then {
     _ctrl ctrlSetText GunnerIcon;
     _ctrl ctrlSetTooltip localize "STR_HR_GRG_Pylons_Gunner";
 } else {
-    Trace("Turret switched to Driver, Ctrl: %1",_ctrl);
+    Trace_1("Turret switched to Driver, Ctrl: %1",_ctrl);
     _ctrl ctrlSetText DriverIcon;
     _ctrl ctrlSetTooltip localize "STR_HR_GRG_Pylons_Driver";
 };

--- a/A3-Antistasi/functions/AI/fn_artySupport.sqf
+++ b/A3-Antistasi/functions/AI/fn_artySupport.sqf
@@ -257,7 +257,8 @@ if (_typeArty != "BARRAGE") then
 	_eta = (_artyArrayDef1 select 0) getArtilleryETA [_positionTel, ((getArtilleryAmmo [(_artyArrayDef1 select 0)]) select 0)];
 	_timeX = time + _eta - 5;
 	if (isNil "_timeX") exitWith {
-        Error_4("Params: %1,%2,%3,%4",_artyArrayDef1 select 0,_positionTel,((getArtilleryAmmo [(_artyArrayDef1 select 0)]) select 0),(_artyArrayDef1 select 0) getArtilleryETA [_positionTel, ((getArtilleryAmmo [(_artyArrayDef1 select 0)]) select 0)]);
+#define ARTILLERY_ERROR_INFORMATION [_positionTel, ((getArtilleryAmmo [(_artyArrayDef1 select 0)]) select 0)]
+        Error_4("Params: %1,%2,%3,%4,%5",_artyArrayDef1 select 0,_positionTel,((getArtilleryAmmo [(_artyArrayDef1 select 0)]) select 0),(_artyArrayDef1 select 0) getArtilleryETA ARTILLERY_ERROR_INFORMATION);
 		};
 	_textX = format ["Acknowledged. Fire mission is inbound. %2 Rounds fired. ETA %1 secs.",round _eta,_roundsMax - _rounds];
 	[petros,"sideChat",_textX] remoteExec ["A3A_fnc_commsMP",[teamPlayer,civilian]];

--- a/A3-Antistasi/functions/Base/fn_mrkWIN.sqf
+++ b/A3-Antistasi/functions/Base/fn_mrkWIN.sqf
@@ -8,7 +8,7 @@ private _markerPos = getMarkerPos _markerX;
 
 if (sidesX getVariable [_markerX,sideUnknown] == teamPlayer) exitWith {};
 
-if !(_playerX call A3A_fnc_canFight) exitWith { ServerError_1("Action somehow used by dead or unconscious player?") };
+if !(_playerX call A3A_fnc_canFight) exitWith { ServerError("Action somehow used by dead or unconscious player?") };
 if (captive _playerX) exitWith {["Capture", "You cannot Capture the Flag while Undercover."] call A3A_fnc_customHint;};
 if ((_markerX in airportsX) and (tierWar < 3)) exitWith {["Capture", "You cannot capture Airports until you reach War Level 3."] call A3A_fnc_customHint;};
 

--- a/A3-Antistasi/functions/Garrison/fn_updatePreference.sqf
+++ b/A3-Antistasi/functions/Garrison/fn_updatePreference.sqf
@@ -37,7 +37,7 @@ for "_i" from (tierPreference + 1) to tierWar do
 
     if(true || debug) then
     {
-        Debug("Airport_preference hit level %1", tierWar)
+        Debug_1("Airport_preference hit level %1", tierWar)
         DebugArray("Airport_preference",_preference);
     };
     garrison setVariable ["Airport_preference", _preference, true];
@@ -62,7 +62,7 @@ for "_i" from (tierPreference + 1) to tierWar do
     };
     if(true || debug) then
     {
-        Debug("Outpost_preference hit level %1", tierWar)
+        Debug_1("Outpost_preference hit level %1", tierWar)
         DebugArray("Outpost_preference",_preference);
     };
     garrison setVariable ["Outpost_preference", _preference, true];
@@ -77,7 +77,7 @@ for "_i" from (tierPreference + 1) to tierWar do
 
     if(true || debug) then
     {
-        Debug("City_preference hit level %1", tierWar)
+        Debug_1("City_preference hit level %1", tierWar)
         DebugArray("City_preference",_preference);
     };
     garrison setVariable ["City_preference", _preference, true];
@@ -98,7 +98,7 @@ for "_i" from (tierPreference + 1) to tierWar do
 
     if(true || debug) then
     {
-        Debug("Other_preference hit level %1", tierWar)
+        Debug_1("Other_preference hit level %1", tierWar)
         DebugArray("Other_preference",_preference);
     };
     garrison setVariable ["Other_preference", _preference, true];

--- a/A3-Antistasi/functions/Missions/fn_AS_Traitor.sqf
+++ b/A3-Antistasi/functions/Missions/fn_AS_Traitor.sqf
@@ -75,7 +75,7 @@ while {count _roads == 0} do
 _road = _roads select 0;
 _posroad = getPos _road;
 _roadcon = roadsConnectedto _road; if (count _roadCon == 0) then {
-    Error("Road has no connection :%1.",position _road);
+    Error_1("Road has no connection :%1.",position _road);
 	};
 if (count _roadCon > 0) then
 	{

--- a/A3-Antistasi/functions/Missions/fn_convoy.sqf
+++ b/A3-Antistasi/functions/Missions/fn_convoy.sqf
@@ -283,7 +283,8 @@ private _fnc_applyResults =
         killZones setVariable [_mrkOrigin,_killZones,true];
     };
 
-    ServerDebug_2("Rebels %1 a %2 convoy mission", ["lost", "won"] select _success, _type);
+#define CONVOY_MISSION_STATUS_ARRAY ["lost", "won"]
+    ServerDebug_2("Rebels %1 a %2 convoy mission", CONVOY_MISSION_STATUS_ARRAY select _success, _type);
 };
 
 if (_convoyType == "Ammunition") then

--- a/A3-Antistasi/functions/Punishment/fn_punishment_oceanGulag.sqf
+++ b/A3-Antistasi/functions/Punishment/fn_punishment_oceanGulag.sqf
@@ -42,7 +42,7 @@ private _detainee = _varspace getVariable ["player",objNull];
 private _playerPos = [0,0,0];
 
 if (!isPlayer _detainee) then { // Prevents punishing AI
-    Info_2("DETAINEE MIA | UID:%1 matches no in-game player. Cleaning up.", _UID);
+    Info_1("DETAINEE MIA | UID:%1 matches no in-game player. Cleaning up.", _UID);
 	_operation = "remove";
 } else {
 	_playerPos = getPosASL _detainee;

--- a/A3-Antistasi/functions/Punishment/fn_punishment_release.sqf
+++ b/A3-Antistasi/functions/Punishment/fn_punishment_release.sqf
@@ -64,7 +64,7 @@ switch (_source) do {
 	case "punishment_warden_manual": {
 		call _forgiveStats;
 		call _releaseFromSentence;
-        Info("FORGIVE | %1", _playerStats);
+        Info_1("FORGIVE | %1", _playerStats);
 		if (isPlayer _detainee) then {
 			["FF Punishment", "An admin looks with pity upon your soul.<br/>You have been forgiven."] remoteExecCall ["A3A_fnc_customHint", _detainee, false];
 		};

--- a/A3-Antistasi/functions/REINF/fn_garrisonDialog.sqf
+++ b/A3-Antistasi/functions/REINF/fn_garrisonDialog.sqf
@@ -28,7 +28,7 @@ if ([_positionX,500] call A3A_fnc_enemyNearCheck) exitWith {["Garrison", "You ca
 //if (((_nearX in outpostsFIA) and !(isOnRoad _positionX)) /*or (_nearX in citiesX)*/ or (_nearX in controlsX)) exitWith {hint "You cannot manage garrisons on this kind of zone"; _nul=CreateDialog "garrison_menu"};
 _outpostFIA = if (_nearX in outpostsFIA) then {true} else {false};
 _wPost = if (_outpostFIA and !(isOnRoad getMarkerPos _nearX)) then {true} else {false};
-_garrison = if (! _wpost) then {garrison getVariable [_nearX,[]]} else {Faction(reb,"groupSniper")};
+_garrison = if (! _wpost) then {garrison getVariable [_nearX,[]]} else {FactionGet(reb,"groupSniper")};
 
 if (_typeX == "rem") then
 	{

--- a/A3-Antistasi/functions/Save/fn_loadStat.sqf
+++ b/A3-Antistasi/functions/Save/fn_loadStat.sqf
@@ -110,7 +110,7 @@ if (_varName in _specialVarLoads) then {
 
             private _building = nearestObjects [_x, ["House"], 1, true] select 0;
             call {
-                if (isNil "_building") exitWith { Error("No building found at %1", _x)};
+                if (isNil "_building") exitWith { Error_1("No building found at %1", _x)};
                 if (_building in antennas) exitWith { Info("Antenna in destroyed building list, ignoring")};
 
                 private _ruin = [_building] call BIS_fnc_createRuin;
@@ -213,7 +213,7 @@ if (_varName in _specialVarLoads) then {
                 //JIP on the _ruin, as repairRuinedBuilding will delete the ruin.
                 [_antenna, true] remoteExec ["hideObject", 0, _ruin];
             } else {
-                Error("Loading Antennas: Unable to create ruin for %1", typeOf _antenna);
+                Error_1("Loading Antennas: Unable to create ruin for %1", typeOf _antenna);
             };
 
             deleteMarker _mrk;

--- a/A3-Antistasi/functions/Supports/fn_SUP_QRFAvailable.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_QRFAvailable.sqf
@@ -26,7 +26,7 @@ if ([_side] call A3A_fnc_remUnitCount < 40) exitWith
 
 if ([_position,false] call A3A_fnc_fogCheck < 0.3) exitWith
 {
-    Debug("Blocked QRF to %1 due to heavy fog", _position);
+    Debug_1("Blocked QRF to %1 due to heavy fog", _position);
     -1;
 };
 

--- a/A3-Antistasi/functions/Supports/fn_SUP_QRFRoutine.sqf
+++ b/A3-Antistasi/functions/Supports/fn_SUP_QRFRoutine.sqf
@@ -76,7 +76,7 @@ while {true} do
 
     if !(_groupAlive) exitWith
     {
-        Info_1("%1 has been eliminated, starting despawn routines");
+        Info_1("%1 has been eliminated, starting despawn routines", _supportName);
         [_side, 10, 60] remoteExec ["A3A_fnc_addAggression", 2];
     };
 

--- a/A3-Antistasi/functions/init/fn_initServer.sqf
+++ b/A3-Antistasi/functions/init/fn_initServer.sqf
@@ -84,7 +84,8 @@ _nul = call A3A_fnc_initVar;
 call A3A_fnc_logistics_initNodes;
 
 savingServer = true;
-Info_2("%1 server version: %2", ["SP","MP"] select isMultiplayer, localize "STR_antistasi_credits_generic_version_text");
+#define MODE_ARRAY ["SP","MP"]
+Info_2("%1 server version: %2", MODE_ARRAY select isMultiplayer, localize "STR_antistasi_credits_generic_version_text");
 bookedSlots = floor ((memberSlots/100) * (playableSlotsNumber teamPlayer)); publicVariable "bookedSlots";
 if (A3A_hasACEMedical) then { call A3A_fnc_initACEUnconsciousHandler };
 call A3A_fnc_loadNavGrid;


### PR DESCRIPTION
For example, in fn_initServer.sqf Info_2 is defined with 3 parameters, but in this case it is passed (unintentially) 4 arguments, this means that the macro will instead be expanded to nothing.

Related documentation can be found on the [wiki](https://community.bistudio.com/wiki/PreProcessor_Commands), relevant part is under __Arguments__.

## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
