### PR TITLE
fixed issue with everyone being considered admin on lh (garage)

### DIFF
--- a/A3A/addons/Garage/Core/fn_requestSelectionChange.sqf
+++ b/A3A/addons/Garage/Core/fn_requestSelectionChange.sqf
@@ -34,7 +34,7 @@ if (-1 in [_catIndex, _vehUID]) exitWith _exit;
 private _cat = HR_GRG_Vehicles#_catIndex;
 private _vehicle = _cat get _vehUID;
 
-if !( ((_vehicle#2) in ["", _UID]) || (_player isEqualTo (_player call HR_GRG_cmdClient)) ) exitWith _exit;
+if !( ((_vehicle#2) in ["", _UID]) || (_player call HR_GRG_isCmdClient) ) exitWith _exit;
 if !((_vehicle#3) in ["", _UID] ) exitWith _exit;
 
 [_UID] call HR_GRG_fnc_releaseAllVehicles;

--- a/A3A/addons/Garage/Core/fn_toggleLock.sqf
+++ b/A3A/addons/Garage/Core/fn_toggleLock.sqf
@@ -35,7 +35,7 @@ private _owner = _veh#5;
 _succes = call {
     if ( _lock isEqualTo "" ) exitWith { true };
     if ( _lock isEqualTo _UID) exitWith { _UID = ""; true };
-    if (_player isEqualTo (_player call HR_GRG_cmdClient)) exitWith { _UID = ""; Info_5("Commander unlock | Vehicle ID: %1 | Owner: %2 [%3] | Commander: %4 [%5]", _vehUID, _owner, _lock, name _player, _UID); true };
+    if (_player call HR_GRG_isCmdClient) exitWith { _UID = ""; Info_5("Commander unlock | Vehicle ID: %1 | Owner: %2 [%3] | Commander: %4 [%5]", _vehUID, _owner, _lock, name _player, _UID); true };
     false
 };
 

--- a/A3A/addons/Garage/Extras/fn_findMount.sqf
+++ b/A3A/addons/Garage/Extras/fn_findMount.sqf
@@ -37,8 +37,8 @@ private _CheckedUID = ["",_UID] select (_newIconIndex isEqualTo 1);
 
 //block checkout condition
 if (
-    !((_mount#2) in ["",_UID])                          //locked by someone else
-    && !(_player isEqualTo (_player call HR_GRG_cmdClient))       //cmd overwrite
+    !((_mount#2) in ["",_UID])                   //locked by someone else
+    && !(_player call HR_GRG_isCmdClient)        //cmd overwrite
 ) exitWith _failed;
 if !((_mount#3) in ["", _UID]) exitWith _failed; //Checked out by someone else
 

--- a/A3A/addons/Garage/Public/config.inc
+++ b/A3A/addons/Garage/Public/config.inc
@@ -19,7 +19,7 @@
 HR_GRG_Prefix = "Antistasi";
 //Overwrite client
 HR_GRG_cmdClient = {
-    if ((isServer && hasInterface) || {admin owner _this > 0}) then {_this} else {theBoss}; //LAN Host or admin on DS or commander
+    if ((isServer && hasInterface && _this isEqualTo player) || {admin owner _this > 0}) then {_this} else {theBoss}; //LAN Host or admin on DS or commander
 };
 
 //condition to automatically close garage/placement as if canceled

--- a/A3A/addons/Garage/Public/config.inc
+++ b/A3A/addons/Garage/Public/config.inc
@@ -18,8 +18,10 @@
 */
 HR_GRG_Prefix = "Antistasi";
 //Overwrite client
-HR_GRG_cmdClient = {
-    if ((isServer && hasInterface && _this isEqualTo player) || {admin owner _this > 0}) then {_this} else {theBoss}; //LAN Host or admin on DS or commander
+HR_GRG_isCmdClient = {
+    (isServer && hasInterface && _this isEqualTo player) //Lan host
+    || {admin owner _this > 0} //admin
+    || {_this isEqualTo theBoss} //commander
 };
 
 //condition to automatically close garage/placement as if canceled


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    on lh it always returned true for cmdClient calls on the server( where its mostly used as most checks that need it are server side) this made everyone able to act as admin/commander on a lh session

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
