### PR TITLE
Move A3A_climate init to initVarCommon for sanity and HC-functionality

### DIFF
--- a/A3A/addons/core/Templates/fn_selector.sqf
+++ b/A3A/addons/core/Templates/fn_selector.sqf
@@ -2,15 +2,10 @@
 FIX_LINE_NUMBERS()
 
 private _worldName = toLower worldName;
-A3A_climate = toLower (if (isText (missionConfigFile/"A3A"/"mapInfo"/_worldName/"climate")) then {
-    getText (missionConfigFile/"A3A"/"mapInfo"/_worldName/"climate")
-} else {
-    getText (configFile/"A3A"/"mapInfo"/_worldName/"climate")
-});
 
 private _fnc_requirementMeet = { getArray (_this/"requiredAddons") findIf { !(isClass (configFile/"CfgPatches"/_x)) } == -1 };
 
-//dependecies: _worldName
+//dependecies: _worldName, A3A_climate
 private _fnc_gatherTemplates = {
     params ["_type", ["_pool", []]]; //_pool and _nodes are modified
     if (isClass (_x/_type)) then {

--- a/A3A/addons/core/functions/init/fn_initVarCommon.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarCommon.sqf
@@ -85,6 +85,13 @@ allDLCMods = _modsInfo select {_x#2};
 allCDLC = _modsInfo select { !(_x#2) && _x#3 };
 allmods = _modsInfo - allDLCMods - allCDLC;
 
+// Load the climate here for the moment, because we need it early and globally
+private _worldName = toLower worldName;
+A3A_climate = toLower (if (isText (missionConfigFile/"A3A"/"mapInfo"/_worldName/"climate")) then {
+    getText (missionConfigFile/"A3A"/"mapInfo"/_worldName/"climate")
+} else {
+    getText (configFile/"A3A"/"mapInfo"/_worldName/"climate")
+});
 
 // Short Info of loaded mods needs to be added to this array. eg: `A3A_loadedTemplateInfoXML pushBack ["RHS","All factions will be replaced by RHS (AFRF &amp; USAF &amp; GREF)."];`
 A3A_loadedTemplateInfoXML = [];


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
A3A_climate was declared in selector.sqf (which only runs on the server) and not published, but used in combatLanding which runs on HCs. This probably caused singleAttack combat landings to follow the wrong path with HCs present.

selector.sqf seemed like a terrible place for it anyway, so I moved A3A_climate to initVarCommon which runs early and everywhere.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
