### PR TITLE
Fix createVehicleCrew placing turret crew in wrong seats

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_createVehicleCrew.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createVehicleCrew.sqf
@@ -42,17 +42,19 @@ if (getNumber (_config >> "hasDriver") > 0 && isNull driver _vehicle) then {
 
 private _fnc_addCrewToTurrets = {
 	params ["_config", ["_path", []]];
-	private _turrets = "getNumber (_x >> 'hasGunner') > 0 && getNumber (_x >> 'dontCreateAI') == 0" configClasses (_config >> "Turrets");
+	private _turrets = "true" configClasses (_config >> "Turrets");
 	{
 		private _turretConfig = _x;
 		private _turretPath = _path + [_forEachIndex];
+		//Handle nested turrets
+		[_turretConfig, _turretPath] call _fnc_addCrewToTurrets;
+
+		if (getNumber (_turretConfig >> "hasGunner") == 0 || getNumber (_turretConfig >> "dontCreateAI") != 0) then { continue };
 		if (isNull (_vehicle turretUnit _turretPath)) then {
 			private _gunner = [_group, _unitType, getPos _vehicle, [], 10] call A3A_fnc_createUnit;
 			_gunner assignAsTurret [_vehicle, _turretPath];
 			_gunner moveInTurret [_vehicle, _turretPath];
 		};
-		//Handle nested turrets
-		[_turretConfig, _turretPath] call _fnc_addCrewToTurrets;
 	} forEach _turrets;
 };
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
createVehicleCrew was pre-filtering the turret classes using configClasses, which doesn't work because it breaks the turret path if earlier items are removed. In the case of the UAZ, the commander FFV turret is before the proper turret.

This PR moves the turret filtering until after the turret path has been established. Also moved the nested turret code, because I'm pretty sure that was also wrong in the case where the first-level turret doesn't have weapons.

### Please specify which Issue this PR Resolves.
closes #2308

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Don't know a vehicle to test the nested turrets logic. Feel free to suggest one.

### How can the changes be tested?
Start game with CUP mods and russian invaders (default Livonia works). Use Zeus to add any empty armed UAZ. Select it in Zeus, then run:
`[east, curatorSelected#0#0] call A3A_fnc_createVehicleCrew`