### PR TITLE
Builder displays when you built 

### DIFF
--- a/Tools/Builder/buildAddons.ps1
+++ b/Tools/Builder/buildAddons.ps1
@@ -68,3 +68,6 @@ Pop-Location
 Pop-Location
 
 Pop-Location
+
+$displayTime = Get-Date -DisplayHint DateTime
+"Antistasi builder ran at: " + $displayTime


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [x] Enhancement

### What have you changed and why?
Information:
    I use Hakon's powershell builder all the time, I like it. I was however fed up with not knowing when I last built was or if I even built. This pr adds support for displaying what time you last ran the builder.

### Please verify the following and ensure all checks are completed.

N/A, its a tool

### Is further testing or are further changes required?
N/A, its a tool

### How can the changes be tested?
Steps: 

********************************************************
Notes:
