### PR TITLE
Fix patrol dogs not despawning with locations

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_createAIAirplane.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIAirplane.sqf
@@ -13,6 +13,7 @@ ServerDebug_1("Spawning Airbase %1", _markerX);
 _vehiclesX = [];
 _groups = [];
 _soldiers = [];
+private _dogs = [];
 
 _positionX = getMarkerPos (_markerX);
 _pos = [];
@@ -125,6 +126,7 @@ if (_patrol) then
 			if ((random 10 < 2.5) and (_typeGroup isNotEqualTo (_faction get "groupSniper"))) then
 			{
 				_dog = [_groupX, "Fin_random_F",_positionX,[],0,"FORM"] call A3A_fnc_createUnit;
+				_dogs pushBack _dog;
 				[_dog] spawn A3A_fnc_guardDog;
 				sleep 1;
 			};
@@ -316,6 +318,7 @@ waitUntil {sleep 1; (spawner getVariable _markerX == 2)};
 
 deleteMarker _mrk;
 { if (alive _x) then { deleteVehicle _x } } forEach _soldiers;
+{ deleteVehicle _x } forEach _dogs;
 { deleteGroup _x } forEach _groups;
 
 {

--- a/A3A/addons/core/functions/CREATE/fn_createAICities.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAICities.sqf
@@ -8,6 +8,7 @@ _markerX = _this select 0;
 
 _groups = [];
 _soldiers = [];
+private _dogs = [];
 
 _positionX = getMarkerPos (_markerX);
 
@@ -58,6 +59,7 @@ while {(spawner getVariable _markerX != 2) and (_countX < _num)} do
 		if (random 10 < 2.5) then
 			{
 			_dog = [_groupX, "Fin_random_F",_positionX,[],0,"FORM"] call A3A_fnc_createUnit;
+			_dogs pushBack _dog;
 			[_dog] spawn A3A_fnc_guardDog;
 			};
 		};
@@ -69,4 +71,5 @@ while {(spawner getVariable _markerX != 2) and (_countX < _num)} do
 waitUntil {sleep 1;(spawner getVariable _markerX == 2)};
 
 {if (alive _x) then {deleteVehicle _x}} forEach _soldiers;
+{deleteVehicle _x} forEach _dogs;
 {deleteGroup _x} forEach _groups;

--- a/A3A/addons/core/functions/CREATE/fn_createAIOutposts.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIOutposts.sqf
@@ -10,6 +10,7 @@ if(spawner getVariable _markerX == 2) exitWith {};
 _vehiclesX = [];
 _groups = [];
 _soldiers = [];
+private _dogs = [];
 
 _positionX = getMarkerPos (_markerX);
 _pos = [];
@@ -83,6 +84,7 @@ if (_patrol) then
 			if ((random 10 < 2.5) and (_typeGroup isNotEqualTo (_faction get "groupSniper"))) then
 			{
 				_dog = [_groupX, "Fin_random_F",_positionX,[],0,"FORM"] call A3A_fnc_createUnit;
+				_dogs pushBack _dog;
 				[_dog] spawn A3A_fnc_guardDog;
 				sleep 1;
 			};
@@ -327,6 +329,7 @@ deleteMarker _mrk;
 //{if ((!alive _x) and (not(_x in destroyedBuildings))) then {destroyedBuildings = destroyedBuildings + [position _x]; publicVariableServer "destroyedBuildings"}} forEach _buildings;
 
 { if (alive _x) then { deleteVehicle _x } } forEach _soldiers;
+{ deleteVehicle _x } forEach _dogs;
 { deleteGroup _x } forEach _groups;
 
 {

--- a/A3A/addons/core/functions/CREATE/fn_createAIResources.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIResources.sqf
@@ -16,6 +16,7 @@ _size = [_markerX] call A3A_fnc_sizeMarker;
 
 _civs = [];
 _soldiers = [];
+private _dogs = [];
 _groups = [];
 _vehiclesX = [];
 
@@ -109,6 +110,7 @@ if (_patrol) then
 			if ((random 10 < 2.5) and (_typeGroup isNotEqualTo (_faction get "groupSniper"))) then
 			{
 				_dog = [_groupX, "Fin_random_F",_positionX,[],0,"FORM"] call A3A_fnc_createUnit;
+				_dogs pushBack _dog;
 				[_dog] spawn A3A_fnc_guardDog;
 				sleep 1;
 			};
@@ -223,6 +225,7 @@ deleteMarker _mrk;
 
 { if (alive _x) then { deleteVehicle _x } } forEach _soldiers;
 { deleteVehicle _x } forEach _civs;
+{ deleteVehicle _x } forEach _dogs;
 { deleteGroup _x } forEach _groups;
 
 {

--- a/A3A/addons/core/functions/CREATE/fn_createAIcontrols.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIcontrols.sqf
@@ -15,6 +15,7 @@ if ((_sideX == teamPlayer) or (_sideX == sideUnknown)) exitWith {};
 if ({if ((sidesX getVariable [_x,sideUnknown] != _sideX) and (_positionX inArea _x)) exitWith {1}} count markersX >1) exitWith {};
 _vehiclesX = [];
 _soldiers = [];
+private _dogs = [];
 _pilots = [];
 _conquered = false;
 _groupX = grpNull;
@@ -118,6 +119,7 @@ if (_isControl) then
 			if (random 10 < 2.5) then
 				{
 				_dog = [_groupX, "Fin_random_F",_positionX,[],0,"FORM"] call A3A_fnc_createUnit;
+				_dogs pushBack _dog;
 				[_dog,_groupX] spawn A3A_fnc_guardDog;
 				};
 			_nul = [leader _groupX, _markerX, "SAFE","SPAWNED","NOVEH2","NOFOLLOW"] execVM QPATHTOFOLDER(scripts\UPSMON.sqf);//TODO need delete UPSMON link
@@ -272,6 +274,7 @@ waitUntil {sleep 1;(spawner getVariable _markerX == 2)};
 
 
 { if (alive _x) then { deleteVehicle _x } } forEach (_soldiers + _pilots);
+{ deleteVehicle _x } forEach _dogs;
 deleteGroup _groupX;
 
 {


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed an old bug where dogs spawned in garrison patrols weren't despawned, potentially blocking singleAttacks and causing unnecessary performance loss.

The traitor mission also spawns a dog, but that's cleaned up with groupDespawner, which appears to work correctly with dogs (by luck rather than judgement).

### Please specify which Issue this PR Resolves.
closes #2211

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?
It'll work. All this stuff runs locally to the garrison.

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Drive around for a while with zeus, check that the dogs are despawning behind you.