### PR TITLE
Add Seaports and Airbases to Jam Script

### DIFF
--- a/A3A/addons/core/functions/OrgPlayers/fn_radioJam.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_radioJam.sqf
@@ -5,14 +5,14 @@ _strength = 49;
 _isJammed = false;
 _interference = 1;
 _sendInterference = 1;
+private _bases = outposts + airportsx + seaports;
 while {true} do
 	{
 	private _antennas = [];
 	{
-	_outpost = [outposts,_x] call BIS_fnc_nearestPosition;
+	_outpost = [_bases,_x] call BIS_fnc_nearestPosition;
 	if (sidesX getVariable [_outpost,sideUnknown] != _sideX) then {_antennas pushBack _x};
 	} forEach antennas;
-	if (_sideX != teamPlayer) then {_antennas pushBack [vehicleBox]};
 	if !(_antennas isEqualTo []) then
 		{
 		_jammer = [_antennas,player] call BIS_fnc_nearestPosition;
@@ -21,7 +21,7 @@ while {true} do
 
 	    if (_dist < _rad) then
 	    	{
-			_interference = _strength - (_distPercent * _strength) + 1; // Calculat the recieving interference, which has to be above 1 to have any effect.
+			_interference = _strength - (_distPercent * _strength) + 1; // Calculate the recieving interference, which has to be above 1 to have any effect.
 			_sendInterference = 1/_interference; //Calculate the sending interference, which needs to be below 1 to have any effect.
 			if (!_isJammed) then {_isJammed = true};
 			player setVariable ["tf_receivingDistanceMultiplicator", _interference];


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
The Jam script only included Outposts, this could cause confusion to Players as they expected Airbases to also Own Radiotowers but they don't.
Seaports are basicly Outposts just with Water so it makes sense to include them.

### Please specify which Issue this PR Resolves.
closes #2248 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Capture Seaports/Airports with Radiotowers nearby,
The Jam script should lower its values/set them to 1 when there is no other Tower Nearby.
Removed the Line for PVP
Possible Maps to check with that:
CLN,
Sahrani

As it Tested with Sahrani:
```sqf
tierwar = 10;
//Occupants
[Teamplayer, "airport_2"] remoteExec ["A3A_fnc_markerChange", 2];
player allowdamage false;
player setpos [9856.02,10056.1,0];
```
Check the Jam applying: 1 is nothing applied
```sqf
player getVariable "tf_sendingDistanceMultiplicator"; //50 to 1

player getVariable "tf_receivingDistanceMultiplicator"; //0.2 to 1
```

If you test before the changes the nearest Outpost at "airport_2" was "outpost_4".
********************************************************
Notes:
