### PR TITLE
fixed incorrect variable used for flight height restrictions

### DIFF
--- a/A3A/addons/core/functions/REINF/fn_NATObomb.sqf
+++ b/A3A/addons/core/functions/REINF/fn_NATObomb.sqf
@@ -69,7 +69,7 @@ _plane setPosATL [getPosATL _plane select 0, getPosATL _plane select 1, if (_isH
 _plane disableAI "TARGET";
 _plane disableAI "AUTOTARGET";
 _plane flyInHeight 100;
-private _minAltASL = ATLToASL [_positionX select 0, _positionX select 1, 0];
+private _minAltASL = ATLToASL [_pos1 select 0, _pos1 select 1, 0];
 _plane flyInHeightASL [(_minAltASL select 2) +100, (_minAltASL select 2) +100, (_minAltASL select 2) +100];
 
 driver _plane sideChat "Starting Bomb Run. ETA 30 seconds.";


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    Corrected a likely copy past error that prevented proper flight height restriction for rebel airstrikes when target is on terrain with steep elevation differenc

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
