### PR TITLE
added a check to block setting prioritsed faction if it has no entry

### DIFF
--- a/A3A/addons/core/Templates/fn_selector.sqf
+++ b/A3A/addons/core/Templates/fn_selector.sqf
@@ -65,7 +65,12 @@ private _updatePreferedFaction = {
     private _side = ["Occ","Inv","Reb","Civ"] # _this;
     if (getNumber (_x/_entryName) > (_prioritisations#_this#0)) then {
         private _defaultFaction = if (getText (_x/"worldDefaults"/_worldName/_side) isNotEqualTo "") then { getText (_x/"worldDefaults"/_worldName/_side) } else { getText (_x/"worldDefaults"/"Default"/_side) };
-        if (_defaultFaction isEqualTo "") exitWith {};
+        if (_defaultFaction isEqualTo "") exitWith {
+            private _pool = ["AI","AI","Reb","Civ"] # _this;
+            if (isClass (_x/_pool)) then { // single civ template defined for modset
+                _prioritisations set [_this, [getNumber (_x/_entryName), "", _modset]]; //_modset hacked from parent scope
+            };
+        };
 
         _prioritisations set [_this, [getNumber (_x/_entryName), _defaultFaction, _modset]]; //_modset hacked from parent scope
     };

--- a/A3A/addons/core/Templates/fn_selector.sqf
+++ b/A3A/addons/core/Templates/fn_selector.sqf
@@ -67,7 +67,14 @@ private _updatePreferedFaction = {
         private _defaultFaction = if (getText (_x/"worldDefaults"/_worldName/_side) isNotEqualTo "") then { getText (_x/"worldDefaults"/_worldName/_side) } else { getText (_x/"worldDefaults"/"Default"/_side) };
         if (_defaultFaction isEqualTo "") exitWith {
             private _pool = ["AI","AI","Reb","Civ"] # _this;
-            if (isClass (_x/_pool)) then { // single civ template defined for modset
+            if (isClass (_x/_pool) && {
+                (count ("true" configClasses (_x/_pool)) == 0)
+                || (
+                    (count ("true" configClasses (_x/_pool)) == 1)
+                    && (toLower configName (_x/_pool)) isEqualTo "camo"
+                )//no factions defined
+            }) then { // single civ template defined for modset, but no faction defined
+                Debug_2("No worldDefault for side %1 on modset: %2", _side, _modset);
                 _prioritisations set [_this, [getNumber (_x/_entryName), "", _modset]]; //_modset hacked from parent scope
             };
         };
@@ -138,6 +145,8 @@ call compile preprocessFileLineNumbers (_nodes deleteAt _vanillaNodes);
     private _side = [west, east, resistance, civilian] # _forEachIndex;
     private _templateName = ([_modset, _type, _faction] select {_x isNotEqualTo ""}) joinString "_";
     private _index = _templatePool findIf {_templateName in _x};
+    Debug_2("Available templates for faction %1: %2", _type, _templatePool);
+    Debug_1("Looking for template with name: %1", _templateName);
     [_templatePool # _index, _side] call A3A_fnc_compatibilityLoadFaction;
 
     Info_2("Loading template: %1 for side: %2", _templatePool#_index, _side);

--- a/A3A/addons/core/Templates/fn_selector.sqf
+++ b/A3A/addons/core/Templates/fn_selector.sqf
@@ -65,6 +65,8 @@ private _updatePreferedFaction = {
     private _side = ["Occ","Inv","Reb","Civ"] # _this;
     if (getNumber (_x/_entryName) > (_prioritisations#_this#0)) then {
         private _defaultFaction = if (getText (_x/"worldDefaults"/_worldName/_side) isNotEqualTo "") then { getText (_x/"worldDefaults"/_worldName/_side) } else { getText (_x/"worldDefaults"/"Default"/_side) };
+        if (_defaultFaction isEqualTo "") exitWith {};
+
         _prioritisations set [_this, [getNumber (_x/_entryName), _defaultFaction, _modset]]; //_modset hacked from parent scope
     };
 };


### PR DESCRIPTION
was problem for baf but is also a needed functionality

## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    When a the highest priority faction was loaded and it didnt have a world default for every side it would sett the faction to be empty, this would break mod sets like BAF

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
