### PR TITLE
Extra message for New Garage

### DIFF
--- a/A3A/addons/Garage/Core/fn_confirmPlacement.sqf
+++ b/A3A/addons/Garage/Core/fn_confirmPlacement.sqf
@@ -11,7 +11,7 @@
     4. <Array>  Pylons (optional)
     5. <Struct/nil> Vehicle state (optional)
     6. <Bool>   use garage vehicle pool for placement (optional: default false)
-    7. <String> extra text which will be shown together with the vehicle placement controls (optional)
+    7. <String> extra text which will be shown together with the vehicle placement hint (optional)
 
     Return Value:
     <nil>

--- a/A3A/addons/Garage/Core/fn_confirmPlacement.sqf
+++ b/A3A/addons/Garage/Core/fn_confirmPlacement.sqf
@@ -41,6 +41,7 @@ params [
 if (!isClass (configFile >> "CfgVehicles" >> _class)) exitWith {HR_GRG_placing = false};
 if (isNil "HR_GRG_curTexture") then {HR_GRG_curTexture = []};
 if (isNil "HR_GRG_curAnims") then {HR_GRG_curAnims = []};
+if (!isNil "HR_GRG_placing" && {HR_GRG_placing}) exitWith {Error_1("already placing, params: %1", _this)};
 HR_GRG_placing = true;
 
 //define global variables
@@ -388,7 +389,7 @@ HR_GRG_EH_EF = addMissionEventHandler ["EachFrame", {
         case 0: {
             [
                 localize "STR_HR_GRG_Feedback_CP_Rotation",
-                format ["%1%2", HR_GRG_CP_extraText, localize "STR_HR_GRG_Feedback_CP_Rotation"]
+                format ["%1<br/>%2", HR_GRG_CP_extraText, localize "STR_HR_GRG_Feedback_CP_Rotation"]
             ] select (HR_GRG_CP_extraText isNotEqualTo "");
         };
         case 1: {localize "STR_HR_GRG_Feedback_CP_TooFar"};

--- a/A3A/addons/Garage/Core/fn_confirmPlacement.sqf
+++ b/A3A/addons/Garage/Core/fn_confirmPlacement.sqf
@@ -11,6 +11,7 @@
     4. <Array>  Pylons (optional)
     5. <Struct/nil> Vehicle state (optional)
     6. <Bool>   use garage vehicle pool for placement (optional: default false)
+    7. <String> extra text which will be shown together with the vehicle placement controls (optional)
 
     Return Value:
     <nil>
@@ -20,7 +21,7 @@
     Public: [Yes]
     Dependencies:
 
-    Example: [_class, [], [], nil, false] call HR_GRG_fnc_confirmPlacement;
+    Example: [_class, "BUYFIA", [], nil, nil, nil, false, _extraText] call HR_GRG_fnc_confirmPlacement;
 
     License: APL-ND
 */
@@ -34,12 +35,12 @@ params [
     , ["_pylons", [], [[]]]
     , "_state"
     , ["_useGRGPool", false, [false]]
+    , ["_extraText", "", [""]]
 ];
 
 if (!isClass (configFile >> "CfgVehicles" >> _class)) exitWith {HR_GRG_placing = false};
 if (isNil "HR_GRG_curTexture") then {HR_GRG_curTexture = []};
 if (isNil "HR_GRG_curAnims") then {HR_GRG_curAnims = []};
-if (!isNil "HR_GRG_placing" && {HR_GRG_placing}) exitWith {Error_1("already placing, params: %1", _this)};
 HR_GRG_placing = true;
 
 //define global variables
@@ -52,6 +53,7 @@ HR_GRG_CP_mounts = _mounts;
 HR_GRG_CP_pylons = _pylons;
 HR_GRG_usePool = _useGRGPool;
 HR_GRG_CP_callBack = [_callBack, _callBackArgs];
+HR_GRG_CP_extraText = _extraText;
 HR_GRG_callBackFeedback = "";
 HR_GRG_EH_EF = -1;
 HR_GRG_EH_keyDown = -1;
@@ -383,7 +385,12 @@ HR_GRG_EH_EF = addMissionEventHandler ["EachFrame", {
 
     //render keybind hint
     private _text = switch HR_GRG_validPlacement do {
-        case 0: {localize "STR_HR_GRG_Feedback_CP_Rotation"};
+        case 0: {
+            [
+                localize "STR_HR_GRG_Feedback_CP_Rotation",
+                format ["%1%2", HR_GRG_CP_extraText, localize "STR_HR_GRG_Feedback_CP_Rotation"]
+            ] select (HR_GRG_CP_extraText isNotEqualTo "");
+        };
         case 1: {localize "STR_HR_GRG_Feedback_CP_TooFar"};
         case 2: {localize "STR_HR_GRG_Feedback_CP_Blocked"};
         case 3: { HR_GRG_callBackFeedback };

--- a/A3A/addons/core/functions/REINF/fn_addFIAveh.sqf
+++ b/A3A/addons/core/functions/REINF/fn_addFIAveh.sqf
@@ -27,6 +27,6 @@ if (_resourcesFIA < vehiclePurchase_cost) exitWith {["Add Vehicle", format ["You
 vehiclePurchase_nearestMarker = [markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer},player] call BIS_fnc_nearestPosition;
 if !(player inArea vehiclePurchase_nearestMarker) exitWith {["Add Vehicle", "You need to be close to the flag to be able to purchase a vehicle."] call A3A_fnc_customHint;};
 
-private _extraMessage =	format ["Buying vehicle for $%1.<br/>", vehiclePurchase_cost];
+private _extraMessage =	format ["Buying vehicle for $%1.", vehiclePurchase_cost];
 
 [_typeVehX, "BUYFIA", [], nil, nil, nil, false, _extraMessage] call HR_GRG_fnc_confirmPlacement;

--- a/A3A/addons/core/functions/REINF/fn_addFIAveh.sqf
+++ b/A3A/addons/core/functions/REINF/fn_addFIAveh.sqf
@@ -27,6 +27,6 @@ if (_resourcesFIA < vehiclePurchase_cost) exitWith {["Add Vehicle", format ["You
 vehiclePurchase_nearestMarker = [markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer},player] call BIS_fnc_nearestPosition;
 if !(player inArea vehiclePurchase_nearestMarker) exitWith {["Add Vehicle", "You need to be close to the flag to be able to purchase a vehicle."] call A3A_fnc_customHint;};
 
-private _extraMessage =	format ["Buying vehicle for $%1.", vehiclePurchase_cost];
+private _extraMessage =	format ["Buying vehicle for $%1.<br/>", vehiclePurchase_cost];
 
-[_typeVehX, "BUYFIA"] call HR_GRG_fnc_confirmPlacement;
+[_typeVehX, "BUYFIA", [], nil, nil, nil, false, _extraMessage] call HR_GRG_fnc_confirmPlacement;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information:
    Old, pre-2.5.0-garage had the ability to show some extra messages during vehicle placement process. This PR implements same thing for Hakon's Garage too.
This might be useful in some non-general use cases: some additional hints, guidances or simply vehicle price can be shown to player.

![image](https://user-images.githubusercontent.com/6746043/190858138-64661d15-0376-471d-b41e-b8fe47ecf0ff.png)

 
### Please specify which Issue this PR Resolves.
-

### Please verify the following and ensure all checks are completed.
-

1. [x] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
For example, fn_addFIAVeh.sqf:
```sqf
private _extraMessage = format ["Buying vehicle for $%1.", vehiclePurchase_cost];

[_typeVehX, "BUYFIA", [], nil, nil, nil, false, _extraMessage] call HR_GRG_fnc_confirmPlacement;
```