### PR TITLE
attachTo use bounding box dimensions

### DIFF
--- a/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
@@ -56,7 +56,9 @@ if (_pickUp) then {
 
     // prevent killing players with item
     [_item, false] remoteExec ["enableSimulationGlobal", 2];
-    _item attachTo [_player, [0, 1.5, 0.5], "Chest"];
+    private _bbDimensions = _item call BIS_fnc_boundingBoxDimensions;
+    private _positionAttached = [0, (_bbDimensions # 1) * 0.65, (_bbDimensions # 2) / 2];
+    _item attachTo [_player, _positionAttached, "Chest"];
     _player setVariable ["A3A_carryingObject", true];
     [_player ,_item] spawn {
         params ["_player", "_item"];

--- a/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
@@ -56,8 +56,9 @@ if (_pickUp) then {
 
     // prevent killing players with item
     [_item, false] remoteExec ["enableSimulationGlobal", 2];
-    private _bbDimensions = _item call BIS_fnc_boundingBoxDimensions;
-    private _positionAttached = [0, (_bbDimensions # 1) * 0.65, (_bbDimensions # 2) / 2];
+    private _bbReal = boundingBoxReal _item;
+    private _diff = (_bbReal select 1) vectorDiff (_bbReal select 0);
+    private _positionAttached = [0, (_diff vectorDotProduct [0,.65,0]) + 1.0, (_diff vectorDotProduct [0,0,0.5]) + 0.5];
     _item attachTo [_player, _positionAttached, "Chest"];
     _player setVariable ["A3A_carryingObject", true];
     [_player ,_item] spawn {


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information:
    Made Carry Item use bounding box dimensions for attaching to. Prevents players from getting stuck in a large object that they are carrying.


### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
