### PR TITLE
Fixed always on debug render for garage

### DIFF
--- a/A3A/addons/Garage/Core/fn_confirmPlacement.sqf
+++ b/A3A/addons/Garage/Core/fn_confirmPlacement.sqf
@@ -395,15 +395,15 @@ HR_GRG_EH_EF = addMissionEventHandler ["EachFrame", {
         call HR_GRG_cleanUp
     };
 
-    #if __A3_DEBUG__ //Debug render
-    HR_GRG_dispSquare params ["_adjustment", "_square"];
-    _square params ["_a","_b"];
-    drawLine3D [HR_GRG_dispVehicle modelToWorldVisual _adjustment,HR_GRG_dispVehicle modelToWorldVisual (_adjustment vectorAdd [_a,0,0]), [0.9,0,0,1]];
-    drawLine3D [HR_GRG_dispVehicle modelToWorldVisual _adjustment,HR_GRG_dispVehicle modelToWorldVisual (_adjustment vectorAdd [0,_b,0]), [0.9,0,0,1]];
-    drawLine3D [HR_GRG_dispVehicle modelToWorldVisual _adjustment,HR_GRG_dispVehicle modelToWorldVisual (_adjustment vectorAdd [0,0,_c]), [0.9,0,0,1]];
-    drawLine3D [HR_GRG_dispVehicle modelToWorldVisual _adjustment,HR_GRG_dispVehicle modelToWorldVisual (_adjustment vectorAdd [-_a,0,0]), [0.9,0,0,1]];
-    drawLine3D [HR_GRG_dispVehicle modelToWorldVisual _adjustment,HR_GRG_dispVehicle modelToWorldVisual (_adjustment vectorAdd [0,-_b,0]), [0.9,0,0,1]];
-    drawLine3D [HR_GRG_dispVehicle modelToWorldVisual _adjustment,HR_GRG_dispVehicle modelToWorldVisual (_adjustment vectorAdd [0,0,-_c]), [0.9,0,0,1]];
-    { drawLine3D [HR_GRG_dispVehicle modelToWorldVisual _x#0,HR_GRG_dispVehicle modelToWorldVisual _x#1, [0.9,0,0,1]] } forEach HR_GRG_rays;
-    #endif
+    if (HR_GRG_renderPlacementRays) then { //Debug render
+        HR_GRG_dispSquare params ["_adjustment", "_square"];
+        _square params ["_a","_b"];
+        drawLine3D [HR_GRG_dispVehicle modelToWorldVisual _adjustment,HR_GRG_dispVehicle modelToWorldVisual (_adjustment vectorAdd [_a,0,0]), [0.9,0,0,1]];
+        drawLine3D [HR_GRG_dispVehicle modelToWorldVisual _adjustment,HR_GRG_dispVehicle modelToWorldVisual (_adjustment vectorAdd [0,_b,0]), [0.9,0,0,1]];
+        drawLine3D [HR_GRG_dispVehicle modelToWorldVisual _adjustment,HR_GRG_dispVehicle modelToWorldVisual (_adjustment vectorAdd [0,0,_c]), [0.9,0,0,1]];
+        drawLine3D [HR_GRG_dispVehicle modelToWorldVisual _adjustment,HR_GRG_dispVehicle modelToWorldVisual (_adjustment vectorAdd [-_a,0,0]), [0.9,0,0,1]];
+        drawLine3D [HR_GRG_dispVehicle modelToWorldVisual _adjustment,HR_GRG_dispVehicle modelToWorldVisual (_adjustment vectorAdd [0,-_b,0]), [0.9,0,0,1]];
+        drawLine3D [HR_GRG_dispVehicle modelToWorldVisual _adjustment,HR_GRG_dispVehicle modelToWorldVisual (_adjustment vectorAdd [0,0,-_c]), [0.9,0,0,1]];
+        { drawLine3D [HR_GRG_dispVehicle modelToWorldVisual _x#0,HR_GRG_dispVehicle modelToWorldVisual _x#1, [0.9,0,0,1]] } forEach HR_GRG_rays;
+    };
 }];

--- a/A3A/addons/Garage/Core/fn_confirmPlacement.sqf
+++ b/A3A/addons/Garage/Core/fn_confirmPlacement.sqf
@@ -395,7 +395,7 @@ HR_GRG_EH_EF = addMissionEventHandler ["EachFrame", {
         call HR_GRG_cleanUp
     };
 
-    #ifdef Debug //Debug render
+    #if __A3_DEBUG__ //Debug render
     HR_GRG_dispSquare params ["_adjustment", "_square"];
     _square params ["_a","_b"];
     drawLine3D [HR_GRG_dispVehicle modelToWorldVisual _adjustment,HR_GRG_dispVehicle modelToWorldVisual (_adjustment vectorAdd [_a,0,0]), [0.9,0,0,1]];

--- a/A3A/addons/Garage/Public/config.inc
+++ b/A3A/addons/Garage/Public/config.inc
@@ -37,6 +37,8 @@ HR_GRG_Cnd_canAccessAir = {
 //Lock on garaged vehicles ( Values: [{""}, { getPlayerUID player }] )
 HR_GRG_dLock = {""};
 
+HR_GRG_renderPlacementRays = false;
+
 //garage pool cap
 if (isNil "HR_GRG_PoolBase") then { HR_GRG_PoolBase = 10 }; //can be overwritten by CBA settings
 if (isNil "HR_GRG_PoolIncr") then { HR_GRG_PoolIncr = 2 }; //can be overwritten by CBA settings
@@ -99,6 +101,10 @@ if (isClass (configfile >> "CBA_Extended_EventHandlers")) then {
 
     ["HR_GRG_PoolIncr", "SLIDER", ["Capacity increase", "Capacity increase per war level"], [HR_GRG_Prefix,"Garage"], [0, 10, HR_GRG_PoolIncr, 0], true, {
         HR_GRG_PoolIncr = round _this;
+    }] call CBA_fnc_addSetting;
+
+    ["HR_GRG_renderPlacementRays", "CHECKBOX", ["Render placement rays", "Render the debug placement rays when placing vehicles"], [HR_GRG_Prefix,"Garage"], false, false, {
+        HR_GRG_renderPlacementRays = _this;
     }] call CBA_fnc_addSetting;
 
 };


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
   When we added the keybinds sript_component.hpp was included into confirmPlacement, this had the negative effect of also including the log macros, which in turn had `Debug` defined.
   In confirmPlacement this define was used durring development to toggle on the debug rendering for ensuring good collision detection and spotting gaps.
   Now this pre proccessor command checks `__A3_DEBUG__` instead.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
