### PR TITLE
No-unlocks support for rebel AI equipping

### DIFF
--- a/A3A/addons/JeroenArsenal/JNA/fn_arsenal_addItem.sqf
+++ b/A3A/addons/JeroenArsenal/JNA/fn_arsenal_addItem.sqf
@@ -34,9 +34,13 @@ if(typeName (_this select 0) isEqualTo "SCALAR")then{//[_index, _item] and [_ind
 				private _radioName = getText(configfile >> "CfgVehicles" >> _item >> "acre_baseClass");
 				if!(_radioName isEqualTo "")then{_item = _radioName};
 
-				//update
-				private _playersInArsenal = +(server getVariable ["jna_playersInArsenal",[]]);
-				if!(0 in _playersInArsenal)then{_playersInArsenal pushBackUnique 2;};
+				// Update server immediately if local. Avoids lag after unlockEquipment
+				if (isServer) then { ["UpdateItemAdd",[_index, _item, _amount,true]] call jn_fnc_arsenal }
+				else { ["UpdateItemAdd",[_index, _item, _amount,true]] remoteExecCall ["jn_fnc_arsenal",2] };
+
+				// then update other players. Don't execute on server twice
+				private _playersInArsenal = +(server getVariable ["jna_playersInArsenal",[]]) - [2];
+				if (0 in _playersInArsenal) then { _playersInArsenal = -2 };
 				["UpdateItemAdd",[_index, _item, _amount,true]] remoteExecCall ["jn_fnc_arsenal",_playersInArsenal];
 			};
 		};

--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -79,7 +79,9 @@ class CfgFunctions
             class equipmentClassToCategories {};
             class equipmentIsValidForCurrentModset {};
             class equipmentSort {};
+            class fetchRebelGear {};
             class fillLootCrate {};
+            class generateRebelGear {};
             class getRadio {};
             class hasARadio {};
             class itemConfig {};

--- a/A3A/addons/core/Templates/Templates.hpp
+++ b/A3A/addons/core/Templates/Templates.hpp
@@ -399,7 +399,7 @@ class Templates
         priorityReb = 6;
         priorityCiv = 6;
 
-        requiredAddons[] = {"CUP_BaseConfigs"};
+        requiredAddons[] = {"CUP_Creatures_People_Civil_Russia", "CUP_BaseConfigs", "CUP_AirVehicles_Core"};        // units, weapons, vehicles
         path = QPATHTOFOLDER(Templates\Templates\CUP);
 
         class AI

--- a/A3A/addons/core/functions/Ammunition/fn_arsenalManage.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_arsenalManage.sqf
@@ -6,6 +6,8 @@ private _item = objNull;
 private _cateogry = objNull;
 ["buttonInvToJNA"] call jn_fnc_arsenal;
 
+if (minWeaps < 0) exitWith {""};		// no unlocks
+
 private _weapons = ((jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON) + (jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_HANDGUN) + (jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_SECONDARYWEAPON)) select {_x select 1 != -1};
 private _explosives = (jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_CARGOPUT) select {_x select 1 != -1};
 private _magazines = (jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL) + (jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_CARGOTHROW) select {_x select 1 != -1};

