### PR TITLE
UtilityItems - Prevent players from carrying objects into vehicles and fix order precedence

### DIFF
--- a/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
@@ -29,7 +29,6 @@ if (_pickUp) then {
         params ["_unit", "_role", "_vehicle", "_turret"];
         // get variables
         private _objectCarrying = _unit getVariable ['A3A_objectCarrying', nil];
-        systemChat str _objectCarrying;
 
         //remove object and find safe placement
         private _pos = [_unit, 1, 10, 3, 0, 20, 0] call BIS_fnc_findSafePos;

--- a/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
@@ -23,11 +23,40 @@ params [["_item", objNull, [objNull]], "_pickUp", ["_player", player]];
 
 if (_pickUp) then {
     if (([_player] call A3A_fnc_countAttachedObjects) > 0) exitWith {[localize "STR_A3A_Utility_Title", localize "STR_A3A_Utility_Items_Feedback_Normal"] call A3A_fnc_customHint};
+
+    // we need to prevent the player from carrying an object into a vehicle to prevent damage to vehicle
+    private _eventIDcarry = _player addEventHandler ["GetInMan", {
+        params ["_unit", "_role", "_vehicle", "_turret"];
+        // get variables
+        private _objectCarrying = _unit getVariable ['A3A_objectCarrying', nil];
+        systemChat str _objectCarrying;
+
+        //remove object and find safe placement
+        private _pos = [_unit, 1, 10, 3, 0, 20, 0] call BIS_fnc_findSafePos;
+
+        detach _objectCarrying;
+        _unit setVelocity [0,0,0];
+        _objectCarrying setVelocity [0,0,0];
+        _objectCarrying setPos [_pos # 0, _pos # 1 , 0];
+
+        _objectCarrying enableSimulationGlobal true;
+
+
+        _unit setVariable ["A3A_carryingObject", nil];
+        _unit setVariable ['A3A_objectCarrying', nil];
+        _unit removeEventHandler ['GetIn', _thisEventHandler];
+
+    }];
+
+    _player setVariable ['A3A_eventIDcarry', _eventIDcarry];
+    _player setVariable ['A3A_objectCarrying', _item];
+
+    _item enableSimulationGlobal false; // prevent killing players with item
     _item attachTo [_player, [0, 1.5, 0.5], "Chest"];
     _player setVariable ["A3A_carryingObject", true];
     [_player ,_item] spawn {
         params ["_player", "_item"];
-        waitUntil {_player forceWalk true; !alive _item or !(_player getVariable ["A3A_carryingObject", false]) or !(vehicle _player isEqualTo _player) or _player getVariable ["incapacitated",false] or !alive _player or !(isPlayer attachedTo _item) };
+        waitUntil {!alive _item or !(_player getVariable ["A3A_carryingObject", false]) or !(vehicle _player isEqualTo _player) or _player getVariable ["incapacitated",false] or !alive _player or !(isPlayer attachedTo _item) };
         [_item, false, _player] call A3A_fnc_carryItem;
     };
 } else {
@@ -42,7 +71,8 @@ if (_pickUp) then {
         detach _item;
         _item setVelocity [0,0,0];
         _item setPos [getPos _item # 0, getPos _item # 1, 0];
+        _item enableSimulationGlobal true;
+        _player removeEventHandler ["GetInMan", _player getVariable ['A3A_eventIDcarry']];
     };
     _player setVariable ["A3A_carryingObject", nil];
-    _player forceWalk false;
 };

--- a/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
@@ -42,14 +42,14 @@ if (_pickUp) then {
 
         _unit setVariable ["A3A_carryingObject", nil];
         _unit setVariable ['A3A_objectCarrying', nil];
-        _unit removeEventHandler ['GetInMan', _thisEventHandler];
 
     }];
 
     _player setVariable ['A3A_eventIDcarry', _eventIDcarry];
     _player setVariable ['A3A_objectCarrying', _item];
 
-    _item enableSimulationGlobal false; // prevent killing players with item
+    // prevent killing players with item
+    [_item, false] remoteExec ["enableSimulationGlobal", 0];
     _item attachTo [_player, [0, 1.5, 0.5], "Chest"];
     _player setVariable ["A3A_carryingObject", true];
     [_player ,_item] spawn {
@@ -70,7 +70,8 @@ if (_pickUp) then {
         _item setVelocity [0,0,0];
         _item setPos [getPos _item # 0, getPos _item # 1, 0];
         [_item, true] remoteExec ["enableSimulationGlobal", 0];
-        _player removeEventHandler ["GetInMan", _player getVariable ['A3A_eventIDcarry']];
+        _eventIDcarry = _player getVariable 'A3A_eventIDcarry';
+        _player removeEventHandler ["GetInMan", _eventIDcarry];
     };
     _player setVariable ["A3A_carryingObject", nil];
 };

--- a/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
@@ -31,19 +31,18 @@ if (_pickUp) then {
         private _objectCarrying = _unit getVariable ['A3A_objectCarrying', nil];
 
         //remove object and find safe placement
-        private _pos = [_unit, 1, 10, 3, 0, 20, 0] call BIS_fnc_findSafePos;
-
         detach _objectCarrying;
         _unit setVelocity [0,0,0];
         _objectCarrying setVelocity [0,0,0];
-        _objectCarrying setPos [_pos # 0, _pos # 1 , 0];
+        _objectCarrying setVehiclePosition [position _unit, [], 10,"NONE"];
 
-        _objectCarrying enableSimulationGlobal true;
+        [_objectCarrying, true] remoteExec ["enableSimulationGlobal", 0];
+        
 
 
         _unit setVariable ["A3A_carryingObject", nil];
         _unit setVariable ['A3A_objectCarrying', nil];
-        _unit removeEventHandler ['GetIn', _thisEventHandler];
+        _unit removeEventHandler ['GetInMan', _thisEventHandler];
 
     }];
 
@@ -70,7 +69,7 @@ if (_pickUp) then {
         detach _item;
         _item setVelocity [0,0,0];
         _item setPos [getPos _item # 0, getPos _item # 1, 0];
-        _item enableSimulationGlobal true;
+        [_item, true] remoteExec ["enableSimulationGlobal", 0];
         _player removeEventHandler ["GetInMan", _player getVariable ['A3A_eventIDcarry']];
     };
     _player setVariable ["A3A_carryingObject", nil];

--- a/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
@@ -29,6 +29,7 @@ if (_pickUp) then {
         params ["_unit", "_role", "_vehicle", "_turret"];
         // get variables
         private _objectCarrying = _unit getVariable ['A3A_objectCarrying', nil];
+        if (isNil _objectCarrying) exitwith {_player removeEventHandler ["GetInMan", _thisEventHandler]};
 
         //remove object and find safe placement
         detach _objectCarrying;
@@ -49,7 +50,7 @@ if (_pickUp) then {
     _player setVariable ['A3A_objectCarrying', _item];
 
     // prevent killing players with item
-    [_item, false] remoteExec ["enableSimulationGlobal", 0];
+    [_item, false] remoteExec ["enableSimulationGlobal", 2];
     _item attachTo [_player, [0, 1.5, 0.5], "Chest"];
     _player setVariable ["A3A_carryingObject", true];
     [_player ,_item] spawn {
@@ -69,7 +70,7 @@ if (_pickUp) then {
         detach _item;
         _item setVelocity [0,0,0];
         _item setPos [getPos _item # 0, getPos _item # 1, 0];
-        [_item, true] remoteExec ["enableSimulationGlobal", 0];
+        [_item, true] remoteExec ["enableSimulationGlobal", 2];
         _eventIDcarry = _player getVariable 'A3A_eventIDcarry';
         _player removeEventHandler ["GetInMan", _eventIDcarry];
     };

--- a/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
@@ -29,7 +29,7 @@ if (_pickUp) then {
         params ["_unit", "_role", "_vehicle", "_turret"];
         // get variables
         private _objectCarrying = _unit getVariable ['A3A_objectCarrying', nil];
-        if (isNil _objectCarrying) exitwith {_player removeEventHandler ["GetInMan", _thisEventHandler]};
+        if (isNil "_objectCarrying") exitwith {_unit removeEventHandler ["GetInMan", _thisEventHandler]};
 
         //remove object and find safe placement
         detach _objectCarrying;

--- a/A3A/addons/core/functions/UtilityItems/fn_remainingFuel.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_remainingFuel.sqf
@@ -25,7 +25,7 @@ if(A3A_hasACE) then {
     private _vehicleMaxFuel = getNumber (_vehCfg >> "ace_refuel_fuelCargo");
     if(_vehicleMaxFuel == 0) exitwith {0};
     private _currentFuelCargo = [_vehicle] call ace_refuel_fnc_getFuel;
-	( _currentFuelCargo / _vehicleMaxFuel);
+    (_currentFuelCargo / _vehicleMaxFuel);
 } else {
-	getFuelCargo _vehicle;
+    getFuelCargo _vehicle;
 };

--- a/A3A/addons/core/functions/UtilityItems/fn_remainingFuel.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_remainingFuel.sqf
@@ -24,7 +24,7 @@ private _vehCfg = configFile/"CfgVehicles"/typeOf _vehicle;
 if(A3A_hasACE) then {
     private _vehicleMaxFuel = getNumber (_vehCfg >> "ace_refuel_fuelCargo");
     if(_vehicleMaxFuel == 0) exitwith {0};
-	(_vehicle getVariable ["ace_refuel_currentFuelCargo"] / _vehicleMaxFuel);
+	((_vehicle getVariable ["ace_refuel_currentFuelCargo"]) / _vehicleMaxFuel);
 } else {
 	getFuelCargo _vehicle;
 };

--- a/A3A/addons/core/functions/UtilityItems/fn_remainingFuel.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_remainingFuel.sqf
@@ -24,7 +24,8 @@ private _vehCfg = configFile/"CfgVehicles"/typeOf _vehicle;
 if(A3A_hasACE) then {
     private _vehicleMaxFuel = getNumber (_vehCfg >> "ace_refuel_fuelCargo");
     if(_vehicleMaxFuel == 0) exitwith {0};
-	((_vehicle getVariable ["ace_refuel_currentFuelCargo"]) / _vehicleMaxFuel);
+    private _currentFuelCargo = [_vehicle] call ace_refuel_fnc_getFuel;
+	( _currentFuelCargo / _vehicleMaxFuel);
 } else {
 	getFuelCargo _vehicle;
 };


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [x] Enhancement

### What have you changed and why?
Information:
    Added an event handler to the play when holding an movable item. Once trigger the item is moved away from the vehicle to stop damage. Also removed forced walk as the intent is use this around base.

### Please specify which Issue this PR Resolves.

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
