### PR TITLE
switched to armake pack from build

### DIFF
--- a/A3A/addons/Garage/config.cpp
+++ b/A3A/addons/Garage/config.cpp
@@ -16,7 +16,10 @@ class CfgPatches {
 
 #include "Dialogs.hpp"
 
-
+#if __A3_DEBUG__
     class A3A {
         #include "CfgFunctions.hpp"
     };
+#else
+    #include "CfgFunctions.hpp"
+#endif

--- a/A3A/addons/JeroenArsenal/config.cpp
+++ b/A3A/addons/JeroenArsenal/config.cpp
@@ -14,6 +14,10 @@ class CfgPatches {
     };
 };
 
+#if __A3_DEBUG__
     class A3A {
         #include "CfgFunctions.hpp"
     };
+#else
+    #include "CfgFunctions.hpp"
+#endif

--- a/A3A/addons/core/Includes/LogMacros.inc
+++ b/A3A/addons/core/Includes/LogMacros.inc
@@ -75,9 +75,9 @@
 #define Log_Debug
 #define Log_Verbose
 
-
+#if __A3_DEBUG__
     #define Log_Trace
-
+#endif
 
 #ifndef VARDEF
     #define VARDEF(Var, Def) (if (isNil #Var) then {Def} else {Var})

--- a/A3A/addons/core/config.cpp
+++ b/A3A/addons/core/config.cpp
@@ -17,11 +17,11 @@ class CfgPatches {
 class A3A {
     #include "Templates.hpp"
 
-
+#if __A3_DEBUG__
     #include "CfgFunctions.hpp"
-
+#endif
 };
-
+#if __A3_DEBUG__
     class CfgFunctions {
         class A3A {
             class debug {
@@ -31,7 +31,9 @@ class A3A {
             };
         };
     };
-
+#else
+    #include "CfgFunctions.hpp"
+#endif
 
 #include "defines.hpp"
 #include "dialogs.hpp"

--- a/A3A/addons/maps/config.cpp
+++ b/A3A/addons/maps/config.cpp
@@ -58,13 +58,13 @@ class CfgMissions
             briefingName = $STR_antistasi_mission_info_sara_mapname_text;
             directory = "x\A3A\addons\maps\Antistasi_sara.sara";
         };
-
+#if __A3_DEBUG__
         class Antistasi_Stratis
         {
             briefingName = $STR_antistasi_mission_info_Stratis_mapname_text;
             directory = "x\A3A\addons\maps\Antistasi_Stratis.Stratis";
         };
-
+#endif
         class Antistasi_takistan
         {
             briefingName = $STR_antistasi_mission_info_takistan_mapname_text;

--- a/Tools/Builder/buildAddons.ps1
+++ b/Tools/Builder/buildAddons.ps1
@@ -28,7 +28,7 @@ foreach ($module in $modules) {
     $pboName = "$($module.Name).pbo"
     #"Building $pboName...  $addonLocation\addons\$($module.Name)   -> $addonsOutLocation\$pboName"
     "Building $pboName ..."
-    .$PSScriptRoot\hemtt armake build --force $module.fullName "$addonsOutLocation\$pboName" -w unquoted-string -w redefinition-wo-undef -w excessive-concatenation
+    .$PSScriptRoot\hemtt armake pack --force $module.fullName "$addonsOutLocation\$pboName"
 }
 
 "`nCopy mod.cpp..."


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
changed from armake build to armake pack to prevent binarisation by HEMTT so we can use PreProcessor commands added with Arma 2.02 and newer

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
