### PR TITLE
Rename Unsung NVA to PAVN / Loadout Adjustments

### DIFF
--- a/A3A/addons/core/Templates/Templates.hpp
+++ b/A3A/addons/core/Templates/Templates.hpp
@@ -628,12 +628,12 @@ class Templates
         file = "UNS_AI_US";
     };
 
-    class UNS_NVA : UNS_Base
+    class UNS_PAVN : UNS_Base
     {
         side = "Occ";
         flagTexture = "\uns_flags\flag_pavn_co.paa";
-        name = "Unsung NVA";
-        file = "UNS_AI_NVA";
+        name = "Unsung PAVN";
+        file = "UNS_AI_PAVN";
     };
 
     class UNS_VC : UNS_Base

--- a/A3A/addons/core/Templates/Templates/UNS/UNS_AI_PAVN.sqf
+++ b/A3A/addons/core/Templates/Templates/UNS/UNS_AI_PAVN.sqf
@@ -2,8 +2,8 @@
 //   Side Information   //
 //////////////////////////
 
-["name", "NVA"] call _fnc_saveToTemplate;
-["spawnMarkerName", "NVA Reinforcements"] call _fnc_saveToTemplate;
+["name", "PAVN"] call _fnc_saveToTemplate;
+["spawnMarkerName", "PAVN Reinforcements"] call _fnc_saveToTemplate;
 
 ["flag", "uns_FlagCarrierNVA"] call _fnc_saveToTemplate;
 ["flagTexture", "\uns_flags\flag_pavn_co.paa"] call _fnc_saveToTemplate;
@@ -189,7 +189,7 @@ _sfLoadoutData set ["rifles", [["uns_sa58p", "", "", "", ["uns_sa58mag"], [], ""
     ["uns_sa58p", "", "", "", ["uns_sa58mag"], [], ""]]];
 _sfLoadoutData set ["carbines", [["uns_sa58v", "", "", "", ["uns_sa58mag"], [], ""],
     ["uns_sa58vf", "", "", "", ["uns_sa58mag"], [], ""]]];
-_sfLoadoutData set ["grenadeLaunchers", [["uns_ex41", "", "", "", ["uns_ex41mag"], ["uns_1Rnd_Smoke_40mm"], ""]]];
+_sfLoadoutData set ["grenadeLaunchers", [["uns_type99_gl", "", "", "", ["uns_type99mag"], ["Uns_1Rnd_30mm_FRAG"], ""]]];
 _sfLoadoutData set ["SMGs", [["uns_type50", "", "", "", ["uns_ppshmag_NT"], [], ""],
     ["uns_ppsh41", "", "", "", ["uns_ppshmag_NT"], [], ""],
     ["uns_m2carbine_shorty", "", "", "", ["uns_m2carbinemag_NT"], [], ""]]];
@@ -241,7 +241,7 @@ _militaryLoadoutData set ["carbines", [
     ["uns_akmsf", "", "", "", [], [], ""],
     ["uns_sks", "", "", "", ["uns_sksmag_NT"], [], ""]]];
 _militaryLoadoutData set ["grenadeLaunchers", [
-    ["uns_ex41", "", "", "", ["uns_ex41mag"], ["uns_1Rnd_Smoke_40mm"], ""],
+    ["uns_type99_gl", "", "", "", ["uns_type99mag"], ["Uns_1Rnd_30mm_FRAG"], ""],
     ["uns_mas4956_gl", "", "", "", ["uns_mas4956mag"], ["Uns_1Rnd_22mm_AT", "Uns_1Rnd_22mm_smoke", "Uns_1Rnd_22mm_WP"], ""]]];
 _militaryLoadoutData set ["SMGs", [
     ["uns_sa61", "", "", "", ["uns_20Rnd_sa61"], [], ""],

--- a/A3A/addons/core/Templates/Templates/UNS/UNS_AI_US.sqf
+++ b/A3A/addons/core/Templates/Templates/UNS/UNS_AI_US.sqf
@@ -223,7 +223,7 @@ _sfLoadoutData set ["sidearms", [
 
 private _militaryLoadoutData = _loadoutData call _fnc_copyLoadoutData;
 _militaryLoadoutData set ["uniforms", ["UNS_USMC_BDU_65"]];
-_militaryLoadoutData set ["vests", ["uns_simc_flak_55", "uns_simc_flak_55_M61_79_belt", "uns_simc_flak_55_bandoleer", "uns_Simc_flak_55_M61_med", "uns_simc_flak_55_M61", "uns_simc_flak_55_mk2_belt_open", "uns_simc_flak_55_mk2_bandoleer_belt"]];
+_militaryLoadoutData set ["vests", ["uns_simc_flak_55_M61_79_belt", "uns_simc_flak_55_bandoleer", "uns_Simc_flak_55_M61_med", "uns_simc_flak_55_M61", "uns_simc_flak_55_mk2_belt_open", "uns_simc_flak_55_mk2_bandoleer_belt"]];
 _militaryLoadoutData set ["backpacks", ["UNS_Alice_F1", "UNS_Alice_FR",  "UNS_USMC_MED", "UNS_USMC_R1", "uns_simc_MC_packboard_flak_3"]];
 _militaryLoadoutData set ["helmets", ["UNS_M1_2", "uns_simc_m1_bitch_op"]];
 _militaryLoadoutData set ["binoculars", ["uns_binocular_army"]];


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Changed NVA to PAVN so i can see what people use when they post Screenshots.
Also Removes the chances to mix up GM NVA with Unsungs NVA as its PAVN now.

Removed EX41 (Chinalake) from PAVN Loadouts.
This should reduce Ai throwing Nades directly at People as its not their Mainweapon anymore.

Removed 1 Pouchless Vest from the US Faction.
There was a chance that US Military Rifleman/Other Classes spawned with no Mags due overfilling.

### Please specify which Issue this PR Resolves.
closes #2506,

My own Sanity a little. (🥳 if someone reads this)

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
