### PR TITLE
Fix leftover setStartTime from #2439

### DIFF
--- a/A3A/addons/core/functions/Templates/fn_compatibilityLoadFaction.sqf
+++ b/A3A/addons/core/functions/Templates/fn_compatibilityLoadFaction.sqf
@@ -16,7 +16,6 @@ FIX_LINE_NUMBERS()
 params ["_file", "_side"];
 
 Info_2("Compatibility loading template: '%1' as side %2", _file, _side);
-setStartTime;
 
 private _factionDefaultFile = ["EnemyDefaults","EnemyDefaults","RebelDefaults","CivilianDefaults"] #([west, east, independent, civilian] find _side);
 _factionDefaultFile = QPATHTOFOLDER(Templates\Templates\FactionDefaults) + "\" + _factionDefaultFile + ".sqf";


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed hanging setStartTime from #2439 that was probably used for pre-PR profiling.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
