### PR TITLE
AFK timeout parameter + status bar indicator and logging tweaks

### DIFF
--- a/A3A/addons/core/Params.hpp
+++ b/A3A/addons/core/Params.hpp
@@ -38,7 +38,7 @@ class Params
     class civTraffic
     {
         title = "Quantity of civilan traffic and parked vehicles";
-        values[] = {0,1,2,4,};
+        values[] = {0,1,2,4};
         texts[] = {"None","Low","Medium","High"};
         default = 2;
     };
@@ -84,7 +84,13 @@ class Params
         texts[] = {"0","1000","2500","5000","10000"};
         default = 1000;
     };
-
+    class A3A_idleTimeout
+    {
+        title = "Time before a player is considered AFK";
+        values[] = {0,180,300,900,1800};
+        texts[] = {"disabled","2min","5min","15min","30min"};
+        default = 300;
+    };
 
     class SpacerMembership
     {

--- a/A3A/addons/core/functions/Base/fn_statistics.sqf
+++ b/A3A/addons/core/functions/Base/fn_statistics.sqf
@@ -17,6 +17,7 @@ _setText ctrlSetBackgroundColor [0,0,0,0];
 
 private _player = player getVariable ["owner",player];		// different, if remote-controlling
 private _ucovertxt = ["Off", "<t color='#1DA81D'>On</t>"] select ((captive _player) and !(_player getVariable ["incapacitated",false]));
+if (_player getVariable ["isAFK", false]) then { _ucovertxt = _ucovertxt + " | <t color='#A81D1D'>AFK</t>" };
 
 if (_player != theBoss) then
 	{

--- a/A3A/addons/core/functions/OrgPlayers/fn_assignBossIfNone.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_assignBossIfNone.sqf
@@ -16,10 +16,10 @@ private _electionReason = call {
     if (theBoss getVariable ["isAFK", false]) exitWith { "the boss is AFK" };
 };
 if (isNil "_electionReason") exitWith {
-    Debug_1("Not attempting to assign new boss - player %1 is the boss", theBoss);
+    Debug_1("Not attempting to assign new boss - player %1 is the boss", name theBoss);
     A3A_electionInProgress = nil;
 };
-Info_2("Election triggered because %1. Previous boss was %2", _electionReason, theBoss);
+Info_2("Election triggered because %1. Previous boss was %2", _electionReason, name theBoss);
 
 
 // Note: allPlayers doesn't work for a while after server startup, so this function isn't used for picking the initial commander

--- a/A3A/addons/core/functions/OrgPlayers/fn_theBossTransfer.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_theBossTransfer.sqf
@@ -5,7 +5,7 @@ params [["_newBoss", objNull], ["_silent", false]];
 
 if (!isNull theBoss) then
 {
-    Debug_1("Removing %1 from Boss roles.", theBoss);
+    Debug_1("Removing %1 from Boss roles.", name theBoss);
 
 	bossHCGroupsTransfer = hcAllGroups theBoss;
 	hcRemoveAllGroups theBoss;
@@ -53,7 +53,7 @@ else {
 	} forEach allGroups;
 };
 
-Debug_1("New boss %1 set.", theBoss);
+Debug_1("New boss %1 set.", name theBoss);
 
 [_silent] spawn {
 	params ["_silent"];

--- a/A3A/addons/core/functions/init/fn_clientIdleChecker.sqf
+++ b/A3A/addons/core/functions/init/fn_clientIdleChecker.sqf
@@ -7,14 +7,15 @@ Arguments:
     None
 */
 
-#define TIMEOUT_AFK 300
-
 A3A_lastActiveTime = time;
 A3A_lastPlayerDir = getDir player;
 
 // In case commander is just controlling HC squads on the map
 addMissionEventHandler ["HCGroupSelectionChanged", {
-    if (player getVariable ["isAFK", false]) then { player setVariable ["isAFK", nil, [2, clientOwner]] };
+    if (player getVariable ["isAFK", false]) then {
+        player setVariable ["isAFK", nil, [2, clientOwner]];
+        [] spawn A3A_fnc_statistics;
+    };
     A3A_lastActiveTime = time;
 }];
 
@@ -26,12 +27,16 @@ while {true} do {
     // "speed player" return zero for sideways walking/crawling
     if (A3A_lastPlayerDir != _oldDir or vectorMagnitude velocity player > 0.1) then {
         A3A_lastActiveTime = time;
-        if (player getVariable ["isAFK", false]) then { player setVariable ["isAFK", nil, [2, clientOwner]] };
+        if (player getVariable ["isAFK", false]) then {
+            player setVariable ["isAFK", nil, [2, clientOwner]];
+            [] spawn A3A_fnc_statistics;
+        };
         continue;
     };
 
-    if (time - A3A_lastActiveTime > TIMEOUT_AFK and !(player getVariable ["isAFK", false])) then { 
+    if (time - A3A_lastActiveTime > A3A_idleTimeout and !(player getVariable ["isAFK", false])) then { 
         player setVariable ["isAFK", true, [2, clientOwner]];
+        [] spawn A3A_fnc_statistics;
         if (player == theBoss) then {
             ["Client idle checker", "You are now considered AFK. You may lose commander if an election is triggered"] call A3A_fnc_customHint;
         };


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
- Made the AFK checker timeout a parameter. 15 minutes probably makes more sense for community servers, but short values are best for SP alt-tabbing.
- Added a red AFK indicator at the end of the status bar.
- Fixed cases where commander switch logging was using the unit rather than the unit name.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
