### PR TITLE
Facewear support for AI loadouts

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -693,6 +693,7 @@ class CfgFunctions
             class loadout_setBackpack {};
             class loadout_addEquipment {};
             class loadout_setHelmet {};
+            class loadout_setFacewear {};
             class loadout_addItems {};
             class loadout_additionalMuzzleMags {};
             class loadout_setUniform {};

--- a/A3A/addons/core/Templates/Templates/#Examples/FactionExample.sqf
+++ b/A3A/addons/core/Templates/Templates/#Examples/FactionExample.sqf
@@ -130,18 +130,6 @@ _loadoutData set ["vests", []];
 _loadoutData set ["backpacks", []];
 _loadoutData set ["longRangeRadios", []];
 _loadoutData set ["helmets", []];
-
-/* Facewear array:
-
-The first item in the array is a number that determines the selection weight of having facewear, ranging from 0 - 1.
-
-1 = There will always be a facewear item selected. Facewear is never unequipped.
-0.5 = All facewear options, including having no facewear, have an equal chance of being selected.
-0 = Facewear is always unequipped.
-
-Everything after the first number is the list of possible facewear that can be worn. 
-All facewear items have an equal chance of being picked, with the exception of the unequipped facewear chance affected by the weight number.
-*/
 _loadoutData set ["facewear", []];
 
 //Item *set* definitions. These are added in their entirety to unit loadouts. No randomisation is applied.

--- a/A3A/addons/core/Templates/Templates/#Examples/FactionExample.sqf
+++ b/A3A/addons/core/Templates/Templates/#Examples/FactionExample.sqf
@@ -131,8 +131,7 @@ _loadoutData set ["backpacks", []];
 _loadoutData set ["longRangeRadios", []];
 _loadoutData set ["helmets", []];
 
-_loadoutData set ["glasses", []];
-_loadoutData set ["goggles", []];
+_loadoutData set ["facewear", []];
 
 //Item *set* definitions. These are added in their entirety to unit loadouts. No randomisation is applied.
 _loadoutData set ["items_medical_basic", ["BASIC"] call A3A_fnc_itemset_medicalSupplies];
@@ -256,7 +255,7 @@ _pilotLoadoutData set ["helmets", []];
 
 private _squadLeaderTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 
