### PR TITLE
Tweak ability of rebels to respond to punishments and major attacks

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_attackHQ.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_attackHQ.sqf
@@ -20,8 +20,8 @@ params ["_side", "_airbase", "_delay"];			// Side is now specified
 private _targPos = markerPos "Synd_HQ";
 private _faction = Faction(_side);
 
-bigAttackInProgress = true;
-publicVariable "bigAttackInProgress";
+bigAttackInProgress = true; publicVariable "bigAttackInProgress";
+forcedSpawn pushBack "Synd_HQ"; publicVariable "forcedSpawn";
 
 private _taskId = "DEF_HQ" + str A3A_taskCount;
 [[teamPlayer,civilian],_taskId,[format ["The enemy has sent SpecOps to find %1. Stop them, or move the HQ before they get here.",name petros],format ["Defend %1",name petros],respawnTeamPlayer],_targPos,true,10,true,"Defend",true] call BIS_fnc_taskCreate;
@@ -97,7 +97,7 @@ if (!alive _origPetros) then {
     };
 };
 
-bigAttackInProgress = false;
-publicVariable "bigAttackInProgress";
+bigAttackInProgress = false; publicVariable "bigAttackInProgress";
+forcedSpawn = forcedSpawn - ["Synd_HQ"]; publicVariable "forcedSpawn";
 
 [_taskId, "DEF_HQ", 1200] spawn A3A_fnc_taskDelete;

--- a/A3A/addons/core/functions/CREATE/fn_invaderPunish.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_invaderPunish.sqf
@@ -19,8 +19,9 @@ params ["_mrkDest", "_mrkOrigin", "_delay"];
 
 ServerInfo_2("Launching CSAT Punishment Against %1 from %2", _mrkDest, _mrkOrigin);
 
-bigAttackInProgress = true;
-publicVariable "bigAttackInProgress";
+// Mostly to prevent fast travel
+bigAttackInProgress = true; publicVariable "bigAttackInProgress";
+forcedSpawn pushBack _mrkDest; publicVariable "forcedSpawn";
 
 private _posDest = getMarkerPos _mrkDest;
 private _posOrigin = getMarkerPos _mrkOrigin;
