### PR TITLE
⛽ Fuel Support Rework

### DIFF
--- a/A3A/addons/Garage/Public/fn_addVehicle.sqf
+++ b/A3A/addons/Garage/Public/fn_addVehicle.sqf
@@ -57,12 +57,23 @@ if (_class in [FactionGet(occ,"surrenderCrate"), FactionGet(inv,"surrenderCrate"
     true
 };
 
-
-//Utility refund and Fuel refund
-if (_vehicle getVariable ['A3A_canGarage', false]) exitwith {
-    [_vehicle getVariable ['A3A_itemPrice', 0]] remoteExec ["A3A_fnc_resourcesPlayer", _client];
-    ["STR_HR_GRG_Feedback_addVehicle_Item_Stored"] remoteExec ["HR_GRG_fnc_Hint", _client];
-    deleteVehicle _vehicle;
+//Utility refund
+if (_vehicle getVariable ['A3A_canGarage', false]) exitwith{
+    if (_class in [FactionGet(reb,"vehicleFuelDrum") # 0, FactionGet(reb,"vehicleFuelTank") # 0]) then {
+        if (_player isEqualTo theBoss) then {
+            [floor (
+                ([_vehicle] call A3A_fnc_remainingFuel) * (_vehicle getVariable ['A3A_itemPrice', 0])
+            )] remoteExec ["A3A_fnc_resourcesPlayer", _client];
+            ["STR_HR_GRG_Feedback_addVehicle_Fuel_sold"] remoteExec ["HR_GRG_fnc_Hint", _client];
+            deleteVehicle _vehicle;
+        } else {
+            ["STR_HR_GRG_Feedback_addVehicle_Fuel_commander_only"] remoteExec ["HR_GRG_fnc_Hint", _client];
+        };
+    } else {
+        [_vehicle getVariable ['A3A_itemPrice', 0]] remoteExec ["A3A_fnc_resourcesPlayer", _client];
+        ["STR_HR_GRG_Feedback_addVehicle_Item_Stored"] remoteExec ["HR_GRG_fnc_Hint", _client];
+        deleteVehicle _vehicle;
+    };
     true
 };
 

--- a/A3A/addons/Garage/Public/fn_addVehicle.sqf
+++ b/A3A/addons/Garage/Public/fn_addVehicle.sqf
@@ -59,19 +59,10 @@ if (_class in [FactionGet(occ,"surrenderCrate"), FactionGet(inv,"surrenderCrate"
 
 
 //Utility refund and Fuel refund
-if (_vehicle getVariable ['A3A_canGarage', false]) exitwith{
-    if (_class in [FactionGet(reb,"vehicleFuelDrum"), FactionGet(reb,"vehicleFuelTank")]) then {
-        [floor (
-            [_vehicle] call A3A_fnc_remainingFuel *
-            (_vehicle getVariable ['A3A_itemPrice', 0])
-        )] remoteExec ["A3A_fnc_resourcesPlayer", _client];
-        ["STR_HR_GRG_Feedback_addVehicle_Fuel_sold"] remoteExec ["HR_GRG_fnc_Hint", _client];
-        deleteVehicle _vehicle;
-    } else {
-        [_vehicle getVariable ['A3A_itemPrice', 0]] remoteExec ["A3A_fnc_resourcesPlayer", _client];
-        ["STR_HR_GRG_Feedback_addVehicle_Item_Stored"] remoteExec ["HR_GRG_fnc_Hint", _client];
-        deleteVehicle _vehicle;
-    };
+if (_vehicle getVariable ['A3A_canGarage', false]) exitwith {
+    [_vehicle getVariable ['A3A_itemPrice', 0]] remoteExec ["A3A_fnc_resourcesPlayer", _client];
+    ["STR_HR_GRG_Feedback_addVehicle_Item_Stored"] remoteExec ["HR_GRG_fnc_Hint", _client];
+    deleteVehicle _vehicle;
     true
 };
 

--- a/A3A/addons/Garage/Stringtable.xml
+++ b/A3A/addons/Garage/Stringtable.xml
@@ -203,6 +203,10 @@
             <Original>Fuel sold</Original>
             <English>Fuel sold</English>
         </Key>
+        <Key ID="STR_HR_GRG_Feedback_addVehicle_Fuel_commander_only">
+            <Original>Fuel sources can only be garaged by commander</Original>
+            <English>Fuel sources can only be garaged by commander</English>
+        </Key>
         <Key ID="STR_HR_GRG_Feedback_addVehicle_Distance">
             <Original>You can't garage vehicles that are more than 25m away from you</Original>
             <English>You can't garage vehicles that are more than 25m away from you</English>

--- a/A3A/addons/core/Templates/Templates/FactionDefaults/RebelDefaults.sqf
+++ b/A3A/addons/core/Templates/Templates/FactionDefaults/RebelDefaults.sqf
@@ -13,5 +13,5 @@
 ["flyGear", ["U_I_pilotCoveralls"]] call _fnc_saveToTemplate;
 
 ["vehicleLightSource", "Land_LampShabby_F"] call _fnc_saveToTemplate;
-["vehicleFuelDrum", ["FlexibleTank_01_forest_F", 80]] call _fnc_saveToTemplate;
+["vehicleFuelDrum", ["FlexibleTank_01_forest_F", 160]] call _fnc_saveToTemplate;
 ["vehicleFuelTank", ["B_Slingload_01_Fuel_F", 1000]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/functions/Base/fn_sellVehicle.sqf
+++ b/A3A/addons/core/functions/Base/fn_sellVehicle.sqf
@@ -84,11 +84,6 @@ private _costs = call {
         or (_typeX in FactionGet(all,"vehiclesArtillery"))
     ) exitWith {3000};
     if (_typeX in (OccAndInv("vehiclesPlanesCAS") + OccAndInv("vehiclesPlanesAA"))) exitWith {4000};
-    if (_typeX in [FactionGet(reb,"vehicleFuelDrum"), FactionGet(reb,"vehicleFuelTank")] 
-        && _veh getVariable ['A3A_canGarage', false]
-    ) exitwith {
-        floor ([_veh] call A3A_fnc_remainingFuel * (_veh getVariable ['A3A_itemPrice', 0]));
-    };
     0;
 };
 

--- a/A3A/addons/core/functions/Base/fn_sellVehicle.sqf
+++ b/A3A/addons/core/functions/Base/fn_sellVehicle.sqf
@@ -86,6 +86,10 @@ private _costs = call {
     if (_typeX in (OccAndInv("vehiclesPlanesCAS") + OccAndInv("vehiclesPlanesAA"))) exitWith {4000};
     0;
 };
+if (_typeX in [FactionGet(reb,"vehicleFuelDrum"), FactionGet(reb,"vehicleFuelTank")] 
+        && _veh getVariable ['A3A_canGarage', false]) exitwith {
+            floor ([_veh] call A3A_fnc_remainingFuel * (_veh getVariable ['A3A_itemPrice', 0]));
+    };
 
 if (_costs == 0) exitWith {
     _veh setVariable ["A3A_sellVehicle_inProgress",false,false];

--- a/A3A/addons/core/functions/Base/fn_sellVehicle.sqf
+++ b/A3A/addons/core/functions/Base/fn_sellVehicle.sqf
@@ -84,12 +84,13 @@ private _costs = call {
         or (_typeX in FactionGet(all,"vehiclesArtillery"))
     ) exitWith {3000};
     if (_typeX in (OccAndInv("vehiclesPlanesCAS") + OccAndInv("vehiclesPlanesAA"))) exitWith {4000};
+    if (_typeX in [FactionGet(reb,"vehicleFuelDrum"), FactionGet(reb,"vehicleFuelTank")] 
+        && _veh getVariable ['A3A_canGarage', false]
+    ) exitwith {
+        floor ([_veh] call A3A_fnc_remainingFuel * (_veh getVariable ['A3A_itemPrice', 0]));
+    };
     0;
 };
-if (_typeX in [FactionGet(reb,"vehicleFuelDrum"), FactionGet(reb,"vehicleFuelTank")] 
-        && _veh getVariable ['A3A_canGarage', false]) exitwith {
-            floor ([_veh] call A3A_fnc_remainingFuel * (_veh getVariable ['A3A_itemPrice', 0]));
-    };
 
 if (_costs == 0) exitWith {
     _veh setVariable ["A3A_sellVehicle_inProgress",false,false];

--- a/A3A/addons/core/functions/UtilityItems/fn_buyItem.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_buyItem.sqf
@@ -37,21 +37,29 @@ if (_price == 0) exitwith {};
 private _lastTimePurchase = _unit getVariable["A3A_spawnItem_cooldown",time];
 if (_lastTimePurchase > time) exitwith {["Item Purchase", format ["You already bought one, wait %1 seconds before you can buy another.", ceil (_lastTimePurchase - time)]] call A3A_fnc_customHint;};
 
-//find out if we have money
-private _money = player getVariable ["moneyX", 0];
 
 if (_money < _price) exitwith {["Item Purchase", "You can't afford this Item."] call A3A_fnc_customHint};
 _unit setVariable["A3A_spawnItem_cooldown", time + 15];
 
-//take money away
-if (player == theBoss) then {
+//try to take money away 😞
+private _noMoneyNoProblems = isNil {
+    if (player == theBoss && (server getVariable ["resourcesFIA", 0] > _price)) exitwith {
     [0,(-_price)] remoteExec ["A3A_fnc_resourcesFIA",2];
-} else {
-    [-_price] call A3A_fnc_resourcesPlayer;
+    false
+    };
+    if ((player getVariable ["moneyX", 0]) >= _price) exitwith { 
+        [-_price] call A3A_fnc_resourcesPlayer;
+        flase
+    };
+    nil
 };
 
+if (_noMoneyNoProblems) exitwith {["Item Purchase", "You can't afford this Item."] call A3A_fnc_customHint};
 
-//spawn the Item
+//had money for item
+_unit setVariable["A3A_spawnItem_cooldown", time + 15];
+
+//spawn the Item 👀
 _position = (getPos _unit vectorAdd [3,0,0]) findEmptyPosition [1,10,_spawnItem];
 if (_position isEqualTo []) then {_position = getPos _unit};
 private _item = _spawnItem createVehicle _position;

--- a/A3A/addons/core/functions/UtilityItems/fn_buyItem.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_buyItem.sqf
@@ -44,7 +44,11 @@ if (_money < _price) exitwith {["Item Purchase", "You can't afford this Item."] 
 _unit setVariable["A3A_spawnItem_cooldown", time + 15];
 
 //take money away
-[-_price] call A3A_fnc_resourcesPlayer;
+if (player == theBoss) then {
+    [0,(-_price)] remoteExec ["A3A_fnc_resourcesFIA",2];
+} else {
+    [-_price] call A3A_fnc_resourcesPlayer;
+};
 
 
 //spawn the Item
@@ -57,7 +61,7 @@ _item allowDamage false;
 _item setVariable ["A3A_canGarage", true, true];
 _item setVariable ["A3A_itemPrice", _price, true];
 
-// callbacks
+    // callbacks
 {
     private _func_name = (_x #0);
     if (_x #1) then {

--- a/A3A/addons/core/functions/UtilityItems/fn_buyItem.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_buyItem.sqf
@@ -39,7 +39,7 @@ if (_lastTimePurchase > time) exitwith {["Item Purchase", format ["You already b
 
 
 //try to take money away 😞
-private _noMoneyNoProblems = isNil {
+private _insufficientFunds = isNil {
     if (_unit == theBoss && (server getVariable ["resourcesFIA", 0]) >= _price) then {
         [0,(-_price)] remoteExec ["A3A_fnc_resourcesFIA",2];
         true;
@@ -50,7 +50,7 @@ private _noMoneyNoProblems = isNil {
         };
     };
 };
-if (_noMoneyNoProblems) exitwith {["Item Purchase", "You can't afford this Item."] call A3A_fnc_customHint};
+if (_insufficientFunds) exitwith {["Item Purchase", "You can't afford this Item."] call A3A_fnc_customHint};
 
 //had money for item
 _unit setVariable ["A3A_spawnItem_cooldown", time + 15];

--- a/A3A/addons/core/functions/UtilityItems/fn_buyItem.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_buyItem.sqf
@@ -32,28 +32,26 @@ if (!hasInterface) exitwith{};
 if (isNull _unit) exitwith {};
 if (!isClass (configFile/"CfgVehicles"/_spawnItem)) exitwith {};
 if (_price == 0) exitwith {};
+systemChat _spawnItem;
 
 //check to make sure that the player is not spamming
 private _lastTimePurchase = _unit getVariable["A3A_spawnItem_cooldown",time];
 if (_lastTimePurchase > time) exitwith {["Item Purchase", format ["You already bought one, wait %1 seconds before you can buy another.", ceil (_lastTimePurchase - time)]] call A3A_fnc_customHint;};
 
 
-if (_money < _price) exitwith {["Item Purchase", "You can't afford this Item."] call A3A_fnc_customHint};
-_unit setVariable["A3A_spawnItem_cooldown", time + 15];
-
 //try to take money away 😞
 private _noMoneyNoProblems = isNil {
-    if (player == theBoss && (server getVariable ["resourcesFIA", 0] > _price)) exitwith {
-    [0,(-_price)] remoteExec ["A3A_fnc_resourcesFIA",2];
-    false
+    if (player == theBoss && (server getVariable ["resourcesFIA", 0]) >= _price) exitwith {
+        [0,(-_price)] remoteExec ["A3A_fnc_resourcesFIA",2];
+        false
     };
     if ((player getVariable ["moneyX", 0]) >= _price) exitwith { 
         [-_price] call A3A_fnc_resourcesPlayer;
-        flase
+        false
     };
     nil
 };
-
+systemChat "made past take money way";
 if (_noMoneyNoProblems) exitwith {["Item Purchase", "You can't afford this Item."] call A3A_fnc_customHint};
 
 //had money for item

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -406,11 +406,11 @@ private _fuelDrum = FactionGet(reb,"vehicleFuelDrum");
 private _fuelTank = FactionGet(reb,"vehicleFuelTank");
 if (isClass (configFile/"CfgVehicles"/_fuelDrum # 0)) then {
     private _dispName = getText (configFile/"CfgVehicles"/_fuelDrum # 0/"displayName");
-    vehicleBox addAction [format["Buy %1 for %2€",_dispName, _fuelDrum # 1], {[player, _this # 3 # 0, _this # 3 # 1, [['A3A_fnc_initMovableObject', true], ['A3A_fnc_logistics_addLoadAction', false]]] call A3A_fnc_buyItem},_fuelDrum,0,false,true,"","true",4];
+    vehicleBox addAction [format["Buy %1 for %2€",_dispName, _fuelDrum # 1], {[player, _this # 3 # 0, _this # 3 # 1, [['A3A_fnc_initMovableObject', true], ['A3A_fnc_logistics_addLoadAction', false]]] call A3A_fnc_buyItem},_fuelDrum,0,false,true,"","_this == theBoss",4];
 };
 if (isClass (configFile/"CfgVehicles"/_fuelTank # 0)) then {
     private _dispName = getText (configFile/"CfgVehicles"/_fuelTank # 0/"displayName");
-    vehicleBox addAction [format["Buy %1 for %2€",_dispName, _fuelTank # 1], {[player, _this # 3 # 0, _this # 3 # 1, [['A3A_fnc_logistics_addLoadAction', false]]] call A3A_fnc_buyItem},_fuelTank,0,false,true,"","true",4];
+    vehicleBox addAction [format["Buy %1 for %2€",_dispName, _fuelTank # 1], {[player, _this # 3 # 0, _this # 3 # 1, [['A3A_fnc_initMovableObject', true], ['A3A_fnc_logistics_addLoadAction', false]]] call A3A_fnc_buyItem},_fuelTank,0,false,true,"","_this == theBoss",4];
 };
 call A3A_fnc_dropObject;
 

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -401,7 +401,7 @@ if (A3A_hasACE) then { [vehicleBox, VehicleBox] call ace_common_fnc_claim;};	//D
 	}},nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull]) and (side (group _this) == teamPlayer)", 4];
 #endif
 vehicleBox addAction ["Move this asset", A3A_fnc_moveHQObject,nil,0,false,true,"","(_this == theBoss)", 4];
-vehicleBox addAction ["Buy Light for 25€", {[player, 'vehicleLightSource', 25, [['A3A_fnc_initMovableObject', 0]]] call A3A_fnc_buyItem},nil,0,false,true,"","true",4];
+vehicleBox addAction ["Buy Light for 25€", {[player, FactionGet(reb,"vehicleLightSource"), 25, [['A3A_fnc_initMovableObject', false]]] call A3A_fnc_buyItem},nil,0,false,true,"","true",4];
 private _fuelDrum = FactionGet(reb,"vehicleFuelDrum");
 private _fuelTank = FactionGet(reb,"vehicleFuelTank");
 if (isClass (configFile/"CfgVehicles"/_fuelDrum # 0)) then {

--- a/A3A/addons/core/functions/init/fn_initZones.sqf
+++ b/A3A/addons/core/functions/init/fn_initZones.sqf
@@ -289,10 +289,11 @@ A3A_fuelStations apply {
 	_mrkFinalFuel = createMarker [format ["Ant%1", mapGridPosition _x], position _x];
 	_mrkFinalFuel setMarkerShape "ICON";
 	_mrkFinalFuel setMarkerType "loc_Fuelstation";
-	_mrkFinalFuel setMarkerColor "ColorPink";
-	_mrkFinalFuel setMarkerText "fuel station";
+	_mrkFinalFuel setMarkerColor "ColorGrey"; 
+	_mrkFinalFuel setMarkerText "Fuel station";
+	_mrkFinalFuel setMarkerAlpha 0.75;
 	if(A3A_hasACE) then {
-		[_x, 10000] call ace_refuel_fnc_setFuel; // only call on fuels that are not blacklisted and first zone init.
+		[_x, 250] call ace_refuel_fnc_setFuel; // only call on fuels that are not blacklisted and first zone init.
 	};
 };
 

--- a/A3A/addons/maps/Antistasi_cam_lao_nam.cam_lao_nam/mapInfo.hpp
+++ b/A3A/addons/maps/Antistasi_cam_lao_nam.cam_lao_nam/mapInfo.hpp
@@ -14,7 +14,7 @@ class cam_lao_nam {
 		{},{"airport_5","outpost_33","outpost_34","resource_4","seaport_3","outpost_15","outpost_22","outpost_8","outpost_4","resource_9","outpost_21","resource_14","outpost_3","outpost_2","factory_3","outpost_1","outpost_7","seaport_2","outpost_32","airport_1","outpost_23","outpost_10","outpost_5","outpost_16","outpost_6","outpost_11","resource_6","resource_20","outpost_9","outpost_38"},{},{"control_1","control_2","control_3","control_4","control_5","control_6","control_7","control_8","control_9","control_10","control_11","control_12","control_13","control_14","control_15","control_16","control_17","control_18","control_19","control_20","control_21","control_22","control_23","control_24","control_25","control_26","control_27","control_28","control_29"}
 	};
 	fuelStationTypes[] = {
-		"Land_vn_fuelstation_01_pump_f","Land_vn_fuelstation_02_pump_f","Land_vn_fuelstation_feed_f"
+		"Land_vn_fuelstation_01_pump_f","Land_vn_fuelstation_02_pump_f","Land_vn_fuelstation_feed_f","Land_vn_usaf_fueltank_75_01"
 	};
 	climate = "tropical";
 };


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?    
* Made fuel only buyable with the commander.
* Fixed fuel station capitalization.
* Changed starting fuel amount for ace in stations
* Added Land_vn_usaf_fueltank_75_01 to cam.
* No more garaging fuel, now only selling. 
* Also changed fuel station marker colour and alpha.

### Please specify which Issue this PR Resolves.
replaces #2216 
closes #2213

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
