### PR TITLE
Tweaks and fixes to GM templates

### DIFF
--- a/A3A/addons/core/Templates/Templates/GM/GM_AI_BW.sqf
+++ b/A3A/addons/core/Templates/Templates/GM/GM_AI_BW.sqf
@@ -265,16 +265,15 @@ _militaryLoadoutData set ["slRifles", [
 _militaryLoadoutData set ["rifles", [
     ["gm_g3a3_blk", "", "acc_pointer_IR", "", ["gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_T_DM21A1_g3_blk", "gm_1rnd_67mm_heat_dm22a1_g3"], [], ""],
     ["gm_g3a3_blk", "", "", "", ["gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_T_DM21A1_g3_blk", "gm_1rnd_67mm_heat_dm22a1_g3"], [], ""],
-    ["gm_c7a1_blk", "", "", "gm_c79a1_blk", ["gm_30Rnd_556x45mm_B_M855_stanag_gry", "gm_30Rnd_556x45mm_B_T_M856_stanag_gry"], [], ""],
-    ["gm_m16a1_blk", "", "", "", ["gm_20Rnd_556x45mm_B_M855_stanag_gry", "gm_20Rnd_556x45mm_B_T_M856_stanag_gry"], [], ""]
+    ["gm_c7a1_blk", "", "", "gm_c79a1_blk", ["gm_30Rnd_556x45mm_B_M855_stanag_gry", "gm_30Rnd_556x45mm_B_T_M856_stanag_gry"], [], ""]
 ]];
 _militaryLoadoutData set ["carbines", [
     ["gm_g3a4_blk", "", "", "", ["gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_T_DM21A1_g3_blk"], [], ""],
     ["gm_gvm75carb_oli", "", "", "", ["gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_T_DM21A1_g3_blk"], [], ""]
 ]];
 _militaryLoadoutData set ["grenadeLaunchers", [
-    ["gm_hk69a1_blk", "", "", "", ["1Rnd_HE_Grenade_shell"], [], ""],
-    ["gm_g3a3_blk", "", "", "", ["gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_T_DM21A1_g3_blk", "gm_1rnd_67mm_heat_dm22a1_g3"], [], ""]
+    ["gm_hk69a1_blk", "", "", "", ["1Rnd_HE_Grenade_shell"], ["1Rnd_HE_Grenade_shell"], ""],
+    ["gm_g3a3_blk", "", "", "", ["gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_T_DM21A1_g3_blk"], ["gm_1rnd_67mm_heat_dm22a1_g3"], ""]
 ]];
 _militaryLoadoutData set ["SMGs", [
     ["gm_mp2a1_blk", "", "", "", ["gm_32Rnd_9x19mm_B_DM11_mp2_blk", "gm_32Rnd_9x19mm_B_DM51_mp2_blk", "gm_32Rnd_9x19mm_AP_DM91_mp2_blk"], [], ""],
@@ -329,7 +328,7 @@ _militiaLoadoutData set ["glBackpacks", ["gm_ge_backpack_satchel_80_blk"]];
 _militiaLoadoutData set ["helmets", ["gm_dk_headgear_m52_oli", "gm_dk_headgear_m52_net_oli", "gm_ge_bgs_headgear_m35_53_blk", "gm_ge_bgs_headgear_m35_53_net_blk"]];
 
 _militiaLoadoutData set ["rifles", [
-    ["gm_c7a1_blk", "", "", "gm_c79a1_blk", ["gm_30Rnd_556x45mm_B_M193_stanag_gry", "gm_30Rnd_556x45mm_B_T_M196_stanag_gry"], [], ""]
+    ["gm_m16a1_blk", "", "", "", ["gm_20Rnd_556x45mm_B_M855_stanag_gry", "gm_20Rnd_556x45mm_B_T_M856_stanag_gry"], [], ""]
 ]];
 _militiaLoadoutData set ["carbines", [
     ["gm_gvm75carb_oli", "", "", "", ["gm_20Rnd_762x51mm_B_DM111_g3_blk", "gm_20Rnd_762x51mm_B_T_DM21_g3_blk"], [], ""]

--- a/A3A/addons/core/Templates/Templates/GM/GM_Civ.sqf
+++ b/A3A/addons/core/Templates/Templates/GM/GM_Civ.sqf
@@ -8,12 +8,20 @@
 
 ["vehiclesCivCar", [
     "gm_gc_civ_p601",  1
-    ,"gm_gc_ff_p601", 0.2
-    ,"gm_gc_dp_p601", 0.2
-    ,"gm_ge_civ_typ1200", 2
-    ,"gm_ge_dbp_typ1200", 0.2
-    ,"gm_ge_ff_typ1200", 0.2
-    ]] call _fnc_saveToTemplate;
+    ,"gm_gc_ff_p601", 0.1
+    ,"gm_gc_dp_p601", 0.1
+    ,"gm_ge_civ_typ1200", 1
+    ,"gm_ge_dbp_typ1200", 0.1
+    ,"gm_ge_ff_typ1200", 0.1
+    ,"CUP_C_Datsun_Covered", 0.5
+    ,"CUP_C_Datsun_Plain", 0.5
+    ,"CUP_C_Volha_CR_CIV", 0.5
+    ,"CUP_C_Lada_CIV", 0.5
+    ,"CUP_C_Skoda_CR_CIV", 0.5
+    ,"CUP_C_S1203_CIV_CR", 0.5
+    ,"CUP_C_Tractor_Old_CIV", 0.2
+    ,"CUP_C_TT650_CIV", 0.2
+]] call _fnc_saveToTemplate;
 
 ["vehiclesCivIndustrial", [
     "gm_ge_civ_u1300l", 1
@@ -29,14 +37,15 @@
     ,"C_Scooter_Transport_01_F", 0.5]] call _fnc_saveToTemplate;
 
 ["vehiclesCivRepair", [
-    "C_Offroad_01_repair_F", 0.3
-    ,"C_Van_02_service_F", 0.3                // orange
+    //"C_Offroad_01_repair_F", 0.3
+    "C_Van_02_service_F", 0.3                // orange
     ,"C_Truck_02_box_F", 0.1]] call _fnc_saveToTemplate;
 
 ["vehiclesCivMedical", [
-    "C_Van_02_medevac_F", 0.1
-    ,"gm_gc_civ_mi2sr", 0.1
-    ,"gm_ge_adak_bo105m_vbh", 0.1
+    "CUP_B_S1203_Ambulance_CR", 0.1
+    ,"C_Van_02_medevac_F", 0.1
+    //,"gm_gc_civ_mi2sr", 0.1
+    //,"gm_ge_adak_bo105m_vbh", 0.1
 ]] call _fnc_saveToTemplate;
 
 ["vehiclesCivFuel", [

--- a/A3A/addons/core/Templates/Templates/GM/GM_Reb.sqf
+++ b/A3A/addons/core/Templates/Templates/GM/GM_Reb.sqf
@@ -49,6 +49,8 @@ private _initialRebelEquipment = [
 "gm_p1_blk","gm_pm_blk","gm_p2a1_blk",
 "CUP_srifle_Mosin_Nagant","CUP_srifle_LeeEnfield", "CUP_srifle_Remington700",
 "CUP_5Rnd_762x54_Mosin_M","CUP_10x_303_M","CUP_6Rnd_762x51_R700",
+["gm_m72a3_oli", 20],
+["IEDUrbanSmall_Remote_Mag", 10], ["IEDLandSmall_Remote_Mag", 10], ["IEDUrbanBig_Remote_Mag", 3], ["IEDLandBig_Remote_Mag", 3],
 "gm_8Rnd_9x18mm_B_pst_pm_blk", "gm_8Rnd_9x19mm_B_DM11_p1_blk",
 "gm_1Rnd_265mm_flare_single_red_gc", "gm_1Rnd_265mm_flare_single_wht_gc", "gm_1Rnd_265mm_flare_single_grn_DM11", 
 "gm_1Rnd_265mm_flare_single_wht_DM15", "gm_1Rnd_265mm_flare_multi_wht_DM25",


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Fixes and tweaks for GM template issues discovered in playtesting:
- Add IEDs and 20 M72A3s to starting GM rebel gear.
- Remove helis from civ medical vehicle arrays.
- Remove vanilla repair offroad (too good).
- Fill out the civ car array with cherno CUP.
- Replace militia C7A1 with M16A1 (C7A1 has mid-range optic).
- Fill out the GL ammo a bit.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
