### PR TITLE
Fix garage pylon removal case sensitivity (kills zu-23)

### DIFF
--- a/A3A/addons/Garage/StatePreservation/fn_prepPylons.sqf
+++ b/A3A/addons/Garage/StatePreservation/fn_prepPylons.sqf
@@ -32,9 +32,10 @@ private _toRemove = [];
 {
     private _turret = _x;
     private _baseWeapons = getArray (([_veh, _turret] call BIS_fnc_turretConfig) / "Weapons");
-    private _weapons = _veh weaponsTurret _turret;
+    private _weapons = (_veh weaponsTurret _turret) apply { toLower _x };
     // Avoiding array subtract in case there's a pylon and non-pylon copy of the same weapon
-    { _weapons deleteAt (_weapons find _x) } forEach _baseWeapons;
+    // RHS has case bugs (zu-23 notably) so we force everything lower
+    { _weapons deleteAt (_weapons find toLower _x) } forEach _baseWeapons;
     { _toRemove pushBack [_x, _turret] } forEach _weapons;
 
 } forEach _turrets;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Turns out weapon classes found in vehicle turret config are not guaranteed to have the same case as weapon classes found using `weaponsTurret`. Which is fun. So the comparison here needs to be case-sensitive.

The RHS zu-23s tripped up on this, which is very bad.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
