### PR TITLE
Player and Rebel Faction starting money parameters

### DIFF
--- a/A3A/addons/core/Params.hpp
+++ b/A3A/addons/core/Params.hpp
@@ -70,6 +70,21 @@ class Params
         texts[] = {"0","2","5","10","15"};
         default = 5;
     };
+    class playerStartingMoney
+    {
+        title = "Player Starting Money";
+        values[] = {0, 100, 250, 500, 1000, 2500};
+        texts[] = {"0","100","250","500","1000","2500"};
+        default = 100;
+    };
+    class rebelStartingMoney
+    {
+        title = "Rebel Faction Starting Money";
+        values[] = {0,1000,2500,5000,10000};
+        texts[] = {"0","1000","2500","5000","10000"};
+        default = 1000;
+    };
+
 
     class SpacerMembership
     {

--- a/A3A/addons/core/Params.hpp
+++ b/A3A/addons/core/Params.hpp
@@ -77,7 +77,7 @@ class Params
         texts[] = {"0","100","250","500","1000","2500"};
         default = 100;
     };
-    class rebelStartingMoney
+    class rebelFactionStartingMoney
     {
         title = "Rebel Faction Starting Money";
         values[] = {0,1000,2500,5000,10000};

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -97,7 +97,7 @@ DECLARE_SERVER_VAR(haveRadio, false);
 //Initial HR
 server setVariable ["hr",8,true];
 //Initial faction money pool
-server setVariable ["resourcesFIA",1000,true];
+server setVariable ["resourcesFIA",rebelStartingMoney,true];
 // Time of last garbage clean. Note: serverTime may not reset to zero if server was not restarted. Therefore, it should capture the time at start of mission.
 DECLARE_SERVER_VAR(A3A_lastGarbageCleanTime, serverTime);
 // Hash map of custom non-member/AI item thresholds
@@ -108,8 +108,6 @@ DECLARE_SERVER_VAR(A3A_arsenalLimits, createHashMap);
 ////////////////////////////////////
 //We shouldn't need to sync these.
 Info("Setting server only variables");
-
-playerStartingMoney = 100;			// should probably be a parameter
 
 // horrible naming
 prestigeOPFOR = [75, 50] select cadetMode;												//Initial % support for NATO on each city

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -97,7 +97,7 @@ DECLARE_SERVER_VAR(haveRadio, false);
 //Initial HR
 server setVariable ["hr",8,true];
 //Initial faction money pool
-server setVariable ["resourcesFIA",rebelStartingMoney,true];
+server setVariable ["resourcesFIA",rebelFactionStartingMoney,true];
 // Time of last garbage clean. Note: serverTime may not reset to zero if server was not restarted. Therefore, it should capture the time at start of mission.
 DECLARE_SERVER_VAR(A3A_lastGarbageCleanTime, serverTime);
 // Hash map of custom non-member/AI item thresholds


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information:
PR gives ability to tune starting money for individual players and overall rebel at startup params menu. 

![image](https://user-images.githubusercontent.com/6746043/198249023-acd5f5f2-7e5d-4a99-8a3a-18de75c446e8.png)

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
1. Choose any starting money dropdown value.
2. Start new game.
3. Check if custom starting money parameter have applied.
********************************************************
Notes:
