### PR TITLE
Added additional Punishment logging for cheking player's UAV body

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -511,7 +511,7 @@ class CfgFunctions
             class punishment {};
             class punishment_addActionForgive {};
             class punishment_checkStatus {};
-            class punishment_FF {};
+            class punishment_evaluateEvent {};
             class punishment_FF_checkNearHQ {};
             class punishment_FF_addEH {};
             class punishment_oceanGulag {};

--- a/A3A/addons/core/functions/Punishment/fn_punishment.sqf
+++ b/A3A/addons/core/functions/Punishment/fn_punishment.sqf
@@ -43,6 +43,9 @@ private _overheadPercent = 0.3;		// Percentage of _offenceAdded that does not ge
 
 //////////Fetches punishment values/////////
 private _originalBody = _instigator getVariable ["owner",_instigator];
+if (isPlayer _instigator && isPlayer _originalBody) then {
+	Error("Post Original Body Set: "+name _instigator+" ["+getPlayerUID _instigator+"]'s owner variable indicates that " + name _originalBody+" ["+getPlayerUID _originalBody+"] is the original body. customMessage: "+_customMessage)
+};
 private _UID = getPlayerUID _instigator;
 private _name = name _instigator;
 private _currentTime = (floor serverTime);
@@ -105,18 +108,25 @@ if (_offenceTotal < 1) exitWith {"WARNING";};
 if (_instigator isEqualTo _originalBody) then {
 	[_UID,_timeTotal] spawn A3A_fnc_punishment_sentence_server;  // Scope is within unscheduled space.
 } else {
+	if (isPlayer _instigator && isPlayer _originalBody) then {
+		Error("Pre UAV set: "+name _instigator+" ["+getPlayerUID _instigator+"]'s owner variable indicates that " + name _originalBody+" ["+getPlayerUID _originalBody+"] is the original body. customMessage: "+_customMessage)
+	};
 	(units group _originalBody) joinSilent group _originalBody;  // Refer to controlunit.sqf for source of this *function*
 	group _instigator selectLeader _originalBody;
 	["Control Unit", "Returned to original Unit due to FF."] remoteExecCall ["A3A_fnc_customHint",_instigator,false];
 	[_originalBody] remoteExec ["selectPlayer",_instigator,false];
 
-	[_instigator,_originalBody,_UID,_timeTotal,_name] spawn {  // Waits for player to control original body. This will be relocated to sentence_client in the future allowing for snappy execution server-side.
-		params ["_instigator","_originalBody","_UID","_timeTotal","_name"];
+	[_instigator,_originalBody,_UID,_timeTotal,_name,_customMessage] spawn {  // Waits for player to control original body. This will be relocated to sentence_client in the future allowing for snappy execution server-side.
+		params ["_instigator","_originalBody","_UID","_timeTotal","_name","_customMessage"];
+
+		if (isPlayer _instigator && isPlayer _originalBody) then {
+			Error("Post UAV set: "+name _instigator+" ["+getPlayerUID _instigator+"]'s owner variable indicates that " + name _originalBody+" ["+getPlayerUID _originalBody+"] is the original body. customMessage: "+_customMessage)
+		};
 		private _timeOut = serverTime + 20;
 		waitUntil {isPlayer _originalBody || _timeOut < serverTime};
 		if !(isPlayer _originalBody) exitWith {
-            private _timeOutLog = ["TIMED-OUT | Gave up waiting for ",_name," [",_UID,"] to exit remote control."] joinString "";
-            Error(_timeOutLog);
+			private _timeOutLog = ["TIMED-OUT | Gave up waiting for ",_name," [",_UID,"] to exit remote control."] joinString "";
+			Error(_timeOutLog);
 		};
 		[_UID,_timeTotal] call A3A_fnc_punishment_sentence_server; // Scope is within scheduled space.
 	};

--- a/A3A/addons/core/functions/Punishment/fn_punishment.sqf
+++ b/A3A/addons/core/functions/Punishment/fn_punishment.sqf
@@ -43,7 +43,7 @@ private _overheadPercent = 0.3;		// Percentage of _offenceAdded that does not ge
 
 //////////Fetches punishment values/////////
 private _originalBody = _instigator getVariable ["owner",_instigator];
-if (isPlayer _instigator && isPlayer _originalBody) then {
+if (isPlayer _instigator && isPlayer _originalBody && _instigator isNotEqualTo _originalBody) then {
 	Error("Post Original Body Set: "+name _instigator+" ["+getPlayerUID _instigator+"]'s owner variable indicates that " + name _originalBody+" ["+getPlayerUID _originalBody+"] is the original body. customMessage: "+_customMessage)
 };
 private _UID = getPlayerUID _instigator;
@@ -108,7 +108,7 @@ if (_offenceTotal < 1) exitWith {"WARNING";};
 if (_instigator isEqualTo _originalBody) then {
 	[_UID,_timeTotal] spawn A3A_fnc_punishment_sentence_server;  // Scope is within unscheduled space.
 } else {
-	if (isPlayer _instigator && isPlayer _originalBody) then {
+	if (isPlayer _instigator && isPlayer _originalBody && _instigator isNotEqualTo _originalBody) then {
 		Error("Pre UAV set: "+name _instigator+" ["+getPlayerUID _instigator+"]'s owner variable indicates that " + name _originalBody+" ["+getPlayerUID _originalBody+"] is the original body. customMessage: "+_customMessage)
 	};
 	(units group _originalBody) joinSilent group _originalBody;  // Refer to controlunit.sqf for source of this *function*
@@ -119,7 +119,7 @@ if (_instigator isEqualTo _originalBody) then {
 	[_instigator,_originalBody,_UID,_timeTotal,_name,_customMessage] spawn {  // Waits for player to control original body. This will be relocated to sentence_client in the future allowing for snappy execution server-side.
 		params ["_instigator","_originalBody","_UID","_timeTotal","_name","_customMessage"];
 
-		if (isPlayer _instigator && isPlayer _originalBody) then {
+		if (isPlayer _instigator && isPlayer _originalBody && _instigator isNotEqualTo _originalBody) then {
 			Error("Post UAV set: "+name _instigator+" ["+getPlayerUID _instigator+"]'s owner variable indicates that " + name _originalBody+" ["+getPlayerUID _originalBody+"] is the original body. customMessage: "+_customMessage)
 		};
 		private _timeOut = serverTime + 20;

--- a/A3A/addons/core/functions/Punishment/fn_punishment.sqf
+++ b/A3A/addons/core/functions/Punishment/fn_punishment.sqf
@@ -109,18 +109,19 @@ if (_instigator isEqualTo _originalBody) then {
 	[_UID,_timeTotal] spawn A3A_fnc_punishment_sentence_server;  // Scope is within unscheduled space.
 } else {
 	if (isPlayer _instigator && isPlayer _originalBody && _instigator isNotEqualTo _originalBody) then {
-		Error("Pre UAV set: "+name _instigator+" ["+getPlayerUID _instigator+"]'s owner variable indicates that " + name _originalBody+" ["+getPlayerUID _originalBody+"] is the original body. customMessage: "+_customMessage)
+		Error("Pre UAV set: "+_name+" ["+_UID+"]'s owner variable indicates that " + name _originalBody+" ["+getPlayerUID _originalBody+"] is the original body. customMessage: "+_customMessage)
 	};
 	(units group _originalBody) joinSilent group _originalBody;  // Refer to controlunit.sqf for source of this *function*
 	group _instigator selectLeader _originalBody;
 	["Control Unit", "Returned to original Unit due to FF."] remoteExecCall ["A3A_fnc_customHint",_instigator,false];
+	Info("Returned "+_name+" ["+_UID+"]'s UAV to original Unit due to FF.")
 	[_originalBody] remoteExec ["selectPlayer",_instigator,false];
 
 	[_instigator,_originalBody,_UID,_timeTotal,_name,_customMessage] spawn {  // Waits for player to control original body. This will be relocated to sentence_client in the future allowing for snappy execution server-side.
 		params ["_instigator","_originalBody","_UID","_timeTotal","_name","_customMessage"];
 
 		if (isPlayer _instigator && isPlayer _originalBody && _instigator isNotEqualTo _originalBody) then {
-			Error("Post UAV set: "+name _instigator+" ["+getPlayerUID _instigator+"]'s owner variable indicates that " + name _originalBody+" ["+getPlayerUID _originalBody+"] is the original body. customMessage: "+_customMessage)
+			Error("Post UAV set: "+_name+" ["+_UID+"]'s owner variable indicates that " + name _originalBody+" ["+getPlayerUID _originalBody+"] is the original body. customMessage: "+_customMessage)
 		};
 		private _timeOut = serverTime + 20;
 		waitUntil {isPlayer _originalBody || _timeOut < serverTime};

--- a/A3A/addons/core/functions/Punishment/fn_punishment.sqf
+++ b/A3A/addons/core/functions/Punishment/fn_punishment.sqf
@@ -4,7 +4,7 @@ Function:
 
 Description:
 	Punishes the player given for FF.
-	Doesn't do the checking itself, refer to A3A_fnc_punishment_FF.
+	Doesn't do the checking itself, refer to A3A_fnc_punishment_evaluateEvent.
 
 Scope:
 	<SERVER>
@@ -22,7 +22,7 @@ Returns:
 	<STRING> Either an exemption type or a return from fn_punishment.sqf.
 
 Examples:
-	[_instigator,_timeAdded,_offenceAdded,_victim] remoteExecCall ["A3A_fnc_punishment",2,false]; // How it should be called from another A3A_fnc_punishment_FF.
+	[_instigator,_timeAdded,_offenceAdded,_victim] remoteExecCall ["A3A_fnc_punishment",2,false]; // How it should be called from another A3A_fnc_punishment_evaluateEvent.
 	// Unit Tests:
 	[cursorObject, 0, 0] remoteExecCall ["A3A_fnc_punishment",2];                                 // Ping with FF Warning
 	[cursorObject,120, 1] remoteExecCall ["A3A_fnc_punishment",2];                                // Punish, 120 additional seconds

--- a/A3A/addons/core/functions/Punishment/fn_punishment_FF_AddEH.sqf
+++ b/A3A/addons/core/functions/Punishment/fn_punishment_FF_AddEH.sqf
@@ -45,11 +45,11 @@ if (_isAI && !_addToAI) exitWith {true};
 
 _unit addEventHandler ["Killed", {
     params ["_unit", "_killer", "_instigator", "_useEffects"];
-    [[_instigator,_killer], 60, 0.4, _unit] remoteExecCall ["A3A_fnc_punishment_FF",2,false];
+    [[_instigator,_killer], 60, 0.4, _unit] remoteExecCall ["A3A_fnc_punishment_evaluateEvent",2,false];
 }];
 _unit addEventHandler ["Hit", {
     params ["_unit", "_source", "_damage", "_instigator"];
-    [[_instigator,_source], 60, 0.4, _unit] remoteExecCall ["A3A_fnc_punishment_FF",2,false];
+    [[_instigator,_source], 60, 0.4, _unit] remoteExecCall ["A3A_fnc_punishment_evaluateEvent",2,false];
 }];
 
 if (_isAI) exitWith {true};

--- a/A3A/addons/core/functions/Punishment/fn_punishment_FF_checkNearHQ.sqf
+++ b/A3A/addons/core/functions/Punishment/fn_punishment_FF_checkNearHQ.sqf
@@ -44,5 +44,5 @@ private _distancePetros = _unit distance petros;
 if !(_distancePetros <= 75) exitWith {false};
 
 deleteVehicle _projectile;
-[_unit, 60, 0.4, objNull, "You cannot throw grenades or place explosives within 75m of base."] remoteExec ["A3A_fnc_punishment_evaluateEvent",2,false];
+[_unit, 60, 0.4, serverTime, objNull, "You cannot throw grenades or place explosives within 75m of base."] remoteExec ["A3A_fnc_punishment_evaluateEvent",2,false];
 true;

--- a/A3A/addons/core/functions/Punishment/fn_punishment_FF_checkNearHQ.sqf
+++ b/A3A/addons/core/functions/Punishment/fn_punishment_FF_checkNearHQ.sqf
@@ -44,5 +44,5 @@ private _distancePetros = _unit distance petros;
 if !(_distancePetros <= 75) exitWith {false};
 
 deleteVehicle _projectile;
-[_unit, 60, 0.4, objNull, "You cannot throw grenades or place explosives within 75m of base."] remoteExec ["A3A_fnc_punishment_FF",2,false];
+[_unit, 60, 0.4, objNull, "You cannot throw grenades or place explosives within 75m of base."] remoteExec ["A3A_fnc_punishment_evaluateEvent",2,false];
 true;

--- a/A3A/addons/core/functions/Punishment/fn_punishment_FF_checkNearHQ.sqf
+++ b/A3A/addons/core/functions/Punishment/fn_punishment_FF_checkNearHQ.sqf
@@ -44,5 +44,5 @@ private _distancePetros = _unit distance petros;
 if !(_distancePetros <= 75) exitWith {false};
 
 deleteVehicle _projectile;
-[_unit, 60, 0.4, serverTime, objNull, "You cannot throw grenades or place explosives within 75m of base."] remoteExec ["A3A_fnc_punishment_evaluateEvent",2,false];
+[_unit, 60, 0.4, objNull, "You cannot throw grenades or place explosives within 75m of base."] remoteExec ["A3A_fnc_punishment_evaluateEvent",2,false];
 true;

--- a/A3A/addons/core/functions/Punishment/fn_punishment_evaluateEvent.sqf
+++ b/A3A/addons/core/functions/Punishment/fn_punishment_evaluateEvent.sqf
@@ -26,8 +26,8 @@ Returns:
 Examples <OBJECT>:
     [_instigator, 60, 0.4, _unit] remoteExec ["A3A_fnc_punishment_evaluateEvent",2,false];   // How it should be called from another object.
     // Unit Tests:
-    [player, 0, 0, objNull] remoteExec ["A3A_fnc_punishment_release",2];          // Test self with no victim
-    [player, 0, 0, cursorObject] remoteExec ["A3A_fnc_punishment_release",2];     // Test self with victim
+    [player, 0, 0, objNull] remoteExec ["A3A_fnc_punishment_evaluateEvent",2];          // Test self with no victim
+    [player, 0, 0, cursorObject] remoteExec ["A3A_fnc_punishment_evaluateEvent",2];     // Test self with victim
     [getPlayerUID player,"forgive"] remoteExec ["A3A_fnc_punishment_release",2];  // Self forgive all sins
 
 Examples <ARRAY<OBJECT,OBJECT>>:

--- a/A3A/addons/core/functions/Punishment/fn_punishment_evaluateEvent.sqf
+++ b/A3A/addons/core/functions/Punishment/fn_punishment_evaluateEvent.sqf
@@ -1,12 +1,12 @@
 /*
 Function:
-    A3A_fnc_punishment_FF
+    A3A_fnc_punishment_evaluateEvent
 
 Description:
     Checks if incident reported is indeed a rebel Friendly Fire event.
     Refer to A3A_fnc_punishment.sqf for actual punishment logic.
     NOTE: When called from an Hit type of EH, use Example 2 in order to detect collisions.
-
+evaluate
 Scope:
     <SERVER> Execute on server only.
 
@@ -24,14 +24,14 @@ Returns:
     <STRING> Either a exemption type or "PROSECUTED".
 
 Examples <OBJECT>:
-    [_instigator, 60, 0.4, _unit] remoteExec ["A3A_fnc_punishment_FF",2,false];   // How it should be called from another object.
+    [_instigator, 60, 0.4, _unit] remoteExec ["A3A_fnc_punishment_evaluateEvent",2,false];   // How it should be called from another object.
     // Unit Tests:
     [player, 0, 0, objNull] remoteExec ["A3A_fnc_punishment_release",2];          // Test self with no victim
     [player, 0, 0, cursorObject] remoteExec ["A3A_fnc_punishment_release",2];     // Test self with victim
     [getPlayerUID player,"forgive"] remoteExec ["A3A_fnc_punishment_release",2];  // Self forgive all sins
 
 Examples <ARRAY<OBJECT,OBJECT>>:
-    [[_instigator,_source], 60, 0.4, _unit] remoteExec ["A3A_fnc_punishment_FF",2,false]; // How it should be called from an EH.
+    [[_instigator,_source], 60, 0.4, _unit] remoteExec ["A3A_fnc_punishment_evaluateEvent",2,false]; // How it should be called from an EH.
 
 Author: Caleb Serafin
 License: MIT License, Copyright (c) 2019 Barbolani & The Official AntiStasi Community


### PR DESCRIPTION
## What type of PR is this.
* Bug
* Change
* [x] Enhancement
* [x] Logging

### What have you changed and why?
* Refactored `A3A_fnc_punishment_FF` to `A3A_fnc_punishment_evaluateEvent`
* Added additional Punishment logging for cheking player's UAV body.

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
* [x] No
* Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
```sqf
        [player, 0, 0, objNull] remoteExec ["A3A_fnc_punishment_evaluateEvent",2];          // Test self with no victim
        [player, 0, 0, cursorObject] remoteExec ["A3A_fnc_punishment_evaluateEvent",2];     // Test self with victim
        [getPlayerUID player,"forgive"] remoteExec ["A3A_fnc_punishment_release",2];  // Self forgive all sins
```