### PR TITLE
Adding more Special Forces Groups

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_createAICities.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAICities.sqf
@@ -29,7 +29,7 @@ _esAAF = true;
 if (_markerX in destroyedSites) then
 	{
 	_esAAF = false;
-	_params = [_positionX,Invaders,_faction get "groupSpecOps"];
+	_params = [_positionX,Invaders, selectRandom (_faction get "groupSpecOpsRandom")];
 	}
 else
 	{

--- a/A3A/addons/core/functions/CREATE/fn_createAIcontrols.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIcontrols.sqf
@@ -153,7 +153,7 @@ else
 	_frontierX = if (count _markersX > 0) then {true} else {false};
 	if (_frontierX) then
 		{
-		_cfg = _faction get "groupSpecOps";
+		_cfg =  selectRandom (_faction get "groupSpecOpsRandom");
 		if (sidesX getVariable [_markerX,sideUnknown] == Occupants) then
 			{
 			_sideX = Occupants;

--- a/A3A/addons/core/functions/Missions/fn_attackHQ.sqf
+++ b/A3A/addons/core/functions/Missions/fn_attackHQ.sqf
@@ -47,7 +47,7 @@ if (count _typesVeh > 0) then
 	};
 _typesVeh = (_faction get "vehiclesHelisLight") + (_faction get "vehiclesHelisTransport");
 if (_typesVeh isEqualTo []) then {_typesVeh = _faction get "vehiclesPlanesTransport"};
-_typeGroup = _faction get "groupSpecOps";
+_typeGroup = selectRandom (_faction get "groupSpecOpsRandom");
 
 for "_i" from 0 to (round random 2) do
 	{

--- a/A3A/addons/core/functions/Templates/fn_compileGroups.sqf
+++ b/A3A/addons/core/functions/Templates/fn_compileGroups.sqf
@@ -87,6 +87,28 @@ _faction set ["groupSpecOps", [
     , unit(SF, "Medic")
 ]];
 
+private _specOpsRandom = [];
+for "_i" from 1 to 6 do {
+    _specOpsRandom pushBack [
+        unit(SF, "SquadLeader"),
+        unit(SF, "Rifleman"),
+        unit(SF, "MachineGunner"),
+        unit(SF, "Medic"),
+        unit(SF, "Marksman"),
+        selectRandom [
+            unit(SF, "ExplosivesExpert")
+            , unit(SF, "LAT")
+            , unit(SF, "Grenadier")
+            , unit(SF, "Sniper")
+            , unit(SF, "Engineer")
+        ]
+    ];
+};
+
+_faction set ["groupSpecOpsRandom", _specOpsRandom];
+
+_faction set ["groupSpecOpsSniper", [unit(SF, "Sniper"), unit(SF, "Rifleman")]];
+
 //militia
 _faction set ["groupsMilitiaSmall", [
     [unit(militia, "Grenadier"), unit(militia, "Rifleman")]


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [x] Enhancement

### What have you changed and why?
Information:
added groupSpecOpsRandom, and groupSpecOpsSniper.
groupSpecOpsRandom is used for random selection of 6 man group of sf units. 
groupSpecOpsSniper will be used for sniper patrols, right now It is not used, just defines it.
groupSpecOps still exist, was kept for no school specOps if needed somewhere later.
all references of groupSpecOps are replaced with groupSpecOpsRandom. (hq_attack, dead towns, and controls)
    

### Please specify which Issue this PR Resolves.
N/A

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
