### PR TITLE
Fix case where autoload game had different params list

### DIFF
--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -72,11 +72,13 @@ waitUntil {sleep 0.1; !isNil "A3A_saveData"};
 
 [localize "STR_A3A_feedback_serverinfo", localize "STR_A3A_feedback_serverinfo_starting"] remoteExec ["A3A_fnc_customHint", 0];
 
-// Set global vars directly from params. Call should guarantee 1:1 validity
+// Use true params list in case we're loading an autosave from a different version
+private _savedParamsHM = createHashMapFromArray (A3A_saveData get "params");
 {
-    _x params ["_name", "_val"];
-    missionNamespace setVariable [_name, _val, true];           // just publish them all, doesn't really hurt
-} forEach (A3A_saveData get "params");
+    if (getArray (_x/"texts") isEqualTo [""]) then { continue };                // spacer/title
+    private _val = _savedParamsHM getOrDefault [configName _x, getNumber (_x/"default")];
+    missionNamespace setVariable [configName _x, _val, true];                   // just publish them all, doesn't really hurt
+} forEach ("true" configClasses (configFile/"A3A"/"Params"));
 
 // Might have params dependency at some point
 if (A3A_hasACEMedical) then { call A3A_fnc_initACEUnconsciousHandler };


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
There was no sanitization of saved params for autoloaded games, which meant that if a parameter name changed between versions, the new parameter would not be initialized when autoloading.

This PR fixes the problem by using the saved params as an override for the true default list.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
