### PR TITLE
🔕 Dismiss hint migrated to modded keybinds.

### DIFF
--- a/A3A/addons/core/functions/UI/fn_customHintInit.sqf
+++ b/A3A/addons/core/functions/UI/fn_customHintInit.sqf
@@ -30,7 +30,6 @@ if (!hasInterface) exitWith {false;}; // Disabled for server & HC.
 if !(isNil {A3A_customHint_InitComplete}) exitWith {false;};
 // These var names don't need to be limited to 16chars for performance as they are not public.
 A3A_customHint_MSGs = [];  // Operates as a upside-down stack (new messages pushed-Back are displayed.)
-A3A_customHint_DismissKeyDown = false;
 A3A_customHint_UpdateTime = 0;
 A3A_customHint_RenderFrameCount = 1;
 if (isNil {A3A_customHintEnable}) then {A3A_customHintEnable = true}; // isNil check in case value was set before this initialises.
@@ -38,10 +37,6 @@ if (isNil {A3A_customHintEnable}) then {A3A_customHintEnable = true}; // isNil c
 A3A_customHint_hexChars = ["0","1","2","3","4","5","6","7","8","9","A","B","C","D","E","F"];
 
 addMissionEventHandler ["EachFrame", {
-    if ((inputAction "User12" isEqualTo 0) isEqualTo A3A_customHint_DismissKeyDown) then {  // This is probably the fastest edge/Xor & key-down detector you can get. ~0.0034ms total execution time on non-edges (`inputAction "User12"` alone uses ~0.0017ms)(The case most of the time when key-state is not changing.).
-        A3A_customHint_DismissKeyDown = !A3A_customHint_DismissKeyDown;                     // user action slot Will be selectable when client-side preferences, Soon™.
-        if (A3A_customHint_DismissKeyDown) then { [] call A3A_fnc_customHintDismiss; };
-    };
     if (A3A_customHint_RenderFrameCount >= 15) then {  // Render loop does not need to run every frame. 4Hz should be enough.
         A3A_customHint_RenderFrameCount = 1;
         [] call A3A_fnc_customHintRender;
@@ -62,7 +57,6 @@ All public created variables:
 | A3A_customHint_hexChars           | ARRAY<STRING> | Client    | missionNamespace  | All hexadecimal symbols in order. Used in shader_ratioToHex.          |
 | A3A_customHint_InitComplete       | BOOLEAN       | Client    | missionNamespace  | Defines if customHintInit should be called.                           |
 | A3A_customHint_MSGs               | ARRAY<CUSTOM> | Client    | missionNamespace  | Stack of hint notifications. <_headerText,_structuredText,_isSilent>  |
-| A3A_customHint_DismissKeyDown     | BOOLEAN       | Client    | missionNamespace  | Whether dismiss key is depressed.                                     |
 | A3A_customHintEnable              | BOOLEAN       | Local     | missionNamespace  | Whether queuing and dismissing is enabled. Defined on all, not synced.|
 | A3A_customHint_UpdateTime         | SCALAR        | Client    | missionNamespace  | ServerTime of last update to the visible message.                     |
 | A3A_customHint_RenderFrameCount   | SCALAR        | Client    | missionNamespace  | Determines intensity of hint footer fading.                           |

--- a/A3A/addons/core/functions/UI/fn_customHintRender.sqf
+++ b/A3A/addons/core/functions/UI/fn_customHintRender.sqf
@@ -40,7 +40,16 @@ if (A3A_customHint_MSGs isEqualTo []) then {
     private _dismissKey = actionKeysNames QGVAR(customHintDismiss);
     _dismissKey = _dismissKey select [1, count _dismissKey - 2];
     private _topMSGIndex = count A3A_customHint_MSGs - 1;
-    private _keyBind = (["<br/><t size='0.8' color='#",_alphaHex,"e5b348' shadow='1' shadowColor='#",_alphaHex,"000000' valign='top' >Press <t color='#",_alphaHex,"f0d498' >",[_dismissKey,"Bind key ""Dismiss Previous Hint"""] select (_dismissKey isEqualTo ""),"</t> to dismiss notification. +",str _topMSGIndex,"</t>"] joinString ""); // Needs to be added to string table.
+    private _keyBind = if (_dismissKey isEqualTo "") then {
+        "<br/><t size='0.8' color='#e5b348' shadow='1' shadowColor='#000000' valign='top' >"+  // No alphaHex fading to allow longer reading time.
+            str _topMSGIndex+" Previous Hints<br/>"+
+            "Bind dismiss key by: <t color='#f0d498'>Escape Manu</t> &gt; <t color='#f0d498'>CONFIGURE</t> &gt; <t color='#f0d498'>CONTROLS</t> &gt; <t color='#f0d498'>SHOW: Antistasi</t> &gt; <t color='#f0d498'>Dismiss Previous Hint</t>"+
+        "</t>"
+    } else {
+        "<br/><t size='0.8' color='#"+_alphaHex+"e5b348' shadow='1' shadowColor='#"+_alphaHex+"000000' valign='top' >"+
+            "Press <t color='#"+_alphaHex+"f0d498' >"+_dismissKey+"</t> to dismiss. +"+str _topMSGIndex+
+        "</t>";
+    }; // Needs to be added to string table.
     private _previousNotifications = ["<t color='#",_alphaHex,"e5b348' font='RobotoCondensed' align='center' valign='middle' underline='0' shadow='1' shadowColor='#",_alphaHex,"000000' shadowOffset='0.0625'>"];
     if (_topMSGIndex < 4) then {
         private _size = (-20/(8-_topMSGIndex) +4.6);

--- a/A3A/addons/core/functions/UI/fn_customHintRender.sqf
+++ b/A3A/addons/core/functions/UI/fn_customHintRender.sqf
@@ -37,9 +37,10 @@ if (A3A_customHint_MSGs isEqualTo []) then {
         [true] call A3A_fnc_customHintDismiss;
     };
     private _alphaHex = [(((_autoDismiss + A3A_customHint_UpdateTime - serverTime) min (_autoDismiss-5)) / (_autoDismiss-5)) ] call A3A_fnc_shader_ratioToHex;
-    private _dismissKey = actionKeysNames ["User12",1];
+    private _dismissKey = actionKeysNames QGVAR(customHintDismiss);
+    _dismissKey = _dismissKey select [1, count _dismissKey - 2];
     private _topMSGIndex = count A3A_customHint_MSGs - 1;
-    private _keyBind = (["<br/><t size='0.8' color='#",_alphaHex,"e5b348' shadow='1' shadowColor='#",_alphaHex,"000000' valign='top' >Press <t color='#",_alphaHex,"f0d498' >",[_dismissKey,"Use Action 12"] select (_dismissKey isEqualTo ""),"</t> to dismiss notification. +",str _topMSGIndex,"</t>"] joinString ""); // Needs to be added to string table.
+    private _keyBind = (["<br/><t size='0.8' color='#",_alphaHex,"e5b348' shadow='1' shadowColor='#",_alphaHex,"000000' valign='top' >Press <t color='#",_alphaHex,"f0d498' >",[_dismissKey,"Bind key ""Dismiss Previous Hint"""] select (_dismissKey isEqualTo ""),"</t> to dismiss notification. +",str _topMSGIndex,"</t>"] joinString ""); // Needs to be added to string table.
     private _previousNotifications = ["<t color='#",_alphaHex,"e5b348' font='RobotoCondensed' align='center' valign='middle' underline='0' shadow='1' shadowColor='#",_alphaHex,"000000' shadowOffset='0.0625'>"];
     if (_topMSGIndex < 4) then {
         private _size = (-20/(8-_topMSGIndex) +4.6);

--- a/A3A/addons/core/functions/UI/fn_customHintRender.sqf
+++ b/A3A/addons/core/functions/UI/fn_customHintRender.sqf
@@ -43,7 +43,7 @@ if (A3A_customHint_MSGs isEqualTo []) then {
     private _keyBind = if (_dismissKey isEqualTo "") then {
         "<br/><t size='0.8' color='#e5b348' shadow='1' shadowColor='#000000' valign='top' >"+  // No alphaHex fading to allow longer reading time.
             str _topMSGIndex+" Previous Hints<br/>"+
-            "Bind dismiss key by: <t color='#f0d498'>Escape Manu</t> &gt; <t color='#f0d498'>CONFIGURE</t> &gt; <t color='#f0d498'>CONTROLS</t> &gt; <t color='#f0d498'>SHOW: Antistasi</t> &gt; <t color='#f0d498'>Dismiss Previous Hint</t>"+
+            "Bind dismiss key by: <t color='#f0d498'>Escape Menu</t> &gt; <t color='#f0d498'>CONFIGURE</t> &gt; <t color='#f0d498'>CONTROLS</t> &gt; <t color='#f0d498'>SHOW: Antistasi</t> &gt; <t color='#f0d498'>Dismiss Previous Hint</t>"+
         "</t>"
     } else {
         "<br/><t size='0.8' color='#"+_alphaHex+"e5b348' shadow='1' shadowColor='#"+_alphaHex+"000000' valign='top' >"+

--- a/A3A/addons/core/keybinds/CfgDefaultKeysPresets.hpp
+++ b/A3A/addons/core/keybinds/CfgDefaultKeysPresets.hpp
@@ -6,6 +6,7 @@ class CfgDefaultKeysPresets {
             GVAR(artyMenu)[] = {0x2A130015}; //combo Left shift + Y (no double tap)
             GVAR(infoBar)[] = {0x381300C7}; //combo Left alt + Home (no double tap)
             GVAR(earPlugs)[] = {DIK_END};
+            GVAR(customHintDismiss)[] = {};
         };
     };
 };

--- a/A3A/addons/core/keybinds/CfgUserActions.hpp
+++ b/A3A/addons/core/keybinds/CfgUserActions.hpp
@@ -24,5 +24,11 @@ class CfgUserActions {
         tooltip = "Toggle use of ear plugs (no effect when using ace)";
         onActivate = ACTION(earPlugs);
     };
+
+    class GVAR(customHintDismiss) {
+        displayName = "Dismiss Previous Hint";
+        tooltip = "Clears the last hint notification.";
+        onActivate = ACTION(customHintDismiss);
+    };
 };
 #undef ACTION

--- a/A3A/addons/core/keybinds/UserActionGroups.hpp
+++ b/A3A/addons/core/keybinds/UserActionGroups.hpp
@@ -6,7 +6,8 @@ class UserActionGroups {
             QGVAR(battleMenu),
             QGVAR(artyMenu),
             QGVAR(infoBar),
-            QGVAR(earPlugs)
+            QGVAR(earPlugs),
+            QGVAR(customHintDismiss)
         };
     };
 };

--- a/A3A/addons/core/keybinds/UserActionsConflictGroups.hpp
+++ b/A3A/addons/core/keybinds/UserActionsConflictGroups.hpp
@@ -4,7 +4,8 @@ class UserActionsConflictsGroups {
             QGVAR(battleMenu),
             QGVAR(artyMenu),
             QGVAR(infoBar),
-            QGVAR(earPlugs)
+            QGVAR(earPlugs),
+            QGVAR(customHintDismiss)
         };
     };
 

--- a/A3A/addons/core/keybinds/fn_keyActions.sqf
+++ b/A3A/addons/core/keybinds/fn_keyActions.sqf
@@ -60,6 +60,10 @@ switch (_key) do {
         };
     };
 
+    case QGVAR(customHintDismiss): {
+        [] call A3A_fnc_customHintDismiss;
+    };
+
     Default {
         Error_1("Key action not registered: %1", _key)
     };


### PR DESCRIPTION
## What type of PR is this.
* Bug
* Change
* [x] Enhancement

### What have you changed and why?
* Dismiss Previous Hint key is now set by Arma 3 Modded Keybinds.
* CustomHint will explain how to set a keybinding if unbound.
* There is no backwards compatibility with the past system. This is because the keybindings cannot be programmatically set.

### Please verify the following and ensure all checks are completed.

* [x] Have you loaded the mission in LAN host?
* Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
* [x] No
* Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
1. Load antistasi.
2. The bottom of the hint should look like Addendum 1
3. Following the instructions to set the keybinding should make the hint look normal.
********************************************************
Addendum 1:
![Custom Hint Explain Keybindings Image](https://cdn.discordapp.com/attachments/644893868780683304/942497482389200937/unknown.png)