### PR TITLE
Block players from mounting a static they're carrying and improve menu behaviour

### DIFF
--- a/A3A/addons/core/functions/Base/fn_flagaction.sqf
+++ b/A3A/addons/core/functions/Base/fn_flagaction.sqf
@@ -179,9 +179,9 @@ switch _typeX do
     case "static":
     {
         private _cond = "(_target getVariable ['ownerSide', teamPlayer] == teamPlayer) and (isNull attachedTo _target) and ";
-        _flag addAction ["Allow AIs to use this weapon", A3A_fnc_unlockStatic, nil, 1, false, false, "", _cond+"!isNil {_target getVariable 'lockedForAI'}", 4];
-        _flag addAction ["Prevent AIs using this weapon", A3A_fnc_lockStatic, nil, 1, false, false, "", _cond+"isNil {_target getVariable 'lockedForAI'}", 4];
+        _flag addAction ["Allow AIs to use this weapon", A3A_fnc_unlockStatic, nil, 1, false, true, "", _cond+"!isNil {_target getVariable 'lockedForAI'}", 4];
+        _flag addAction ["Prevent AIs using this weapon", A3A_fnc_lockStatic, nil, 1, false, true, "", _cond+"isNil {_target getVariable 'lockedForAI'}", 4];
     //    _flag addAction ["Kick AI off this weapon", A3A_fnc_lockStatic, nil, 1, true, false, "", _cond+"isNil {_target getVariable 'lockedForAI'} and !(isNull gunner _target) and !(isPlayer gunner _target)}", 4];
-        _flag addAction ["Move this asset", A3A_fnc_moveHQObject, nil, 1.5, false, false, "",  _cond+"(count crew _target == 0)", 4];
+        _flag addAction ["Move this asset", A3A_fnc_moveHQObject, nil, 1.5, false, true, "",  _cond+"(count crew _target == 0)", 4];
     };
 };

--- a/A3A/addons/core/functions/Dialogs/fn_moveHQObject.sqf
+++ b/A3A/addons/core/functions/Dialogs/fn_moveHQObject.sqf
@@ -12,6 +12,7 @@ if (!(isNull attachedTo _thingX)) exitWith {["Move HQ", "The asset you want to m
 if (vehicle _playerX != _playerX) exitWith {["Move HQ", "You cannot move HQ assets while in a vehicle."] call A3A_fnc_customHint;};
 
 if (([_playerX] call A3A_fnc_countAttachedObjects) > 0) exitWith {["Move HQ", "You have other things attached, you cannot move this."] call A3A_fnc_customHint;};
+
 _sites = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
 _markerX = [_sites,_playerX] call BIS_fnc_nearestPosition;
 _size = [_markerX] call A3A_fnc_sizeMarker;
@@ -22,6 +23,7 @@ if (captive _playerX) then { _playerX setCaptive false };
 
 _thingX setVariable ["objectBeingMoved", true];
 if !(_isStatic) then { _thingX removeAction _id };
+if (_isStatic) then { _thingX lock true };
 
 private _spacing = 2 max (1 - (boundingBoxReal _thingX select 0 select 1));
 private _height = 0.1 - (boundingBoxReal _thingX select 0 select 2);
@@ -67,6 +69,8 @@ private _fnc_placeObject = {
 
 	// _thingX setPosATL [getPosATL _thingX select 0,getPosATL _thingX select 1,0.1];
 
+	if (_thingX isKindOf "StaticWeapon") then { _thingX lock false };
+
 	_thingX setVariable ["objectBeingMoved", false];
 };
 
@@ -74,7 +78,7 @@ private _actionX = _playerX addAction ["Drop Here", {
 	(_this select 3) params ["_thingX", "_fnc_placeObject"];
 
 	[_thingX, player, (_this select 2)] call _fnc_placeObject;
-}, [_thingX, _fnc_placeObject],4,true,true,"",""];
+}, [_thingX, _fnc_placeObject],6,true,true,"",""];
 
 waitUntil {sleep 1;
 	(_playerX != attachedTo _thingX)


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
- Locked static for the player carrying it, preventing horrible Arma physics glitches. This removes the "get in as ..." actions. Other players mounting the static is less bad physics-wise and is already handled.
- Fixed the static actions not closing the menu on selection, which was causing Arma's wackass UI to default to the wrong action after pickup. Now everything gets "Drop object" in the screen centre while carrying.

Was tempted to fix some other shit but that's more involved and overdue a general rewrite.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

No locality-related changes.

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
