### PR TITLE
Fix behaviour and remoteExec bugs in undercover AI

### DIFF
--- a/A3A/addons/core/functions/AI/fn_undercoverAI.sqf
+++ b/A3A/addons/core/functions/AI/fn_undercoverAI.sqf
@@ -1,3 +1,5 @@
+// Note: leader might not be group leader, so locality isn't guaranteed. This case is a bit broken (disableAI etc)
+// AIs may even switch locality mid-function
 private ["_unit","_LeaderX","_airportsX","_base","_loadOut", "_oldBehaviour"];
 
 _unit = _this select 0;
@@ -6,14 +8,14 @@ _LeaderX = _unit getVariable ["owner",leader group _unit];
 if (!isPlayer _LeaderX) exitWith {};
 if (!captive _LeaderX) exitWith {};
 if (captive _unit) exitWith {};
-[_unit,true] remoteExec ["setCaptive",0,_unit];
+[_unit,true] remoteExec ["setCaptive",_unit];
 _unit setCaptive true;
 _unit disableAI "TARGET";
 _unit disableAI "AUTOTARGET";
 
-_oldBehaviour = behaviour _unit;
+_oldBehaviour = combatBehaviour _unit;		// actually the same as behaviour _unit?
 
-_unit setBehaviour "CARELESS";
+_unit setCombatBehaviour "CARELESS";
 _unit setUnitPos "UP";
 _loadOut = getUnitLoadout _unit;
 removeAllItems _unit;
@@ -35,9 +37,9 @@ while {(captive _LeaderX) and (captive _unit)} do
 	};
 
 //_unit removeAllEventHandlers "FIRED";
-if (!captive _unit) then {_unit groupChat "Shit, they have spotted me!"} else {[_unit,false] remoteExec ["setCaptive",0,_unit]; _unit setCaptive false};
-if (captive player) then {sleep 5};
-_unit setBehaviour _oldBehaviour;
+if (!captive _unit) then {_unit groupChat "Shit, they have spotted me!"} else {[_unit,false] remoteExec ["setCaptive",_unit]; _unit setCaptive false};
+if (captive _LeaderX) then {sleep 5};
+_unit setCombatBehaviour _oldBehaviour;
 _unit enableAI "TARGET";
 _unit enableAI "AUTOTARGET";
 _unit setUnitPos "AUTO";


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed some bugs in undercover AI:
- Incorrect use of setBehaviour often caused group to be stuck in careless after leaving undercover.
- Incorrect setCaptive remoteExec use with unnecessary broadcasts and bogus JIP.
- Minor player dependency bug.

### Please specify which Issue this PR Resolves.
closes #2385

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Hire several AIs, enter and leave undercover. Run this as local to check their behaviour:
`units player apply { behaviour _x };`
