### PR TITLE
Fix rebel static mounting on DS

### DIFF
--- a/A3A/addons/core/functions/Base/fn_updateRebelStatics.sqf
+++ b/A3A/addons/core/functions/Base/fn_updateRebelStatics.sqf
@@ -65,7 +65,7 @@ if (isNull _staticGroup) then { _staticGroup = createGroup [teamPlayer, true] };
     if (count _possibleCrew == 0) exitWith {};
     private _unit = _possibleCrew deleteAt 0;
     [_unit] joinSilent _staticGroup;
-    [_static, clientOwner] remoteExec ["setOwner", 2];                      // otherwise unit tends to jump back off for some reason
+    [_x, clientOwner] remoteExec ["setOwner", 2];                      // otherwise unit tends to jump back off for some reason
     [_staticGroup, clientOwner] remoteExec ["setGroupOwner", 2];            // required because joinSilent won't switch locality if the group is empty
 
     // Wait until the unit is local before we do anything else

--- a/A3A/addons/core/functions/Base/fn_updateRebelStatics.sqf
+++ b/A3A/addons/core/functions/Base/fn_updateRebelStatics.sqf
@@ -65,12 +65,14 @@ if (isNull _staticGroup) then { _staticGroup = createGroup [teamPlayer, true] };
     if (count _possibleCrew == 0) exitWith {};
     private _unit = _possibleCrew deleteAt 0;
     [_unit] joinSilent _staticGroup;
+    [_static, clientOwner] remoteExec ["setOwner", 2];                      // otherwise unit tends to jump back off for some reason
+    [_staticGroup, clientOwner] remoteExec ["setGroupOwner", 2];            // required because joinSilent won't switch locality if the group is empty
 
     // Wait until the unit is local before we do anything else
     [_unit, _x] spawn {
         params ["_unit", "_static"];
-        private _timeout = 10;
-        waitUntil { sleep 1; _timeout = _timeout-1; _timeout < 0 or local _unit };
+        private _timeout = time + 10;
+        waitUntil { sleep 1; _timeout < time or (local _unit and local _static) };
         if (isNull objectParent _unit and isNull gunner _static and isNull objectParent _static and isNull attachedTo _static) then {
             _unit assignAsGunner _static;
             _unit moveInGunner _static;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The code that makes rebels mount statics in live garrisons (either when static weapons are placed or when units are added) didn't work well on a dedicated server because joining them to an empty group didn't change their locality. This code works around the problem by forcing locality immediately with changeOwner. This seems to work - I wasn't sure if it'd need a delay.

### Please specify which Issue this PR Resolves.
closes #2409 

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
