### PR TITLE
Minor fixes for 3.0

### DIFF
--- a/A3A/addons/core/functions/Base/fn_commsMP.sqf
+++ b/A3A/addons/core/functions/Base/fn_commsMP.sqf
@@ -1,4 +1,5 @@
 if (!hasInterface) exitWith {};
+if (isNil "teamPlayer") exitWith {};
 if ((side player != teamPlayer) and (side player != civilian)) exitWith {};
 private ["_unit","_typeX","_textX","_display","_setText"];
 

--- a/A3A/addons/core/functions/Base/fn_markerChange.sqf
+++ b/A3A/addons/core/functions/Base/fn_markerChange.sqf
@@ -64,7 +64,7 @@ if (_winner == teamPlayer) then
 {
 	// Old garrison surrender
 	private _oldGarrison = units _loser select { _x getVariable ["markerX", ""] == _markerX };
-	{ _x spawn A3A_fnc_surrenderAction } forEach _oldGarrison;
+	{ [_x] remoteExec ["A3A_fnc_surrenderAction", _x] } forEach _oldGarrison;
 
 	// Cap to 0.6 max to reward captures without previous support calls
 	private _resources = [_loser, teamPlayer, _markerX, 0.6] call A3A_fnc_maxDefenceSpend;

--- a/A3A/addons/core/functions/CREATE/fn_wavedAttack.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_wavedAttack.sqf
@@ -35,7 +35,7 @@ private _taskId = "wavedAttack" + str A3A_taskCount;
 if (_targside == teamPlayer) then {
     private _taskStr = format ["%1 is attacking our garrison at %2. Stop them if you can, or live to fight another day.", _nameEnemy, _nameDest];
     [true,_taskId,[_taskStr,format ["%1 Attack",_nameEnemy],_mrkDest],markerPos _mrkDest,false,0,true,"Defend",true] call BIS_fnc_taskCreate;
-    [_taskId, "wavedAttack", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+    [_taskId, "rebelAttack", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 } else {
     private _text = format ["%1 is attacking the %2 garrison at %3.", _nameEnemy, Faction(_targside) get "name", _nameDest];
     ["RadioIntercepted", [_text]] remoteExec ["BIS_fnc_showNotification", 0];

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -186,7 +186,7 @@ call A3A_fnc_initSupports;
 call A3A_fnc_generateRebelGear;
 
 // Needs A3A_rebelGear for equipping
-call A3A_fnc_initPetros;
+call A3A_fnc_createPetros;
 
 // Some of these may already be unhidden but we make sure
 { _x hideObjectGlobal false } forEach [boxX, flagX, vehicleBox, fireX, mapX, petros];


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Minor bug fixes:
- Switch back to createPetros on init so he gets the right uniform.
- Prevent commsMP trying to run before client init.
- Fix non-local surrenderAction call.

### Please specify which Issue this PR Resolves.
closes #2516

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
