### PR TITLE
Fix #2319 int greater than 6 digits cause visual error

### DIFF
--- a/A3A/addons/GUI/functions/GUI/fn_hqDialog.sqf
+++ b/A3A/addons/GUI/functions/GUI/fn_hqDialog.sqf
@@ -293,7 +293,8 @@ switch (_mode) do
 
         private _factionMoney = server getVariable ["resourcesFIA", 0];
         private _factionMoneyText = _display displayCtrl A3A_IDC_FACTIONMONEYTEXT;
-        _factionMoneyText ctrlSetText format ["%1 €", _factionMoney];
+        private _factionMoneyString = _factionMoney call A3A_fnc_intToString; // Convert int to string. Used to avoid cases where int goes greater than 6 digits
+        _factionMoneyText ctrlSetText format ["%1 €", _factionMoneyString];
 
         // Faction money slider update
         private _factionMoneySlider = _display displayCtrl A3A_IDC_FACTIONMONEYSLIDER;
@@ -540,10 +541,11 @@ switch (_mode) do
         private _factionMoneySlider = _display displayCtrl A3A_IDC_FACTIONMONEYSLIDER;
         private _factionMoneyEditBoxValue = floor parseNumber ctrlText _factionMoneyEditBox;
         private _factionMoney = server getVariable ["resourcesFIA", 0];
+        private _factionMoneyString = _factionMoney call A3A_fnc_intToString; // Convert int to string. Used to avoid cases where int goes greater than 6 digits
         _factionMoneyEditBox ctrlSetText str _factionMoneyEditBoxValue; // Strips non-numeric characters
         _factionMoneySlider sliderSetPosition _factionMoneyEditBoxValue;
         if (_factionMoneyEditBoxValue < 0) then {_factionMoneyEditBox ctrlSetText str 0};
-        if (_factionMoneyEditBoxValue > _factionMoney) then {_factionMoneyEditBox ctrlSetText str _factionMoney};
+        if (_factionMoneyEditBoxValue > _factionMoney) then {_factionMoneyEditBox ctrlSetText _factionMoneyString};
     };
 
     case("factionMoneyButtonClicked"):

--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -753,6 +753,7 @@ class CfgFunctions
             class createNamespace {};
             class deleteNamespace {};
             class getAdmin {};
+            class intToString {};
             class localLog {};
             class log {};
             class setPos {};

--- a/A3A/addons/core/functions/Base/fn_logPerformance.sqf
+++ b/A3A/addons/core/functions/Base/fn_logPerformance.sqf
@@ -29,6 +29,9 @@ private _countCiv = 0;
 	};
 } forEach allGroups;
 
