### PR TITLE
Silence Players with Ace / Missed Semicolon

### DIFF
--- a/A3A/addons/core/Templates/Templates.hpp
+++ b/A3A/addons/core/Templates/Templates.hpp
@@ -38,7 +38,7 @@ class Templates
             {
                 class camo
                 {
-                    arid = "Arid"
+                    arid = "Arid";
                     tropical = "Tropical";
                     Default = "Temperate";
                 };

--- a/A3A/addons/core/functions/Templates/Verification/fn_TV_verifyAssets.sqf
+++ b/A3A/addons/core/functions/Templates/Verification/fn_TV_verifyAssets.sqf
@@ -115,6 +115,7 @@ private _handleUniqueCases = { //handles unique name cases that the stored value
 
         //array of vehicle class names
         case "minefieldAT";
+        case "flyGear";
         case "minefieldAPERS";
         case "uavsAttack";
         case "uavsPortable": _validateArrayOfClasses;
@@ -139,8 +140,6 @@ private _handleUniqueCases = { //handles unique name cases that the stored value
         case "initialRebelEquipment": { { [_x] call _genericClassExists } forEach _y };
 
         //bool
-        case "addDiveGear";
-        case "addFlightGear": { if !(_y isEqualType true) then {_invalidReasons pushBack ("Entry: "+(str _entry)+" is not of type bool")} };
 
         //truly unique cases
         case "magazines": _validateMagazinesHM;
@@ -160,7 +159,9 @@ private _handleUniqueCases = { //handles unique name cases that the stored value
                 ["CfgMagazines",(_x#0),_entry] call _validClassCaseSensitive;
             } forEach _y;
         };
-
+        case "diveGear"; //Mixed CFGVehicles and CFGGlasses
+        case "voices"; //CfgVoice maybe later
+        case "faces": {continue};
         default { Info("Entry: "+(str _entry)+" is lacking validation") };
     };
 };

--- a/A3A/addons/core/functions/Templates/Verification/fn_TV_verifyAssets.sqf
+++ b/A3A/addons/core/functions/Templates/Verification/fn_TV_verifyAssets.sqf
@@ -115,7 +115,6 @@ private _handleUniqueCases = { //handles unique name cases that the stored value
 
         //array of vehicle class names
         case "minefieldAT";
-        case "flyGear";
         case "minefieldAPERS";
         case "uavsAttack";
         case "uavsPortable": _validateArrayOfClasses;
@@ -160,6 +159,7 @@ private _handleUniqueCases = { //handles unique name cases that the stored value
             } forEach _y;
         };
         case "diveGear"; //Mixed CFGVehicles and CFGGlasses
+        case "flyGear";
         case "voices"; //CfgVoice maybe later
         case "faces": {continue};
         default { Info("Entry: "+(str _entry)+" is lacking validation") };

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -98,8 +98,9 @@ player setVariable ["punish",0,true];
 stragglers = creategroup teamPlayer;
 (group player) enableAttack false;
 
+if (!A3A_hasACE) {
 [player, nil, selectRandom (A3A_faction_reb get "voices")] call BIS_fnc_setIdentity;
-
+};
 //Give the player the base loadout.
 [player] call A3A_fnc_dress;
 

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -98,12 +98,8 @@ player setVariable ["punish",0,true];
 stragglers = creategroup teamPlayer;
 (group player) enableAttack false;
 
-if (A3A_hasACE) then {
-	if (!ace_noradio_enabled) then {
-	[player, nil, selectRandom (A3A_faction_reb get "voices")] call BIS_fnc_setIdentity;
-	};
-} else {
-	[player, nil, selectRandom (A3A_faction_reb get "voices")] call BIS_fnc_setIdentity;
+if (isNil "ace_radio_enabled" or {!ace_radio_enabled}) then {
+    [player, nil, selectRandom (A3A_faction_reb get "voices")] call BIS_fnc_setIdentity
 };
 //Give the player the base loadout.
 [player] call A3A_fnc_dress;

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -98,7 +98,7 @@ player setVariable ["punish",0,true];
 stragglers = creategroup teamPlayer;
 (group player) enableAttack false;
 
-if (!A3A_hasACE) {
+if (!A3A_hasACE) then {
 [player, nil, selectRandom (A3A_faction_reb get "voices")] call BIS_fnc_setIdentity;
 };
 //Give the player the base loadout.

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -98,7 +98,7 @@ player setVariable ["punish",0,true];
 stragglers = creategroup teamPlayer;
 (group player) enableAttack false;
 
-if (isNil "ace_radio_enabled" or {!ace_radio_enabled}) then {
+if (isNil "ace_noradio_enabled" or {!ace_noradio_enabled}) then {
     [player, nil, selectRandom (A3A_faction_reb get "voices")] call BIS_fnc_setIdentity
 };
 //Give the player the base loadout.

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -98,8 +98,12 @@ player setVariable ["punish",0,true];
 stragglers = creategroup teamPlayer;
 (group player) enableAttack false;
 
-if (!A3A_hasACE) then {
-[player, nil, selectRandom (A3A_faction_reb get "voices")] call BIS_fnc_setIdentity;
+if (A3A_hasACE) then {
+	if (!ace_noradio_enabled) then {
+	[player, nil, selectRandom (A3A_faction_reb get "voices")] call BIS_fnc_setIdentity;
+	};
+} else {
+	[player, nil, selectRandom (A3A_faction_reb get "voices")] call BIS_fnc_setIdentity;
 };
 //Give the player the base loadout.
 [player] call A3A_fnc_dress;

--- a/A3A/addons/core/functions/proxy/fn_onPlayerRespawn.sqf
+++ b/A3A/addons/core/functions/proxy/fn_onPlayerRespawn.sqf
@@ -60,8 +60,6 @@ if (side group player == teamPlayer) then
 	_newUnit setCaptive false;
 	_newUnit setRank (_rankX);
 	_newUnit setVariable ["rankX",_rankX,true];
-	_speaker = speaker _oldUnit;
-	[_newUnit,_speaker] remoteExec ["setSpeaker",0,_newUnit];
 	{
     _newUnit addOwnedMine _x;
     } count (getAllOwnedMines (_oldUnit));


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Added a Check for not having Ace, so Players with Ace won't get a Speaker set and it should stay with "Ace_novoice".
Removed the Speaker Lines in OnPlayerRespawn.
Added a missed Semicolon.

### Please specify which Issue this PR Resolves.


### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
