### PR TITLE
Fix GM & Unsung rebel launchers

### DIFF
--- a/A3A/addons/core/Templates/Templates/GM/GM_Reb.sqf
+++ b/A3A/addons/core/Templates/Templates/GM/GM_Reb.sqf
@@ -49,7 +49,7 @@ private _initialRebelEquipment = [
 "gm_p1_blk","gm_pm_blk","gm_p2a1_blk",
 "CUP_srifle_Mosin_Nagant","CUP_srifle_LeeEnfield", "CUP_srifle_Remington700",
 "CUP_5Rnd_762x54_Mosin_M","CUP_10x_303_M","CUP_6Rnd_762x51_R700",
-["gm_m72a3_oli", 20],
+["gm_m72a3_oli", 20], "gm_1Rnd_66mm_heat_m72a3",
 ["IEDUrbanSmall_Remote_Mag", 10], ["IEDLandSmall_Remote_Mag", 10], ["IEDUrbanBig_Remote_Mag", 3], ["IEDLandBig_Remote_Mag", 3],
 "gm_8Rnd_9x18mm_B_pst_pm_blk", "gm_8Rnd_9x19mm_B_DM11_p1_blk",
 "gm_1Rnd_265mm_flare_single_red_gc", "gm_1Rnd_265mm_flare_single_wht_gc", "gm_1Rnd_265mm_flare_single_grn_DM11", 

--- a/A3A/addons/core/Templates/Templates/UNS/UNS_Reb_VC.sqf
+++ b/A3A/addons/core/Templates/Templates/UNS/UNS_Reb_VC.sqf
@@ -44,6 +44,8 @@
 
 private _initialRebelEquipment = [
 "uns_baikal", "uns_mosin", "uns_kar98k", "uns_mas36", "uns_type99", "uns_nagant_m1895", "uns_m127a1_flare", "uns_1Rnd_M127_mag",
+["uns_rpg2", 15], ["uns_rpg2grenade", 45],
+["IEDUrbanSmall_Remote_Mag", 10], ["IEDLandSmall_Remote_Mag", 10], ["IEDUrbanBig_Remote_Mag", 3], ["IEDLandBig_Remote_Mag", 3],
 "uns_12gaugemag_2", "uns_mosinmag", "uns_kar98kmag", "uns_mas36mag", "uns_type99mag", "uns_nagant_m1895mag", "uns_f1gren", "uns_molotov_mag", "uns_rdg2",
 "uns_men_NVA_65_AS3_Bag", "uns_simc_ARVN_ruck_1", "uns_simc_ARVN_ruck_2", "UNS_VC_R1",
 "uns_vc_chestrig", "UNS_VC_A2",

--- a/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
@@ -318,7 +318,9 @@ private _categoryOverrideTable = [
 ["uns_type99_gl", ["Rifles","Weapons","GrenadeLaunchers"]],
 ["uns_mas4956", ["Rifles","Weapons"]],
 ["uns_mas4956_gl", ["Rifles","Weapons","GrenadeLaunchers"]],
-["uns_m72used", ["Unknown","Weapons"]],
+["uns_m72", ["RocketLaunchers","Weapons","AT","Disposable"]],
+["uns_m72used", ["UsedLaunchers","Weapons"]],
+
 //ACRE Radios
 //Using Gadgets instead of Radios to prevent future issues as they don't use the Radio Slot
 ["ACRE_PRC148", ["Gadgets","items"]],
@@ -343,11 +345,14 @@ private _categoryOverrideTable = [
 ["LIB_M2_60_Tripod", ["StaticWeaponParts","Items"]],
 ["LIB_M2_60_Barrel", ["StaticWeaponParts","Items"]],
 
-
 //GM wrong listed stuff
-["gm_fim43_oli",["MissileLaunchers","Weapons","AA"]],
-["gm_fim43_spent_oli",["MissileLaunchers","Weapons","AA"]],
-["gm_9k32m_oli",["MissileLaunchers","Weapons","AA"]],
+["gm_m72a3_oli", ["RocketLaunchers","Weapons","AT","Disposable"]],
+["gm_m72a3_spent_oli", ["UsedLaunchers","Weapons"]],
+["gm_fim43_oli",["MissileLaunchers","Weapons","AA","Disposable"]],
+["gm_fim43_spent_oli", ["UsedLaunchers","Weapons"]],
+["gm_9k32m_oli", ["MissileLaunchers","Weapons","AA","Disposable"]],
+["gm_9k32m_spent_oli", ["UsedLaunchers","Weapons"]],
+
 ["gm_mp2a1_blk",["SMGs","Weapons"]],
 ["gm_rpk_wud",["MachineGuns","Weapons"]],
 ["gm_lmgrpk_brn",["MachineGuns","Weapons"]],


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Overlooked/forgotten stuff in GM & Unsung launchers and rebel gear:
- Add M72 ammo to GM initial equipment. The launchers don't work otherwise.
- Add some RPG2s plus ammo to Unsung initial equipment.
- Add IEDs to Unsung initial equipment.
- Fix classification of GM & Unsung disposable launchers and their used tubes.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