+// Convert int to string. Used to avoid cases where int goes greater than 6 digits
+private _factionMoneyString = (server getVariable "resourcesFIA") call A3A_fnc_intToString;
+
 private _performanceLog = format [
 	"%10 ServerFPS:%1, Players:%11, DeadUnits:%2, AllUnits:%3, UnitsAwareOfEnemies:%14, AllVehicles:%4, WreckedVehicles:%12, Entities:%13, GroupsRebels:%5, GroupsInvaders:%6, GroupsOccupants:%7, GroupsCiv:%8, GroupsTotal:%9, GroupsCombatBehaviour:%15, Faction Cash:%16, HR:%17, OccAggro: %18, InvAggro: %19, Warlevel: %20"
 	,diag_fps
@@ -46,7 +49,7 @@ private _performanceLog = format [
 	,count entities ""
 	,{!isPlayer _x && !isNull (_x findNearestEnemy _x)} count allUnits
 	,{behaviour leader _x == "COMBAT"} count allGroups
-	,server getVariable "resourcesFIA"
+	,_factionMoneyString
 	,server getVariable "hr"
     ,aggressionOccupants
     ,aggressionInvaders

--- a/A3A/addons/core/functions/Base/fn_statistics.sqf
+++ b/A3A/addons/core/functions/Base/fn_statistics.sqf
@@ -18,6 +18,9 @@ _setText ctrlSetBackgroundColor [0,0,0,0];
 private _player = player getVariable ["owner",player];		// different, if remote-controlling
 private _ucovertxt = ["Off", "<t color='#1DA81D'>On</t>"] select ((captive _player) and !(_player getVariable ["incapacitated",false]));
 
+// Convert int to string. Used to avoid cases where int goes greater than 6 digits
+private _factionMoneyString = (server getVariable "resourcesFIA") call A3A_fnc_intToString;
+
 if (!isMultiplayer) then
 	{
 	_textX = format ["<t size='0.67' shadow='2'>" + "HR: %1 | %9 Money: %2 € | Airstrikes: %5 | %7 Aggr: %3 | %8 Aggr: %4 | War Level: %6 | Undercover Mode: %10", server getVariable "hr", server getVariable "resourcesFIA",[aggressionLevelOccupants] call A3A_fnc_getAggroLevelString,[aggressionLevelInvaders] call A3A_fnc_getAggroLevelString,floor bombRuns,tierWar,FactionGet(occ,"name"),FactionGet(inv,"name"),FactionGet(reb,"name"),_ucovertxt];
@@ -33,11 +36,11 @@ else
 		{
 		if ([_player] call A3A_fnc_isMember) then
 			{
-			_textX = format ["<t size='0.67' shadow='2'>" + "Rank: %5 | HR: %1 | Your Money: %6 € | %11 Money: %2 € | Airstrikes: %7 | %9 Aggr: %3 | %10 Aggr: %4 | War Level: %8 | Undercover Mode: %12", server getVariable "hr", server getVariable "resourcesFIA", [aggressionLevelOccupants] call A3A_fnc_getAggroLevelString,[aggressionLevelInvaders] call A3A_fnc_getAggroLevelString,rank _player, _player getVariable "moneyX",floor bombRuns,tierWar,FactionGet(occ,"name"),FactionGet(inv,"name"),FactionGet(reb,"name"),_ucovertxt];
+			_textX = format ["<t size='0.67' shadow='2'>" + "Rank: %5 | HR: %1 | Your Money: %6 € | %11 Money: %2 € | Airstrikes: %7 | %9 Aggr: %3 | %10 Aggr: %4 | War Level: %8 | Undercover Mode: %12", server getVariable "hr", _factionMoneyString, [aggressionLevelOccupants] call A3A_fnc_getAggroLevelString,[aggressionLevelInvaders] call A3A_fnc_getAggroLevelString,rank _player, _player getVariable "moneyX",floor bombRuns,tierWar,FactionGet(occ,"name"),FactionGet(inv,"name"),FactionGet(reb,"name"),_ucovertxt];
 			}
 		else
 			{
-			_textX = format ["<t size='0.67' shadow='2'>" + "Rank: %1 | Your Money: %2 € | %3 Money: %4 € | %5 Aggr: %6 | %7 Aggr: %8 | War Level: %9 | Undercover Mode: %10",rank _player,_player getVariable "moneyX",FactionGet(reb,"name"),server getVariable "resourcesFIA", FactionGet(occ,"name"), [aggressionLevelOccupants] call A3A_fnc_getAggroLevelString, FactionGet(inv,"name"),[aggressionLevelInvaders] call A3A_fnc_getAggroLevelString,tierWar,_ucovertxt];
+			_textX = format ["<t size='0.67' shadow='2'>" + "Rank: %1 | Your Money: %2 € | %3 Money: %4 € | %5 Aggr: %6 | %7 Aggr: %8 | War Level: %9 | Undercover Mode: %10",rank _player,_player getVariable "moneyX",FactionGet(reb,"name"),_factionMoneyString, FactionGet(occ,"name"), [aggressionLevelOccupants] call A3A_fnc_getAggroLevelString, FactionGet(inv,"name"),[aggressionLevelInvaders] call A3A_fnc_getAggroLevelString,tierWar,_ucovertxt];
 			};
 		};
 	};

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -258,8 +258,11 @@ _fuelAmountleftArray = [];
 //Saving the state of the testing timer
 ["testingTimerIsActive", testingTimerIsActive] call A3A_fnc_setStatVariable;
 
+// Convert int to string. Used to avoid cases where int goes greater than 6 digits
+private _factionMoneyString = _resourcesBackground call A3A_fnc_intToString;
+
 saveProfileNamespace;
 savingServer = false;
-_saveHintText = ["<t size='1.5'>",FactionGet(reb,"name")," Assets:<br/><t color='#f0d498'>HR: ",str _hrBackground,"<br/>Money: ",str _resourcesBackground," €</t></t><br/><br/>Further infomation is provided in <t color='#f0d498'>Map Screen > Game Options > Persistent Save-game</t>."] joinString "";
+_saveHintText = ["<t size='1.5'>",FactionGet(reb,"name")," Assets:<br/><t color='#f0d498'>HR: ",str _hrBackground,"<br/>Money: ",_factionMoneyString," €</t></t><br/><br/>Further infomation is provided in <t color='#f0d498'>Map Screen > Game Options > Persistent Save-game</t>."] joinString "";
 ["Persistent Save",_saveHintText] remoteExec ["A3A_fnc_customHint",0,false];
 Info("Persistent Save Completed");

--- a/A3A/addons/core/functions/Utility/fn_intToString.sqf
+++ b/A3A/addons/core/functions/Utility/fn_intToString.sqf
@@ -1,0 +1,36 @@
+/*
+    Author: [Hazey]
+
+    Description:
+		Converts 32bit Floats longer than 6 digits to string.
+
+    Arguments:
+    	<Number> Number you want converted
+
+    Return Value:
+    	N/A
+
+    Scope: Any
+    Environment: Any
+    Public: No
+
+    Example: 
+		_number call A3A_fnc_intToString;
+		
+    License: MIT License
+
+	Notes:
+		If the int is 7 digits or less long, string representation of it will be the exact number, above 7 digits, some rounding must occur.
+
+*/
+params ["_int"];
+
+private _string = "";
+
+while {_int >= 10} do {
+	_int = _int / 10;
+	_string = format ["%1%2", round ((_int % floor _int) * 10), _string];
+	_int = floor _int;
+};
+
+format ["%1%2", _int, _string];


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Takes a 7 digit int and converts it to string.

One thing to note, any digits greater than 7 will start to become rounded. This is a limitation. However I don't see how its possible for the user to get more than 7 digits worth of faction cash.

### Please specify which Issue this PR Resolves.
closes #2319

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
See #2319
********************************************************
Notes:
![unknown (1)](https://user-images.githubusercontent.com/1194692/162373772-bc7a60b8-d13e-4b5f-90e2-0af58317c966.png)

