### PR TITLE
Fix enemy militia trucks not being sellable

### DIFF
--- a/A3A/addons/core/functions/Base/fn_sellVehicle.sqf
+++ b/A3A/addons/core/functions/Base/fn_sellVehicle.sqf
@@ -61,17 +61,19 @@ private _costs = call {
         or (_typeX in [FactionGet(reb,"vehicleCivBoat"),FactionGet(reb,"vehicleCivCar"),FactionGet(reb,"vehicleCivTruck")])
     ) exitWith {25};
     if (
-        _typeX in (FactionGet(all,"vehiclesLight")
-            + FactionGet(all,"vehiclesLightAPCs")
-            + OccAndInv("vehiclesTrucks")
-            + OccAndInv("vehiclesCargoTrucks")
-            + OccAndInv("vehiclesAmmoTrucks")
-            + OccAndInv("vehiclesRepairTrucks")
-            + OccAndInv("vehiclesFuelTrucks")
-            + OccAndInv("vehiclesMedical")
-        )
-        or (_typeX in FactionGet(all,"vehiclesBoats"))
+        (_typeX in FactionGet(all,"vehiclesLight"))
+        or (_typeX in OccAndInv("vehiclesTrucks"))
+        or (_typeX in OccAndInv("vehiclesCargoTrucks"))
+        or (_typeX in OccAndInv("vehiclesMilitiaTrucks"))
     ) exitWith {100};
+    if (
+        (_typeX in FactionGet(all,"vehiclesBoats"))
+        or (_typeX in FactionGet(all,"vehiclesLightAPCs"))
+        or (_typeX in OccAndInv("vehiclesAmmoTrucks"))
+        or (_typeX in OccAndInv("vehiclesRepairTrucks"))
+        or (_typeX in OccAndInv("vehiclesFuelTrucks"))
+        or (_typeX in OccAndInv("vehiclesMedical"))
+    ) exitWith {200};
     if (_typeX in (FactionGet(all,"vehiclesHelisLight") + [FactionGet(reb,"vehicleCivHeli")])) exitWith {500};
     if (
         (_typeX in FactionGet(all,"vehiclesAPCs"))


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
This PR fixes a bug where enemy militia trucks weren't sellable unless their classname was also in the regular truck list. Also added a $200 category for light APCs, enemy boats and utility trucks.

### Please specify which Issue this PR Resolves.
closes #2463

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
