### PR TITLE
Western Sahara CDLC detection fix

### DIFF
--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -255,7 +255,9 @@ FIX_LINE_NUMBERS()
 Info("Setting up faction and DLC equipment flags");
 
 // Set enabled & disabled DLC/CDLC arrays for faction/equipment modification
-private _loadedDLC = getLoadedModsInfo select {_x#3 and !(_x#1 in ["A3","curator","argo","tacops"])} apply {tolower (_x#1)};
+private _loadedDLC = getLoadedModsInfo select {
+	(_x#3 or {_x#1 isEqualTo "ws"}) and {!(_x#1 in ["A3","curator","argo","tacops"])}} apply {tolower (_x#1)
+};
 A3A_enabledDLC = (_saveData get "DLC") apply {tolower _x};                 // should be pre-checked against _loadedDLC
 {
 	A3A_enabledDLC insert [0, getArray (configFile/"A3A"/"Templates"/_x/"forceDLC"), true];		// add unique elements only

--- a/A3A/addons/core/functions/init/fn_setupMonitor.sqf
+++ b/A3A/addons/core/functions/init/fn_setupMonitor.sqf
@@ -18,7 +18,7 @@ call {
 
 // Ignore DLC without equipment and vehicles
 // Need the true names from here, so pass it all in
-private _loadedDLC = getLoadedModsInfo select {_x#3 and !(_x#1 in ["A3","curator","argo","tacops"])};
+private _loadedDLC = getLoadedModsInfo select {(_x#3 or {_x#1 isEqualTo "ws"}) and {!(_x#1 in ["A3","curator","argo","tacops"])}};
 
 
 private _autoLoadTime = "autoLoadLastGame" call BIS_fnc_getParamValue;


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:

CDLCs have no positive flag on `#3` index
```json
[
        "Arma 3 Creator DLC: Western Sahara",
        "ws",
        false,
        false,
        "GAME DIR",
        "2179d4a085ac65e7da04b2685410844e10141ac0",
        "6ba95015",
        "1681170"
]
```
, thus making it undetectable, so any `"ws" in A3A_enabledDLC` checks will return false when WS CDLC is actually turned on.
This PR fixes this issue.

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

1. Enable WS CDLC.
2. Start Antistasi mission.
3. Select WS CDLC in DLC section in mission setup menu.
4. Type `"ws" in A3A_enabledDLC`, the result should be `true`.

********************************************************
Notes:
