### PR TITLE
Fix non-pylons being removed by prepPylons

### DIFF
--- a/A3A/addons/Garage/Extras/fn_reloadExtras.sqf
+++ b/A3A/addons/Garage/Extras/fn_reloadExtras.sqf
@@ -157,9 +157,10 @@ private _typeSource = switch (_source find true) do {
 
 
 //state indicator
-private _getPrecentageAmmo = {
+private _getPercentageAmmo = {
     if (count _this isEqualTo 0) exitWith {0};
     private _sumPercent = 0;
+    private _weaponsWithAmmo = 0;
     {
         (if (_x#0) then { //pylon
             [_x#1#3, _x#1#4]
@@ -168,13 +169,15 @@ private _getPrecentageAmmo = {
         }) params ["_mag", "_count"];
 
         private _maxAmmo = getNumber (configFile/"CfgMagazines"/_mag/"count");
+        if (_maxAmmo <= 0) then { continue };
         _sumPercent = _sumPercent + (_count/_maxAmmo);
+        _weaponsWithAmmo = _weaponsWithAmmo + 1;
     } forEach _this;
-    _sumPercent / count _this;
+    if (_weaponsWithAmmo > 0) then { _sumPercent / _weaponsWithAmmo } else { 1 };
 };
 
 private _hasAmmo = (HR_GRG_previewVehState#2) isNotEqualTo [];//Preview state >> Ammo data
-private _avgAmmo = (HR_GRG_previewVehState#2) call _getPrecentageAmmo; //Preview state >> Ammo data
+private _avgAmmo = (HR_GRG_previewVehState#2) call _getPercentageAmmo; //Preview state >> Ammo data
 private _avgFuel = HR_GRG_previewVehState#0#0; //Preview state >> Fuel data >> Fuel
 private _avgDmg = 1 - (HR_GRG_previewVehState#1#0); //Preview state >> Damage data >> Damage
 private _selectStateColor = {

--- a/A3A/addons/Garage/StatePreservation/fn_getAmmoData.sqf
+++ b/A3A/addons/Garage/StatePreservation/fn_getAmmoData.sqf
@@ -52,7 +52,7 @@ private _magName = getPylonMagazines _veh;
         , [
             _pylonIndex
             , configName _x
-            , [_veh, _pylonIndex] call HR_GRG_fnc_getPylonTurret
+            , [_veh, _forEachIndex] call HR_GRG_fnc_getPylonTurret
             , _magName#_forEachIndex
             , _veh ammoOnPylon _pylonIndex
         ]

--- a/A3A/addons/Garage/StatePreservation/fn_prepPylons.sqf
+++ b/A3A/addons/Garage/StatePreservation/fn_prepPylons.sqf
@@ -31,15 +31,12 @@ private _turrets = [[-1]] + allTurrets _veh;
 private _toRemove = [];
 {
     private _turret = _x;
-    {
-        private _mags = weaponMag(_x);
-        if (_mags isEqualTo []) then {continue}; //no mags, dont remove
+    private _baseWeapons = getArray (([_veh, _turret] call BIS_fnc_turretConfig) / "Weapons");
+    private _weapons = _veh weaponsTurret _turret;
+    // Avoiding array subtract in case there's a pylon and non-pylon copy of the same weapon
+    { _weapons deleteAt (_weapons find _x) } forEach _baseWeapons;
+    { _toRemove pushBack [_x, _turret] } forEach _weapons;
 
-        private _pylonWeapon = _mags findIf {magPylonWeapon(_x) != ""};
-        if (_pylonWeapon isEqualTo -1) then {continue}; //no pylon weapon, dont remove
-
-        _toRemove pushBack [_x, _turret]; //pylon weapon, remove
-    } forEach (_veh weaponsTurret _turret);
 } forEach _turrets;
 
 Trace_1("Removing pylon weapons: %1", _toRemove);


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed a bug where the garage's pylon-removal code could remove weapons that were not pylons due to them sharing magazines with pylon weapons. The new code should work correctly with everything but I haven't tested it with much.

Also fixed a zero-divisor bug in the ammo percentage calculation that I ran into with the FA-181.

### Please specify which Issue this PR Resolves.
closes #2246

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Should ideally be tested with a decent selection of vehicles. I've only tried a few vanilla air vehicles so far.

### How can the changes be tested?
Enable debug mode to get TRACE working. Take vehicles out of garage and check the output of `HR_GRG_fnc_prepPylons | Removing pylon weapons:`.
