### PR TITLE
Quality-of-life looting/logistics tweaks

### DIFF
--- a/A3A/addons/core/functions/Base/fn_flagaction.sqf
+++ b/A3A/addons/core/functions/Base/fn_flagaction.sqf
@@ -148,6 +148,7 @@ switch _typeX do
 #endif
         removeAllActions _flag;
         _flag addAction ["Unit Recruitment", {if ([player,300] call A3A_fnc_enemyNearCheck) then {["Unit Recruitment", "You cannot recruit units while there are enemies near you."] call A3A_fnc_customHint;} else { [] spawn A3A_fnc_unit_recruit; };},nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull])",4];
+        _flag addAction ["Buy loot box for 10€", {player call A3A_fnc_spawnCrate},nil,0,false,true,"","true", 4];
         _flag addAction ["Buy Vehicle", {if ([player,300] call A3A_fnc_enemyNearCheck) then {
             ["Buy Vehicle", "You cannot buy vehicles while there are enemies near you."] call A3A_fnc_customHint;
         } else {

--- a/A3A/addons/core/functions/LTC/fn_carryCrate.sqf
+++ b/A3A/addons/core/functions/LTC/fn_carryCrate.sqf
@@ -32,7 +32,7 @@ if (_pickUp) then {
     _player setVariable ["carryingCrate", true];
     [_player ,_crate] spawn {
         params ["_player", "_crate"];
-        waitUntil {_player forceWalk true; !alive _crate or !(_player getVariable ["carryingCrate", false]) or !(vehicle _player isEqualTo _player) or _player getVariable ["incapacitated",false] or !alive _player or !(isPlayer attachedTo _crate) };
+        waitUntil {_player allowSprint false; !alive _crate or !(_player getVariable ["carryingCrate", false]) or !(vehicle _player isEqualTo _player) or _player getVariable ["incapacitated",false] or !alive _player or !(isPlayer attachedTo _crate) };
         [_crate, false, _player] call A3A_fnc_carryCrate;
     };
 } else {
@@ -47,5 +47,5 @@ if (_pickUp) then {
         _crate setVelocity [0,0,0.3];
     };
     _player setVariable ["carryingCrate", nil];
-    _player forceWalk false;
+    _player allowSprint true;
 };

--- a/A3A/addons/core/functions/LTC/fn_carryCrate.sqf
+++ b/A3A/addons/core/functions/LTC/fn_carryCrate.sqf
@@ -28,6 +28,11 @@ params [["_crate", objNull], "_pickUp", ["_player", player]];
 
 if (_pickUp) then {
     if (([_player] call A3A_fnc_countAttachedObjects) > 0) exitWith {systemChat "you are already carrying something."};
+
+    // Set crate mass low so that it doesn't damage units when you run into them
+    if (isNil {_crate getVariable "A3A_originalMass"}) then { _crate setVariable ["A3A_originalMass", getMass _crate] };
+    [_crate, 1e-12] remoteExecCall ["setMass", 0];             // global because setMass propagation is glacially slow
+
     _crate attachTo [_player, [0, 1.5, 0], "Pelvis"];
     _player setVariable ["carryingCrate", true];
     [_player ,_crate] spawn {
@@ -45,6 +50,12 @@ if (_pickUp) then {
         _player setVelocity [0,0,0];
         detach _crate;
         _crate setVelocity [0,0,0.3];
+        _crate spawn {
+            sleep 1;
+            if (isNull _this) exitWith {};
+            // Restore original crate mass. This one can be slow.
+            [_this, _this getVariable "A3A_originalMass"] remoteExecCall ["setMass", _this];
+        };
     };
     _player setVariable ["carryingCrate", nil];
     _player allowSprint true;

--- a/A3A/addons/core/functions/Logistics/functions/fn_logistics_load.sqf
+++ b/A3A/addons/core/functions/Logistics/functions/fn_logistics_load.sqf
@@ -74,9 +74,9 @@ private _offsetAndDir = [_cargo] call A3A_fnc_logistics_getCargoOffsetAndDir;
 private _location = _offsetAndDir#0;
 private _location = _location vectorAdd _nodeOffset;
 
-private _bbVehicle = (boundingBoxReal _vehicle select 0 select 1) + ((boundingCenter _vehicle) select 1);
-private _bbCargo = (boundingBoxReal _cargo select 0 select 1) + ((boundingCenter _cargo) select 1);
-private _yStart = _bbVehicle + _bbCargo - 0.1;
+private _bbVehicle = (boundingBoxReal _vehicle select 0 select 1);
+private _bbCargo = (boundingBoxReal _cargo select 0 select 1);
+private _yStart = _bbVehicle + _bbCargo;
 private _yEnd = _location#1;
 _cargo setVariable ["AttachmentOffset", _location];
 
@@ -104,10 +104,12 @@ if (_instant) then {
     _location set [1, _yEnd+0.1];
     _cargo attachto [_vehicle,_location];
 } else {
+    private _prevTime = time;
     while {(_location#1) < _yEnd} do {
         uiSleep 0.1;
-        _location = _location vectorAdd [0,0.1,0];
+        _location = _location vectorAdd [0,time-_prevTime,0];
         _cargo attachto [_vehicle,_location];
+        _prevTime = time;
     };
 };
 

--- a/A3A/addons/core/functions/Logistics/functions/fn_logistics_unload.sqf
+++ b/A3A/addons/core/functions/Logistics/functions/fn_logistics_unload.sqf
@@ -102,19 +102,21 @@ if !(_cargo isEqualTo objNull) then {//cargo not deleted
     private _location = ([_cargo] call A3A_fnc_logistics_getCargoOffsetAndDir)#0;
     private _location = _location vectorAdd _nodeOffset;
 
-    private _bbv = (boundingBoxReal _vehicle select 0 select 1) + ((boundingCenter _vehicle) select 1);
-    private _bbc = (boundingBoxReal _cargo select 0 select 1) + ((boundingCenter _cargo) select 1);
-    private _yEnd = _bbv + _bbc - 0.1;
+    private _bbv = (boundingBoxReal _vehicle select 0 select 1);
+    private _bbc = (boundingBoxReal _cargo select 0 select 1);
+    private _yEnd = _bbv + _bbc;
 
     if (_instant) then {
         _location set [1, _yEnd-0.1];
         _cargo attachto [_vehicle,_location];
     } else {
+        private _prevTime = time;
         while {(_location#1) > _yEnd} do {
             uiSleep 0.1;
             if (isNull _cargo || isNull _vehicle) exitWith {};//vehicle or cargo deleted
-            _location = _location vectorAdd [0,-0.1,0];
+            _location = _location vectorAdd [0,_prevTime-time,0];
             _cargo attachto [_vehicle,_location];
+            _prevTime = time;
         };
     };
     if (isNull _cargo || isNull _vehicle) exitWith {};//vehicle or cargo deleted


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Test PR for looting/logistics tweaks, intended to make the looting process less annoying without removing the time cost entirely.

- Switch loot crate carrying from forceWalk true to allowSprint false (about 2x faster movement).
- Enabled buying loot crates from any rebel flag.
- Fixed incorrect bounding box calc for load/unload.
- Changed load/unload speed to be independent of script load.

The bounding box calc change will have little effect for some vehicles (eg. vanilla offroad) but a huge effect for others (eg. vanilla HEMTT). Unloading a box from an HEMTT will no longer place it >5m behind the vehicle.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

I'll probably chuck it on the test server and see if anyone cares.
