### PR TITLE
Fixes and tweaks related to guest commander functionality

### DIFF
--- a/A3A/addons/core/functions/Base/fn_statistics.sqf
+++ b/A3A/addons/core/functions/Base/fn_statistics.sqf
@@ -25,14 +25,7 @@ if (_player != theBoss) then
 	}
 else
 	{
-	if ([_player] call A3A_fnc_isMember) then
-		{
-		_textX = format ["<t size='0.67' shadow='2'>" + "Rank: %5 | HR: %1 | Your Money: %6 € | %11 Money: %2 € | Airstrikes: %7 | %9 Aggr: %3 | %10 Aggr: %4 | War Level: %8 | Undercover Mode: %12", (server getVariable "hr") toFixed 0, (server getVariable "resourcesFIA") toFixed 0, [aggressionLevelOccupants] call A3A_fnc_getAggroLevelString,[aggressionLevelInvaders] call A3A_fnc_getAggroLevelString,rank _player, (_player getVariable "moneyX") toFixed 0,floor bombRuns,tierWar,FactionGet(occ,"name"),FactionGet(inv,"name"),FactionGet(reb,"name"),_ucovertxt];
-		}
-	else
-		{
-		_textX = format ["<t size='0.67' shadow='2'>" + "Rank: %1 | Your Money: %2 € | %3 Money: %4 € | %5 Aggr: %6 | %7 Aggr: %8 | War Level: %9 | Undercover Mode: %10",rank _player,(_player getVariable "moneyX") toFixed 0,FactionGet(reb,"name"),(server getVariable "resourcesFIA") toFixed 0, FactionGet(occ,"name"), [aggressionLevelOccupants] call A3A_fnc_getAggroLevelString, FactionGet(inv,"name"),[aggressionLevelInvaders] call A3A_fnc_getAggroLevelString,tierWar,_ucovertxt];
-		};
+	_textX = format ["<t size='0.67' shadow='2'>" + "Rank: %5 | HR: %1 | Your Money: %6 € | %11 Money: %2 € | Airstrikes: %7 | %9 Aggr: %3 | %10 Aggr: %4 | War Level: %8 | Undercover Mode: %12", (server getVariable "hr") toFixed 0, (server getVariable "resourcesFIA") toFixed 0, [aggressionLevelOccupants] call A3A_fnc_getAggroLevelString,[aggressionLevelInvaders] call A3A_fnc_getAggroLevelString,rank _player, (_player getVariable "moneyX") toFixed 0,floor bombRuns,tierWar,FactionGet(occ,"name"),FactionGet(inv,"name"),FactionGet(reb,"name"),_ucovertxt];
 	};
 
 //if (captive player) then {_textX = format ["%1 ON",_textX]} else {_textX = format ["%1 OFF",_textX]};

--- a/A3A/addons/core/functions/OrgPlayers/fn_assignBossIfNone.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_assignBossIfNone.sqf
@@ -44,7 +44,7 @@ private _bossRank = 0;
 
 if (!isNull _nextBoss) then
 {
-    Info_1("Player chosen for Boss: %1", _nextBoss);
+    Info_1("Player chosen for Boss: %1", name _nextBoss);
     if (theBoss != _nextBoss) then { [_nextBoss] call A3A_fnc_theBossTransfer };
 }
 else

--- a/A3A/addons/core/functions/OrgPlayers/fn_makePlayerBossIfEligible.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_makePlayerBossIfEligible.sqf
@@ -2,10 +2,11 @@
 FIX_LINE_NUMBERS()
 params ["_player"];
 
-Info_1("Attempting to make %1 the boss", _player);
+Info_1("Attempting to make %1 the boss", name _player);
 
 if !(_player getVariable ["eligible", false]) exitWith { Error("Attempted boss transfer to an ineligible player"); false };
-if (!A3A_guestCommander and !([_player] call A3A_fnc_isMember)) exitWith { Error("Attempted to transfer boss to a guest"); false };
+if (!A3A_guestCommander and !(_player call A3A_fnc_isMember)) exitWith { Error("Attempted to transfer boss to a guest"); false };
 
 Info("Player is eligible, making them the boss");
+[_player] call A3A_fnc_theBossTransfer;
 true;

--- a/A3A/addons/core/functions/OrgPlayers/fn_memberAdd.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_memberAdd.sqf
@@ -14,6 +14,7 @@ if ((_this select 0 == "remove") and  !([_target] call A3A_fnc_isMember)) exitWi
 if (_this select 0 == "add") then
 	{
 	membersX pushBackUnique _uid;
+	_target setVariable ["eligible", true, true];
 	["Membership", format ["%1 has been added to the Server Members List.",name _target]] call A3A_fnc_customHint;
 	["Membership", "You have been added to the Server Members list."] remoteExec ["A3A_fnc_customHint", _target];
 	}

