### PR TITLE
Bug Fixes for city supplies 🛢️, QOL for fuel ⛽, and Out of Bounds Check for Moving assets. 

### DIFF
--- a/A3A/addons/core/functions/Dialogs/fn_moveHQObject.sqf
+++ b/A3A/addons/core/functions/Dialogs/fn_moveHQObject.sqf
@@ -16,7 +16,13 @@ _sites = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
 _markerX = [_sites,_playerX] call BIS_fnc_nearestPosition;
 _size = [_markerX] call A3A_fnc_sizeMarker;
 _positionX = getMarkerPos _markerX;
-if (_playerX distance2D _positionX > _size) exitWith {["Move HQ", "This asset needs to be closer to it relative zone center to be able to be moved."] call A3A_fnc_customHint;};
+
+if(_playerX distance2D _positionX > _size) then {
+	if (_thingX getVariable ['A3A_OutOfBoundsCheck', false]) exitWith {["Move HQ", "Object out of movable area"] call A3A_fnc_customHint;};
+	_thingX setVariable ['A3A_OutOfBoundsCheck', true, true]; //outofbounds
+} else {
+	_thingX setVariable ['A3A_OutOfBoundsCheck', false, true]; //inbounds
+};
 
 if (captive _playerX) then { _playerX setCaptive false };
 

--- a/A3A/addons/core/functions/Missions/fn_LOG_Supplies.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Supplies.sqf
@@ -118,6 +118,8 @@ if (isNull attachedTo _truckX) then {
 	_emptybox = "Land_Pallet_F" createVehicle _ecpos;
 	[_emptybox] spawn A3A_fnc_postmortem;
 } else {
+	//add seat back!
+	[attachedTo _truckX] remoteExec ["A3A_fnc_logistics_unload",2];
 	deleteVehicle _truckX;
 };
 

--- a/A3A/addons/core/functions/Missions/fn_LOG_Supplies.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Supplies.sqf
@@ -113,8 +113,12 @@ else
 	};
 
 _ecpos = getpos _truckX;
-deleteVehicle _truckX;
-_emptybox = "Land_Pallet_F" createVehicle _ecpos;
-[_emptybox] spawn A3A_fnc_postmortem;
+if (isNull attachedTo _truckX) then {
+	deleteVehicle _truckX;
+	_emptybox = "Land_Pallet_F" createVehicle _ecpos;
+	[_emptybox] spawn A3A_fnc_postmortem;
+} else {
+	deleteVehicle _truckX;
+};
 
 [_taskId, "SUPP", 900] spawn A3A_fnc_taskDelete;

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -406,7 +406,7 @@ private _fuelDrum = FactionGet(reb,"vehicleFuelDrum");
 private _fuelTank = FactionGet(reb,"vehicleFuelTank");
 if (isClass (configFile/"CfgVehicles"/_fuelDrum # 0)) then {
     private _dispName = getText (configFile/"CfgVehicles"/_fuelDrum # 0/"displayName");
-    vehicleBox addAction [format["Buy %1 for %2€",_dispName, _fuelDrum # 1], {[player, _this # 3 # 0, _this # 3 # 1, [['A3A_fnc_initMovableObject', true], ['A3A_fnc_logistics_addLoadAction', false]]] call A3A_fnc_buyItem},_fuelDrum,0,false,true,"","_this == theBoss",4];
+    vehicleBox addAction [format["Buy %1 for %2€",_dispName, _fuelDrum # 1], {[player, _this # 3 # 0, _this # 3 # 1, [['A3A_fnc_initMovableObject', true], ['A3A_fnc_logistics_addLoadAction', false]]] call A3A_fnc_buyItem},_fuelDrum,0,false,true,"","true",4];
 };
 if (isClass (configFile/"CfgVehicles"/_fuelTank # 0)) then {
     private _dispName = getText (configFile/"CfgVehicles"/_fuelTank # 0/"displayName");

--- a/A3A/addons/core/functions/init/fn_initZones.sqf
+++ b/A3A/addons/core/functions/init/fn_initZones.sqf
@@ -289,7 +289,7 @@ A3A_fuelStations apply {
 	_mrkFinalFuel = createMarker [format ["Ant%1", mapGridPosition _x], position _x];
 	_mrkFinalFuel setMarkerShape "ICON";
 	_mrkFinalFuel setMarkerType "loc_Fuelstation";
-	_mrkFinalFuel setMarkerColor "ColorGrey"; 
+	_mrkFinalFuel setMarkerColor "ColorWhite"; 
 	_mrkFinalFuel setMarkerText "Fuel station";
 	_mrkFinalFuel setMarkerAlpha 0.75;
 	if(A3A_hasACE) then {


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    Added an attachedTo check on the pallet to see if it was attached to anything before deletion.
Changed color of the fuel marker and made the small fuel containers purchasable for non-commanders.
Added a check for moving objects out of bounds, allows for objects that are out of bounds to be moved.

### Please specify which Issue this PR Resolves.
closes #2193 
closes #2164 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