--- a/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
@@ -172,7 +172,7 @@ private _categoryOverrideTable = [
 ["vn_sten", ["SMGs","Weapons"]],
 ["vn_mpu", ["SMGs","Weapons"]],
 ["vn_vz61", ["SMGs","Weapons"]],
-["vn_m72", ["RocketLaunchers","Weapons","AT","Disposable"];
+["vn_m72", ["RocketLaunchers","Weapons","AT","Disposable"]],
 ["vn_m79", ["GrenadeLaunchers","Weapons"]],
 ["vn_sa7b", ["MissileLaunchers","Weapons","AA"]],
 ["vn_sa7", ["MissileLaunchers","Weapons","AA"]],

--- a/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
@@ -112,13 +112,17 @@ private _categoryOverrideTable = [
 ["CUP_MK19_carry" , ["StaticWeaponParts","Items"]],
 ["CUP_SPG9_carry" , ["StaticWeaponParts","Items"]],
 
-["CUP_launch_M136", ["RocketLaunchers","Weapons"]],
-["CUP_launch_NLAW", ["RocketLaunchers","Weapons"]],
+
+["CUP_launch_M136", ["RocketLaunchers","Weapons","AT"]],
+["CUP_launch_NLAW", ["RocketLaunchers","Weapons","AT"]],
+/*
+// These work correctly now
 ["CUP_launch_FIM92Stinger", ["AA","Weapons"]],
 ["CUP_launch_Igla", ["AA","Weapons"]],
 ["CUP_launch_9K32Strela", ["MissileLaunchers","Weapons"]],
 ["CUP_launch_Metis", ["MissileLaunchers","Weapons"]],
 ["CUP_launch_Javelin", ["MissileLaunchers","Weapons"]],
+*/
 
 ["CUP_item_Money", ["Unknown","Items"]],
 ["CUP_item_Kostey_photos", ["Unknown","Items"]],
@@ -154,7 +158,7 @@ private _categoryOverrideTable = [
 ["vn_default_helmetbase_09", ["Unknown","Headgear"]],	//Goat Hat
 ["vn_m1897", ["Shotguns","Weapons"]],
 ["vn_izh54", ["Shotguns","Weapons"]],
-["vn_izh54_shorty", ["Shotguns","Weapons"]],
+["vn_izh54_shorty", ["Shotguns","Weapons"]],		// might be a handgun...
 ["vn_pps52", ["SMGs","Weapons"]],
 ["vn_pps43", ["SMGs","Weapons"]],
 ["vn_mc10", ["SMGs","Weapons"]],
@@ -169,7 +173,7 @@ private _categoryOverrideTable = [
 ["vn_sa7b", ["MissileLaunchers","Weapons"]],
 ["vn_sa7", ["MissileLaunchers","Weapons"]],
 ["vn_m4956_gl", ["GrenadeLaunchers","Weapons"]],
-["vn_m2carbine_gl", ["GrenadeLaunchers","Weapons"]],
+["vn_m2carbine_gl", ["GrenadeLaunchers","Weapons"]],		// some of these should be rifles/weapons/grenadelaunchers...
 ["vn_m1carbine_gl", ["GrenadeLaunchers","Weapons"]],
 ["vn_sks_gl", ["GrenadeLaunchers","Weapons"]],
 ["vn_type56", ["Rifles","Weapons"]],

--- a/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
@@ -159,7 +159,7 @@ private _categoryOverrideTable = [
 ["vn_default_helmetbase_09", ["Unknown","Headgear"]],	//Goat Hat
 ["vn_m1897", ["Shotguns","Weapons"]],
 ["vn_izh54", ["Shotguns","Weapons"]],
-["vn_izh54_shorty", ["Shotguns","Weapons"]],		// might be a handgun...
+["vn_izh54_shorty", ["Shotguns","Weapons"]],
 ["vn_pps52", ["SMGs","Weapons"]],
 ["vn_pps43", ["SMGs","Weapons"]],
 ["vn_mc10", ["SMGs","Weapons"]],
@@ -170,14 +170,24 @@ private _categoryOverrideTable = [
 ["vn_mat49_vc", ["SMGs","Weapons"]],
 ["vn_m3a1", ["SMGs","Weapons"]],
 ["vn_sten", ["SMGs","Weapons"]],
+["vn_mpu", ["SMGs","Weapons"]],
+["vn_vz61", ["SMGs","Weapons"]],
+["vn_m72", ["RocketLaunchers","Weapons","AT","Disposable"];
 ["vn_m79", ["GrenadeLaunchers","Weapons"]],
-["vn_sa7b", ["MissileLaunchers","Weapons"]],
-["vn_sa7", ["MissileLaunchers","Weapons"]],
-["vn_m4956_gl", ["GrenadeLaunchers","Weapons"]],
-["vn_m2carbine_gl", ["GrenadeLaunchers","Weapons"]],		// some of these should be rifles/weapons/grenadelaunchers...
-["vn_m1carbine_gl", ["GrenadeLaunchers","Weapons"]],
-["vn_sks_gl", ["GrenadeLaunchers","Weapons"]],
+["vn_sa7b", ["MissileLaunchers","Weapons","AA"]],
+["vn_sa7", ["MissileLaunchers","Weapons","AA"]],
+["vn_m2carbine", ["Rifles","Weapons"]],
+["vn_m2carbine_gl", ["Rifles","Weapons","GrenadeLaunchers"]],
+["vn_m1carbine", ["Rifles","Weapons"]],
+["vn_m1carbine_gl", ["Rifles","Weapons","GrenadeLaunchers"]],
+["vn_m3carbine", ["Rifles","Weapons"]],
+["vn_m4956_gl", ["Rifles","Weapons","GrenadeLaunchers"]],
+["vn_sks_gl", ["Rifles","Weapons","GrenadeLaunchers"]],				// plain versions left as SniperRifles. This is fine
 ["vn_type56", ["Rifles","Weapons"]],
+["vn_m63a_lmg", ["MachineGuns","Weapons"]],
+["vn_m63a_cdo", ["MachineGuns","Weapons"]],
+["vn_m127", ["Unknown","Weapons"]],								// flare launcher secondary
+["vn_mk1_udg", ["Unknown","Weapons"]],							// underwater defence gun
 
 //ACRE Radios
 //Using Gadgets instead of Radios to prevent future issues as they don't use the Radio Slot

--- a/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
@@ -39,7 +39,8 @@ private _categoryOverrideTable = [
 ["rhs_weap_m32", ["GrenadeLaunchers","Weapons"]],
 ["rhs_weap_m79", ["GrenadeLaunchers","Weapons"]],
 
-["B_rhsusf_B_BACKPACK", ["Unknown","Items"]],
+["B_rhsusf_B_BACKPACK", ["Unknown","Items"]],		// Drone backpack
+["UK3CB_BAF_L103A2", ["Unknown","Items"]],			// Drill practice rifle, no mags
 
 ["UK3CB_Enfield", ["SniperRifles","Weapons"]],
 ["UK3CB_Enfield_rail", ["SniperRifles","Weapons"]],
@@ -50,7 +51,7 @@ private _categoryOverrideTable = [
 
 ["UK3CB_BAF_Javelin_Launcher", ["MissileLaunchers","Weapons","AT"]],
 ["UK3CB_BAF_Javelin_CLU", ["Binoculars","Items"]],
-["UK3CB_BAF_Javelin_Slung_Tube", ["MissileLaunchers","Weapons","AT"]],
+["UK3CB_BAF_Javelin_Slung_Tube", ["StaticWeaponParts","Items"]],
 ["UK3CB_M79", ["GrenadeLaunchers","Weapons"]],
 ["UK3CB_BAF_AT4_CS_AT_Launcher", ["RocketLaunchers","Weapons","AT"]],
 ["UK3CB_BAF_AT4_CS_AP_Launcher", ["RocketLaunchers","Weapons","AT"]],
@@ -134,7 +135,7 @@ private _categoryOverrideTable = [
 
 ["CUP_smg_BallisticShield_MP7", ["Unknown","Weapons"]],
 
-["ace_dragon_super", ["MissileLaunchers","Weapons","AT"]],
+["ace_dragon_super", ["StaticWeaponParts","Items"]],
 ["ace_dragon_sight", ["Binoculars","Items"]],
 
 ["ACE_Kestrel4500", ["Gadgets","Items"]],

--- a/A3A/addons/core/functions/Ammunition/fn_equipmentClassToCategories.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_equipmentClassToCategories.sqf
@@ -140,7 +140,7 @@ call {
     };
 
     if (_basecategory == "Optics") exitWith {
-        if (isArray (configFile >> "CfgWeapons" >> _className >> "ace_scopeAdjust_vertical")) exitWith { _categories pushBack "OpticsLong" };
+        if (getNumber (configFile >> "CfgWeapons" >> _className >> "ace_scopeAdjust_verticalIncrement") > 0) exitWith { _categories pushBack "OpticsLong" };
         if !(isClass (configFile >> "CfgWeapons" >> _className >> "ItemInfo" >> "OpticsModes")) exitWith {};
         private _configs = "true" configClasses (configFile >> "CfgWeapons" >> _className >> "ItemInfo" >> "OpticsModes");
         private _rangeCat = "OpticsClose";

--- a/A3A/addons/core/functions/Ammunition/fn_equipmentClassToCategories.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_equipmentClassToCategories.sqf
@@ -140,6 +140,7 @@ call {
     };
 
     if (_basecategory == "Optics") exitWith {
+        if (isArray (configFile >> "CfgWeapons" >> _className >> "ace_scopeAdjust_vertical")) exitWith { _categories pushBack "OpticsLong" };
         if !(isClass (configFile >> "CfgWeapons" >> _className >> "ItemInfo" >> "OpticsModes")) exitWith {};
         private _configs = "true" configClasses (configFile >> "CfgWeapons" >> _className >> "ItemInfo" >> "OpticsModes");
         private _rangeCat = "OpticsClose";

--- a/A3A/addons/core/functions/Ammunition/fn_equipmentClassToCategories.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_equipmentClassToCategories.sqf
@@ -96,55 +96,106 @@ if (_aggregateCategory != "") then {
     _categories pushBack _aggregateCategory;
 };
 
-//Every explosive is a magazine.
 if (_aggregateCategory == "Explosives") then {
-    _categories pushBack "Magazines";
+    _categories pushBack "Magazines";         //Every explosive is a magazine.
+    // Charge detection. Not great, detects everything with vanilla time/remote trigger placement
+    // except the CUP satchel charge which somehow dodges the "Mine" part
+    if (_baseCategory == "Mine") then {
+        private _magcfg = configFile >> "CfgMagazines" >> _classname;
+        private _ammocfg = configFile / "CfgAmmo" / getText (_magcfg / "ammo");
+        if (getText (_ammoCfg / "mineTrigger") == "remotetrigger") then { _categories pushBack "ExplosiveCharges" };
+    };
 };
 
-if (_baseCategory == "RocketLaunchers") then {
-    _categories pushBack "AT";
-};
-
-if (_baseCategory == "MissileLaunchers") then {
-    private _launcherInfo = [_className] call A3A_fnc_launcherInfo;
-
-    //If we can lock air, it's AA.
-    if (_launcherInfo select 1) then {
-        _categories pushBack "AA";
+call {
+    if (_baseCategory == "Rifles") exitWith {
+        private _config = configfile >> "CfgWeapons" >> _className;
+        private _muzzles = getArray (_config >> "muzzles");
+        // workaround for RHS having an extra muzzle for "SAFE"
+        if (count _muzzles >= 2 && {"gl" == getText (_config >> (_muzzles select 1) >> "cursorAim")}) then {
+            _categories pushBack "GrenadeLaunchers";
+        };
     };
 
-    //If we can lock ground, or can't lock either air or ground, it's AT.
-    if (_launcherInfo select 0 || !(_launcherInfo select 0 || _launcherInfo select 1)) then {
+    if (_basecategory == "Vests") exitWith {
+        if (getNumber (configfile >> "CfgWeapons" >> _className >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Chest" >> "armor") > 5) then {
+            _categories pushBack "ArmoredVests";
+        };
+    };
+
+    if (_basecategory == "Headgear") exitWith {
+        if (getNumber (configfile >> "CfgWeapons" >> _className >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Head" >> "armor") > 0) then {
+            _categories pushBack "ArmoredHeadgear";
+        };
+    };
+
+    if (_basecategory == "Backpacks") exitWith {
+        // 160 = assault pack. Just a way to limit which backpacks friendly AI are using.
+        if (getNumber (configFile >> "CfgVehicles" >> _className >> "maximumLoad") >= 160) then {
+            _categories pushBack "BackpacksCargo";
+        };
+    };
+
+    if (_basecategory == "Optics") exitWith {
+        // Do we care about anything except the max range optic here?
+        if !(isClass (configFile >> "CfgWeapons" >> _className >> "ItemInfo" >> "OpticsModes")) exitWith {};
+        private _configs = "true" configClasses (configFile >> "CfgWeapons" >> _className >> "ItemInfo" >> "OpticsModes");
+        private _maxzoom = 0.25;
+        { _maxzoom = _maxzoom min getNumber (_x >> "opticsZoomMin") } forEach _configs;
+        if (_maxzoom >= 0.2 ) exitWith { _categories pushBack "OpticsClose" };         // reflex typically 0.25
+        if (_maxzoom >= 0.0625 ) exitWith { _categories pushBack "OpticsMid" };        // su230 etc
+        _categories pushBack "OpticsLong";
+    };
+
+    if (_baseCategory == "RocketLaunchers") exitWith {
         _categories pushBack "AT";
+        private _config = configFile >> "CfgWeapons" >> _classname; 
+        if (getNumber (_config >> "rhs_disposable") == 1 or {getArray (_config >> "magazines") # 0 == "CBA_fakeLauncherMagazine"}) then {
+            // Need to consider scope 1 stuff in case it ends up in arsenal, or this function is used on equipped/dropped items
+            if (getNumber (_config >> "scope") == 1) then { _categories set [0, "UsedLaunchers"] };
+            _categories pushBack "Disposable";
+        };
     };
+
+    if (_baseCategory == "MissileLaunchers") exitWith {
+        private _config = configFile >> "CfgWeapons" >> _classname; 
+        private _mainmag = getArray (_config >> "Magazines") # 0;
+        if (getNumber (_config >> "rhs_disposable") == 1 or _mainmag == "CBA_fakeLauncherMagazine") then {
+            _categories pushBack "Disposable";
+            if (getNumber (_config >> "scope") == 1) exitWith { _categories set [0, "UsedLaunchers"] };
+            if (_mainmag == "CBA_fakeLauncherMagazine" and !isNil "cba_disposable_normalLaunchers") then {
+                _mainmag = (cba_disposable_normalLaunchers getVariable _classname) # 1;     // format is [realLauncher, magazine]
+            };
+        };
+        if (_categories#0 == "UsedLaunchers") exitWith {};
+        // Should now have a real magazine
+        private _magcfg = configFile >> "CfgMagazines" >> _mainmag;
+        private _ammocfg = configFile >> "CfgAmmo" >> getText (_magcfg >> "ammo");
+        _categories pushBack (["AT", "AA"] select (getNumber (_ammocfg >> "airLock") == 2));
+    };
+
+    if (_basecategory == "MagSmokeShell") exitWith {
+        private _nameSound = getText(configfile >> "CfgMagazines" >> _classname >> "nameSound");
+        call {
+            if (_nameSound == "smokeshell") exitWith { _categories pushBack "SmokeGrenades" };
+            if (_nameSound == "ChemLight") exitWith { _categories pushBack "Chemlights" };
+            if (_nameSound == "") exitWith { _categories pushBack "LaunchedSmokeGrenades" };
+        };
+    };
+
+    if (_baseCategory == "NVGs") exitWith {
+        private _thermal = getArray (configFile >> "CfgWeapons" >> _classname >> "thermalMode");
+        if (_thermal isNotEqualTo []) then { _categories pushBack "NVGThermal" };
+    };
+
+    if (_baseCategory == "PointerAttachments") exitWith {
+        private _isLight = isClass(configfile >> "CfgWeapons" >> _classname >> "ItemInfo" >> "FlashLight" >> "Attenuation");
+        _categories pushBack (["LaserAttachments", "LightAttachments"] select _isLight);
+    };
+
 };
 
-if (_baseCategory == "Rifles") then {
-    private _config = configfile >> "CfgWeapons" >> _className;
-    private _muzzles = getArray (_config >> "muzzles");
-    // workaround for RHS having an extra muzzle for "SAFE"
-    if (count _muzzles >= 2 && {"gl" == getText (_config >> (_muzzles select 1) >> "cursorAim")}) then {
-        _categories pushBack "GrenadeLaunchers";
-    };
-};
-
-if (_basecategory == "Vests") then {
-    if (getNumber (configfile >> "CfgWeapons" >> _className >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Chest" >> "armor") > 5) then {
-        _categories pushBack "ArmoredVests";
-    };
-};
-
-if (_basecategory == "Headgear") then {
-    if (getNumber (configfile >> "CfgWeapons" >> _className >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Head" >> "armor") > 0) then {
-        _categories pushBack "ArmoredHeadgear";
-    };
-};
-
-if (_basecategory == "Backpacks") then {
-    // 160 = assault pack. Just a way to limit which backpacks friendly AI are using.
-    if (getNumber (configFile >> "CfgVehicles" >> _className >> "maximumLoad") >= 160) then {
-        _categories pushBack "BackpacksCargo";
-    };
-};
+// Add to cache for future use
+categoryOverrides setVariable [_classname, _categories];
 
 _categories;

--- a/A3A/addons/core/functions/Ammunition/fn_equipmentClassToCategories.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_equipmentClassToCategories.sqf
@@ -143,7 +143,7 @@ call {
         private _maxzoom = 0.25;
         { _maxzoom = _maxzoom min getNumber (_x >> "opticsZoomMin") } forEach _configs;
         if (_maxzoom >= 0.2 ) exitWith { _categories pushBack "OpticsClose" };         // reflex typically 0.25
-        if (_maxzoom >= 0.0625 ) exitWith { _categories pushBack "OpticsMid" };        // su230 etc
+        if (_maxzoom >= 0.04 ) exitWith { _categories pushBack "OpticsMid" };        // 6.25x, includes RHS SU260/MDO
         _categories pushBack "OpticsLong";
     };
 

--- a/A3A/addons/core/functions/Ammunition/fn_fetchRebelGear.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_fetchRebelGear.sqf
@@ -1,0 +1,24 @@
+/*
+    Ensures A3A_rebelGear and related caches are valid and updated for equipping rebel AIs
+
+Parameters:
+    None, returns nothing
+
+Environment:
+    Scheduled, executed anywhere
+*/
+
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+
+// Send current version of rebelGear from server if we're out of date
+if (!isNil "A3A_rebelGear" and { A3A_rebelGear get "Version" == A3A_rebelGearVersion}) exitWith {};
+
+Info("Fetching new version of rebelGear data...");
+[clientOwner, "A3A_rebelGear"] remoteExecCall ["publicVariableClient", 2];
+waitUntil { sleep 1; !isNil "A3A_rebelGear" and { A3A_rebelGear get "Version" == A3A_rebelGearVersion } };
+Info("New version of rebelGear data received");
+
+// Create/clear local accessory-compatibility caches
+A3A_rebelOpticsCache = createHashMap;
+A3A_rebelFlashlightsCache = createHashMap;

--- a/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
@@ -110,7 +110,7 @@ private _uvests = [];
 } forEach (jna_datalist select IDC_RSCDISPLAYARSENAL_TAB_VEST);
 
 _rebelGear set ["ArmoredVests", _avests];
-_rebelGear set ["UnarmoredVests", _uvests];          // not a category name, but whatever
+_rebelGear set ["CivilianVests", _uvests];
 
 // Helmet filtering
 private _aheadgear = ["", [1.5,0.5] select (minWeaps < 0)];     // blank entry to phase in armour use gradually
@@ -123,7 +123,7 @@ private _uheadgear = [];
 } forEach (jna_datalist select IDC_RSCDISPLAYARSENAL_TAB_HEADGEAR);
 
 _rebelGear set ["ArmoredHeadgear", _aheadgear];
-//_rebelGear set ["UnarmoredHeadgear", _uheadgear];           // not used, rebels have template-defined basic headgear
+//_rebelGear set ["CosmeticHeadgear", _uheadgear];           // not used, rebels have template-defined basic headgear
 
 // Backpack filtering
 private _backpacks = [];

--- a/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
@@ -31,6 +31,13 @@ private _fnc_addItemUnlocks = {
     if (_amount < 0) exitWith { _array append [_class, 1] };
 };
 
+private _fnc_magCount = {
+    private _defaultMag = getArray (configFile >> "CfgWeapons" >> _this >> "Magazines") # 0;
+    if (isNil "_defaultMag") exitWith { Error_1("Weapon class %1 has no magazines", _this); 0 };
+    private _magcount = _magLookup getOrDefault [_defaultMag, 0];
+    [_magCount, 1e6] select (_magCount < 0);
+};
+
 private _fnc_addItem = [_fnc_addItemUnlocks, _fnc_addItemNoUnlocks] select (minWeaps < 0);
 
 // First make a lookup for magazines
@@ -50,8 +57,7 @@ private _gl = [];
 {
     _x params ["_class", "_amount"];
     private _categories = _class call A3A_fnc_equipmentClassToCategories;
-    private _bullets = _magLookup getOrDefault [getArray (configFile >> "CfgWeapons" >>_class >> "Magazines") # 0, 0];
-    if (_bullets < 0) then { _bullets = 1e6 };
+    private _bullets = _class call _fnc_magCount;
 
     call {
         if ("GrenadeLaunchers" in _categories) exitWith { [_gl, _class, _amount min _bullets/150] call _fnc_addItem };       // call before rifles
@@ -78,8 +84,7 @@ private _mlaunchersAA = [];
     _x params ["_class", "_amount"];
     private _categories = _class call A3A_fnc_equipmentClassToCategories;
     if !("Disposable" in _categories) then {
-        private _magcount = _magLookup getOrDefault [getArray (configFile >> "CfgWeapons" >>_class >> "Magazines") # 0, 0];
-        if (_magCount < 0) then { _magCount = 1e6 };
+        private _magcount = _class call _fnc_magCount;
         _amount = _amount min (_magcount/2);
     };
 

--- a/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
@@ -1,0 +1,241 @@
+/*
+    Generate the rebel gear array for equipping AIs
+
+Parameters:
+    No parameters, returns nothing
+
+Environment:
+    Server, scheduled or unscheduled
+*/
+
+#include "..\..\script_component.hpp"
+#include "\A3\Ui_f\hpp\defineResinclDesign.inc"     // jna_datalist indices
+FIX_LINE_NUMBERS()
+if (!isServer) exitWith { Error("Server-only function miscalled") };
+Info("Started updating A3A_rebelGear");
+
+// Base weight mappings, MIN->0, MAX->1
+#define ITEM_MIN 10
+#define ITEM_MAX 50
+
+private _fnc_addItemNoUnlocks = {
+    params ["_array", "_class", "_amount"];
+    if (_amount < 0) exitWith { _array append [_class, 1] };
+    if (_amount <= ITEM_MIN) exitWith {};
+    _array pushBack _class;
+    _array pushBack linearConversion [ITEM_MIN, ITEM_MAX, _amount, 0, 1, true];
+};
+
+private _fnc_addItemUnlocks = {
+    params ["_array", "_class", "_amount"];
+    if (_amount < 0) exitWith { _array append [_class, 1] };
+};
+
+private _fnc_addItem = [_fnc_addItemUnlocks, _fnc_addItemNoUnlocks] select (minWeaps < 0);
+
+// First make a lookup for magazines
+private _magLookup = createHashMapFromArray (jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL);
+
+// Work with temporary array so that we're not transferring partials
+private _rebelGear = createHashMap;
+
+
+// Primary weapon filtering
+private _rifle = [];
+private _smg = [];
+private _shotgun = [];
+private _sniper = [];
+private _mg = [];
+private _gl = [];
+{
+    _x params ["_class", "_amount"];
+    private _categories = _class call A3A_fnc_equipmentClassToCategories;
+    private _bullets = _magLookup getOrDefault [getArray (configFile >> "CfgWeapons" >>_class >> "Magazines") # 0, 0];
+    if (_bullets < 0) then { _bullets = 1e6 };
+
+    call {
+        if ("GrenadeLaunchers" in _categories) exitWith { [_gl, _class, _amount min _bullets/150] call _fnc_addItem };       // call before rifles
+        if ("Rifles" in _categories) exitWith { [_rifle, _class, _amount/2 min _bullets/150] call _fnc_addItem };
+        if ("SniperRifles" in _categories) exitWith { [_sniper, _class, _amount min _bullets/50] call _fnc_addItem };
+        if ("MachineGuns" in _categories) exitWith { [_mg, _class, _amount min _bullets/300] call _fnc_addItem };
+        if ("SMGs" in _categories) exitWith { [_smg, _class, _amount min _bullets/150] call _fnc_addItem };
+        if ("Shotguns" in _categories) exitWith { [_shotgun, _class, _amount min _bullets/50] call _fnc_addItem };
+    };
+} forEach (jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON);
+
+_rebelGear set ["Rifles", _rifle];
+_rebelGear set ["SMGs", _smg];
+_rebelGear set ["Shotguns", _shotgun];
+_rebelGear set ["MachineGuns", _mg];
+_rebelGear set ["SniperRifles", _sniper];
+_rebelGear set ["GrenadeLaunchers", _gl];
+
+// Secondary weapon filtering
+private _rlaunchers = [];
+private _mlaunchersAT = [];
+private _mlaunchersAA = [];
+{
+    _x params ["_class", "_amount"];
+    private _categories = _class call A3A_fnc_equipmentClassToCategories;
+    if !("Disposable" in _categories) then {
+        private _magcount = _magLookup getOrDefault [getArray (configFile >> "CfgWeapons" >>_class >> "Magazines") # 0, 0];
+        if (_magCount < 0) then { _magCount = 1e6 };
+        _amount = _amount min (_magcount/2);
+    };
+
+    if ("RocketLaunchers" in _categories) then { [_rlaunchers, _class, _amount] call _fnc_addItem; continue };
+    if ("MissileLaunchers" in _categories) then {
+        if ("AA" in _categories) exitWith { [_mlaunchersAA, _class, _amount] call _fnc_addItem };
+        if ("AT" in _categories) exitWith { [_mlaunchersAT, _class, _amount] call _fnc_addItem };
+    };
+} forEach (jna_datalist select IDC_RSCDISPLAYARSENAL_TAB_SECONDARYWEAPON);
+
+_rebelGear set ["RocketLaunchers", _rlaunchers];
+_rebelGear set ["MissileLaunchersAT", _mlaunchersAT];
+_rebelGear set ["MissileLaunchersAA", _mlaunchersAA];
+
+// Vest filtering
+private _avests = ["", [1.5,0.5] select (minWeaps < 0)];     // blank entry to phase in armour use gradually
+private _uvests = [];
+{
+    _x params ["_class", "_amount"];
+    private _categories = _class call A3A_fnc_equipmentClassToCategories;
+    private _array = [_uvests, _avests] select ("ArmoredVests" in _categories);
+    [_array, _class, _amount] call _fnc_addItem;
+} forEach (jna_datalist select IDC_RSCDISPLAYARSENAL_TAB_VEST);
+
+_rebelGear set ["ArmoredVests", _avests];
+_rebelGear set ["UnarmoredVests", _uvests];          // not a category name, but whatever
+
+// Helmet filtering
+private _aheadgear = ["", [1.5,0.5] select (minWeaps < 0)];     // blank entry to phase in armour use gradually
+private _uheadgear = [];
+{
+    _x params ["_class", "_amount"];
+    private _categories = _class call A3A_fnc_equipmentClassToCategories;
+    private _array = [_uheadgear, _aheadgear] select ("ArmoredHeadgear" in _categories);
+    [_array, _class, _amount] call _fnc_addItem;
+} forEach (jna_datalist select IDC_RSCDISPLAYARSENAL_TAB_HEADGEAR);
+
+_rebelGear set ["ArmoredHeadgear", _aheadgear];
+//_rebelGear set ["UnarmoredHeadgear", _uheadgear];           // not used, rebels have template-defined basic headgear
+
+// Backpack filtering
+private _backpacks = [];
+{
+    _x params ["_class", "_amount"];
+    private _categories = _class call A3A_fnc_equipmentClassToCategories;
+    if ("BackpacksCargo" in _categories) then { [_backpacks, _class, _amount] call _fnc_addItem };
+} forEach (jna_datalist select IDC_RSCDISPLAYARSENAL_TAB_BACKPACK);
+
+_rebelGear set ["BackpacksCargo", _backpacks];
+
+// NVG filtering
+private _nvgs = ["", 0.5];          // blank entry for phase-in
+{
+    _x params ["_class", "_amount"];
+    private _categories = _class call A3A_fnc_equipmentClassToCategories;
+    if !("NVGThermal" in _categories) then { [_nvgs, _class, _amount] call _fnc_addItem };
+} forEach (jna_datalist select IDC_RSCDISPLAYARSENAL_TAB_NVGS);
+
+_rebelGear set ["NVGs", _nvgs];
+
+// Unfiltered stuff (just radios atm? could add GPS)
+private _radios = [];
+{ [_radios, _x#0, _x#1] call _fnc_addItem } forEach (jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_RADIO);
+_rebelGear set ["Radios", _radios];
+
+// Misc items. Don't really need weighting but whatever
+private _minedetectors = [];
+private _toolkits = [];
+private _medikits = [];
+{
+    _x params ["_class", "_amount"];
+    private _categories = _class call A3A_fnc_equipmentClassToCategories;
+    call {
+        if ("MineDetectors" in _categories) exitWith { [_minedetectors, _class, _amount] call _fnc_addItem };
+        if ("Toolkits" in _categories) exitWith { [_toolkits, _class, _amount] call _fnc_addItem };
+        if ("Medikits" in _categories) exitWith { [_medikits, _class, _amount] call _fnc_addItem };
+    };
+} forEach (jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_CARGOMISC);
+
+_rebelGear set ["MineDetectors", _minedetectors];
+_rebelGear set ["Toolkits", _toolkits];
+_rebelGear set ["Medikits", _medikits];
+
+// Hand grenades
+private _smokes = [];
+private _nades = [];
+{
+    _x params ["_class", "_amount"];
+    private _categories = _class call A3A_fnc_equipmentClassToCategories;
+    call {
+        if ("SmokeGrenades" in _categories) exitWith { [_smokes, _class, _amount] call _fnc_addItem };
+        if ("Grenades" in _categories) exitWith { [_nades, _class, _amount] call _fnc_addItem };
+    };
+} forEach (jna_datalist select IDC_RSCDISPLAYARSENAL_TAB_CARGOTHROW);
+
+_rebelGear set ["SmokeGrenades", _smokes];
+_rebelGear set ["Grenades", _nades];
+
+// Explosives. Could add mines but don't want them atm.
+private _charges = [];
+{
+    _x params ["_class", "_amount"];
+    private _categories = _class call A3A_fnc_equipmentClassToCategories;
+    if ("ExplosiveCharges" in _categories) then { [_charges, _class, _amount] call _fnc_addItem };
+} forEach (jna_datalist select IDC_RSCDISPLAYARSENAL_TAB_CARGOPUT);
+
+_rebelGear set ["ExplosiveCharges", _charges];
+
+// Optic filtering. No weighting because of weapon compatibilty complexity
+private _opticClose = [];
+private _opticMid = [];
+private _opticLong = [];
+{
+    _x params ["_class", "_amount"];
+    if (_amount > 0 and {minWeaps > 0 or _amount < ITEM_MIN}) then { continue };
+    private _categories = _class call A3A_fnc_equipmentClassToCategories;
+    call {
+        if ("OpticsMid" in _categories) exitWith { _opticMid pushBack _class };        // most common first
+        if ("OpticsClose" in _categories) exitWith { _opticClose pushBack _class };
+        if ("OpticsLong" in _categories) exitWith { _opticLong pushBack _class };
+    };
+} forEach (jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_ITEMOPTIC);
+
+_rebelGear set ["OpticsClose", _opticClose];
+_rebelGear set ["OpticsMid", _opticMid];
+_rebelGear set ["OpticsLong", _opticLong];
+_rebelGear set ["OpticsAll", _opticClose + _opticMid + _opticLong];     // for launchers
+
+// Light attachments, also no weights because of weapon compat
+private _lights = [];
+{
+    _x params ["_class", "_amount"];
+    if (_amount > 0 and {minWeaps > 0 or _amount < ITEM_MIN}) then { continue };
+    private _categories = _class call A3A_fnc_equipmentClassToCategories;
+    if ("LightAttachments" in _categories) then { _lights pushBack _class };
+} forEach (jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_ITEMACC);
+
+_rebelGear set ["LightAttachments", _lights];
+
+// Update everything while unscheduled so that version numbers match
+isNil {
+    A3A_rebelGearVersion = time;
+    _rebelGear set ["Version", A3A_rebelGearVersion];
+    A3A_rebelGear = _rebelGear;
+
+    // Clear these two locally
+    A3A_rebelOpticsCache = createHashMap;
+    A3A_rebelFlashlightsCache = createHashMap;
+};
+// Only broadcast the version number so that clients & HCs can request as required
+publicVariable "A3A_rebelGearVersion";
+
+Info("Finished updating A3A_rebelGear");
+
+/*
+// Alternatively just broadcast it
+A3A_rebelGear = _rebelGear;
+publicVariable "A3A_rebelGear";
+*/

--- a/A3A/addons/core/functions/Ammunition/fn_itemSort.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_itemSort.sqf
@@ -1,3 +1,4 @@
+/*
 //Lights Vs Laser ID
 {
 if (isClass(configfile >> "CfgWeapons" >> _x >> "ItemInfo" >> "FlashLight" >> "Attenuation")) then
@@ -9,7 +10,8 @@ if (isClass(configfile >> "CfgWeapons" >> _x >> "ItemInfo" >> "FlashLight" >> "A
      allLaserAttachments pushBack _x;
      };
 } forEach allPointerAttachments;
-
+*/
+/*
 //Signal Mags ID
 {
 if (getText(configfile >> "CfgMagazines" >> _x >> "nameSound") isEqualTo "Chemlight") then
@@ -25,6 +27,7 @@ if (getText(configfile >> "CfgMagazines" >> _x >> "nameSound") isEqualTo "") the
      allLaunchedSmokeGrenades pushback _x;
      };
 } forEach allMagSmokeShell;
+*/
 
 //Flares ID
 //PBP - NOT WORKING

--- a/A3A/addons/core/functions/Ammunition/fn_randomRifle.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_randomRifle.sqf
@@ -27,7 +27,7 @@ if (_pool isEqualTo []) then {
     if (_pool isEqualTo []) then {
         _pool = A3A_rebelGear get "SMGs";
         if (_pool isEqualTo []) then {
-            _pool = A3A_rebelGear get "Shotguns" + A3A_rebelGear get "SniperRifles";
+            _pool = (A3A_rebelGear get "Shotguns") + (A3A_rebelGear get "SniperRifles");
         };
     };
 };

--- a/A3A/addons/core/functions/Ammunition/fn_randomRifle.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_randomRifle.sqf
@@ -1,37 +1,78 @@
-private _unit = _this select 0;
-private _pool = _this select 1;
+/*
+    Equip unit with random weapon of preferred type using A3A_rebelGear
+    Adds magazines by mass. Uses default magazine of selected weapon
+
+Parameters:
+    0. <OBJECT> Rebel unit to equip with primary weapon.
+    1. <STRING> Preferred weapon type ("Rifles", "MachineGuns" etc).
+    2. <NUMBER> Optional, total mass of carried magazines to add.
+
+Returns:
+    Nothing
+
+Environment:
+    Scheduled, any machine
+*/
+
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+
+params ["_unit", "_weaponType", ["_totalMagWeight", 50]];
+
+call A3A_fnc_fetchRebelGear;        // Send current version of rebelGear from server if we're out of date
+
+private _pool = A3A_rebelGear get _weaponType;
 if (_pool isEqualTo []) then {
-	if !(unlockedRifles isEqualTo []) then {
-		_pool = unlockedRifles;
-	} else {
-		if !(unlockedSMGs isEqualTo []) then {
-			_pool = unlockedSMGs;
-		} else {
-			_pool = unlockedShotguns + unlockedSniperRifles;
-		};
-	};
+    _pool = A3A_rebelGear get "Rifles";
+    if (_pool isEqualTo []) then {
+        _pool = A3A_rebelGear get "SMGs";
+        if (_pool isEqualTo []) then {
+            _pool = A3A_rebelGear get "Shotguns" + A3A_rebelGear get "SniperRifles";
+        };
+    };
 };
-private _rifleFinal = selectRandom _pool;
+private _weapon = selectRandomWeighted _pool;
 
+// Probably shouldn't ever be executed
 if !(primaryWeapon _unit isEqualTo "") then {
-	if (_rifleFinal == primaryWeapon _unit) exitWith {};
-	private _magazines = getArray (configFile / "CfgWeapons" / (primaryWeapon _unit) / "magazines");
-	{_unit removeMagazines _x} forEach _magazines;			// Broken, doesn't remove mags globally. Pain to fix.
-	_unit removeWeapon (primaryWeapon _unit);
+    if (_weapon == primaryWeapon _unit) exitWith {};
+    private _magazines = getArray (configFile / "CfgWeapons" / (primaryWeapon _unit) / "magazines");
+    {_unit removeMagazines _x} forEach _magazines;			// Broken, doesn't remove mags globally. Pain to fix.
+    _unit removeWeapon (primaryWeapon _unit);
 };
 
-if (_rifleFinal in unlockedGrenadeLaunchers && {_rifleFinal in unlockedRifles} ) then {
-	// lookup real underbarrel GL magazine, because not everything is 40mm
-	private _config = configFile >> "CfgWeapons" >> _rifleFinal;
-	private _glmuzzle = getArray (_config >> "muzzles") select 1;		// guaranteed by category
-	private _glmag = getArray (_config >> _glmuzzle >> "magazines") select 0;
-	_unit addMagazines [_glmag, 5];
+private _categories = _weapon call A3A_fnc_equipmentClassToCategories;
+
+if ("GrenadeLaunchers" in _categories && {"Rifles" in _categories} ) then {
+    // lookup real underbarrel GL magazine, because not everything is 40mm
+    private _config = configFile >> "CfgWeapons" >> _weapon;
+    private _glmuzzle = getArray (_config >> "muzzles") select 1;		// guaranteed by category?
+    private _glmag = getArray (_config >> _glmuzzle >> "magazines") select 0;
+    _unit addMagazines [_glmag, 5];
 };
 
-[_unit, _rifleFinal, 5, 0] call BIS_fnc_addWeapon;
+private _magazine = getArray (configFile >> "CfgWeapons" >> _weapon >> "magazines") select 0;
+private _magweight = 5 max getNumber (configFile >> "CfgMagazines" >> _magazine >> "mass");
 
-if (count unlockedOptics > 0) then {
-	private _compatibleX = [primaryWeapon _unit] call BIS_fnc_compatibleItems;
-	private _potentials = unlockedOptics select {_x in _compatibleX};
-	if (count _potentials > 0) then {_unit addPrimaryWeaponItem (selectRandom _potentials)};
+_unit addWeapon _weapon;
+_unit addPrimaryWeaponItem _magazine;
+_unit addMagazines [_magazine, round (random 0.5 + _totalMagWeight / _magWeight)];
+
+
+private _compatOptics = A3A_rebelOpticsCache get _weapon;
+if (isNil "_compatOptics") then {
+    private _compatItems = [_weapon] call BIS_fnc_compatibleItems;		// cached, should be fast
+    _compatOptics = _compatItems arrayIntersect call {
+        if (_weaponType in ["Rifles", "MachineGuns"]) exitWith { A3A_rebelGear get "OpticsMid" };
+        if (_weaponType == "SniperRifles") exitWith { A3A_rebelGear get "OpticsLong" };
+        A3A_rebelGear get "OpticsClose";
+    };
+    if (_compatOptics isEqualTo []) then {
+        _compatOptics = _compatItems arrayIntersect call {
+            if (_weaponType in ["Rifles", "MachineGuns"]) exitWith { A3A_rebelGear get "OpticsClose" };
+            A3A_rebelGear get "OpticsMid";
+        };
+    };
+    A3A_rebelOpticsCache set [_weapon, _compatOptics];
 };
+if (_compatOptics isNotEqualTo []) then { _unit addPrimaryWeaponItem (selectRandom _compatOptics) };

--- a/A3A/addons/core/functions/Base/fn_initPetros.sqf
+++ b/A3A/addons/core/functions/Base/fn_initPetros.sqf
@@ -8,7 +8,7 @@ petros setSkill 1;
 petros setVariable ["respawning",false];
 petros allowDamage false;
 private _vest = selectRandomWeighted (A3A_rebelGear get "ArmoredVests");
-if (_vest == "") then { _vest = selectRandomWeighted (A3A_rebelGear get "UnarmoredVests") };
+if (_vest == "") then { _vest = selectRandomWeighted (A3A_rebelGear get "CivilianVests") };
 petros addVest _vest;
 [petros, "Rifles"] call A3A_fnc_randomRifle;
 petros selectWeapon (primaryWeapon petros);

--- a/A3A/addons/core/functions/Base/fn_initPetros.sqf
+++ b/A3A/addons/core/functions/Base/fn_initPetros.sqf
@@ -7,11 +7,10 @@ removeGoggles petros;
 petros setSkill 1;
 petros setVariable ["respawning",false];
 petros allowDamage false;
-if !(unlockedVests isEqualTo []) then {
-	if (count unlockedArmoredVests * 20 < random(100)) then { petros addVest (selectRandom unlockedVests) }
-	else { petros addVest (selectRandom unlockedArmoredVests); };
-};
-[petros,unlockedRifles] call A3A_fnc_randomRifle;
+private _vest = selectRandomWeighted (A3A_rebelGear get "ArmoredVests");
+if (_vest == "") then { _vest = selectRandomWeighted (A3A_rebelGear get "UnarmoredVests") };
+petros addVest _vest;
+[petros, "Rifles"] call A3A_fnc_randomRifle;
 petros selectWeapon (primaryWeapon petros);
 [petros,true] call A3A_fnc_punishment_FF_addEH;
 petros addEventHandler

--- a/A3A/addons/core/functions/REINF/fn_dismissPlayerGroup.sqf
+++ b/A3A/addons/core/functions/REINF/fn_dismissPlayerGroup.sqf
@@ -44,7 +44,7 @@ _weaponsX = [];
 {_unit = _x;
 if ([_unit] call A3A_fnc_canFight) then
 	{
-	_resourcesFIA = _resourcesFIA + (server getVariable (_unit getVariable "unitType"));
+	_resourcesFIA = _resourcesFIA + (server getVariable (_unit getVariable "unitType")) / 2;
 	_hr = _hr +1;
 	{if (not(([_x] call BIS_fnc_baseWeapon) in unlockedWeapons)) then {_weaponsX pushBack ([_x] call BIS_fnc_baseWeapon)}} forEach weapons _unit;
 	{if (not(_x in unlockedMagazines)) then {_ammunition pushBack _x}} forEach magazines _unit;

--- a/A3A/addons/core/functions/REINF/fn_dismissSquad.sqf
+++ b/A3A/addons/core/functions/REINF/fn_dismissSquad.sqf
@@ -43,7 +43,7 @@ private _assignedVehicles =	[];
 		if (alive _x) then
 		{
 			_hr = _hr + 1;
-			_resourcesFIA = _resourcesFIA + (server getVariable [_x getVariable "unitType",0]);
+			_resourcesFIA = _resourcesFIA + (server getVariable [_x getVariable "unitType",0]) / 2;
 			if (!isNull (assignedVehicle _x) and {isNull attachedTo (assignedVehicle _x)}) then
 			{
 				_assignedVehicles pushBackUnique (assignedVehicle _x);

--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -23,11 +23,11 @@ private _fnc_addSecondaryAndMags = {
     params ["_unit", "_weapon", "_totalMagWeight"];
 
     _unit addWeapon _weapon;
-    if ("Disposable" in (_weapon call A3A_fnc_equipmentClassToCategories)) exitWith {};
-
     private _magazine = getArray (configFile / "CfgWeapons" / _weapon / "magazines") select 0;
-    _unit addSecondaryWeaponItem _magazine;
-    private _magWeight = 10 max getNumber (configFile / "CfgMagazines" / _magazine / "mass");
+    _unit addSecondaryWeaponItem _magazine;         // probably harmless at worst for CBA disposables
+
+    if ("Disposable" in (_weapon call A3A_fnc_equipmentClassToCategories)) exitWith {};
+    private _magWeight = 20 max getNumber (configFile / "CfgMagazines" / _magazine / "mass");
     _unit addMagazines [_magazine, round (random 0.5 + _totalMagWeight / _magWeight)];
 
     private _compatOptics = A3A_rebelOpticsCache get _weapon;

--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -27,7 +27,7 @@ private _fnc_addSecondaryAndMags = {
 
     private _magazine = getArray (configFile / "CfgWeapons" / _weapon / "magazines") select 0;
     _unit addSecondaryWeaponItem _magazine;
-    private _magWeight = getNumber (configFile / "CfgMagazines" / _magazine / "mass");
+    private _magWeight = 10 max getNumber (configFile / "CfgMagazines" / _magazine / "mass");
     _unit addMagazines [_magazine, round (random 0.5 + _totalMagWeight / _magWeight)];
 
     private _compatOptics = A3A_rebelOpticsCache get _weapon;

--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -61,7 +61,7 @@ if (_helmet == "") then { _helmet = selectRandom (A3A_faction_reb get "headgear"
 _unit addHeadgear _helmet;
 
 private _vest = selectRandomWeighted (A3A_rebelGear get "ArmoredVests");
-if (_vest == "") then { _vest = selectRandomWeighted (A3A_rebelGear get "UnarmoredVests") };
+if (_vest == "") then { _vest = selectRandomWeighted (A3A_rebelGear get "CivilianVests") };
 _unit addVest _vest;
 
 private _backpack = selectRandomWeighted (A3A_rebelGear get "BackpacksCargo");

--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -1,153 +1,173 @@
-// Fully equips a rebel infantry unit based on their class and unlocked gear
-// _recruitType param allows some variation based on recruiting method: 0 recruit, 1 HC squad, 2 garrison
+/*
+    Fully equips a rebel infantry unit based on their class and unlocked gear
 
-params ["_unit", "_recruitType"];
+Parameters:
+    0. <OBJECT> Unit to equip
+    1. <NUMBER> Recruit type: 0 recruit, 1 HC squad, 2 garrison. Doesn't currently have any effect
+
+Returns:
+    Nothing
+
+Environment:
+    Scheduled, any machine
+*/
+
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
 
-// Mostly exists because BIS_fnc_addWeapon won't use backpack space properly with AT launchers
-private _addWeaponAndMags = {
-	params["_unit", "_weapon", "_magCount"];
+params ["_unit", "_recruitType"];
 
-	if !(isClass (configFile / "CfgWeapons" / _weapon)) exitwith {
-		[1, format ["Bad weapon class: %1", _weapon], _filename, true] call A3A_log;
-	};
+call A3A_fnc_fetchRebelGear;        // Send current version of rebelGear from server if we're out of date
 
-	_unit addWeapon _weapon;
-	private _magazine = getArray (configFile / "CfgWeapons" / _weapon / "magazines") select 0;
-	_unit addSecondaryWeaponItem _magazine;
-	_unit addMagazines [_magazine, _magCount-1];
+private _fnc_addSecondaryAndMags = {
+    params ["_unit", "_weapon", "_totalMagWeight"];
+
+    _unit addWeapon _weapon;
+    if ("Disposable" in (_weapon call A3A_fnc_equipmentClassToCategories)) exitWith {};
+
+    private _magazine = getArray (configFile / "CfgWeapons" / _weapon / "magazines") select 0;
+    _unit addSecondaryWeaponItem _magazine;
+    private _magWeight = getNumber (configFile / "CfgMagazines" / _magazine / "mass");
+    _unit addMagazines [_magazine, round (random 0.5 + _totalMagWeight / _magWeight)];
+
+    private _compatOptics = A3A_rebelOpticsCache get _weapon;
+    if (isNil "_compatOptics") then {
+        private _compatItems = [_weapon] call BIS_fnc_compatibleItems;		// cached, should be fast
+        _compatOptics = _compatItems arrayIntersect (A3A_rebelGear get "OpticsAll");
+        A3A_rebelOpticsCache set [_weapon, _compatOptics];
+    };
+    if (_compatOptics isNotEqualTo []) then { _unit addSecondaryWeaponItem (selectRandom _compatOptics) };
 };
 
-if (haveRadio) then {_unit linkItem selectrandom (unlockedRadios)};
+private _fnc_addCharges = {
+    params ["_unit", "_totalWeight"];
 
-// Chance of picking armored rather than random vests and headgear, rising with unlocked gear counts
-if !(unlockedHeadgear isEqualTo []) then {
-	if (count unlockedArmoredHeadgear * 20 < random(100)) then { _unit addHeadgear (selectRandom (A3A_faction_reb get "headgear")) }
-	else { _unit addHeadgear (selectRandom unlockedArmoredHeadgear) };
+    private _charges = A3A_rebelGear get "ExplosiveCharges";
+    if (_charges isEqualTo []) exitWith {};
+
+    private _weight = 0;
+    while { _weight < _totalWeight } do {
+        private _charge = selectRandomWeighted _charges;
+        _weight = _weight + getNumber (configFile / "CfgMagazines" / _charge / "mass");
+        _unit addItemToBackpack _charge;
+    };
 };
-if !(unlockedVests isEqualTo []) then {
-	if (count unlockedArmoredVests * 20 < random(100)) then { _unit addVest (selectRandom unlockedVests) }
-	else { _unit addVest (selectRandom unlockedArmoredVests); };
-};
-if !(unlockedBackpacksCargo isEqualTo []) then { _unit addBackpack (selectRandom unlockedBackpacksCargo) };
 
-// this should be improved by categorising grenades properly
-private _unlockedSmokes = allSmokeGrenades arrayIntersect unlockedMagazines;
-if !(_unlockedSmokes isEqualTo []) then { _unit addMagazines [selectRandom _unlockedSmokes, 2] };
+private _radio = selectRandomWeighted (A3A_rebelGear get "Radios");
+if (!isNil "_radio") then {_unit linkItem _radio};
 
+private _helmet = selectRandomWeighted (A3A_rebelGear get "ArmoredHeadgear");
+if (_helmet == "") then { _helmet = selectRandom (A3A_faction_reb get "headgear") };
+_unit addHeadgear _helmet;
 
+private _vest = selectRandomWeighted (A3A_rebelGear get "ArmoredVests");
+if (_vest == "") then { _vest = selectRandomWeighted (A3A_rebelGear get "UnarmoredVests") };
+_unit addVest _vest;
+
+private _backpack = selectRandomWeighted (A3A_rebelGear get "BackpacksCargo");
+if !(isNil "_backpack") then { _unit addBackpack _backpack };
+
+private _smokes = A3A_rebelGear get "SmokeGrenades";
+if (_smokes isNotEqualTo []) then { _unit addMagazines [selectRandomWeighted _smokes, 1] };
+private _grenades = A3A_rebelGear get "Grenades";
+if (_grenades isNotEqualTo []) then { _unit addMagazines [selectRandomWeighted _grenades, 1] };
+
+// TODO: add types unitAA and unitAT(name?) when UI is ready
 private _unitType = _unit getVariable "unitType";
-switch (true) do {
-	case (_unitType isEqualTo FactionGet(reb,"unitSniper")): {
-		if (count unlockedSniperRifles > 0) then {
-			[_unit, selectRandom unlockedSniperRifles, 8] call _addWeaponAndMags;
-			if (count unlockedOptics > 0) then {
-				private _compatibleX = [primaryWeapon _unit] call BIS_fnc_compatibleItems;
-				private _potentials = unlockedOptics select {_x in _compatibleX};
-				if (count _potentials > 0) then {_unit addPrimaryWeaponItem (_potentials select 0)};
-			};
-		} else {
-			[_unit,unlockedRifles] call A3A_fnc_randomRifle;
-		};
-	};
-	case (_unitType isEqualTo FactionGet(reb,"unitRifle")): {
-		[_unit,unlockedRifles] call A3A_fnc_randomRifle;
-		// Adding AA launchers to garrison riflemen because explosives guys can't currently be purchased there
-		if (_recruitType == 2 && {count unlockedAA > 0}) then {
-			[_unit, selectRandom unlockedAA, 1] call _addWeaponAndMags;
-		};
-	};
-	case (_unitType isEqualTo FactionGet(reb,"unitMG")): {
-		[_unit,unlockedMachineGuns] call A3A_fnc_randomRifle;
-	};
-	case (_unitType isEqualTo FactionGet(reb,"unitGL")): {
-		[_unit,unlockedGrenadeLaunchers] call A3A_fnc_randomRifle;
-	};
-	case (_unitType isEqualTo FactionGet(reb,"unitExp")): {
-		[_unit,unlockedRifles] call A3A_fnc_randomRifle;
-		_unit enableAIFeature ["MINEDETECTION", true]; //This should prevent them from Stepping on the Mines as an "Expert" (It helps, they still step on them)
-		if (count unlockedAA > 0) then {
-			[_unit, selectRandom unlockedAA, 1] call _addWeaponAndMags;
-		};
-			_unit addItemToBackpack (selectRandom unlockedToolKits);
-			_unit addItemToBackpack (selectRandom unlockedMineDetectors);
-		// TODO: explosives. Not that they know what to do with them.
-	};
-	case (_unitType isEqualTo FactionGet(reb,"unitEng")): {
-		[_unit,unlockedRifles] call A3A_fnc_randomRifle;
-		_unit addItemToBackpack (selectRandom unlockedToolKits);
-	};
-	case (_unitType isEqualTo FactionGet(reb,"unitMedic")): {
-		[_unit,unlockedSMGs] call A3A_fnc_randomRifle;
-		// temporary hack
-		private _medItems = [];
-		{
-			for "_i" from 1 to (_x#1) do { _medItems pushBack (_x#0) };
-		} forEach (["MEDIC",independent] call A3A_fnc_itemset_medicalSupplies);
-		{
-			_medItems deleteAt (_medItems find _x);
-		} forEach items _unit;
-		{
-			_unit addItemToBackpack _x;
-		} forEach _medItems;
-	};
-	case (_unitType isEqualTo FactionGet(reb,"unitLAT")): {
-		[_unit,unlockedRifles] call A3A_fnc_randomRifle;
-		if !(unlockedAT isEqualTo []) then {
-			[_unit, selectRandom unlockedAT, 4] call _addWeaponAndMags;
-		} else {
-			if (A3A_hasIFA) then {
-				[_unit, "LIB_PTRD", 10] call _addWeaponAndMags;
-			};
-		};
-	};
-	// squad leaders and
-	case (_unitType isEqualTo FactionGet(reb,"unitSL")): {
-		[_unit,unlockedRifles] call A3A_fnc_randomRifle;
-		if (_recruitType == 1) then {_unit linkItem selectrandom (unlockedRadios)};
-	};
- 	case (_unitType isEqualTo FactionGet(reb,"unitCrew")): {
-		[_unit,unlockedRifles] call A3A_fnc_randomRifle;
-		if (_recruitType == 1) then {_unit linkItem selectrandom (unlockedRadios)};
-	};
-	default {
-		[_unit,unlockedSMGs] call A3A_fnc_randomRifle;
+switch (true) do
+{
+    case (_unitType isEqualTo FactionGet(reb,"unitSniper")): {
+        [_unit, "SniperRifles", 50] call A3A_fnc_randomRifle;
+    };
+    case (_unitType isEqualTo FactionGet(reb,"unitRifle")): {
+        [_unit, "Rifles", 70] call A3A_fnc_randomRifle;
+        if (_grenades isNotEqualTo []) then { _unit addMagazines [selectRandomWeighted _grenades, 2] };
+        if (_smokes isNotEqualTo []) then { _unit addMagazines [selectRandomWeighted _smokes, 1] };
+
+        // could throw in some disposable launchers here...
+    };
+    case (_unitType isEqualTo FactionGet(reb,"unitMG")): {
+        [_unit, "MachineGuns", 150] call A3A_fnc_randomRifle;
+    };
+    case (_unitType isEqualTo FactionGet(reb,"unitGL")): {
+        [_unit, "GrenadeLaunchers", 50] call A3A_fnc_randomRifle;
+    };
+    case (_unitType isEqualTo FactionGet(reb,"unitExp")): {
+        [_unit, "Rifles", 40] call A3A_fnc_randomRifle;
+
+        _unit enableAIFeature ["MINEDETECTION", true]; //This should prevent them from Stepping on the Mines as an "Expert" (It helps, they still step on them)
+
+        private _mineDetector = selectRandomWeighted (A3A_rebelGear get "MineDetectors");
+        if !(isNil "_mineDetector") then { _unit addItem _mineDetector };
+
+        private _toolkit = selectRandomWeighted (A3A_rebelGear get "Toolkits");
+        if !(isNil "_toolkit") then { _unit addItem _toolkit };
+
+        [_unit, 50] call _fnc_addCharges;
+    };
+    case (_unitType isEqualTo FactionGet(reb,"unitEng")): {
+        [_unit, "Rifles", 50] call A3A_fnc_randomRifle;
+
+        private _toolkit = selectRandomWeighted (A3A_rebelGear get "Toolkits");
+        if !(isNil "_toolkit") then { _unit addItem _toolkit };
+
+        [_unit, 50] call _fnc_addCharges;
+    };
+    case (_unitType isEqualTo FactionGet(reb,"unitMedic")): {
+        [_unit, "SMGs", 40] call A3A_fnc_randomRifle;
+        if (_smokes isNotEqualTo []) then { _unit addMagazines [selectRandomWeighted _smokes, 2] };
+
+        // not-so-temporary hack
+        private _medItems = [];
+        {
+            for "_i" from 1 to (_x#1) do { _medItems pushBack (_x#0) };
+        } forEach (["MEDIC",independent] call A3A_fnc_itemset_medicalSupplies);
+        {
+            _medItems deleteAt (_medItems find _x);
+        } forEach items _unit;
+        {
+            _unit addItemToBackpack _x;
+        } forEach _medItems;
+    };
+    case (_unitType isEqualTo FactionGet(reb,"unitLAT")): {
+        [_unit, "Rifles", 40] call A3A_fnc_randomRifle;
+
+        private _launcher = selectRandomWeighted (A3A_rebelGear get "RocketLaunchers");
+        if !(isNil "_launcher") then { [_unit, _launcher, 100] call _fnc_addSecondaryAndMags };
+
+//		if (A3A_hasIFA) then {
+//			[_unit, "LIB_PTRD", 100] call _addSecondaryAndMags;
+//		};
+    };
+    case (_unitType isEqualTo FactionGet(reb,"unitSL")): {
+        [_unit, "Rifles", 50] call A3A_fnc_randomRifle;
+        if (_smokes isNotEqualTo []) then { _unit addMagazines [selectRandomWeighted _smokes, 2] };
+    };
+     case (_unitType isEqualTo FactionGet(reb,"unitCrew")): {
+        [_unit, "Rifles", 50] call A3A_fnc_randomRifle;
+    };
+    default {
+        [_unit, "SMGs", 50] call A3A_fnc_randomRifle;
         Error_1("Unknown unit class: %1", _unitType);
-	};
+    };
 };
 
-if (!A3A_hasIFA && sunOrMoon < 1) then {
-	if !(haveNV) then {
-		// horrible, although at least it stops once you unlock NV
-		private _flashlights = allLightAttachments arrayIntersect unlockedItems;
-		if !(_flashlights isEqualTo []) then {
-			_flashlights = _flashlights arrayIntersect ((primaryWeapon _unit) call BIS_fnc_compatibleItems);
-			if !(_flashlights isEqualTo []) then {
-				private _flashlight = selectRandom _flashlights;
-				_unit addPrimaryWeaponItem _flashlight;
-				_unit assignItem _flashlight;
-				_unit enableGunLights _flashlight;
-			};
-		};
-	} else {
-		// inclined to hand these out even in daytime, but whatever
-		_unit linkItem (selectRandom unlockedNVGs);
-
-/* Removed because it's pretty daft to use IR pointers when all your enemies have NV
-		private _pointers = allLaserAttachments arrayIntersect unlockedItems;
-		if !(_pointers isEqualTo []) then {
-			_pointers = _pointers arrayIntersect ((primaryWeapon _unit) call BIS_fnc_compatibleItems);
-			if !(_pointers isEqualTo []) then {
-				_pointer = selectRandom _pointers;
-				_unit addPrimaryWeaponItem _pointer;
-				_unit assignItem _pointer;
-				_unit enableIRLasers true;
-			};
-		};
-*/
-	};
+private _nvg = selectRandomWeighted (A3A_rebelGear get "NVGs");
+if (_nvg != "") then { _unit linkItem _nvg }
+else {
+    private _weapon = primaryWeapon _unit;
+    private _compatLights = A3A_rebelFlashlightsCache get _weapon;
+    if (isNil "_compatLights") then {
+        private _compatItems = [_weapon] call BIS_fnc_compatibleItems;		// cached, should be fast
+        _compatLights = _compatItems arrayIntersect (A3A_rebelGear get "LightAttachments");
+        A3A_rebelFlashlightsCache set [_weapon, _compatLights];
+    };
+    if (_compatLights isNotEqualTo []) then {
+        private _flashlight = selectRandom _compatLights;
+        _unit addPrimaryWeaponItem _flashlight;		// should be used automatically by AI as necessary
+    };
 };
+
 
 // remove backpack if empty, otherwise squad troops will throw it on the ground
 if (backpackItems _unit isEqualTo []) then { removeBackpack _unit };

--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -24,7 +24,7 @@ private _fnc_addSecondaryAndMags = {
 
     _unit addWeapon _weapon;
     private _magazine = getArray (configFile / "CfgWeapons" / _weapon / "magazines") select 0;
-    _unit addSecondaryWeaponItem _magazine;         // probably harmless at worst for CBA disposables
+    _unit addSecondaryWeaponItem _magazine;
 
     if ("Disposable" in (_weapon call A3A_fnc_equipmentClassToCategories)) exitWith {};
     private _magWeight = 20 max getNumber (configFile / "CfgMagazines" / _magazine / "mass");

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -83,7 +83,7 @@ _vehInGarage = _vehInGarage + vehInGarage;
 	if ((_friendX getVariable ["spawner",false]) and (side group _friendX == teamPlayer))then {
 		if ((alive _friendX) and (!isPlayer _friendX)) then {
 			if (((isPlayer leader _friendX) and (!isMultiplayer)) or (group _friendX in (hcAllGroups theBoss)) and (not((group _friendX) getVariable ["esNATO",false]))) then {
-				_resourcesBackground = _resourcesBackground + (server getVariable [(_friendX getVariable "unitType"),0]);
+				_resourcesBackground = _resourcesBackground + (server getVariable [(_friendX getVariable "unitType"),0]) / 2;
 				_backpck = backpack _friendX;
 				if (_backpck != "") then {
                     private _assemblesTo = getText (configFile/"CfgVehicles"/_backpck/"assembleInfo"/"assembleTo");

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -160,6 +160,7 @@ if !(loadLastSave) then {
 	} foreach FactionGet(reb,"initialRebelEquipment");
     Info("Initial arsenal unlocks completed");
 };
+call A3A_fnc_generateRebelGear;
 call A3A_fnc_createPetros;
 
 [petros,"hint","Server load finished", "Server Information"] remoteExec ["A3A_fnc_commsMP", 0];

--- a/A3A/addons/core/functions/init/fn_initVarCommon.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarCommon.sqf
@@ -47,7 +47,7 @@ colorInvaders = "colorOPFOR";
 ////////////////////////////////////////
 Info("Declaring item categories");
 
-weaponCategories = ["Rifles", "Handguns", "MachineGuns", "MissileLaunchers", "Mortars", "RocketLaunchers", "Shotguns", "SMGs", "SniperRifles"];
+weaponCategories = ["Rifles", "Handguns", "MachineGuns", "MissileLaunchers", "Mortars", "RocketLaunchers", "Shotguns", "SMGs", "SniperRifles", "UsedLaunchers"];
 itemCategories = ["Gadgets", "Bipods", "MuzzleAttachments", "PointerAttachments", "Optics", "Binoculars", "Compasses", "FirstAidKits", "GPS", "LaserDesignators",
 	"Maps", "Medikits", "MineDetectors", "NVGs", "Radios", "Toolkits", "UAVTerminals", "Watches", "Glasses", "Headgear", "Vests", "Uniforms", "Backpacks"];
 
@@ -67,7 +67,7 @@ aggregateCategories = ["Weapons", "Items", "Magazines", "Explosives"];
 //It's recommended that these categories be used with caution.
 specialCategories = ["AA", "AT", "GrenadeLaunchers", "LightAttachments", "LaserAttachments", "Chemlights", "SmokeGrenades", "LaunchedSmokeGrenades", "LaunchedFlares", "HandFlares", "IRGrenades","LaserBatteries",
 	"RebelUniforms", "CivilianUniforms", "BackpacksEmpty", "BackpacksTool", "BackpacksStatic", "BackpacksDevice", "BackpacksRadio", "CivilianVests", "ArmoredVests", "ArmoredHeadgear", "CosmeticHeadgear",
-	"CosmeticGlasses"];
+	"CosmeticGlasses", "ThermalNVGs", "OpticsClose", "OpticsMid", "OpticsLong", "ExplosiveCharges", "Disposable"];
 
 
 allCategoriesExceptSpecial = weaponCategories + itemCategories + magazineCategories + explosiveCategories + otherCategories + aggregateCategories;

--- a/A3A/addons/core/functions/init/fn_resourcecheck.sqf
+++ b/A3A/addons/core/functions/init/fn_resourcecheck.sqf
@@ -113,6 +113,7 @@ while {true} do
 	if (_textArsenal != "") then {_textX = format ["%1<br/>Arsenal Updated<br/><br/>%2", _textX, _textArsenal]};
 	[petros, "taxRep", _textX] remoteExec ["A3A_fnc_commsMP", [teamPlayer, civilian]];
 
+	[] call A3A_fnc_generateRebelGear;
 
 	[] call A3A_fnc_FIAradio;
 	[] call A3A_fnc_economicsAI;

--- a/A3A/addons/maps/MissionDescription/params.hpp
+++ b/A3A/addons/maps/MissionDescription/params.hpp
@@ -112,8 +112,8 @@ class Params
     class unlockItem
     {
         title = "Number of the same item required to unlock";
-        values[] = {9999,15,25,40,1e6};
-        texts[] = {"Load from save (Default: 25)","15","25","40","1 000 000"};
+        values[] = {9999,15,25,40,-1};
+        texts[] = {"Load from save (Default: 25)","15","25","40","No unlocks"};
         default = 9999;
     };
     class memberOnlyMagLimit


### PR DESCRIPTION

### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
We need a new method of picking rebel AI equipment after removing unlocks. I've decided that the best method is to base AI equipment on the arsenal contents but generate new items. This is relatively simple (actually taking items from the arsenal is complex and expensive, especially with garrisons) and should have low exploit potential and no significant player count balance problems.

Processing the arsenal for each unit recruited is still too expensive, so this PR rewrites the rebel AI equipping code to use server-generated weighted lists. Some details:
- Generates weighted arrays on server every 10mins, transmits to clients as required.
- Weight based on arsenal contents. Typically 10 items min chance, 50 max.
- Item usage is also capped by available magazines/bullets.
- Refund value halved to reduce effectiveness of exploits.
- Still works correctly with unlocks enabled.

General improvements to rebel AI equipping:
- Improved use of NV, grenades, explosives and launchers.
- Optics are now weapon-appropriate.
- Magazines are now added by weight instead of count.

General improvements to automatic item categorisation:
- equipmentClassToCategories now caches for fast subsequent use.
- Disposable launcher support added.
- Optic categorization added.
- Explosive charge detection added.
- Moved smoke grenade, flashlight and thermal detection to equipmentClassToCategories.
- Simplified and fixed missile launcher support.
- Fixed some broken CUP stuff in categoryOverrides.

Misc:
- Fixed incorrect CUP template dependency.

The only regression at the moment is that missile launchers will no longer be used even if the unlocks are enabled. The plan is to add AT/AA missile launcher rebel infantry types which should be much more expensive to buy, but this requires additional entries added to each rebel template, and some UI work.

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

This is insufficiently tested. I've run the categorization code on RHS and CUP, but not VN or BAF yet. The rebel equipping code should be somewhat solid if the categorization works, although if weapons exist without a default magazine then that may trip up some config calls.

### How can the changes be tested?
A3A_rebelGear is the hashmap containing all the gear lists, so that's worth looking at before spamming soldiers.