@@ -287,7 +286,7 @@ private _squadLeaderTemplate = {
 
 private _riflemanTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -313,7 +312,7 @@ private _riflemanTemplate = {
 
 private _medicTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -338,7 +337,7 @@ private _medicTemplate = {
 
 private _grenadierTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -365,7 +364,7 @@ private _grenadierTemplate = {
 
 private _explosivesExpertTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -398,7 +397,7 @@ private _explosivesExpertTemplate = {
 
 private _engineerTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -427,7 +426,7 @@ private _engineerTemplate = {
 
 private _latTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -457,7 +456,7 @@ private _latTemplate = {
 
 private _atTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -487,7 +486,7 @@ private _atTemplate = {
 
 private _aaTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -517,7 +516,7 @@ private _aaTemplate = {
 
 private _machineGunnerTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -543,7 +542,7 @@ private _machineGunnerTemplate = {
 
 private _marksmanTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -570,7 +569,7 @@ private _marksmanTemplate = {
 
 private _sniperTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -620,7 +619,7 @@ private _policeTemplate = {
 
 private _crewTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 

--- a/A3A/addons/core/Templates/Templates/#Examples/FactionExample.sqf
+++ b/A3A/addons/core/Templates/Templates/#Examples/FactionExample.sqf
@@ -131,6 +131,19 @@ _loadoutData set ["backpacks", []];
 _loadoutData set ["longRangeRadios", []];
 _loadoutData set ["helmets", []];
 
+/* Facewear array:
+
+The first item in the array is a number that determines the selection weight of having facewear, ranging from 0 - 1.
+
+1 = There will always be a facewear item selected. Facewear is never unequipped.
+0.5 = All facewear options, including having no facewear, have an equal chance of being selected.
+0 = Facewear is always unequipped.
+
+Everything after the first number is the list of possible facewear that can be worn. 
+All facewear items have an equal chance of being picked, with the exception of the unequipped facewear chance affected by the weight number.
+*/
+_loadoutData set ["facewear", []];
+
 //Item *set* definitions. These are added in their entirety to unit loadouts. No randomisation is applied.
 _loadoutData set ["items_medical_basic", ["BASIC"] call A3A_fnc_itemset_medicalSupplies];
 _loadoutData set ["items_medical_standard", ["STANDARD"] call A3A_fnc_itemset_medicalSupplies];
@@ -253,6 +266,7 @@ _pilotLoadoutData set ["helmets", []];
 
 private _squadLeaderTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setHelmet;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 
@@ -283,6 +297,7 @@ private _squadLeaderTemplate = {
 
 private _riflemanTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setHelmet;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -308,6 +323,7 @@ private _riflemanTemplate = {
 
 private _medicTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setHelmet;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -332,6 +348,7 @@ private _medicTemplate = {
 
 private _grenadierTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setHelmet;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -358,6 +375,7 @@ private _grenadierTemplate = {
 
 private _explosivesExpertTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setHelmet;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -390,6 +408,7 @@ private _explosivesExpertTemplate = {
 
 private _engineerTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setHelmet;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -418,6 +437,7 @@ private _engineerTemplate = {
 
 private _latTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setHelmet;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -447,6 +467,7 @@ private _latTemplate = {
 
 private _atTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setHelmet;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -476,6 +497,7 @@ private _atTemplate = {
 
 private _aaTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setHelmet;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -505,6 +527,7 @@ private _aaTemplate = {
 
 private _machineGunnerTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setHelmet;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -530,6 +553,7 @@ private _machineGunnerTemplate = {
 
 private _marksmanTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setHelmet;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -556,6 +580,7 @@ private _marksmanTemplate = {
 
 private _sniperTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setHelmet;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -605,6 +630,7 @@ private _policeTemplate = {
 
 private _crewTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setHelmet;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 

--- a/A3A/addons/core/Templates/Templates/#Examples/FactionExample.sqf
+++ b/A3A/addons/core/Templates/Templates/#Examples/FactionExample.sqf
@@ -130,7 +130,9 @@ _loadoutData set ["vests", []];
 _loadoutData set ["backpacks", []];
 _loadoutData set ["longRangeRadios", []];
 _loadoutData set ["helmets", []];
-_loadoutData set ["facewear", []];
+
+_loadoutData set ["glasses", []];
+_loadoutData set ["goggles", []];
 
 //Item *set* definitions. These are added in their entirety to unit loadouts. No randomisation is applied.
 _loadoutData set ["items_medical_basic", ["BASIC"] call A3A_fnc_itemset_medicalSupplies];
@@ -254,7 +256,7 @@ _pilotLoadoutData set ["helmets", []];
 
 private _squadLeaderTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 
@@ -285,7 +287,7 @@ private _squadLeaderTemplate = {
 
 private _riflemanTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -311,7 +313,7 @@ private _riflemanTemplate = {
 
 private _medicTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -336,7 +338,7 @@ private _medicTemplate = {
 
 private _grenadierTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -363,7 +365,7 @@ private _grenadierTemplate = {
 
 private _explosivesExpertTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -396,7 +398,7 @@ private _explosivesExpertTemplate = {
 
 private _engineerTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -425,7 +427,7 @@ private _engineerTemplate = {
 
 private _latTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -455,7 +457,7 @@ private _latTemplate = {
 
 private _atTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -485,7 +487,7 @@ private _atTemplate = {
 
 private _aaTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -515,7 +517,7 @@ private _aaTemplate = {
 
 private _machineGunnerTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -541,7 +543,7 @@ private _machineGunnerTemplate = {
 
 private _marksmanTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -568,7 +570,7 @@ private _marksmanTemplate = {
 
 private _sniperTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -618,7 +620,7 @@ private _policeTemplate = {
 
 private _crewTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 

--- a/A3A/addons/core/Templates/Templates/#Examples/FactionExample.sqf
+++ b/A3A/addons/core/Templates/Templates/#Examples/FactionExample.sqf
@@ -266,7 +266,7 @@ _pilotLoadoutData set ["helmets", []];
 
 private _squadLeaderTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 
@@ -297,7 +297,7 @@ private _squadLeaderTemplate = {
 
 private _riflemanTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -323,7 +323,7 @@ private _riflemanTemplate = {
 
 private _medicTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -348,7 +348,7 @@ private _medicTemplate = {
 
 private _grenadierTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -375,7 +375,7 @@ private _grenadierTemplate = {
 
 private _explosivesExpertTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -408,7 +408,7 @@ private _explosivesExpertTemplate = {
 
 private _engineerTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -437,7 +437,7 @@ private _engineerTemplate = {
 
 private _latTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -467,7 +467,7 @@ private _latTemplate = {
 
 private _atTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -497,7 +497,7 @@ private _atTemplate = {
 
 private _aaTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -527,7 +527,7 @@ private _aaTemplate = {
 
 private _machineGunnerTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -553,7 +553,7 @@ private _machineGunnerTemplate = {
 
 private _marksmanTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -580,7 +580,7 @@ private _marksmanTemplate = {
 
 private _sniperTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -630,7 +630,7 @@ private _policeTemplate = {
 
 private _crewTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 

--- a/A3A/addons/core/Templates/Templates/#Examples/FactionExample.sqf
+++ b/A3A/addons/core/Templates/Templates/#Examples/FactionExample.sqf
@@ -255,7 +255,7 @@ _pilotLoadoutData set ["helmets", []];
 
 private _squadLeaderTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 
@@ -286,7 +286,7 @@ private _squadLeaderTemplate = {
 
 private _riflemanTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -312,7 +312,7 @@ private _riflemanTemplate = {
 
 private _medicTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -337,7 +337,7 @@ private _medicTemplate = {
 
 private _grenadierTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -364,7 +364,7 @@ private _grenadierTemplate = {
 
 private _explosivesExpertTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -397,7 +397,7 @@ private _explosivesExpertTemplate = {
 
 private _engineerTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -426,7 +426,7 @@ private _engineerTemplate = {
 
 private _latTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -456,7 +456,7 @@ private _latTemplate = {
 
 private _atTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -486,7 +486,7 @@ private _atTemplate = {
 
 private _aaTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -516,7 +516,7 @@ private _aaTemplate = {
 
 private _machineGunnerTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -542,7 +542,7 @@ private _machineGunnerTemplate = {
 
 private _marksmanTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -569,7 +569,7 @@ private _marksmanTemplate = {
 
 private _sniperTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -619,7 +619,7 @@ private _policeTemplate = {
 
 private _crewTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 

--- a/A3A/addons/core/Templates/Templates/#Examples/RebelExample.sqf
+++ b/A3A/addons/core/Templates/Templates/#Examples/RebelExample.sqf
@@ -84,9 +84,7 @@ _loadoutData set ["binoculars", ["Binocular"]];
 
 _loadoutData set ["uniforms", _rebUniforms];
 
-_loadoutData set ["glasses", []];
-_loadoutData set ["goggles", []];
-_loadoutData set ["facemask", []];
+_loadoutData set ["facewear", []];
 
 _loadoutData set ["items_medical_basic", ["BASIC"] call A3A_fnc_itemset_medicalSupplies];
 _loadoutData set ["items_medical_standard", ["STANDARD"] call A3A_fnc_itemset_medicalSupplies];
@@ -99,7 +97,7 @@ _loadoutData set ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials
 
 private _squadLeaderTemplate = {
     ["uniforms"] call _fnc_setUniform;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5, "facemask", 0.8]] call _fnc_setFacewear;
+    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
 
     ["maps"] call _fnc_addMap;
     ["watches"] call _fnc_addWatch;
@@ -109,7 +107,7 @@ private _squadLeaderTemplate = {
 
 private _riflemanTemplate = {
     ["uniforms"] call _fnc_setUniform;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5, "facemask", 0.8]] call _fnc_setFacewear;
+    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
     
     ["maps"] call _fnc_addMap;
     ["watches"] call _fnc_addWatch;

--- a/A3A/addons/core/Templates/Templates/#Examples/RebelExample.sqf
+++ b/A3A/addons/core/Templates/Templates/#Examples/RebelExample.sqf
@@ -97,7 +97,7 @@ _loadoutData set ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials
 
 private _squadLeaderTemplate = {
     ["uniforms"] call _fnc_setUniform;
-    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
+    ["facewear"] call _fnc_setFacewear;
 
     ["maps"] call _fnc_addMap;
     ["watches"] call _fnc_addWatch;
@@ -107,7 +107,7 @@ private _squadLeaderTemplate = {
 
 private _riflemanTemplate = {
     ["uniforms"] call _fnc_setUniform;
-    [selectRandomWeighted ["facewear", 1]] call _fnc_setFacewear;
+    ["facewear"] call _fnc_setFacewear;
     
     ["maps"] call _fnc_addMap;
     ["watches"] call _fnc_addWatch;

--- a/A3A/addons/core/Templates/Templates/#Examples/RebelExample.sqf
+++ b/A3A/addons/core/Templates/Templates/#Examples/RebelExample.sqf
@@ -65,6 +65,19 @@ if (allowDLCExpansion) then {_dlcUniforms append [];
 
 ["headgear", []] call _fnc_saveToTemplate;          //Headgear used by Rebell Ai until you have Armored Headgear.
 
+/* Facewear array:
+
+The first item in the array is a number that determines the selection weight of having facewear, ranging from 0 - 1.
+
+1 = There will always be a facewear item selected. Facewear is never unequipped.
+0.5 = All facewear options, including having no facewear, have an equal chance of being selected.
+0 = Facewear is always unequipped.
+
+Everything after the first number is the list of possible facewear that can be worn. 
+All facewear items have an equal chance of being picked, with the exception of the unequipped facewear chance affected by the weight number.
+*/
+["facewear", []] call _fnc_saveToTemplate;
+
 /////////////////////
 ///  Identities   ///
 /////////////////////

--- a/A3A/addons/core/Templates/Templates/#Examples/RebelExample.sqf
+++ b/A3A/addons/core/Templates/Templates/#Examples/RebelExample.sqf
@@ -83,7 +83,10 @@ _loadoutData set ["compasses", ["ItemCompass"]];
 _loadoutData set ["binoculars", ["Binocular"]];
 
 _loadoutData set ["uniforms", _rebUniforms];
-_loadoutData set ["facewear", []];
+
+_loadoutData set ["glasses", []];
+_loadoutData set ["goggles", []];
+_loadoutData set ["facemask", []];
 
 _loadoutData set ["items_medical_basic", ["BASIC"] call A3A_fnc_itemset_medicalSupplies];
 _loadoutData set ["items_medical_standard", ["STANDARD"] call A3A_fnc_itemset_medicalSupplies];
@@ -96,7 +99,7 @@ _loadoutData set ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials
 
 private _squadLeaderTemplate = {
     ["uniforms"] call _fnc_setUniform;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5, "facemask", 0.8]] call _fnc_setFacewear;
 
     ["maps"] call _fnc_addMap;
     ["watches"] call _fnc_addWatch;
@@ -106,7 +109,7 @@ private _squadLeaderTemplate = {
 
 private _riflemanTemplate = {
     ["uniforms"] call _fnc_setUniform;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5, "facemask", 0.8]] call _fnc_setFacewear;
     
     ["maps"] call _fnc_addMap;
     ["watches"] call _fnc_addWatch;

--- a/A3A/addons/core/Templates/Templates/#Examples/RebelExample.sqf
+++ b/A3A/addons/core/Templates/Templates/#Examples/RebelExample.sqf
@@ -65,17 +65,6 @@ if (allowDLCExpansion) then {_dlcUniforms append [];
 
 ["headgear", []] call _fnc_saveToTemplate;          //Headgear used by Rebell Ai until you have Armored Headgear.
 
-/* Facewear array:
-
-The first item in the array is a number that determines the selection weight of having facewear, ranging from 0 - 1.
-
-1 = There will always be a facewear item selected. Facewear is never unequipped.
-0.5 = All facewear options, including having no facewear, have an equal chance of being selected.
-0 = Facewear is always unequipped.
-
-Everything after the first number is the list of possible facewear that can be worn. 
-All facewear items have an equal chance of being picked, with the exception of the unequipped facewear chance affected by the weight number.
-*/
 ["facewear", []] call _fnc_saveToTemplate;
 
 /////////////////////

--- a/A3A/addons/core/Templates/Templates/#Examples/RebelExample.sqf
+++ b/A3A/addons/core/Templates/Templates/#Examples/RebelExample.sqf
@@ -65,8 +65,6 @@ if (allowDLCExpansion) then {_dlcUniforms append [];
 
 ["headgear", []] call _fnc_saveToTemplate;          //Headgear used by Rebell Ai until you have Armored Headgear.
 
-["facewear", []] call _fnc_saveToTemplate;
-
 /////////////////////
 ///  Identities   ///
 /////////////////////
@@ -85,6 +83,7 @@ _loadoutData set ["compasses", ["ItemCompass"]];
 _loadoutData set ["binoculars", ["Binocular"]];
 
 _loadoutData set ["uniforms", _rebUniforms];
+_loadoutData set ["facewear", []];
 
 _loadoutData set ["items_medical_basic", ["BASIC"] call A3A_fnc_itemset_medicalSupplies];
 _loadoutData set ["items_medical_standard", ["STANDARD"] call A3A_fnc_itemset_medicalSupplies];
@@ -97,6 +96,7 @@ _loadoutData set ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials
 
 private _squadLeaderTemplate = {
     ["uniforms"] call _fnc_setUniform;
+    ["facewear"] call _fnc_setFacewear;
 
     ["maps"] call _fnc_addMap;
     ["watches"] call _fnc_addWatch;
@@ -106,7 +106,8 @@ private _squadLeaderTemplate = {
 
 private _riflemanTemplate = {
     ["uniforms"] call _fnc_setUniform;
-
+    ["facewear"] call _fnc_setFacewear;
+    
     ["maps"] call _fnc_addMap;
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -152,7 +152,7 @@ _loadoutData set ["atBackpacks", ["B_Carryall_oli"]];
 _loadoutData set ["helmets", []];
 _loadoutData set ["slHat", ["H_Beret_blk"]];
 _loadoutData set ["sniHats", ["H_Booniehat_dgtl"]];
-_loadoutData set ["facewear", ["!EMPTY", 1, "G_Tactical_Clear", 1, "G_Tactical_Black", 1, "G_Combat", 1, "G_Shades_Black", 1, "G_Shades_Blue", 1, "G_Shades_Green", 1, "G_Shades_Red", 1, "G_Aviator", 1, "G_Spectacles", 1, "G_Spectacles_Tinted", 1, "G_Sport_BlackWhite", 1, "G_Sport_Blackyellow", 1, "G_Sport_Greenblack", 1, "G_Sport_Checkered", 1, "G_Sport_Red", 1, "G_Squares", 1, "G_Squares_Tinted", 1, "G_Lowprofile", 1]];
+_loadoutData set ["facewear", ["", 1, "G_Tactical_Clear", 1, "G_Tactical_Black", 1, "G_Combat", 1, "G_Shades_Black", 1, "G_Shades_Blue", 1, "G_Shades_Green", 1, "G_Shades_Red", 1, "G_Aviator", 1, "G_Spectacles", 1, "G_Spectacles_Tinted", 1, "G_Sport_BlackWhite", 1, "G_Sport_Blackyellow", 1, "G_Sport_Greenblack", 1, "G_Sport_Checkered", 1, "G_Sport_Red", 1, "G_Squares", 1, "G_Squares_Tinted", 1, "G_Lowprofile", 1]];
 
 //Item *set* definitions. These are added in their entirety to unit loadouts. No randomisation is applied.
 _loadoutData set ["items_medical_basic", ["BASIC"] call A3A_fnc_itemset_medicalSupplies]; //this line defines the basic medical loadout for vanilla

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -152,7 +152,9 @@ _loadoutData set ["atBackpacks", ["B_Carryall_oli"]];
 _loadoutData set ["helmets", []];
 _loadoutData set ["slHat", ["H_Beret_blk"]];
 _loadoutData set ["sniHats", ["H_Booniehat_dgtl"]];
-_loadoutData set ["facewear", ["", 1, "G_Tactical_Clear", 1, "G_Tactical_Black", 1, "G_Combat", 1, "G_Shades_Black", 1, "G_Shades_Blue", 1, "G_Shades_Green", 1, "G_Shades_Red", 1, "G_Aviator", 1, "G_Spectacles", 1, "G_Spectacles_Tinted", 1, "G_Sport_BlackWhite", 1, "G_Sport_Blackyellow", 1, "G_Sport_Greenblack", 1, "G_Sport_Checkered", 1, "G_Sport_Red", 1, "G_Squares", 1, "G_Squares_Tinted", 1, "G_Lowprofile", 1]];
+
+_loadoutData set ["glasses", ["G_Tactical_Clear", "G_Tactical_Black", "G_Shades_Black", "G_Shades_Blue", "G_Shades_Green", "G_Shades_Red", "G_Aviator", "G_Spectacles", "G_Spectacles_Tinted", "G_Sport_BlackWhite", "G_Sport_Blackyellow", "G_Sport_Greenblack", "G_Sport_Checkered", "G_Sport_Red", "G_Squares", "G_Squares_Tinted"]];
+_loadoutData set ["goggles", ["G_Combat", "G_Lowprofile"]];
 
 //Item *set* definitions. These are added in their entirety to unit loadouts. No randomisation is applied.
 _loadoutData set ["items_medical_basic", ["BASIC"] call A3A_fnc_itemset_medicalSupplies]; //this line defines the basic medical loadout for vanilla
@@ -379,7 +381,7 @@ _pilotLoadoutData set ["helmets", ["H_PilotHelmetHeli_I", "H_CrewHelmetHeli_I"]]
 
 private _squadLeaderTemplate = {
     ["slHat"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     [["Hvests", "vests"] call _fnc_fallback] call _fnc_setVest;
     [["slUniforms", "uniforms"] call _fnc_fallback] call _fnc_setUniform;
 
@@ -410,7 +412,7 @@ private _squadLeaderTemplate = {
 
 private _riflemanTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 
@@ -436,7 +438,7 @@ private _riflemanTemplate = {
 
 private _medicTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     [["Hvests", "vests"] call _fnc_fallback] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -461,7 +463,7 @@ private _medicTemplate = {
 
 private _grenadierTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     [["Hvests", "vests"] call _fnc_fallback] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -488,7 +490,7 @@ private _grenadierTemplate = {
 
 private _explosivesExpertTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     [["Hvests", "vests"] call _fnc_fallback] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -521,7 +523,7 @@ private _explosivesExpertTemplate = {
 
 private _engineerTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -550,7 +552,7 @@ private _engineerTemplate = {
 
 private _latTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     [["atBackpacks", "backpacks"] call _fnc_fallback] call _fnc_setBackpack;
@@ -580,7 +582,7 @@ private _latTemplate = {
 
 private _atTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     [["atBackpacks", "backpacks"] call _fnc_fallback] call _fnc_setBackpack;
@@ -610,7 +612,7 @@ private _atTemplate = {
 
 private _aaTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     [["atBackpacks", "backpacks"] call _fnc_fallback] call _fnc_setBackpack;
@@ -640,7 +642,7 @@ private _aaTemplate = {
 
 private _machineGunnerTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -666,7 +668,7 @@ private _machineGunnerTemplate = {
 
 private _marksmanTemplate = {
     ["sniHats"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 
@@ -693,7 +695,7 @@ private _marksmanTemplate = {
 
 private _sniperTemplate = {
     ["sniHats"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     [["sniVests","vests"] call _fnc_fallback] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 
@@ -743,7 +745,7 @@ private _policeTemplate = {
 
 private _crewTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -152,19 +152,6 @@ _loadoutData set ["atBackpacks", ["B_Carryall_oli"]];
 _loadoutData set ["helmets", []];
 _loadoutData set ["slHat", ["H_Beret_blk"]];
 _loadoutData set ["sniHats", ["H_Booniehat_dgtl"]];
-
-/* Facewear array:
-
-The first item in the array is a number that determines the selection weight of having facewear, ranging from 0 - 1.
-
-1 = There will always be a facewear item selected. Facewear is never unequipped.
-0.5 = All facewear options, including having no facewear, have an equal chance of being selected.
-0 = Facewear is always unequipped.
-
-Everything after the first number is the list of possible facewear that can be worn. 
-All facewear items have an equal chance of being picked, with the exception of the unequipped facewear chance affected by the weight number.
-*/
-
 _loadoutData set ["facewear", [0.5, "G_Tactical_Clear", "G_Tactical_Black", "G_Combat", "G_Shades_Black", "G_Shades_Blue", "G_Shades_Green", "G_Shades_Red", "G_Aviator", "G_Spectacles", "G_Spectacles_Tinted", "G_Sport_BlackWhite", "G_Sport_Blackyellow", "G_Sport_Greenblack", "G_Sport_Checkered", "G_Sport_Red", "G_Squares", "G_Squares_Tinted", "G_Lowprofile"]];
 
 //Item *set* definitions. These are added in their entirety to unit loadouts. No randomisation is applied.

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -152,7 +152,7 @@ _loadoutData set ["atBackpacks", ["B_Carryall_oli"]];
 _loadoutData set ["helmets", []];
 _loadoutData set ["slHat", ["H_Beret_blk"]];
 _loadoutData set ["sniHats", ["H_Booniehat_dgtl"]];
-_loadoutData set ["facewear", [0.5, "G_Tactical_Clear", "G_Tactical_Black", "G_Combat", "G_Shades_Black", "G_Shades_Blue", "G_Shades_Green", "G_Shades_Red", "G_Aviator", "G_Spectacles", "G_Spectacles_Tinted", "G_Sport_BlackWhite", "G_Sport_Blackyellow", "G_Sport_Greenblack", "G_Sport_Checkered", "G_Sport_Red", "G_Squares", "G_Squares_Tinted", "G_Lowprofile"]];
+_loadoutData set ["facewear", ["!EMPTY", 1, "G_Tactical_Clear", 1, "G_Tactical_Black", 1, "G_Combat", 1, "G_Shades_Black", 1, "G_Shades_Blue", 1, "G_Shades_Green", 1, "G_Shades_Red", 1, "G_Aviator", 1, "G_Spectacles", 1, "G_Spectacles_Tinted", 1, "G_Sport_BlackWhite", 1, "G_Sport_Blackyellow", 1, "G_Sport_Greenblack", 1, "G_Sport_Checkered", 1, "G_Sport_Red", 1, "G_Squares", 1, "G_Squares_Tinted", 1, "G_Lowprofile", 1]];
 
 //Item *set* definitions. These are added in their entirety to unit loadouts. No randomisation is applied.
 _loadoutData set ["items_medical_basic", ["BASIC"] call A3A_fnc_itemset_medicalSupplies]; //this line defines the basic medical loadout for vanilla

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -381,7 +381,7 @@ _pilotLoadoutData set ["helmets", ["H_PilotHelmetHeli_I", "H_CrewHelmetHeli_I"]]
 
 private _squadLeaderTemplate = {
     ["slHat"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 1.25, "glasses", 1, "goggles", 0.75]] call _fnc_setFacewear;
     [["Hvests", "vests"] call _fnc_fallback] call _fnc_setVest;
     [["slUniforms", "uniforms"] call _fnc_fallback] call _fnc_setUniform;
 
@@ -412,7 +412,7 @@ private _squadLeaderTemplate = {
 
 private _riflemanTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 1.25, "glasses", 1, "goggles", 0.75]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 
@@ -438,7 +438,7 @@ private _riflemanTemplate = {
 
 private _medicTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 1.25, "glasses", 1, "goggles", 0.75]] call _fnc_setFacewear;
     [["Hvests", "vests"] call _fnc_fallback] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -463,7 +463,7 @@ private _medicTemplate = {
 
 private _grenadierTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 1.25, "glasses", 1, "goggles", 0.75]] call _fnc_setFacewear;
     [["Hvests", "vests"] call _fnc_fallback] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -490,7 +490,7 @@ private _grenadierTemplate = {
 
 private _explosivesExpertTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 1.25, "glasses", 1, "goggles", 0.75]] call _fnc_setFacewear;
     [["Hvests", "vests"] call _fnc_fallback] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -523,7 +523,7 @@ private _explosivesExpertTemplate = {
 
 private _engineerTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 1.25, "glasses", 1, "goggles", 0.75]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -552,7 +552,7 @@ private _engineerTemplate = {
 
 private _latTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 1.25, "glasses", 1, "goggles", 0.75]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     [["atBackpacks", "backpacks"] call _fnc_fallback] call _fnc_setBackpack;
@@ -582,7 +582,7 @@ private _latTemplate = {
 
 private _atTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 1.25, "glasses", 1, "goggles", 0.75]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     [["atBackpacks", "backpacks"] call _fnc_fallback] call _fnc_setBackpack;
@@ -612,7 +612,7 @@ private _atTemplate = {
 
 private _aaTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 1.25, "glasses", 1, "goggles", 0.75]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     [["atBackpacks", "backpacks"] call _fnc_fallback] call _fnc_setBackpack;
@@ -642,7 +642,7 @@ private _aaTemplate = {
 
 private _machineGunnerTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 1.25, "glasses", 1, "goggles", 0.75]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -668,7 +668,7 @@ private _machineGunnerTemplate = {
 
 private _marksmanTemplate = {
     ["sniHats"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 1.25, "glasses", 1, "goggles", 0.75]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 
@@ -695,7 +695,7 @@ private _marksmanTemplate = {
 
 private _sniperTemplate = {
     ["sniHats"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 1.25, "glasses", 1, "goggles", 0.75]] call _fnc_setFacewear;
     [["sniVests","vests"] call _fnc_fallback] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 
@@ -745,7 +745,7 @@ private _policeTemplate = {
 
 private _crewTemplate = {
     ["helmets"] call _fnc_setHelmet;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5]] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 1.25, "glasses", 1, "goggles", 0.75]] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -153,6 +153,20 @@ _loadoutData set ["helmets", []];
 _loadoutData set ["slHat", ["H_Beret_blk"]];
 _loadoutData set ["sniHats", ["H_Booniehat_dgtl"]];
 
+/* Facewear array:
+
+The first item in the array is a number that determines the selection weight of having facewear, ranging from 0 - 1.
+
+1 = There will always be a facewear item selected. Facewear is never unequipped.
+0.5 = All facewear options, including having no facewear, have an equal chance of being selected.
+0 = Facewear is always unequipped.
+
+Everything after the first number is the list of possible facewear that can be worn. 
+All facewear items have an equal chance of being picked, with the exception of the unequipped facewear chance affected by the weight number.
+*/
+
+_loadoutData set ["facewear", [0.5, "G_Tactical_Clear", "G_Tactical_Black", "G_Combat", "G_Shades_Black", "G_Shades_Blue", "G_Shades_Green", "G_Shades_Red", "G_Aviator", "G_Spectacles", "G_Spectacles_Tinted", "G_Sport_BlackWhite", "G_Sport_Blackyellow", "G_Sport_Greenblack", "G_Sport_Checkered", "G_Sport_Red", "G_Squares", "G_Squares_Tinted", "G_Lowprofile"]];
+
 //Item *set* definitions. These are added in their entirety to unit loadouts. No randomisation is applied.
 _loadoutData set ["items_medical_basic", ["BASIC"] call A3A_fnc_itemset_medicalSupplies]; //this line defines the basic medical loadout for vanilla
 _loadoutData set ["items_medical_standard", ["STANDARD"] call A3A_fnc_itemset_medicalSupplies]; //this line defines the standard medical loadout for vanilla
@@ -378,6 +392,7 @@ _pilotLoadoutData set ["helmets", ["H_PilotHelmetHeli_I", "H_CrewHelmetHeli_I"]]
 
 private _squadLeaderTemplate = {
     ["slHat"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     [["Hvests", "vests"] call _fnc_fallback] call _fnc_setVest;
     [["slUniforms", "uniforms"] call _fnc_fallback] call _fnc_setUniform;
 
@@ -408,6 +423,7 @@ private _squadLeaderTemplate = {
 
 private _riflemanTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 
@@ -433,6 +449,7 @@ private _riflemanTemplate = {
 
 private _medicTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     [["Hvests", "vests"] call _fnc_fallback] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -457,6 +474,7 @@ private _medicTemplate = {
 
 private _grenadierTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     [["Hvests", "vests"] call _fnc_fallback] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -483,6 +501,7 @@ private _grenadierTemplate = {
 
 private _explosivesExpertTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     [["Hvests", "vests"] call _fnc_fallback] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -515,6 +534,7 @@ private _explosivesExpertTemplate = {
 
 private _engineerTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -543,6 +563,7 @@ private _engineerTemplate = {
 
 private _latTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     [["atBackpacks", "backpacks"] call _fnc_fallback] call _fnc_setBackpack;
@@ -572,6 +593,7 @@ private _latTemplate = {
 
 private _atTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     [["atBackpacks", "backpacks"] call _fnc_fallback] call _fnc_setBackpack;
@@ -601,6 +623,7 @@ private _atTemplate = {
 
 private _aaTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     [["atBackpacks", "backpacks"] call _fnc_fallback] call _fnc_setBackpack;
@@ -630,6 +653,7 @@ private _aaTemplate = {
 
 private _machineGunnerTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
@@ -655,6 +679,7 @@ private _machineGunnerTemplate = {
 
 private _marksmanTemplate = {
     ["sniHats"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 
@@ -681,6 +706,7 @@ private _marksmanTemplate = {
 
 private _sniperTemplate = {
     ["sniHats"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     [["sniVests","vests"] call _fnc_fallback] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 
@@ -730,6 +756,7 @@ private _policeTemplate = {
 
 private _crewTemplate = {
     ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
@@ -125,6 +125,18 @@ if (allowDLCWS && A3A_hasWS) then {_dlcUniforms append [
     "H_Bandanna_cbr"
 ]] call _fnc_saveToTemplate;
 
+/* Facewear array:
+
+The first item in the array is a number that determines the selection weight of having facewear, ranging from 0 - 1.
+
+1 = There will always be a facewear item selected. Facewear is never unequipped.
+0.5 = All facewear options, including having no facewear, have an equal chance of being selected.
+0 = Facewear is always unequipped.
+
+Everything after the first number is the list of possible facewear that can be worn. 
+All facewear items have an equal chance of being picked, with the exception of the unequipped facewear chance affected by the weight number.
+*/
+
 ["facewear", [0.5, 
     "G_Shades_Black", 
     "G_Shades_Blue", 

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
@@ -161,7 +161,7 @@ _loadoutData set ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials
 
 private _squadLeaderTemplate = {
     ["uniforms"] call _fnc_setUniform;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5, "facemask", 0.8]] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 1.25, "glasses", 1, "goggles", 0.75, "facemask", 1]] call _fnc_setFacewear;
 
     ["items_medical_standard"] call _fnc_addItemSet;
     ["items_miscEssentials"] call _fnc_addItemSet;
@@ -174,7 +174,7 @@ private _squadLeaderTemplate = {
 
 private _riflemanTemplate = {
     ["uniforms"] call _fnc_setUniform;
-    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5, "facemask", 0.8]] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 1.25, "glasses", 1, "goggles", 0.75, "facemask", 1]] call _fnc_setFacewear;
     
     ["items_medical_standard"] call _fnc_addItemSet;
     ["items_miscEssentials"] call _fnc_addItemSet;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
@@ -125,32 +125,6 @@ if (allowDLCWS && A3A_hasWS) then {_dlcUniforms append [
     "H_Bandanna_cbr"
 ]] call _fnc_saveToTemplate;
 
-["facewear", [0.5, 
-    "G_Shades_Black", 
-    "G_Shades_Blue", 
-    "G_Shades_Green", 
-    "G_Shades_Red", 
-    "G_Aviator", 
-    "G_Spectacles", 
-    "G_Spectacles_Tinted", 
-    "G_Sport_BlackWhite", 
-    "G_Sport_Blackyellow", 
-    "G_Sport_Greenblack", 
-    "G_Sport_Checkered", 
-    "G_Sport_Red", 
-    "G_Squares", 
-    "G_Squares_Tinted", 
-    "G_Lowprofile",
-    "G_Bandanna_blk",
-    "G_Bandanna_oli",
-    "G_Bandanna_khk",
-    "G_Bandanna_tan",
-    "G_Bandanna_beast",
-    "G_Bandanna_shades",
-    "G_Bandanna_sport",
-    "G_Bandanna_aviator"
-]] call _fnc_saveToTemplate;
-
 /////////////////////
 ///  Identities   ///
 /////////////////////
@@ -171,6 +145,7 @@ _loadoutData set ["compasses", ["ItemCompass"]];
 _loadoutData set ["binoculars", ["Binocular"]];
 
 _loadoutData set ["uniforms", _rebUniforms];
+_loadoutData set ["facewear", ["!EMPTY", 1, "G_Shades_Black", 1, "G_Shades_Blue", 1, "G_Shades_Green", 1, "G_Shades_Red", 1, "G_Aviator", 1, "G_Spectacles", 1, "G_Spectacles_Tinted", 1, "G_Sport_BlackWhite", 1, "G_Sport_Blackyellow", 1, "G_Sport_Greenblack", 1, "G_Sport_Checkered", 1, "G_Sport_Red", 1, "G_Squares", 1, "G_Squares_Tinted", 1, "G_Lowprofile", 1, "G_Bandanna_blk", "G_Bandanna_oli", 1, "G_Bandanna_khk", 1, "G_Bandanna_tan", 1, "G_Bandanna_beast", 1, "G_Bandanna_shades", 1, "G_Bandanna_sport", 1, "G_Bandanna_aviator", 1]];
 
 _loadoutData set ["items_medical_basic", ["BASIC"] call A3A_fnc_itemset_medicalSupplies];
 _loadoutData set ["items_medical_standard", ["STANDARD"] call A3A_fnc_itemset_medicalSupplies];
@@ -183,6 +158,7 @@ _loadoutData set ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials
 
 private _squadLeaderTemplate = {
     ["uniforms"] call _fnc_setUniform;
+    ["facewear"] call _fnc_setFacewear;
 
     ["items_medical_standard"] call _fnc_addItemSet;
     ["items_miscEssentials"] call _fnc_addItemSet;
@@ -195,7 +171,8 @@ private _squadLeaderTemplate = {
 
 private _riflemanTemplate = {
     ["uniforms"] call _fnc_setUniform;
-
+    ["facewear"] call _fnc_setFacewear;
+    
     ["items_medical_standard"] call _fnc_addItemSet;
     ["items_miscEssentials"] call _fnc_addItemSet;
 

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
@@ -145,7 +145,7 @@ _loadoutData set ["compasses", ["ItemCompass"]];
 _loadoutData set ["binoculars", ["Binocular"]];
 
 _loadoutData set ["uniforms", _rebUniforms];
-_loadoutData set ["facewear", ["!EMPTY", 1, "G_Shades_Black", 1, "G_Shades_Blue", 1, "G_Shades_Green", 1, "G_Shades_Red", 1, "G_Aviator", 1, "G_Spectacles", 1, "G_Spectacles_Tinted", 1, "G_Sport_BlackWhite", 1, "G_Sport_Blackyellow", 1, "G_Sport_Greenblack", 1, "G_Sport_Checkered", 1, "G_Sport_Red", 1, "G_Squares", 1, "G_Squares_Tinted", 1, "G_Lowprofile", 1, "G_Bandanna_blk", "G_Bandanna_oli", 1, "G_Bandanna_khk", 1, "G_Bandanna_tan", 1, "G_Bandanna_beast", 1, "G_Bandanna_shades", 1, "G_Bandanna_sport", 1, "G_Bandanna_aviator", 1]];
+_loadoutData set ["facewear", ["", 1, "G_Shades_Black", 1, "G_Shades_Blue", 1, "G_Shades_Green", 1, "G_Shades_Red", 1, "G_Aviator", 1, "G_Spectacles", 1, "G_Spectacles_Tinted", 1, "G_Sport_BlackWhite", 1, "G_Sport_Blackyellow", 1, "G_Sport_Greenblack", 1, "G_Sport_Checkered", 1, "G_Sport_Red", 1, "G_Squares", 1, "G_Squares_Tinted", 1, "G_Lowprofile", 1, "G_Bandanna_blk", "G_Bandanna_oli", 1, "G_Bandanna_khk", 1, "G_Bandanna_tan", 1, "G_Bandanna_beast", 1, "G_Bandanna_shades", 1, "G_Bandanna_sport", 1, "G_Bandanna_aviator", 1]];
 
 _loadoutData set ["items_medical_basic", ["BASIC"] call A3A_fnc_itemset_medicalSupplies];
 _loadoutData set ["items_medical_standard", ["STANDARD"] call A3A_fnc_itemset_medicalSupplies];

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
@@ -125,6 +125,32 @@ if (allowDLCWS && A3A_hasWS) then {_dlcUniforms append [
     "H_Bandanna_cbr"
 ]] call _fnc_saveToTemplate;
 
+["facewear", [0.5, 
+    "G_Shades_Black", 
+    "G_Shades_Blue", 
+    "G_Shades_Green", 
+    "G_Shades_Red", 
+    "G_Aviator", 
+    "G_Spectacles", 
+    "G_Spectacles_Tinted", 
+    "G_Sport_BlackWhite", 
+    "G_Sport_Blackyellow", 
+    "G_Sport_Greenblack", 
+    "G_Sport_Checkered", 
+    "G_Sport_Red", 
+    "G_Squares", 
+    "G_Squares_Tinted", 
+    "G_Lowprofile",
+    "G_Bandanna_blk",
+    "G_Bandanna_oli",
+    "G_Bandanna_khk",
+    "G_Bandanna_tan",
+    "G_Bandanna_beast",
+    "G_Bandanna_shades",
+    "G_Bandanna_sport",
+    "G_Bandanna_aviator"
+]] call _fnc_saveToTemplate;
+
 /////////////////////
 ///  Identities   ///
 /////////////////////

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
@@ -145,7 +145,10 @@ _loadoutData set ["compasses", ["ItemCompass"]];
 _loadoutData set ["binoculars", ["Binocular"]];
 
 _loadoutData set ["uniforms", _rebUniforms];
-_loadoutData set ["facewear", ["", 1, "G_Shades_Black", 1, "G_Shades_Blue", 1, "G_Shades_Green", 1, "G_Shades_Red", 1, "G_Aviator", 1, "G_Spectacles", 1, "G_Spectacles_Tinted", 1, "G_Sport_BlackWhite", 1, "G_Sport_Blackyellow", 1, "G_Sport_Greenblack", 1, "G_Sport_Checkered", 1, "G_Sport_Red", 1, "G_Squares", 1, "G_Squares_Tinted", 1, "G_Lowprofile", 1, "G_Bandanna_blk", "G_Bandanna_oli", 1, "G_Bandanna_khk", 1, "G_Bandanna_tan", 1, "G_Bandanna_beast", 1, "G_Bandanna_shades", 1, "G_Bandanna_sport", 1, "G_Bandanna_aviator", 1]];
+
+_loadoutData set ["glasses", ["G_Shades_Black", "G_Shades_Blue", "G_Shades_Green", "G_Shades_Red", "G_Aviator", "G_Spectacles", "G_Spectacles_Tinted", "G_Sport_BlackWhite", "G_Sport_Blackyellow", "G_Sport_Greenblack", "G_Sport_Checkered", "G_Sport_Red", "G_Squares", "G_Squares_Tinted"]];
+_loadoutData set ["goggles", ["G_Lowprofile"]];
+_loadoutData set ["facemask", ["G_Bandanna_blk", "G_Bandanna_oli", "G_Bandanna_khk", "G_Bandanna_tan", "G_Bandanna_beast", "G_Bandanna_shades", "G_Bandanna_sport", "G_Bandanna_aviator"]];
 
 _loadoutData set ["items_medical_basic", ["BASIC"] call A3A_fnc_itemset_medicalSupplies];
 _loadoutData set ["items_medical_standard", ["STANDARD"] call A3A_fnc_itemset_medicalSupplies];
@@ -158,7 +161,7 @@ _loadoutData set ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials
 
 private _squadLeaderTemplate = {
     ["uniforms"] call _fnc_setUniform;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5, "facemask", 0.8]] call _fnc_setFacewear;
 
     ["items_medical_standard"] call _fnc_addItemSet;
     ["items_miscEssentials"] call _fnc_addItemSet;
@@ -171,7 +174,7 @@ private _squadLeaderTemplate = {
 
 private _riflemanTemplate = {
     ["uniforms"] call _fnc_setUniform;
-    ["facewear"] call _fnc_setFacewear;
+    [selectRandomWeighted [[], 2, "glasses", 1, "goggles", 0.5, "facemask", 0.8]] call _fnc_setFacewear;
     
     ["items_medical_standard"] call _fnc_addItemSet;
     ["items_miscEssentials"] call _fnc_addItemSet;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
@@ -125,18 +125,6 @@ if (allowDLCWS && A3A_hasWS) then {_dlcUniforms append [
     "H_Bandanna_cbr"
 ]] call _fnc_saveToTemplate;
 
-/* Facewear array:
-
-The first item in the array is a number that determines the selection weight of having facewear, ranging from 0 - 1.
-
-1 = There will always be a facewear item selected. Facewear is never unequipped.
-0.5 = All facewear options, including having no facewear, have an equal chance of being selected.
-0 = Facewear is always unequipped.
-
-Everything after the first number is the list of possible facewear that can be worn. 
-All facewear items have an equal chance of being picked, with the exception of the unequipped facewear chance affected by the weight number.
-*/
-
 ["facewear", [0.5, 
     "G_Shades_Black", 
     "G_Shades_Blue", 

--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -60,28 +60,9 @@ private _helmet = selectRandomWeighted (A3A_rebelGear get "ArmoredHeadgear");
 if (_helmet == "") then { _helmet = selectRandom (A3A_faction_reb get "headgear") };
 _unit addHeadgear _helmet;
 
-// Add facewear for rebels, if rebel faction has a facewear table
-private _facewearData = A3A_faction_reb get "facewear";
-if (!isNil "_facewearData") then {
-    // Setup weights for weighted randomization. (See vanilla AAF template for details)
-	private _selectFacewearWeight = _facewearData select 0;
-    
-	private _weightsArray = [0]; // 0 here so that _selectFacewearWeight variable in the array has no weight and doesn't get selected as a facewear
-	
-	for "_i" from 1 to (count _facewearData) - 1 do {
-		_weightsArray set [_i, _selectFacewearWeight];
-	};
-
-	// Resize data table to add "none/unequipped" option, and add corresponding weight to it.
-	_facewearData resize ((count _facewearData) + 1);
-	_weightsArray set [(count _weightsArray), 1 - _selectFacewearWeight];
-
-	// Randomy pick facewear option. If an option other than unequipped is picked, insert facewear to unit loadout.
-	private _facewear = _facewearData selectRandomWeighted _weightsArray;
-
-    if (!isNil "_facewear") then {
-        _unit addGoggles _facewear;
-    };
+private _facewear = selectRandomWeighted (A3A_faction_reb get "facewear");
+if (_facewear != "!EMPTY") then {
+    _unit addGoggles _facewear;
 };
 
 private _vest = selectRandomWeighted (A3A_rebelGear get "ArmoredVests");

--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -60,6 +60,30 @@ private _helmet = selectRandomWeighted (A3A_rebelGear get "ArmoredHeadgear");
 if (_helmet == "") then { _helmet = selectRandom (A3A_faction_reb get "headgear") };
 _unit addHeadgear _helmet;
 
+// Add facewear for rebels, if rebel faction has a facewear table
+private _facewearData = A3A_faction_reb get "facewear";
+if (!isNil "_facewearData") then {
+    // Setup weights for weighted randomization. (See vanilla AAF template for details)
+	private _selectFacewearWeight = _facewearData select 0;
+    
+	private _weightsArray = [0]; // 0 here so that _selectFacewearWeight variable in the array has no weight and doesn't get selected as a facewear
+	
+	for "_i" from 1 to (count _facewearData) - 1 do {
+		_weightsArray set [_i, _selectFacewearWeight];
+	};
+
+	// Resize data table to add "none/unequipped" option, and add corresponding weight to it.
+	_facewearData resize ((count _facewearData) + 1);
+	_weightsArray set [(count _weightsArray), 1 - _selectFacewearWeight];
+
+	// Randomy pick facewear option. If an option other than unequipped is picked, insert facewear to unit loadout.
+	private _facewear = _facewearData selectRandomWeighted _weightsArray;
+
+    if (!isNil "_facewear") then {
+        _unit addGoggles _facewear;
+    };
+};
+
 private _vest = selectRandomWeighted (A3A_rebelGear get "ArmoredVests");
 if (_vest == "") then { _vest = selectRandomWeighted (A3A_rebelGear get "CivilianVests") };
 _unit addVest _vest;

--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -60,11 +60,6 @@ private _helmet = selectRandomWeighted (A3A_rebelGear get "ArmoredHeadgear");
 if (_helmet == "") then { _helmet = selectRandom (A3A_faction_reb get "headgear") };
 _unit addHeadgear _helmet;
 
-private _facewear = selectRandomWeighted (A3A_faction_reb get "facewear");
-if (_facewear != "!EMPTY") then {
-    _unit addGoggles _facewear;
-};
-
 private _vest = selectRandomWeighted (A3A_rebelGear get "ArmoredVests");
 if (_vest == "") then { _vest = selectRandomWeighted (A3A_rebelGear get "CivilianVests") };
 _unit addVest _vest;

--- a/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_builder.sqf
+++ b/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_builder.sqf
@@ -124,7 +124,7 @@ private _fnc_setFacewear = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _facewear = _data selectRandomWeighted;
+	private _facewear = selectRandomWeighted _data;
 	if (_facewear != "!EMPTY") then {
 		[_finalLoadout, _facewear] call A3A_fnc_loadout_setFacewear;
 	};

--- a/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_builder.sqf
+++ b/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_builder.sqf
@@ -120,6 +120,34 @@ private _fnc_setHelmet = {
 	[_finalLoadout, _helmet] call A3A_fnc_loadout_setHelmet;
 };
 
+//Adds facewear to the loadout, selected at random from the category in loadout data.
+private _fnc_setFacewear = {
+	params ["_key"];
+
+	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
+	if (_data isEqualTo []) exitWith {};
+
+	// Setup weights for weighted randomization. (See vanilla AAF template for details)
+	private _selectFacewearWeight = _data select 0;
+	
+	private _weightsArray = [0]; // 0 here so that _selectFacewearWeight variable in the array has no weight and doesn't get selected as a facewear
+	
+	for "_i" from 1 to (count _data) - 1 do {
+		_weightsArray set [_i, _selectFacewearWeight];
+	};
+
+	// Resize data table to add "none/unequipped" option, and add corresponding weight to it.
+	_data resize ((count _data) + 1);
+	_weightsArray set [(count _weightsArray), 1 - _selectFacewearWeight];
+
+	// Randomy pick facewear option. If an option other than unequipped is picked, insert facewear to unit loadout.
+	private _facewear = _data selectRandomWeighted _weightsArray;
+	
+	if (!isNil "_facewear") then {
+		[_finalLoadout, _facewear] call A3A_fnc_loadout_setFacewear;
+	};
+};
+
 //Adds a vest to the loadout, selected at random from the category in loadout data.
 private _fnc_setVest = {
 	params ["_key"];

--- a/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_builder.sqf
+++ b/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_builder.sqf
@@ -125,9 +125,7 @@ private _fnc_setFacewear = {
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
 	private _facewear = selectRandomWeighted _data;
-	if (_facewear != "!EMPTY") then {
-		[_finalLoadout, _facewear] call A3A_fnc_loadout_setFacewear;
-	};
+	[_finalLoadout, _facewear] call A3A_fnc_loadout_setFacewear;
 };
 
 //Adds a vest to the loadout, selected at random from the category in loadout data.

--- a/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_builder.sqf
+++ b/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_builder.sqf
@@ -124,7 +124,7 @@ private _fnc_setFacewear = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _facewear = selectRandomWeighted _data;
+	private _facewear = selectRandom _data;
 	[_finalLoadout, _facewear] call A3A_fnc_loadout_setFacewear;
 };
 

--- a/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_builder.sqf
+++ b/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_builder.sqf
@@ -120,30 +120,12 @@ private _fnc_setHelmet = {
 	[_finalLoadout, _helmet] call A3A_fnc_loadout_setHelmet;
 };
 
-//Adds facewear to the loadout, selected at random from the category in loadout data.
 private _fnc_setFacewear = {
 	params ["_key"];
-
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-
-	// Setup weights for weighted randomization. (See vanilla AAF template for details)
-	private _selectFacewearWeight = _data select 0;
-	
-	private _weightsArray = [0]; // 0 here so that _selectFacewearWeight variable in the array has no weight and doesn't get selected as a facewear
-	
-	for "_i" from 1 to (count _data) - 1 do {
-		_weightsArray set [_i, _selectFacewearWeight];
-	};
-
-	// Resize data table to add "none/unequipped" option, and add corresponding weight to it.
-	_data resize ((count _data) + 1);
-	_weightsArray set [(count _weightsArray), 1 - _selectFacewearWeight];
-
-	// Randomy pick facewear option. If an option other than unequipped is picked, insert facewear to unit loadout.
-	private _facewear = _data selectRandomWeighted _weightsArray;
-	
-	if (!isNil "_facewear") then {
+	private _facewear = _data selectRandomWeighted;
+	if (_facewear != "!EMPTY") then {
 		[_finalLoadout, _facewear] call A3A_fnc_loadout_setFacewear;
 	};
 };

--- a/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_setFacewear.sqf
+++ b/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_setFacewear.sqf
@@ -1,6 +1,6 @@
 /*
  * File: fn_loadout_setFacewear.sqf
- * Author: Spoffy
+ * Author: dZ
  * Description:
  *    Adds facewear to a unit loadout
  * Params:
@@ -14,8 +14,6 @@
 
 params ["_loadout", "_facewear"];
 
-_loadout set [ 7,
-	_facewear
-];
+_loadout set [7, _facewear];
 
 _loadout

--- a/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_setFacewear.sqf
+++ b/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_setFacewear.sqf
@@ -1,0 +1,21 @@
+/*
+ * File: fn_loadout_setFacewear.sqf
+ * Author: Spoffy
+ * Description:
+ *    Adds facewear to a unit loadout
+ * Params:
+ *    _loadout - Loadout to add facewear to
+ *    _facewear - Facewear class to add
+ * Returns:
+ *    Modified loadout array
+ * Example Usage:
+ *    [_loadout, "G_Tactical_Clear"] call A3A_fnc_setFacewear
+ */
+
+params ["_loadout", "_facewear"];
+
+_loadout set [ 7,
+	_facewear
+];
+
+_loadout

--- a/A3A/addons/core/functions/Templates/Verification/fn_TV_verifyLoadout.sqf
+++ b/A3A/addons/core/functions/Templates/Verification/fn_TV_verifyLoadout.sqf
@@ -36,7 +36,7 @@ params [
     ,"_vest"
     ,"_backpack"
     ,"_helmet"
-    ,"_faceWear"
+    ,"_facewear"
     ,"_binocular"
     ,"_linkedItems"
 ];
@@ -242,8 +242,7 @@ private _validLinkedItems = true;
     };
 } forEach _linkedItems;
 
-//this is unused, but lets check its empty as intended
-private _validFaceWear = _faceWear isEqualTo "";
+private _validFacewear = _facewear isEqualTo "" || {["CfgGlasses", _facewear] call _validClassCaseSensitive};
 
 //================|
 // Return results |
@@ -253,7 +252,7 @@ private _validFaceWear = _faceWear isEqualTo "";
 [
     _validPrimary && _validLauncher && _validHandgun && _validBinocular
     && _validUniform && _validVest && _validBackpack
-    && _validFaceWear && _validLinkedItems
+    && _validFacewear && _validLinkedItems
 
     , _invalidReasons
 ];


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
This pull request adds the ability for AI to randomly select from facewear items to wear specified in their template (e.g. goggles, glasses, bandanas, custom mod items like beards, etc.).

![image](https://user-images.githubusercontent.com/92134872/176320127-6be9fe66-2dd4-4e1c-9636-ba2219f641a3.png)


This has been something requested occasionally by other community members on the Discord server, and I personally wanted to add this functionality myself as well after I started playing around with faction templates. Essentially, its overall purpose is adding more variety with AI appearance.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
The AAF and FIA factions are setup with facewear. By spawning any FIA units (except for Petros), or by travelling to an area with AAF units, you can observe the randomized facewear on the AI.