### PR TITLE
Add ace hearing reset to vehicle box heal

### DIFF
--- a/A3A/addons/core/functions/Base/fn_vehicleBoxHeal.sqf
+++ b/A3A/addons/core/functions/Base/fn_vehicleBoxHeal.sqf
@@ -39,6 +39,9 @@ private _posHQ = getMarkerPos respawnTeamPlayer;
         if (A3A_hasACEMedical) then {
             [_x, _x] call ace_medical_treatment_fnc_fullHeal;
         };
+        if (A3A_hasACEHearing) then {
+            ["antistasi_heal", 1, true] remoteExec ["ace_common_fnc_setHearingCapability", _x]
+        };
         _x setDamage 0;
         _x setVariable ["incapacitated",false,true];
         _x setVariable ["compromised", 0, true];

--- a/A3A/addons/core/functions/Base/fn_vehicleBoxHeal.sqf
+++ b/A3A/addons/core/functions/Base/fn_vehicleBoxHeal.sqf
@@ -40,7 +40,7 @@ private _posHQ = getMarkerPos respawnTeamPlayer;
             [_x, _x] call ace_medical_treatment_fnc_fullHeal;
         };
         if (A3A_hasACEHearing) then {
-            ["antistasi_heal", 1, true] remoteExec ["ace_common_fnc_setHearingCapability", _x]
+            ["antistasi_heal", 1, false] remoteExec ["ace_common_fnc_setHearingCapability", _x];
         };
         _x setDamage 0;
         _x setVariable ["incapacitated",false,true];


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information: Added ace hearing reset to vehicle box heal function.
    

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:
1. Fire gun until deaf.
2. Use "Heal nearby units" action on the vehicle crate at HQ.
3. Hearing should be reset and no longer damaged.

********************************************************
Notes:
Still need to figure out a way to stop ringing. I also think this breaks hearing loss after the first use.