### PR TITLE
Ace unload on garage

### DIFF
--- a/A3A/addons/Garage/Public/fn_addVehicle.sqf
+++ b/A3A/addons/Garage/Public/fn_addVehicle.sqf
@@ -51,7 +51,7 @@ if ([getPosATL _player] call A3A_fnc_enemyNearCheck) exitWith {
 //LTC refund
 private _ltcRefund = {
     params ["_box", ["_instantRefund", true]];
-    [_box,boxX,true] call A3A_fnc_ammunitionTransfer;
+    [_box, boxX, true] call A3A_fnc_ammunitionTransfer;
 
     if (_instantRefund) then {
         [10] remoteExec ["A3A_fnc_resourcesPlayer", _client];

--- a/A3A/addons/Garage/Public/fn_addVehicle.sqf
+++ b/A3A/addons/Garage/Public/fn_addVehicle.sqf
@@ -49,32 +49,47 @@ if ([getPosATL _player] call A3A_fnc_enemyNearCheck) exitWith {
 };
 
 //LTC refund
-if (_class in [FactionGet(occ,"surrenderCrate"), FactionGet(inv,"surrenderCrate")]) exitWith {
-    [_vehicle,boxX,true] call A3A_fnc_ammunitionTransfer;
-    [10] remoteExec ["A3A_fnc_resourcesPlayer", _client];
-    ["STR_HR_GRG_Feedback_addVehicle_LTC"] remoteExec ["HR_GRG_fnc_Hint", _client];
-    true
+private _ltcRefund = {
+    params ["_box", ["_instantRefund", true]];
+    [_box,boxX,true] call A3A_fnc_ammunitionTransfer;
+
+    if (_instantRefund) then {
+        [10] remoteExec ["A3A_fnc_resourcesPlayer", _client];
+        ["STR_HR_GRG_Feedback_addVehicle_LTC"] remoteExec ["HR_GRG_fnc_Hint", _client];
+        true
+    } else {10};
 };
+if (_class in [FactionGet(occ,"surrenderCrate"), FactionGet(inv,"surrenderCrate")]) exitWith {[_vehicle] call _ltcRefund};
 
 //Utility refund
-if (_vehicle getVariable ['A3A_canGarage', false]) exitwith{
-    if (_class in [FactionGet(reb,"vehicleFuelDrum") # 0, FactionGet(reb,"vehicleFuelTank") # 0]) then {
-        if (_player isEqualTo theBoss) then {
-            [floor (
-                ([_vehicle] call A3A_fnc_remainingFuel) * (_vehicle getVariable ['A3A_itemPrice', 0])
-            )] remoteExec ["A3A_fnc_resourcesPlayer", _client];
-            ["STR_HR_GRG_Feedback_addVehicle_Fuel_sold"] remoteExec ["HR_GRG_fnc_Hint", _client];
-            deleteVehicle _vehicle;
-        } else {
-            ["STR_HR_GRG_Feedback_addVehicle_Fuel_commander_only"] remoteExec ["HR_GRG_fnc_Hint", _client];
+private _utilityRefund = {
+    params ["_object", ["_instantRefund", true]];
+
+    private _toRefund = 0;
+    private _feedBack = "STR_HR_GRG_Feedback_addVehicle_Item_Stored";
+    if (typeOf _object in [FactionGet(reb,"vehicleFuelDrum")#0 + FactionGet(reb,"vehicleFuelTank")#0]) then {
+        if (_player isNotEqualTo theBoss && _instantRefund) exitWith {
+            _feedBack = "STR_HR_GRG_Feedback_addVehicle_Fuel_commander_only";
         };
+
+        _toRefund = floor (([_object] call A3A_fnc_remainingFuel) * (_object getVariable ['A3A_itemPrice', 0]));
+        _feedBack = "STR_HR_GRG_Feedback_addVehicle_Fuel_sold";
     } else {
-        [_vehicle getVariable ['A3A_itemPrice', 0]] remoteExec ["A3A_fnc_resourcesPlayer", _client];
-        ["STR_HR_GRG_Feedback_addVehicle_Item_Stored"] remoteExec ["HR_GRG_fnc_Hint", _client];
-        deleteVehicle _vehicle;
+        _toRefund = _object getVariable ['A3A_itemPrice', 0];
     };
-    true
+
+    deleteVehicle _object;
+    if (_instantRefund) exitWith {
+        if (_toRefund > 0) then {
+            [_toRefund] remoteExec ["A3A_fnc_resourcesPlayer", _client];
+        };
+        [_feedBack] remoteExec ["HR_GRG_fnc_Hint", _client];
+        true;
+    };
+
+    _toRefund
 };
+if (_vehicle getVariable ['A3A_canGarage', false]) exitwith { [_vehicle] call _utilityRefund };
 
     //Towing
 if !((_vehicle getVariable ["SA_Tow_Ropes",objNull]) isEqualTo objNull) exitWith {["STR_HR_GRG_Feedback_addVehicle_SATow"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
@@ -117,6 +132,23 @@ private _transferToArsenal = {
     [_this,boxX] call A3A_fnc_ammunitionTransfer;
 };
 
+//_this is vehicle
+private _unloadAceCargo = {
+    private _toRefund = 0;
+    {
+        if !(_x isEqualType objNull) then { continue };
+        if (typeOf _x in ["ACE_Wheel", "ACE_Track"]) then { continue };
+        [_x, _this] call ace_cargo_fnc_unloadItem;
+
+        if (typeOf _x in [FactionGet(occ,"surrenderCrate"), FactionGet(inv,"surrenderCrate")]) then { _toRefund = _toRefund + ([_x, false] call _ltcRefund) };
+        if (_x getVariable ['A3A_canGarage', false]) then { _toRefund = _toRefund + ([_x, false] call _utilityRefund) };
+    } forEach (_this getVariable ["ace_cargo_loaded", []]);
+
+    if (_toRefund > 0) then {
+        [_toRefund] remoteExec ["A3A_fnc_resourcesPlayer", _client];
+    };
+};
+
 //---------------------------------------------------------|
 // Everything above this line is under the license: MIT    |
 // Everything under this line is under the license: APL-ND |
@@ -146,6 +178,7 @@ private _addVehicle = {
     //Antistasi adaptions
     _this call _transferToArsenal;
     _this call _deleteFromReportedVehsAndStaticsToSave;
+    _this call _unloadAceCargo;
 
     deleteVehicle _this;
 

--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -44,7 +44,7 @@ private _fnc_remoteExecObjectJIPSafe = {
         ,["_function", "", [""]]
     ];
 
-    private _jipKey = _function+"_"+((str _object splitString ":") joinString "");
+    private _jipKey = _function + "_" + ((str _object splitString ":") joinString "");
     _arguments remoteExecCall [_function, 0, _jipKey];
 };
 

--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -28,6 +28,26 @@ Example:
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
 
+/*
+    Function: _fnc_remoteExecObjectJIPSafe
+    remote executes a function with a safe object JIP, The JIP key will be "FunctionName_ObjID"
+
+    Params:
+        _object - [Object] the object the JIP is tied to
+        _arguments - [ARRAY] An array of arguments for the function
+        _function - [String] the function name to be remote executed (needs to be available in the global namespace of the targets)
+*/
+private _fnc_remoteExecObjectJIPSafe = {
+    params [
+         ["_object", objNull, [objNull]]
+        ,["_arguments", [], [[]]]
+        ,["_function", "", [""]]
+    ];
+
+    private _jipKey = _function+"_"+((str _object splitString ":") joinString "");
+    _arguments remoteExecCall [_function, 0, _jipKey];
+};
+
 private _translateMarker = {
     params ["_mrk"];
     if (_mrk find "puesto" == 0) exitWith { "outpost" + (_mrk select [6]) };
@@ -328,6 +348,29 @@ if (_varName in _specialVarLoads) then {
                 };
                 [_veh] spawn A3A_fnc_vehDespawner;
             };
+
+        //this is less flexible than buyItem is but is fine for the specific use case of fuel drums and light sources
+        //future objects that needs initialising needs another unique handler here which might eventually become troublessome
+            //handle buyable fuel containers
+            if (typeOf _veh in [FactionGet(reb,"vehicleFuelDrum")#0,FactionGet(reb,"vehicleFuelTank")#0]) then {
+                [_veh,[_veh],"A3A_fnc_initMovableObject"] call _fnc_remoteExecObjectJIPSafe;
+                [_veh,[_veh],"A3A_fnc_logistics_addLoadAction"] call _fnc_remoteExecObjectJIPSafe;
+                _veh allowDamage false;
+                _veh setVariable ["A3A_canGarage", true, true];
+                private _cat = if (typeOf _veh isEqualTo "vehicleFuelDrum") then {"vehicleFuelDrum"} else {"vehicleFuelTank"};
+                _veh setVariable ["A3A_itemPrice",
+                    FactionGet(reb,_cat)#1
+                , true];
+            };
+        /* we currently dont save the light sources (guessing because its a "building")
+            //handle buyable light sources
+            if (typeOf _veh isEqualTo FactionGet(reb,"vehicleLightSource")) then {
+                [_veh,[_veh],"A3A_fnc_initMovableObject"] call _fnc_remoteExecObjectJIPSafe;
+                _veh allowDamage false;
+                _veh setVariable ["A3A_canGarage", true, true];
+                _veh setVariable ["A3A_itemPrice", 25, true];
+            };
+         */
         };
         publicVariable "staticsToSave";
     };

--- a/A3A/addons/core/functions/UtilityItems/fn_buyItem.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_buyItem.sqf
@@ -69,7 +69,7 @@ _item setVariable ["A3A_itemPrice", _price, true];
 {
     private _func_name = (_x #0);
     if (_x #1) then {
-            private _jipKey = "A3A_utilityItems_item_" + ((str _item splitString ":") joinString "");
+            private _jipKey = "A3A_utilityItems_item_"+_func_name+"_" + ((str _item splitString ":") joinString "");
             [_item, _jipKey] remoteExecCall [_func_name, 0, _jipKey];
     } else {
         [_item] call (missionNamespace getVariable _func_name);

--- a/A3A/addons/core/functions/UtilityItems/fn_buyItem.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_buyItem.sqf
@@ -69,7 +69,7 @@ _item setVariable ["A3A_itemPrice", _price, true];
 {
     private _func_name = (_x #0);
     if (_x #1) then {
-            private _jipKey = "A3A_utilityItems_item_"+_func_name+"_" + ((str _item splitString ":") joinString "");
+            private _jipKey = "A3A_utilityItems_item_" + _func_name + "_" + ((str _item splitString ":") joinString "");
             [_item, _jipKey] remoteExecCall [_func_name, 0, _jipKey];
     } else {
         [_item] call (missionNamespace getVariable _func_name);


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information:
    - added unload for ace cargo on unload, also refunds ltc crates (emptying its contents to arsenal first)
    - fixed fuel containers interaction and important variables not being restored on load

### Please specify which Issue this PR Resolves.
closes #2447 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
 - load items into ace cargo
 - garage vehicle
 - buy fuel container
 - save and load game
 - garage fuel container
********************************************************
Notes: as purchased light sources cost money we should consider refunding or restoring them on load