--- a/A3A/addons/core/functions/OrgPlayers/fn_playerLeashCheckPosition.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_playerLeashCheckPosition.sqf
@@ -36,7 +36,7 @@ if (memberDistance <= 0 || !membershipEnabled) exitWith {true};
 
 private _leashCentres = [];
 _leashCentres pushBack getMarkerPos respawnTeamPlayer;
-private _memberPositions = (call A3A_fnc_playableUnits select {[_x] call A3A_fnc_isMember}) apply {getPos _x};
+private _memberPositions = (call A3A_fnc_playableUnits select {_x call A3A_fnc_isMember or _x == theBoss}) apply {getPosATL _x};
 _leashCentres append _memberPositions;
 
 _nearestLeashCentre = [_leashCentres,_targetPos] call BIS_fnc_nearestPosition;

--- a/A3A/addons/core/functions/OrgPlayers/fn_playerLeashCheckPosition.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_playerLeashCheckPosition.sqf
@@ -36,6 +36,7 @@ if (memberDistance <= 0 || !membershipEnabled) exitWith {true};
 
 private _leashCentres = [];
 _leashCentres pushBack getMarkerPos respawnTeamPlayer;
+{ if (sidesX getVariable _x == teamPlayer) then { _leashCentres pushBack getMarkerPos _x } } forEach forcedSpawn;         // Enable guests to defend
 private _memberPositions = (call A3A_fnc_playableUnits select {_x call A3A_fnc_isMember or _x == theBoss}) apply {getPosATL _x};
 _leashCentres append _memberPositions;
 

--- a/A3A/addons/core/functions/REINF/fn_addFIAsquadHC.sqf
+++ b/A3A/addons/core/functions/REINF/fn_addFIAsquadHC.sqf
@@ -5,19 +5,20 @@ params ["_typeGroup", ["_withBackpck", ""]];
 if (player != theBoss) exitWith {["Recruit Squad", "Only the Commander has access to this function."] call A3A_fnc_customHint;};
 if (markerAlpha respawnTeamPlayer == 0) exitWith {["Recruit Squad", "You cannot recruit a new squad while you are moving your HQ."] call A3A_fnc_customHint;};
 if (!([player] call A3A_fnc_hasRadio)) exitWith {if !(A3A_hasIFA) then {["Recruit Squad", "You need a radio in your inventory to be able to give orders to other squads."] call A3A_fnc_customHint;} else {["Recruit Squad", "You need a Radio Man in your group to be able to give orders to other squads"] call A3A_fnc_customHint;}};
+if ([getPosATL petros] call A3A_fnc_enemyNearCheck) exitWith {["Recruit Squad", "You cannot recruit squads with enemies near your HQ."] call A3A_fnc_customHint;};
+
+private _maxGroups = [6,10] select (player call A3A_fnc_isMember);
+if (count hcAllGroups player >= _maxGroups) exitWith {
+    ["Recruit Squad", "You have too many high command squads active. Disband or garrison some to recruit more."] call A3A_fnc_customHint;
+};
 
 private _exit = false;
-{
-	if (((side _x == Invaders) or (side _x == Occupants)) and (_x distance petros < 500) and ([_x] call A3A_fnc_canFight) and !(isPlayer _x)) exitWith {_exit = true};
-} forEach allUnits;
-if (_exit) exitWith {["Recruit Squad", "You cannot recruit squads with enemies near your HQ."] call A3A_fnc_customHint;};
-
 if (_typeGroup isEqualType "") then {
 	if (_typeGroup == "") then {_exit = true; ["Recruit Squad", "The group or vehicle type you requested is not supported in your modset."] call A3A_fnc_customHint;};
 	if (A3A_hasIFA and ((_typeGroup == FactionGet(reb,"staticMortar")) or (_typeGroup == FactionGet(reb,"staticMG"))) and !debug) then {_exit = true; ["Recruit Squad", "The group or vehicle type you requested is not supported in your modset."] call A3A_fnc_customHint;};
 };
-
 if (_exit) exitWith {};
+
 private _isInfantry = false;
 private _typeVehX = "";
 private _costs = 0;

--- a/A3A/addons/core/functions/REINF/fn_controlHCsquad.sqf
+++ b/A3A/addons/core/functions/REINF/fn_controlHCsquad.sqf
@@ -51,7 +51,7 @@ _eh2 = _unit addEventHandler ["HandleDamage",
 	}];
 selectPlayer _unit;
 
