### PR TITLE
Remove Ravenbackpack from Loot

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
@@ -39,6 +39,8 @@ private _categoryOverrideTable = [
 ["rhs_weap_m32", ["GrenadeLaunchers","Weapons"]],
 ["rhs_weap_m79", ["GrenadeLaunchers","Weapons"]],
 
+["B_rhsusf_B_BACKPACK", ["Unknown","Items"]],
+
 ["UK3CB_Enfield", ["SniperRifles","Weapons"]],
 ["UK3CB_Enfield_rail", ["SniperRifles","Weapons"]],
 ["UK3CB_M14DMR", ["SniperRifles","Weapons"]],


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
This change removes the Raven Drone Backpack from Loot and prevents Unlocking if people spawn them in using Zeus.

### Please specify which Issue this PR Resolves.
closes #2274

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Check 
```sqf
"B_rhsusf_B_BACKPACK" in allbackpacks //Should be false
"B_rhsusf_B_BACKPACK" in lootbackpack //Should be false
"B_rhsusf_B_BACKPACK" in allunknown //Should be true
```
********************************************************
Notes:
