### PR TITLE
Fix arsenal weapon switch duping magazines

### DIFF
--- a/A3A/addons/JeroenArsenal/JNA/fn_arsenal.sqf
+++ b/A3A/addons/JeroenArsenal/JNA/fn_arsenal.sqf
@@ -14,6 +14,10 @@
 #include "\A3\ui_f\hpp\defineDIKCodes.inc"
 #include "\A3\Ui_f\hpp\defineResinclDesign.inc"
 
+#include "..\script_component.hpp"
+FIX_LINE_NUMBERS()
+
+
 #define FADE_DELAY	0.15
 
 #define MODLIST ["","curator","kart","heli","mark","expansion","expansionpremium"]
@@ -1860,6 +1864,10 @@ switch _mode do {
 						};
 					}forEach _oldMagazines;
 
+					{ _x resize 2 } forEach _oldMagazines;
+					_newMagazines = magazinesAmmoFull player;
+					{ _x resize 2 } forEach _newMagazines;
+
 					_updateMagazineList = [];
 					{
 						_magazine = _x select 0;
@@ -1867,7 +1875,7 @@ switch _mode do {
 						_indexItem = _magazine call jn_fnc_arsenal_itemType;
 
 						[_indexItem, _magazine, _amount] call jn_fnc_arsenal_addItem;//TODO
-					}forEach(_oldMagazines - magazinesAmmoFull player);
+					}forEach(_oldMagazines - _newMagazines);
 
 					_newAttachments = switch _index do {
 						case IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON: {primaryweaponitems player};

--- a/A3A/addons/JeroenArsenal/JNA/fn_arsenal_addItem.sqf
+++ b/A3A/addons/JeroenArsenal/JNA/fn_arsenal_addItem.sqf
@@ -49,6 +49,7 @@ if(typeName (_this select 0) isEqualTo "SCALAR")then{//[_index, _item] and [_ind
 				// then update other players. Don't execute on server twice
 				private _playersInArsenal = +(server getVariable ["jna_playersInArsenal",[]]) - [2];
 				if (0 in _playersInArsenal) then { _playersInArsenal = -2 };
+				if (_playersInArsenal isEqualTo []) exitWith {};
 				["UpdateItemAdd",[_index, _item, _amount,true]] remoteExecCall ["jn_fnc_arsenal",_playersInArsenal];
 			};
 		};


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
A3 patch 2.07 changed the behaviour of magazinesAmmoFull by adding unique IDs to each magazine. This broke some janky arsenal code that subtracted the new magazinesAmmoFull array from the old one after a weapon switch, causing it to duplicate all player magazines into the arsenal contents.

This patch fixes the problem by cutting the offending elements out of the arrays. Also threw in a fix for the update code causing bogus RPT complaints about remoteExecCalls to 0 targets (0 is apparently greater than 1000).

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Easiest to see the effects if you run a  script first to hack the arsenal bullet counts down to a readable number:
`{ _x set [1, 500] } forEach jna_datalist#26;`

Obviously don't do this if you have autosave enabled.