### PR TITLE
Disable Arma rating changes for players

### DIFF
--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -260,6 +260,9 @@ if (A3A_hasACE) then {
     }] call CBA_fnc_addEventHandler;
 };
 
+// Prevent players getting shot by their own AIs. EH is respawn-persistent
+player addEventHandler ["HandleRating", {0}];
+
 call A3A_fnc_initUndercover;
 
 if (isMultiplayer) then {


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Added an EH to disable rating changes for players. It's common for players to end up in negative rating for bad reasons and then get attacked by their own AIs. Some reasons for losing rating:
- Crashing their own vehicles.
- Blowing up unoccupied vehicles with mortars.
- Shooting down enemy vehicles that have an inherent side as greenfor (eg. some AAF stuff).

AIs don't seem to take rating penalties (although oddly enough they do get the bonuses), so I don't think we need to do anything complicated here. Only remaining problem case is if a player remote-controls AI and blows up something, but that's not a major or common issue.

### Please specify which Issue this PR Resolves.
closes #2386

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
