### PR TITLE
Improve arsenal and vehicle arsenal compatible-magazine lists

### DIFF
--- a/A3A/addons/JeroenArsenal/JNA/fn_arsenal.sqf
+++ b/A3A/addons/JeroenArsenal/JNA/fn_arsenal.sqf
@@ -766,26 +766,14 @@ switch _mode do {
 		_type = (ctrltype _ctrlList == 102);
 
 
-		_inventory = if(_index == IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG)then{
-
+		_inventory = if(_index == IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG) then
+		{
 			_usableMagazines = [];
 			{
-				_cfgWeapon = configfile >> "cfgweapons" >> _x;
-				{
-					_cfgMuzzle = if (_x == "this") then {_cfgWeapon} else {_cfgWeapon >> _x};
-					{
-						_usableMagazines pushBackUnique _x;
-					} foreach getarray (_cfgMuzzle >> "magazines");
-				} foreach getarray (_cfgWeapon >> "muzzles");
+				private _cfgWeapon = configfile >> "cfgweapons" >> _x;
+				private _mags = _cfgWeapon call A3A_fnc_allMagazines;
+				{ _usableMagazines pushBackUnique _x } forEach _mags;
 			} foreach (weapons player - ["Throw","Put"]);
-
-
-
-			{
-				{
-					_usableMagazines pushBackUnique _x;
-				} forEach (getarray (configfile >> "cfgweapons" >> _x >> "magazines"));
-			}forEach [primaryweapon player, secondaryweapon player, handgunweapon player];
 
 			//loop all magazines and find usable
 			_magazines = [];

--- a/A3A/addons/JeroenArsenal/JNA/fn_vehicleArsenal.sqf
+++ b/A3A/addons/JeroenArsenal/JNA/fn_vehicleArsenal.sqf
@@ -362,22 +362,22 @@ switch _mode do {
 
 			_usableMagazines = [];
 			{
-				_weapons = jnva_loadout select _x;
+				private _weapons = jnva_loadout select _x;
 				{
-					_weapon = _x select 0;
-					_cfgWeapon = configfile >> "cfgweapons" >> _weapon;
-					{
-						_cfgMuzzle = if (_x == "this") then {_cfgWeapon} else {_cfgWeapon >> _x};
-						{
-							_usableMagazines pushBackUnique _x;
-						} foreach getarray (_cfgMuzzle >> "magazines");
-					} foreach getarray (_cfgWeapon >> "muzzles");
+					private _cfgWeapon = configfile >> "cfgweapons" >> (_x select 0);
+					private _mags = _cfgWeapon call A3A_fnc_allMagazines;
+					{ _usableMagazines pushBackUnique _x } forEach _mags;
 				} forEach _weapons;
 			}forEach [
 				IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON,
 				IDC_RSCDISPLAYARSENAL_TAB_SECONDARYWEAPON,
 				IDC_RSCDISPLAYARSENAL_TAB_HANDGUN
 			];
+
+			// Add vehicle magazines for 3CB-style ammunition systems
+			private _cfgVehicle = configFile >> "cfgVehicles" >> typeof _veh;
+			private _vehMags = _cfgVehicle call A3A_fnc_allMagazines;
+			{ _usableMagazines pushBackUnique _x } forEach _vehMags;
 
 			//loop all magazines and find usable
 			//First, search mags in Arsenal


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Used Hakon's allMagazines function to generate compatible magazine lists for the top-right arsenal tab button. This is much better at finding the full list of compatible magazines. IIRC some AKs were pretty bad for this before.

Also used the same function to add vehicle mags in the vehicle arsenal. This makes 3CB BAF much easier to work with. You can now easily top up vehicle weapon mags without having to search through several pages of magazines.

### Please specify which Issue this PR Resolves.
There was an issue for the personal-weapon side but it was prematurely closed. Not sure if there's an issue for the 3CB vehicle ammunition annoyance.

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Should probably check a few different modsets and see if it does anything weird. I've tried basic vanilla/RHS/BAF but not extensively.
