### PR TITLE
Templates - CUP Blufor updates for consistency with ACR changes

### DIFF
--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_BAF_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_BAF_Arid.sqf
@@ -149,6 +149,7 @@ _loadoutData set ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials
 private _slItems = ["Laserbatteries", "Laserbatteries", "Laserbatteries"];
 private _eeItems = ["ToolKit", "MineDetector"];
 private _mmItems = [];
+private _sfmmItems = ["cup_optic_an_pvs_10_black"];
 
 if (A3A_hasACE) then {
 	_slItems append ["ACE_microDAGR", "ACE_DAGR"];

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_BAF_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_BAF_Arid.sqf
@@ -180,6 +180,8 @@ _loadoutData set ["items_unarmed_extras", []];
 ///////////////////////////////////////
 
 private _sfLoadoutData = _loadoutData call _fnc_copyLoadoutData;
+_sfLoadoutData set ["items_marksman_extras", (_mmItems + _sfmmItems)];
+_sfLoadoutData set ["items_sniper_extras", (_mmItems + _sfmmItems)];
 _sfLoadoutData set ["uniforms", ["CUP_U_B_BAF_MTP_UBACSLONG", "CUP_U_B_BAF_MTP_UBACSLONG_Gloves"]];
 _sfLoadoutData set ["vests", ["CUP_V_B_BAF_MTP_Osprey_Mk4_Scout"]];
 _sfLoadoutData set ["mgVests", ["CUP_V_B_BAF_MTP_Osprey_Mk4_AutomaticRifleman"]];

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_BAF_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_BAF_Arid.sqf
@@ -194,7 +194,7 @@ _sfLoadoutData set ["helmets", ["CUP_H_OpsCore_Green", "CUP_H_OpsCore_Tan_SF"]];
 _sfLoadoutData set ["slHat", ["CUP_H_BAF_PARA_PRROVER_BERET"]];
 _sfLoadoutData set ["sniHats", ["CUP_H_USArmy_Boonie_OCP"]];
 _sfLoadoutData set ["NVGs", ["CUP_NVG_GPNVG_black"]];
-_sfLoadoutData set ["binoculars", ["CUP_LRTV"]];
+_sfLoadoutData set ["binoculars", ["CUP_SOFLAM"]];
 //["Weapon", "Muzzle", "Rail", "Sight", [], [], "Bipod"];
 
 

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_BAF_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_BAF_Temperate.sqf
@@ -183,6 +183,8 @@ _loadoutData set ["items_unarmed_extras", []];
 ///////////////////////////////////////
 
 private _sfLoadoutData = _loadoutData call _fnc_copyLoadoutData;
+_sfLoadoutData set ["items_marksman_extras", (_mmItems + _sfmmItems)];
+_sfLoadoutData set ["items_sniper_extras", (_mmItems + _sfmmItems)];
 _sfLoadoutData set ["uniforms", ["CUP_U_B_BAF_MTP_UBACSLONG", "CUP_U_B_BAF_MTP_UBACSLONG_Gloves"]];
 _sfLoadoutData set ["vests", ["CUP_V_B_BAF_MTP_Osprey_Mk4_Scout"]];
 _sfLoadoutData set ["mgVests", ["CUP_V_B_BAF_MTP_Osprey_Mk4_AutomaticRifleman"]];

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_BAF_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_BAF_Temperate.sqf
@@ -152,6 +152,7 @@ _loadoutData set ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials
 private _slItems = ["Laserbatteries", "Laserbatteries", "Laserbatteries"];
 private _eeItems = ["ToolKit", "MineDetector"];
 private _mmItems = [];
+private _sfmmItems = ["cup_optic_an_pvs_10_black"];
 
 if (A3A_hasACE) then {
 	_slItems append ["ACE_microDAGR", "ACE_DAGR"];

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_BAF_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_BAF_Temperate.sqf
@@ -197,7 +197,7 @@ _sfLoadoutData set ["helmets", ["CUP_H_OpsCore_Green", "CUP_H_OpsCore_Tan_SF"]];
 _sfLoadoutData set ["slHat", ["CUP_H_BAF_PARA_PRROVER_BERET"]];
 _sfLoadoutData set ["sniHats", ["CUP_H_USArmy_Boonie_OCP"]];
 _sfLoadoutData set ["NVGs", ["CUP_NVG_GPNVG_black"]];
-_sfLoadoutData set ["binoculars", ["CUP_LRTV"]];
+_sfLoadoutData set ["binoculars", ["CUP_SOFLAM"]];
 //["Weapon", "Muzzle", "Rail", "Sight", [], [], "Bipod"];
 
 _sfLoadoutData set ["slRifles", [

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_ION_Arctic.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_ION_Arctic.sqf
@@ -191,6 +191,8 @@ _loadoutData set ["items_unarmed_extras", []];
 ///////////////////////////////////////
 
 private _sfLoadoutData = _loadoutData call _fnc_copyLoadoutData;
+_sfLoadoutData set ["items_marksman_extras", (_mmItems + _sfmmItems)];
+_sfLoadoutData set ["items_sniper_extras", (_mmItems + _sfmmItems)];
 _sfLoadoutData set ["uniforms", ["CUP_I_B_PMC_Unit_30", "CUP_I_B_PMC_Unit_27", "CUP_I_B_PMC_Unit_34"]];
 _sfLoadoutData set ["vests", ["CUP_V_PMC_CIRAS_Winter_TL"]];
 _sfLoadoutData set ["mgVests", ["CUP_V_PMC_CIRAS_Winter_Patrol"]];

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_ION_Arctic.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_ION_Arctic.sqf
@@ -205,7 +205,7 @@ _sfLoadoutData set ["helmets", ["CUP_H_OpsCore_Black_NoHS"]];
 _sfLoadoutData set ["slHat", ["CUP_H_OpsCore_Black_SF"]];
 _sfLoadoutData set ["sniHats", ["CUP_H_PMC_Cap_Back_PRR_Grey"]];
 _sfLoadoutData set ["NVGs", ["CUP_NVG_GPNVG_black"]];
-_sfLoadoutData set ["binoculars", []];
+_sfLoadoutData set ["binoculars", ["CUP_SOFLAM"]];
 //["Weapon", "Muzzle", "Rail", "Sight", [], [], "Bipod"];
 
 _sfLoadoutData set ["slRifles", [

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_ION_Arctic.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_ION_Arctic.sqf
@@ -160,6 +160,7 @@ _loadoutData set ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials
 private _slItems = ["Laserbatteries", "Laserbatteries", "Laserbatteries"];
 private _eeItems = ["ToolKit", "MineDetector"];
 private _mmItems = [];
+private _sfmmItems = ["cup_optic_an_pvs_10_black"];
 
 if (A3A_hasACE) then {
 	_slItems append ["ACE_microDAGR", "ACE_DAGR"];

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_ION_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_ION_Arid.sqf
@@ -158,6 +158,7 @@ _loadoutData set ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials
 private _slItems = ["Laserbatteries", "Laserbatteries", "Laserbatteries"];
 private _eeItems = ["ToolKit", "MineDetector"];
 private _mmItems = [];
+private _sfmmItems = ["cup_optic_an_pvs_10_black"];
 
 if (A3A_hasACE) then {
 	_slItems append ["ACE_microDAGR", "ACE_DAGR"];

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_ION_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_ION_Arid.sqf
@@ -203,7 +203,7 @@ _sfLoadoutData set ["helmets", ["CUP_H_OpsCore_Black_NoHS"]];
 _sfLoadoutData set ["slHat", ["CUP_H_OpsCore_Black_SF"]];
 _sfLoadoutData set ["sniHats", ["CUP_H_PMC_Cap_Back_PRR_Grey"]];
 _sfLoadoutData set ["NVGs", ["CUP_NVG_GPNVG_black"]];
-_sfLoadoutData set ["binoculars", []];
+_sfLoadoutData set ["binoculars", ["CUP_SOFLAM"]];
 //["Weapon", "Muzzle", "Rail", "Sight", [], [], "Bipod"];
 
 _sfLoadoutData set ["slRifles", [

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_ION_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_ION_Arid.sqf
@@ -189,6 +189,8 @@ _loadoutData set ["items_unarmed_extras", []];
 ///////////////////////////////////////
 
 private _sfLoadoutData = _loadoutData call _fnc_copyLoadoutData;
+_sfLoadoutData set ["items_marksman_extras", (_mmItems + _sfmmItems)];
+_sfLoadoutData set ["items_sniper_extras", (_mmItems + _sfmmItems)];
 _sfLoadoutData set ["uniforms", ["CUP_I_B_PMC_Unit_11", "CUP_I_B_PMC_Unit_20", "CUP_I_B_PMC_Unit_42"]];
 _sfLoadoutData set ["vests", ["CUP_V_PMC_CIRAS_Black_TL"]];
 _sfLoadoutData set ["mgVests", ["CUP_V_B_Armatus_BB_Black"]];

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_RACS_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_RACS_Arid.sqf
@@ -152,6 +152,7 @@ _loadoutData set ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials
 private _slItems = ["Laserbatteries", "Laserbatteries", "Laserbatteries"];
 private _eeItems = ["ToolKit", "MineDetector"];
 private _mmItems = [];
+private _sfmmItems = ["cup_optic_an_pvs_10_black"];
 
 if (A3A_hasACE) then {
 	_slItems append ["ACE_microDAGR", "ACE_DAGR"];

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_RACS_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_RACS_Arid.sqf
@@ -197,7 +197,7 @@ _sfLoadoutData set ["helmets", ["CUP_H_OpsCore_Spray_SF", "CUP_H_OpsCore_Green_S
 _sfLoadoutData set ["slHat", ["CUP_H_PMC_Cap_EP_Grey"]];
 _sfLoadoutData set ["sniHats", ["CUP_H_CZ_Booniehat_vz95_des"]];
 _sfLoadoutData set ["NVGs", ["CUP_NVG_GPNVG_black"]];
-_sfLoadoutData set ["binoculars", ["CUP_LRTV"]];
+_sfLoadoutData set ["binoculars", ["CUP_SOFLAM"]];
 //["Weapon", "Muzzle", "Rail", "Sight", [], [], "Bipod"];
 
 _sfLoadoutData set ["slRifles", [

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_RACS_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_RACS_Arid.sqf
@@ -183,6 +183,8 @@ _loadoutData set ["items_unarmed_extras", []];
 ///////////////////////////////////////
 
 private _sfLoadoutData = _loadoutData call _fnc_copyLoadoutData;
+_sfLoadoutData set ["items_marksman_extras", (_mmItems + _sfmmItems)];
+_sfLoadoutData set ["items_sniper_extras", (_mmItems + _sfmmItems)];
 _sfLoadoutData set ["uniforms", ["CUP_U_I_RACS_Desert_1", "CUP_U_I_RACS_Desert_2"]];
 _sfLoadoutData set ["vests", ["CUP_V_CPC_Fastbelt_coy"]];
 _sfLoadoutData set ["mgVests", ["CUP_V_CPC_weapons_coy"]];

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_RACS_Tropical.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_RACS_Tropical.sqf
@@ -152,6 +152,7 @@ _loadoutData set ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials
 private _slItems = ["Laserbatteries", "Laserbatteries", "Laserbatteries"];
 private _eeItems = ["ToolKit", "MineDetector"];
 private _mmItems = [];
+private _sfmmItems = ["cup_optic_an_pvs_10_black"];
 
 if (A3A_hasACE) then {
 	_slItems append ["ACE_microDAGR", "ACE_DAGR"];

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_RACS_Tropical.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_RACS_Tropical.sqf
@@ -183,6 +183,8 @@ _loadoutData set ["items_unarmed_extras", []];
 ///////////////////////////////////////
 
 private _sfLoadoutData = _loadoutData call _fnc_copyLoadoutData;
+_sfLoadoutData set ["items_marksman_extras", (_mmItems + _sfmmItems)];
+_sfLoadoutData set ["items_sniper_extras", (_mmItems + _sfmmItems)];
 _sfLoadoutData set ["vests", ["CUP_V_CPC_Fastbelt_rngr"]];
 _sfLoadoutData set ["mgVests", ["CUP_V_CPC_weapons_rngr"]];
 _sfLoadoutData set ["medVests", ["CUP_V_JPC_medicalbelt_rngr"]];

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_RACS_Tropical.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_RACS_Tropical.sqf
@@ -196,7 +196,7 @@ _sfLoadoutData set ["helmets", ["CUP_H_OpsCore_Spray_SF", "CUP_H_OpsCore_Green_S
 _sfLoadoutData set ["slHat", ["CUP_H_PMC_Cap_EP_Grey"]];
 _sfLoadoutData set ["sniHats", ["CUP_H_USA_Boonie_wdl"]];
 _sfLoadoutData set ["NVGs", ["CUP_NVG_GPNVG_black"]];
-_sfLoadoutData set ["binoculars", ["CUP_LRTV"]];
+_sfLoadoutData set ["binoculars", ["CUP_SOFLAM"]];
 //["Weapon", "Muzzle", "Rail", "Sight", [], [], "Bipod"];
 
 _sfLoadoutData set ["slRifles", [

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Arid.sqf
@@ -181,6 +181,8 @@ _loadoutData set ["items_unarmed_extras", []];
 ///////////////////////////////////////
 
 private _sfLoadoutData = _loadoutData call _fnc_copyLoadoutData;
+_sfLoadoutData set ["items_marksman_extras", (_mmItems + _sfmmItems)];
+_sfLoadoutData set ["items_sniper_extras", (_mmItems + _sfmmItems)];
 _sfLoadoutData set ["uniforms", ["CUP_U_CRYE_G3C_MC_US", "CUP_U_CRYE_G3C_MC_V2", "CUP_U_CRYE_G3C_MC", "CUP_U_CRYE_V1_Full"]];
 _sfLoadoutData set ["vests", ["CUP_V_CPC_Fastbelt_mc"]];
 _sfLoadoutData set ["mgVests", ["CUP_V_CPC_weapons_mc"]];

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Arid.sqf
@@ -150,6 +150,7 @@ _loadoutData set ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials
 private _slItems = ["Laserbatteries", "Laserbatteries", "Laserbatteries"];
 private _eeItems = ["ToolKit", "MineDetector"];
 private _mmItems = [];
+private _sfmmItems = ["cup_optic_an_pvs_10_black"];
 
 if (A3A_hasACE) then {
 	_slItems append ["ACE_microDAGR", "ACE_DAGR"];

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Arid.sqf
@@ -195,7 +195,7 @@ _sfLoadoutData set ["helmets", ["CUP_H_OpsCore_Spray_SF", "CUP_H_OpsCore_Covered
 _sfLoadoutData set ["slHat", ["CUP_H_USA_Cap_Mcam_DEF"]];
 _sfLoadoutData set ["sniHats", ["CUP_H_USArmy_Boonie_hs_OCP"]];
 _sfLoadoutData set ["NVGs", ["CUP_NVG_GPNVG_black"]];
-_sfLoadoutData set ["binoculars", ["CUP_LRTV"]];
+_sfLoadoutData set ["binoculars", ["CUP_SOFLAM"]];
 //["Weapon", "Muzzle", "Rail", "Sight", [], [], "Bipod"];
 
 _sfLoadoutData set ["slRifles", [

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Temperate.sqf
@@ -181,6 +181,8 @@ _loadoutData set ["items_unarmed_extras", []];
 ///////////////////////////////////////
 
 private _sfLoadoutData = _loadoutData call _fnc_copyLoadoutData;
+_sfLoadoutData set ["items_marksman_extras", (_mmItems + _sfmmItems)];
+_sfLoadoutData set ["items_sniper_extras", (_mmItems + _sfmmItems)];
 _sfLoadoutData set ["uniforms", ["CUP_U_CRYE_G3C_MC_US", "CUP_U_CRYE_G3C_MC_V2", "CUP_U_CRYE_G3C_MC", "CUP_U_CRYE_V1_Full"]];
 _sfLoadoutData set ["vests", ["CUP_V_CPC_Fastbelt_mc"]];
 _sfLoadoutData set ["mgVests", ["CUP_V_CPC_weapons_mc"]];

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Temperate.sqf
@@ -150,6 +150,7 @@ _loadoutData set ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials
 private _slItems = ["Laserbatteries", "Laserbatteries", "Laserbatteries"];
 private _eeItems = ["ToolKit", "MineDetector"];
 private _mmItems = [];
+private _sfmmItems = ["cup_optic_an_pvs_10_black"];
 
 if (A3A_hasACE) then {
 	_slItems append ["ACE_microDAGR", "ACE_DAGR"];

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Temperate.sqf
@@ -195,7 +195,7 @@ _sfLoadoutData set ["helmets", ["CUP_H_OpsCore_Spray_SF", "CUP_H_OpsCore_Covered
 _sfLoadoutData set ["slHat", ["CUP_H_USA_Cap_Mcam_DEF"]];
 _sfLoadoutData set ["sniHats", ["CUP_H_USArmy_Boonie_hs_OCP"]];
 _sfLoadoutData set ["NVGs", ["CUP_NVG_GPNVG_black"]];
-_sfLoadoutData set ["binoculars", ["CUP_LRTV"]];
+_sfLoadoutData set ["binoculars", ["CUP_SOFLAM"]];
 //["Weapon", "Muzzle", "Rail", "Sight", [], [], "Bipod"];
 
 _sfLoadoutData set ["slRifles", [

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Marine_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Marine_Arid.sqf
@@ -201,7 +201,7 @@ _sfLoadoutData set ["atBackpacks", ["CUP_B_USPack_Coyote"]];
 _sfLoadoutData set ["helmets", ["CUP_H_OpsCore_Tan_SF", "CUP_H_USArmy_ECH_MARPAT_des"]];
 _sfLoadoutData set ["slHat", ["CUP_H_USA_Cap_MARSOC_DEF"]];
 _sfLoadoutData set ["NVGs", ["CUP_NVG_GPNVG_black"]];
-_sfLoadoutData set ["binoculars", ["CUP_LRTV"]];
+_sfLoadoutData set ["binoculars", ["CUP_SOFLAM"]];
 //["Weapon", "Muzzle", "Rail", "Sight", [], [], "Bipod"];
 
 _sfLoadoutData set ["slRifles", [

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Marine_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Marine_Arid.sqf
@@ -188,6 +188,8 @@ _loadoutData set ["items_unarmed_extras", []];
 ///////////////////////////////////////
 
 private _sfLoadoutData = _loadoutData call _fnc_copyLoadoutData;
+_sfLoadoutData set ["items_marksman_extras", (_mmItems + _sfmmItems)];
+_sfLoadoutData set ["items_sniper_extras", (_mmItems + _sfmmItems)];
 _sfLoadoutData set ["uniforms", ["CUP_U_B_USMC_FROG1_DMARPAT", "CUP_U_B_USMC_FROG2_DMARPAT", "CUP_U_B_USMC_FROG3_DMARPAT", "CUP_U_B_USMC_FROG4_DMARPAT"]];
 _sfLoadoutData set ["vests", ["CUP_V_B_RRV_DA1"]];
 _sfLoadoutData set ["mgVests", ["CUP_V_CPC_weaponsbelt_mc"]];

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Marine_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Marine_Arid.sqf
@@ -157,6 +157,7 @@ _loadoutData set ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials
 private _slItems = ["Laserbatteries", "Laserbatteries", "Laserbatteries"];
 private _eeItems = ["ToolKit", "MineDetector"];
 private _mmItems = [];
+private _sfmmItems = ["cup_optic_an_pvs_10_black"];
 
 if (A3A_hasACE) then {
 	_slItems append ["ACE_microDAGR", "ACE_DAGR"];

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Marine_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Marine_Temperate.sqf
@@ -201,7 +201,7 @@ _sfLoadoutData set ["atBackpacks", ["B_AssaultPack_khk"]];
 _sfLoadoutData set ["helmets", ["CUP_H_OpsCore_Tan_SF", "CUP_H_USArmy_ECH_MARPAT"]];
 _sfLoadoutData set ["slHat", ["CUP_H_USA_Cap_MARSOC_DEF"]];
 _sfLoadoutData set ["NVGs", ["CUP_NVG_GPNVG_black"]];
-_sfLoadoutData set ["binoculars", ["CUP_LRTV"]];
+_sfLoadoutData set ["binoculars", ["CUP_SOFLAM"]];
 //["Weapon", "Muzzle", "Rail", "Sight", [], [], "Bipod"];
 
 _sfLoadoutData set ["slRifles", [

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Marine_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Marine_Temperate.sqf
@@ -188,6 +188,8 @@ _loadoutData set ["items_unarmed_extras", []];
 ///////////////////////////////////////
 
 private _sfLoadoutData = _loadoutData call _fnc_copyLoadoutData;
+_sfLoadoutData set ["items_marksman_extras", (_mmItems + _sfmmItems)];
+_sfLoadoutData set ["items_sniper_extras", (_mmItems + _sfmmItems)];
 _sfLoadoutData set ["uniforms", ["CUP_U_B_USMC_FROG1_WMARPAT", "CUP_U_B_USMC_FROG2_WMARPAT", "CUP_U_B_USMC_FROG3_WMARPAT", "CUP_U_B_USMC_FROG4_WMARPAT"]];
 _sfLoadoutData set ["vests", ["CUP_V_CPC_Fast_coy"]];
 _sfLoadoutData set ["mgVests", ["CUP_V_CPC_weaponsbelt_mc"]];

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Marine_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Marine_Temperate.sqf
@@ -157,6 +157,7 @@ _loadoutData set ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials
 private _slItems = ["Laserbatteries", "Laserbatteries", "Laserbatteries"];
 private _eeItems = ["ToolKit", "MineDetector"];
 private _mmItems = [];
+private _sfmmItems = ["cup_optic_an_pvs_10_black"];
 
 if (A3A_hasACE) then {
 	_slItems append ["ACE_microDAGR", "ACE_DAGR"];


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [x] Enhancement

### What have you changed and why?
Information:
    #2312 added extra items for marksman and sniper loadouts. This PR adds consistency to rest of the blufor cup templates.
    Adds ir, nightvision scopes to the loadouts. Changes the binocular to the SOFLAM. These changes try to award the players with better and higher quality items from sf units. 

### Please specify which Issue this PR Resolves.
N/A

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