-_timeX = 60;
+_timeX = 180;
 
 _unit addAction ["Return Control to AI",{selectPlayer (player getVariable ["owner",player])}];
 

--- a/A3A/addons/core/functions/REINF/fn_garrisonAdd.sqf
+++ b/A3A/addons/core/functions/REINF/fn_garrisonAdd.sqf
@@ -4,7 +4,7 @@ private ["_hr","_resourcesFIA","_typeX","_costs","_markerX","_garrison","_positi
 
 _hr = server getVariable "hr";
 
-if (_hr < 1) exitWith {["Garrisons", "You lack of HR to make a new recruitment."] call A3A_fnc_customHint;};
+if (_hr < 1) exitWith {["Garrisons", "You lack HR to make a new recruitment."] call A3A_fnc_customHint;};
 
 _resourcesFIA = server getVariable "resourcesFIA";
 
@@ -26,6 +26,21 @@ _positionX = getMarkerPos _markerX;
 if (surfaceIsWater _positionX) exitWith {["Garrisons", "This Garrison is still updating, please try again in a few seconds."] call A3A_fnc_customHint;};
 
 if ([_positionX] call A3A_fnc_enemyNearCheck) exitWith {["Garrisons", "You cannot Recruit Garrison Units with enemies near the zone."] call A3A_fnc_customHint;};
+
+scopename "main";
+if !(player call A3A_fnc_isMember) then {
+	private _curSize = count (garrison getVariable _markerX);
+	private _maxSize = call {
+		if (_markerX in airportsX) exitWith { 30 };
+		if (_markerX in outposts) exitWith { 20 };
+		15;
+	};
+	if (_curSize >= _maxSize) then {
+		["Garrisons", "You cannot add any more troops to this garrison as a guest"] call A3A_fnc_customHint;
+		breakout "main";
+	};
+};
+
 _nul = [-1,-_costs] remoteExec ["A3A_fnc_resourcesFIA",2];
 /*
 _garrison = [];

--- a/A3A/addons/core/functions/init/fn_clientIdleChecker.sqf
+++ b/A3A/addons/core/functions/init/fn_clientIdleChecker.sqf
@@ -7,7 +7,7 @@ Arguments:
     None
 */
 
-#define TIMEOUT_AFK 120
+#define TIMEOUT_AFK 300
 
 A3A_lastActiveTime = time;
 A3A_lastPlayerDir = getDir player;

--- a/A3A/addons/core/functions/init/fn_clientIdleChecker.sqf
+++ b/A3A/addons/core/functions/init/fn_clientIdleChecker.sqf
@@ -32,5 +32,8 @@ while {true} do {
 
     if (time - A3A_lastActiveTime > TIMEOUT_AFK and !(player getVariable ["isAFK", false])) then { 
         player setVariable ["isAFK", true, [2, clientOwner]];
+        if (player == theBoss) then {
+            ["Client idle checker", "You are now considered AFK. You may lose commander if an election is triggered"] call A3A_fnc_customHint;
+        };
     };
 };

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -52,7 +52,7 @@ private _side = side group player;
 _isJip = _this select 1;
 if (isMultiplayer) then {
 	if (side player == teamPlayer) then {
-		player setVariable ["eligible",true,true];
+		player setVariable ["eligible",player call A3A_fnc_isMember,true];
 	};
 	musicON = false;
 	disableUserInput true;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
1. AFK timeout increased to five minutes. Two minutes was a bit short in practice: Didn't give players enough time for bio breaks and ACE unconsciousness was a bit harsh. Will see how this goes.
2. Fixed missing eligibility-toggle cursorTarget transfer code.
3. Fixed wrong info bar string being shown to guest-commanders. There was some weird old code that only applied to guest-commanders.
4. Guests are now initialized to ineligible. Mostly an issue when the server's guest-only and someone who has no idea what they doing and/or poor comms gets commander.
5. Fixed a couple of debug logs not showing player names.
6. Added a warning for commanders who go AFK.
7. Increased HC squad remote control limit to three minutes. Should be fine.

Added in 7da8d9a: 

8. Restricted guest commanders to six HC squads and non-guests to 10.
9. Restricted guest commander direct garrison sizes. They can still increase them by adding HC squads because that's much more complex to handle, and HC squads are a worse perf cost when they're not in a garrison.
10. Treat guest commanders as members for the purpose of the non-member leash. This allows all-guest servers to defend attacks (eg. punishments) far from HQ.
11. Switched HC squad recruitment over to enemyNearCheck. Not strictly related but the code was adjacent.

Added in 0ba41eb:

12. Expand guest leash centres to include locations under attack.

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

Should get a DS test but the changes are pretty simple compared to the initial PR.