### PR TITLE
Switch back to moving recruited rebel squads into their vehicles

### DIFF
--- a/A3A/addons/core/functions/REINF/fn_spawnHCGroup.sqf
+++ b/A3A/addons/core/functions/REINF/fn_spawnHCGroup.sqf
@@ -55,7 +55,7 @@ private _bypassAI = true;
 //vehicle init funcs
 private _initInfVeh = {
     if (isNull _vehicle) exitWith {};
-    leader _group assignAsDriver _vehicle;
+    leader _group moveInDriver _vehicle;
     call _initVeh;
     ["Recruit Squad", "Vehicle Purchased"] call A3A_fnc_customHint;
     petros directSay "SentGenBaseUnlockVehicle";
@@ -67,7 +67,7 @@ private _initVeh = {
     _group addVehicle _vehicle;
     _vehicle setVariable ["owner",_group,true];
     driver _vehicle action ["engineOn", _vehicle];
-    {[_x] orderGetIn true; [_x] allowGetIn true} forEach units _group;
+    { if (vehicle _x == _x) then { _x moveInAny _vehicle } } forEach units _group;
 };
 
 // special handling
@@ -89,15 +89,15 @@ switch _special do {
     //vehicle squad
     case "BuildAA": {
         private _static = ((attachedObjects _vehicle) select {typeOf _x == FactionGet(reb,"staticAA")})#0;
-        (_units # (_countUnits -1)) assignAsDriver _vehicle;
-        (_units # _countUnits) assignAsGunner _static;
+        (_units # (_countUnits -1)) moveInDriver _vehicle;
+        (_units # _countUnits) moveInGunner _static;
         call _initVeh;
         _cost = _cost + ([FactionGet(reb,"staticAA")] call A3A_fnc_vehiclePrice);
 
     };
     case "VehicleSquad": {
-        (_units # (_countUnits -1)) assignAsDriver _vehicle;
-        (_units # _countUnits) assignAsGunner _vehicle;
+        (_units # (_countUnits -1)) moveInDriver _vehicle;
+        (_units # _countUnits) moveInGunner _vehicle;
         call _initVeh;
     };
 


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Changed the rebel squad recruiting to move units directly into their purchased vehicles, an in pre-2.5 versions. Prevents issues with AI pathing at busy HQs and generally speeds up recruit->use for the commander.

Technical note: moveInXXX functions appear to assign the specified role too, so assign+moveIn is unnecessary. 

### Please specify which Issue this PR Resolves.
closes #2203

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Recruit various vehicle-based or vehicle-added high command squads. Check that they're moved into the vehicle correctly. Make sure they move afterwards.
