### PR TITLE
Fix typo in how to build.md guide

### DIFF
--- a/How to build.md
+++ b/How to build.md
@@ -3,7 +3,7 @@
 * install Arma 3 Tools in the same steam library that Arma 3 is installed
 ## With Vs code Arma Dev Extension
 ### First time setup
-* Install extension from [markedplace](https://marketplace.visualstudio.com/items?itemName=ole1986.arma-dev)
+* Install extension from [marketplace](https://marketplace.visualstudio.com/items?itemName=ole1986.arma-dev)
 * configure the extension from the Antistasi workspace by opening the command pallet <kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>P</kbd> and running the `Arma 3: configure` command
 * fill in the configuration `.json` file something like this
 ```json


### PR DESCRIPTION


## What type of PR is this.
1. [X ] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The link to vs code market was misspelled for `markedplace`, I edited and added the t instead of the d
    
