### PR TITLE
Fix cargo trucks not being sellable

### DIFF
--- a/A3A/addons/core/functions/Base/fn_sellVehicle.sqf
+++ b/A3A/addons/core/functions/Base/fn_sellVehicle.sqf
@@ -63,13 +63,13 @@ private _costs = call {
     if (
         _typeX in (OccAndInv("vehiclesLight")
             + OccAndInv("vehiclesTrucks")
+            + OccAndInv("vehiclesCargoTrucks")
             + OccAndInv("vehiclesAmmoTrucks")
             + OccAndInv("vehiclesRepairTrucks")
             + OccAndInv("vehiclesFuelTrucks")
             + OccAndInv("vehiclesMedical")
         )
         or (_typeX in FactionGet(all,"vehiclesBoats"))
-        or (_typeX in FactionGet(all,"vehiclesAmmoTrucks"))
     ) exitWith {100};
     if (_typeX in (OccAndInv("vehiclesHelisLight") + [FactionGet(reb,"vehicleCivHeli")])) exitWith {500};
     if (


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
vehiclesCargoTrucks wasn't included in the sell checks, so flatbed trucks couldn't be sold.    

### Please specify which Issue this PR Resolves.
closes #2291

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
