### PR TITLE
Fix categoryOverrides not being created on clients, and tag with A3A

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
@@ -213,8 +213,8 @@ private _categoryOverrideTable = [
 ["LIB_M2_60_Tripod", ["StaticWeaponParts","Items"]],
 ["LIB_M2_60_Barrel", ["StaticWeaponParts","Items"]]   ];
 
-//Create a local namespace. Should only run on the server.
-categoryOverrides = false call A3A_fnc_createNamespace;
+//Create a local namespace.
+A3A_categoryOverrides = false call A3A_fnc_createNamespace;
 {
-	categoryOverrides setVariable [_x select 0, _x select 1];
+	A3A_categoryOverrides setVariable [_x select 0, _x select 1];
 } forEach _categoryOverrideTable;

--- a/A3A/addons/core/functions/Ammunition/fn_equipmentClassToCategories.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_equipmentClassToCategories.sqf
@@ -14,7 +14,7 @@ FIX_LINE_NUMBERS()
 params ["_className"];
 
 // First check if the item has hardcoded categories
-private _categories = categoryOverrides getVariable [_className, []];
+private _categories = A3A_categoryOverrides getVariable [_className, []];
 if (count _categories > 0) exitWith { _categories };
 
 private _itemType = [_className] call A3A_fnc_itemType;
@@ -203,6 +203,6 @@ call {
 };
 
 // Add to cache for future use
-categoryOverrides setVariable [_classname, _categories];
+A3A_categoryOverrides setVariable [_classname, _categories];
 
 _categories;

--- a/A3A/addons/core/functions/init/fn_initVarCommon.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarCommon.sqf
@@ -73,6 +73,9 @@ specialCategories = ["AA", "AT", "GrenadeLaunchers", "LightAttachments", "LaserA
 allCategoriesExceptSpecial = weaponCategories + itemCategories + magazineCategories + explosiveCategories + otherCategories + aggregateCategories;
 allCategories = allCategoriesExceptSpecial + specialCategories;
 
+// Initialize categoryOverrides. Clients need this for equipmentClassToCategories to work.
+[] call A3A_fnc_categoryOverrides;
+
 ////////////////////////////////////
 //     BEGIN MOD DETECTION       ///
 ////////////////////////////////////

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -335,8 +335,6 @@ DECLARE_SERVER_VAR(undercoverVehicles, _undercoverVehicles);
 //This is all very tightly coupled.
 //Beware when changing these, or doing anything with them, really.
 
-Info("Initializing hardcoded categories");
-[] call A3A_fnc_categoryOverrides;
 Info("Scanning config entries for items");
 [A3A_fnc_equipmentIsValidForCurrentModset] call A3A_fnc_configSort;
 Info("Categorizing vehicle classes");


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug fix
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Forgot to test #2305 on DS+client. Apparently the only broken bit was that categoryOverrides is only created on the server, but now needs to be created everywhere because equipmentClassToCategories is used for general equipment identification.

Also tagged it with A3A_.

### Please specify which Issue this PR Resolves.
closes #2327

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
