### PR TITLE
Fix Carrier Markertype after loading a Save

### DIFF
--- a/A3A/addons/core/functions/init/fn_initGarrisons.sqf
+++ b/A3A/addons/core/functions/init/fn_initGarrisons.sqf
@@ -134,10 +134,6 @@ else
 
 if (!(isNil "loadLastSave") && {loadLastSave}) exitWith {};
 
-//Set carrier markers to the same as airbases below.
-if (isServer) then {"NATO_carrier" setMarkertype FactionGet(occ,"flagMarkerType")};
-if (isServer) then {"CSAT_carrier" setMarkertype FactionGet(inv,"flagMarkerType")};
-
 if (debug) then {
     Debug("Setting up Airbase stuff.");
 };

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -245,6 +245,8 @@ call A3A_fnc_selector;
 if (local flagX) then { flagX setFlagTexture FactionGet(reb,"flagTexture") } else { [flagX, FactionGet(reb,"flagTexture")] remoteExec ["setFlagTexture", owner flagX] };
 "NATO_carrier" setMarkerText FactionGet(occ,"spawnMarkerName");
 "CSAT_carrier" setMarkerText FactionGet(inv,"spawnMarkerName");
+"NATO_carrier" setMarkertype FactionGet(occ,"flagMarkerType");
+"CSAT_carrier" setMarkertype FactionGet(inv,"flagMarkerType");
 
 ////////////////////////////////////
 //      CIVILIAN VEHICLES       ///


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
This moved the problematic solution in InitGarrisons to InitServers, right next to where we set the Carriermarkers Names.


### Please specify which Issue this PR Resolves.
closes #2282 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Load a Save, the Carriers should get their Factions Markertypes applied.
********************************************************
Notes:
