### PR TITLE
Improve attack selection dependency on rebel HQ position

### DIFF
--- a/A3A/addons/core/Params.hpp
+++ b/A3A/addons/core/Params.hpp
@@ -158,13 +158,13 @@ class Params
         texts[] =  {"1.0x","1.1x","1.2x","1.3x","1.4x","1.5x"};
         default = 12;
     };
-    class A3A_attackMissionDistMul
+    class A3A_attackHQProximityMul
     {
         attr[] = {"server"};
-        title = "Enemy preference for attacking rebel targets within mission distance";
-        values[] = {1,2,3,5};
-        texts[] =  {"No change","2x","3x","5x"};
-        default = 2;
+        title = "Enemy preference for attacking rebel targets closer to HQ";
+        values[] = {1,2,3,5,8};
+        texts[] =  {"No change","2x","3x","5x","8x"};
+        default = 3;
     };
     class A3A_enemySkillMul
     {

--- a/A3A/addons/core/functions/Base/fn_chooseAttack.sqf
+++ b/A3A/addons/core/functions/Base/fn_chooseAttack.sqf
@@ -28,11 +28,12 @@ private _rebWeightMul = call {
     private _hqPos = markerPos "Synd_HQ";
     {
         _totalW = _totalW + _x; 
-        if (markerPos (_targets#_forEachIndex#0) distance2d _hqPos > distanceMission) then { continue };
-        _distW = _distW + _x;
-        _weights set [_forEachIndex, _x * A3A_attackMissionDistMul];
+        private _dist = markerPos (_targets#_forEachIndex#0) distance2d _hqPos;
+        private _weightMul = linearConversion [3000, 8000, _dist, A3A_attackHQProximityMul, 1, true];
+        _distW = _distW + _x * _weightMul;
+        _weights set [_forEachIndex, _x * _weightMul];
     } forEach _weights;
-    1 + _distW * (A3A_attackMissionDistMul - 1) / _totalW;
+    _distW / _totalW;
 };
 
 // Add in the targets for the other enemy side


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Made some changes to rebel target attack selection because it had artifacts (enemies tended to prefer targets 10km from HQ over targets 4.1km from HQ due to distance from airbase) and generally wasn't strong enough:
- Removed dependence on mission distance, because the attack logic is more bound by airbase separation.
- Increased default maximum multiplier but smoothed it out, so there's no sudden jump at a specific radius.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
