### PR TITLE
added lootCrates to roadblocks

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_createAIAirplane.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIAirplane.sqf
@@ -71,6 +71,8 @@ if (_frontierX) then
 		_dirveh = [_roadcon, _road] call BIS_fnc_DirTo;
 		_pos = [getPos _road, 7, _dirveh + 270] call BIS_Fnc_relPos;
 		_bunker = "Land_BagBunker_01_small_green_F" createVehicle _pos;
+		private _truckX = createVehicle ["B_supplyCrate_F", _pos, [],0, "NONE"];
+		[_truckX] spawn A3A_fnc_fillLootCrate; 
 		_vehiclesX pushBack _bunker;
 		_bunker setDir _dirveh;
 		_pos = getPosATL _bunker;

--- a/A3A/addons/core/functions/CREATE/fn_createAIOutposts.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIOutposts.sqf
@@ -216,6 +216,8 @@ else
 			_groups pushBack _groupX;
 			_pos = [getPos _road, 7, _dirveh + 270] call BIS_Fnc_relPos;
 			_bunker = "Land_BagBunker_01_Small_green_F" createVehicle _pos;
+			private _truckX = createVehicle ["B_supplyCrate_F", _pos, [],0, "NONE"];
+			[_truckX] spawn A3A_fnc_fillLootCrate; 
 			_vehiclesX pushBack _bunker;
 			_bunker setDir _dirveh;
 			_pos = getPosATL _bunker;

--- a/A3A/addons/core/functions/CREATE/fn_createAIResources.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIResources.sqf
@@ -55,6 +55,8 @@ if (_frontierX) then
 		_groups pushBack _groupX;
 		_pos = [getPos _road, 7, _dirveh + 270] call BIS_Fnc_relPos;
 		_bunker = "Land_BagBunker_01_small_green_F" createVehicle _pos;
+		private _truckX = createVehicle ["B_supplyCrate_F", _pos, [],0, "NONE"];
+		[_truckX] spawn A3A_fnc_fillLootCrate; 
 		_vehiclesX pushBack _bunker;
 		_bunker setDir _dirveh;
 		_pos = getPosATL _bunker;

--- a/A3A/addons/core/functions/CREATE/fn_createAIcontrols.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIcontrols.sqf
@@ -74,6 +74,8 @@ if (_isControl) then
 			{
 			_pos = [getPos (_roads select 0), 7, _dirveh + 270] call BIS_Fnc_relPos;
 			_bunker = "Land_BagBunker_01_Small_green_F" createVehicle _pos;
+			private _truckX = createVehicle ["B_supplyCrate_F", _pos, [],0, "NONE"];
+			[_truckX] spawn A3A_fnc_fillLootCrate; 
 			_vehiclesX pushBack _bunker;
 			_bunker setDir _dirveh;
 			_pos = getPosATL _bunker;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [x] Enhancement

### What have you changed and why?
Information:
    adds lootCrates to roadblocks. Useful for solo players as they can get some better or different weapons from road blocks. Also useful for moving to the no unlocks system by giving the players more loot.

### Please specify which Issue this PR Resolves.

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
