### PR TITLE
Fix/tweak various rebel gear & loot issues found in public testing

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_loot.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_loot.sqf
@@ -13,7 +13,9 @@ lootNVG append allNVGs;
 /////////////////////
 // Assigned Items ///
 /////////////////////
-lootItem append allUAVTerminals + allMineDetectors + allGPS + allRadios + allLaserDesignators + allBinoculars + allLaserBatteries + lootNVG + allGadgets;
+
+// Only the trash in here now, GPS/NVG/Terminal handled separately
+lootItem append allMineDetectors + allRadios + allLaserDesignators + allBinoculars + allLaserBatteries + allGadgets;
 
 ////////////////////
 //    Weapons    ///

--- a/A3A/addons/core/functions/Ammunition/fn_randomRifle.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_randomRifle.sqf
@@ -46,12 +46,12 @@ private _categories = _weapon call A3A_fnc_equipmentClassToCategories;
 if ("GrenadeLaunchers" in _categories && {"Rifles" in _categories} ) then {
     // lookup real underbarrel GL magazine, because not everything is 40mm
     private _config = configFile >> "CfgWeapons" >> _weapon;
-    private _glmuzzle = getArray (_config >> "muzzles") select 1;		// guaranteed by category?
-    private _glmag = getArray (_config >> _glmuzzle >> "magazines") select 0;
+    private _glmuzzle = getArray (_config >> "muzzles") select 1;		// guaranteed by category
+    private _glmag = compatibleMagazines [_weapon, _glmuzzle] select 0;
     _unit addMagazines [_glmag, 5];
 };
 
-private _magazine = getArray (configFile >> "CfgWeapons" >> _weapon >> "magazines") select 0;
+private _magazine = compatibleMagazines _weapon select 0;
 private _magweight = 5 max getNumber (configFile >> "CfgMagazines" >> _magazine >> "mass");
 
 _unit addWeapon _weapon;

--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -23,7 +23,7 @@ private _fnc_addSecondaryAndMags = {
     params ["_unit", "_weapon", "_totalMagWeight"];
 
     _unit addWeapon _weapon;
-    private _magazine = getArray (configFile / "CfgWeapons" / _weapon / "magazines") select 0;
+    private _magazine = compatibleMagazines _weapon select 0;
     _unit addSecondaryWeaponItem _magazine;
 
     if ("Disposable" in (_weapon call A3A_fnc_equipmentClassToCategories)) exitWith {};


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Fixes and balance adjustments for various issues discovered during public testing:

- Remove magazine limitations on rebel equipping for the moment. This was too complicated to do correctly with the combination of black-box template data and broken mods, and not important enough to worry about.
- Use compatibleMagazines instead of config magazines#0 generally. Fewer reliability issues with broken/weird mods.
- Always use no-unlocks selection rules for missile launchers & explosives. Because they're never unlocked by default, and if those flags are enabled then the no-unlocks rules still work.
- Fill out mid-range optics with close range when it's thin. There was an exploit/weirdness where your riflemen would always get the first mid-range optic you had 10 of otherwise.
- Increase proportions of useful weapons in loot crates. Way too many trash SMGs, shotguns and handguns and not quite enough launchers otherwise. Launcher buff should help with running no-unlocks.
- Use fixed (not mod-dependent) rates of NVGs, GPS and terminals in loot crates. Previously mods with a lot of trash items would have a very low chance of finding NV or GPS/terminals in the boxes. Should also smooth out some no-unlocks problems.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

Shouldn't be any changes to data locality requirements.

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