@@ -32,8 +33,9 @@ private _taskId = "invaderPunish" + str A3A_taskCount;
 [_taskId, "invaderPunish", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
 
-// Give smaller player groups a bit more time to respond
-if (isNil "_delay") then { _delay = 420 / A3A_balancePlayerScale };
+if (isNil "_delay") then {
+    _delay = 300 + 60 * (markerPos "Synd_HQ" distance2d _posDest) / 2000;            // +1 min per 2km
+};
 
 // Create the attacking force
 // probably doesn't make much sense to aggro-scale this one as it's not a response
@@ -122,7 +124,7 @@ if (({_x call A3A_fnc_canFight} count _soldiers < count _soldiers / 3) or (time 
 
     // Invaders pay extra to destroy a city
     private _citypop = (server getVariable _mrkDest) select 0;
-    [-4 * _citypop, Invaders, "attack"] remoteExec ["A3A_fnc_addEnemyResources", 2];
+    [-4 * _citypop * A3A_balancePlayerScale, Invaders, "attack"] remoteExec ["A3A_fnc_addEnemyResources", 2];
 
     destroyedSites = destroyedSites + [_mrkDest];
     publicVariable "destroyedSites";
@@ -138,11 +140,11 @@ if (({_x call A3A_fnc_canFight} count _soldiers < count _soldiers / 3) or (time 
     [_mrkDest] call A3A_fnc_mrkUpdate;
 };
 
-sleep 15;
+sleep 60;
 [_taskId, "invaderPunish", 0] spawn A3A_fnc_taskDelete;
 
-bigAttackInProgress = false;
-publicVariable "bigAttackInProgress";
+bigAttackInProgress = false; publicVariable "bigAttackInProgress";
+forcedSpawn = forcedSpawn - [_mrkDest]; publicVariable "forcedSpawn";
 
 
 // Order remaining aggressor units back to base, hand them to the group despawner

--- a/A3A/addons/core/functions/CREATE/fn_wavedAttack.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_wavedAttack.sqf
@@ -91,7 +91,7 @@ while {_wave <= _maxWaves and !_victory} do
 
 
     // Send the land units and air transports. Returns once air sent
-    private _minDelay = [0, 300 / A3A_balancePlayerScale] select (_wave == 1 and _targSide == teamPlayer);
+    private _minDelay = [0, 300] select (_wave == 1 and _targSide == teamPlayer);
     //params ["_side", "_airbase", "_target", "_resPool", "_vehCount", "_delay", "_modifiers", "_attackType", "_reveal"];
     private _data = [_side, _mrkOrigin, _mrkDest, "attack", _vehCount, _minDelay, ["noairsupport"], "MajorAttack", _reveal] call A3A_fnc_createAttackForceMixed;
     _data params ["", "_newVehicles", "_crewGroups", "_cargoGroups"];
@@ -192,7 +192,7 @@ if (_victory) then {
 };
 
 ServerInfo("Reached end of winning conditions. Starting despawn");
-sleep 30;
+sleep 60;
 
 bigAttackInProgress = false; publicVariable "bigAttackInProgress";
 forcedSpawn = forcedSpawn - [_mrkDest]; publicVariable "forcedSpawn";

--- a/A3A/addons/core/functions/CREATE/fn_wavedAttack.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_wavedAttack.sqf
@@ -178,25 +178,19 @@ while {_wave <= _maxWaves and !_victory} do
 if (_victory) then {
     if (_targSide != teamPlayer) exitWith {};
     [_taskId, "rebelAttack", "FAILED"] call A3A_fnc_taskSetState;
-    [_taskId, "rebelAttack", 30] spawn A3A_fnc_taskDelete;
     if (_targside == teamPlayer) then { [-10,theBoss] call A3A_fnc_playerScoreAdd };
 } else {
     [_mrkDest, _mrkOrigin] call A3A_fnc_minefieldAAF;
 
     if (_targSide != teamPlayer) exitWith {};
     [_taskId, "rebelAttack", "SUCCEEDED"] call A3A_fnc_taskSetState;
-    [_taskId, "rebelAttack", 30] spawn A3A_fnc_taskDelete;
     private _nearRebels = [500, 0, markerPos _mrkDest, teamPlayer] call A3A_fnc_distanceUnits;
     { if (isPlayer _x) then { [10, _x] call A3A_fnc_playerScoreAdd } } forEach _nearRebels;
     [10, theBoss] call A3A_fnc_playerScoreAdd;
 };
+[_taskId, "rebelAttack", 30] spawn A3A_fnc_taskDelete;
 
 ServerInfo("Reached end of winning conditions. Starting despawn");
-sleep 60;
-
-bigAttackInProgress = false; publicVariable "bigAttackInProgress";
-forcedSpawn = forcedSpawn - [_mrkDest]; publicVariable "forcedSpawn";
-
 
 { [_x] spawn A3A_fnc_VEHDespawner } forEach _allVehicles;
 { [_x] spawn A3A_fnc_enemyReturnToBase } forEach _allCrewGroups;
@@ -204,3 +198,8 @@ forcedSpawn = forcedSpawn - [_mrkDest]; publicVariable "forcedSpawn";
     [_x, [nil, _mrkDest] select _victory] spawn A3A_fnc_enemyReturnToBase;
     sleep 10;
 } forEach _allCargoGroups;
+
+sleep 60;
+
+bigAttackInProgress = false; publicVariable "bigAttackInProgress";
+forcedSpawn = forcedSpawn - [_mrkDest]; publicVariable "forcedSpawn";

--- a/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -49,7 +49,7 @@ if (count _positionTel > 0) then
 	_base = [_markersX, _positionTel] call BIS_Fnc_nearestPosition;
 	if (_checkForPlayer and ((_base != "SYND_HQ") and !(_base in airportsX))) exitWith {["Fast Travel", "Player groups are only allowed to Fast Travel to HQ or Airbases."] call A3A_fnc_customHint;};
 	if ((sidesX getVariable [_base,sideUnknown] == Occupants) or (sidesX getVariable [_base,sideUnknown] == Invaders)) exitWith {["Fast Travel", "You cannot Fast Travel to an enemy controlled zone."] call A3A_fnc_customHint; openMap [false,false]};
-	if (_base in forcedSpawn) exitWith {["Fast Travel", "You cannot Fast Travel to location that's under attack."] call A3A_fnc_customHint; openMap [false,false]};
+	if (_base in forcedSpawn) exitWith {["Fast Travel", "You cannot Fast Travel to a location that is under attack."] call A3A_fnc_customHint; openMap [false,false]};
 
 	//if (_base in outpostsFIA) exitWith {hint "You cannot Fast Travel to roadblocks and watchposts"; openMap [false,false]};
 

--- a/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -21,9 +21,7 @@ if (!isNil "A3A_FFPun_Jailed" && {(getPlayerUID player) in A3A_FFPun_Jailed}) ex
 
 _checkX = false;
 //_distanceX = 500 - (([_boss,false] call A3A_fnc_fogCheck) * 450);
-
 {if ([getPosATL _x] call A3A_fnc_enemyNearCheck) exitWith {_checkX = true}} forEach units _groupX;
-
 if (_checkX) exitWith {["Fast Travel", "You cannot Fast Travel with enemies near the group."] call A3A_fnc_customHint;};
 
 {if ((vehicle _x!= _x) and ((isNull (driver vehicle _x)) or (!canMove vehicle _x) or (vehicle _x isKindOf "Boat"))) then
@@ -31,7 +29,6 @@ if (_checkX) exitWith {["Fast Travel", "You cannot Fast Travel with enemies near
 	if (not(vehicle _x isKindOf "StaticWeapon")) then {_checkX = true};
 	}
 } forEach units _groupX;
-
 if (_checkX) exitWith {["Fast Travel", "You cannot Fast Travel if you don't have a driver in all your vehicles or your vehicles are damaged and cannot move or your group is in a boat."] call A3A_fnc_customHint;};
 
 positionTel = [];
@@ -52,6 +49,7 @@ if (count _positionTel > 0) then
 	_base = [_markersX, _positionTel] call BIS_Fnc_nearestPosition;
 	if (_checkForPlayer and ((_base != "SYND_HQ") and !(_base in airportsX))) exitWith {["Fast Travel", "Player groups are only allowed to Fast Travel to HQ or Airbases."] call A3A_fnc_customHint;};
 	if ((sidesX getVariable [_base,sideUnknown] == Occupants) or (sidesX getVariable [_base,sideUnknown] == Invaders)) exitWith {["Fast Travel", "You cannot Fast Travel to an enemy controlled zone."] call A3A_fnc_customHint; openMap [false,false]};
+	if (_base in forcedSpawn) exitWith {["Fast Travel", "You cannot Fast Travel to location that's under attack."] call A3A_fnc_customHint; openMap [false,false]};
 
 	//if (_base in outpostsFIA) exitWith {hint "You cannot Fast Travel to roadblocks and watchposts"; openMap [false,false]};
 


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
- HQ attacks and punishments now add the location to forced spawns. This is to prevent various direct actions (eg. fast travel, recruiting) during the warning time, but also adds the locations to leash centres (see #2462) to make it easier for guests to respond to attacks.
- Fast travel (including high command) no longer possible to markers in the forced spawn list.
- Player scale effect on min travel time removed for punishments and waved attacks. While larger servers have more capability to respond to attacks, they're also less organized and generally slower to react. Base time is now a flat five minutes.
- Added 1min per 2km increase in min travel time for punishments. Enough for reasonably fast driving, and you can often shortcut with friendly airfields.
- Scaled cost of city destruction by invaders. This should now give a similar minimum time delay between punishments regardless of player count.
- Increased post-attack delay a bit so that guests aren't immediately teleported away after defending a distant attack.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
