### PR TITLE
Fix roadblock vehicles being despawned after stealing

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_createAIcontrols.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIcontrols.sqf
@@ -287,12 +287,6 @@ deleteGroup _groupX;
 } forEach _vehiclesX;
 
 
-{
-	// delete all vehicles that haven't been captured
-	if !(_x getVariable ["inDespawner", false]) then { deleteVehicle _x };
-} forEach _vehiclesX;
-
-
 if (_conquered) then
 	{
 	_indexX = controlsX find _markerX;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
An accidentally preserved code section (merge fail?) could deleting vehicles from roadblocks after being stolen by players. This PR removes it, fixing the problem.
    
### Please specify which Issue this PR Resolves.
closes #2289

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
