### PR TITLE
Fix up GM vehicle categories to work better with attack/support

### DIFF
--- a/A3A/addons/core/Templates/Templates/GM/GM_AI_BW.sqf
+++ b/A3A/addons/core/Templates/Templates/GM/GM_AI_BW.sqf
@@ -19,22 +19,21 @@
 
 ["vehiclesBasic", ["gm_ge_army_k125"]] call _fnc_saveToTemplate;
 ["vehiclesLightUnarmed", ["gm_ge_army_iltis_cargo", "gm_dk_army_typ1200_cargo"]] call _fnc_saveToTemplate;
-["vehiclesLightArmed", ["gm_ge_army_iltis_milan", "gm_ge_army_iltis_mg3"]] call _fnc_saveToTemplate; //this line determines light and armed vehicles -- Example: ["vehiclesLightArmed", ["B_MRAP_01_hmg_F", "B_MRAP_01_gmg_F"]] -- Array, can contain multiple assets
+["vehiclesLightArmed", ["gm_ge_army_iltis_milan", "gm_ge_army_iltis_mg3", "gm_ge_army_iltis_mg3", "gm_ge_army_luchsa1", "gm_ge_army_luchsa2"]] call _fnc_saveToTemplate; //this line determines light and armed vehicles -- Example: ["vehiclesLightArmed", ["B_MRAP_01_hmg_F", "B_MRAP_01_gmg_F"]] -- Array, can contain multiple assets
 ["vehiclesTrucks", ["gm_ge_army_u1300l_cargo", "gm_ge_army_u1300l_container", "gm_ge_army_kat1_451_cargo", "gm_ge_army_kat1_451_container"]] call _fnc_saveToTemplate;
 ["vehiclesCargoTrucks", ["gm_ge_army_kat1_454_cargo", "gm_ge_army_u1300l_container", "gm_ge_army_kat1_452_container", "gm_ge_army_kat1_451_container"]] call _fnc_saveToTemplate;
 ["vehiclesAmmoTrucks", ["gm_ge_army_kat1_454_reammo", "gm_ge_army_kat1_451_reammo"]] call _fnc_saveToTemplate;
 ["vehiclesRepairTrucks", ["gm_ge_army_u1300l_repair", "gm_ge_army_bpz2a0", "gm_ge_army_fuchsa0_engineer", "gm_dk_army_m113a1dk_engineer"]] call _fnc_saveToTemplate;
 ["vehiclesFuelTrucks", ["gm_ge_army_kat1_451_refuel"]] call _fnc_saveToTemplate;
 ["vehiclesMedical", ["gm_ge_army_u1300l_medic", "gm_ge_army_m113a1g_medic"]] call _fnc_saveToTemplate;
-["vehiclesTanks", ["gm_ge_army_Leopard1a1", "gm_ge_army_Leopard1a1a1", "gm_ge_army_Leopard1a1a2", "gm_ge_army_Leopard1a3", "gm_ge_army_Leopard1a3a1", "gm_ge_army_Leopard1a5", 
+["vehiclesTanks", ["gm_dk_army_m113a2dk", "gm_ge_army_Leopard1a1", "gm_ge_army_Leopard1a1a1", "gm_ge_army_Leopard1a1a2", "gm_ge_army_Leopard1a3", "gm_ge_army_Leopard1a3a1", "gm_ge_army_Leopard1a5", 
     "gm_dk_army_Leopard1a3"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["gm_ge_army_gepard1a1"]] call _fnc_saveToTemplate;
 
+["vehiclesLightAPCs", ["gm_ge_army_fuchsa0_command", "gm_ge_army_fuchsa0_reconnaissance"]] call _fnc_saveToTemplate;
 ["vehiclesAPCs", ["gm_ge_army_m113a1g_apc_milan",
     "gm_dk_army_m113a1dk_apc", "gm_ge_army_m113a1g_apc", "gm_ge_army_m113a1g_command"]] call _fnc_saveToTemplate;
-
-["vehiclesLightAPCs", ["gm_ge_army_fuchsa0_command", "gm_ge_army_fuchsa0_reconnaissance"]] call _fnc_saveToTemplate;
-["vehiclesIFVs", ["gm_ge_army_luchsa1", "gm_ge_army_luchsa2", "gm_dk_army_m113a2dk", "gm_ge_army_marder1a1plus", "gm_ge_army_marder1a1a", "gm_ge_army_marder1a2", "CUP_B_M2A3Bradley_USA_W", 
+["vehiclesIFVs", ["gm_ge_army_marder1a1plus", "gm_ge_army_marder1a1a", "gm_ge_army_marder1a2", "CUP_B_M2A3Bradley_USA_W", 
     "CUP_B_M2Bradley_USA_W"]] call _fnc_saveToTemplate;
 
 ["vehiclesTransportBoats", ["CUP_B_Zodiac_USMC"]] call _fnc_saveToTemplate;
@@ -59,8 +58,6 @@
     ["gm_dk_army_m109",["gm_20Rnd_155mm_he_m107","gm_20Rnd_155mm_he_m795","gm_20Rnd_155mm_he_dm21","gm_20Rnd_155mm_he_dm111","gm_20Rnd_155mm_icm_dm602"]]
 ]] call _fnc_saveToTemplate;
 
-//
-
 ["uavsAttack", []] call _fnc_saveToTemplate;
 ["uavsPortable", []] call _fnc_saveToTemplate;
 
@@ -82,6 +79,8 @@
 //Minefield definition
 ["minefieldAT", ["gm_minestatic_at_dm21", "gm_minestatic_at_dm1233"]] call _fnc_saveToTemplate;
 ["minefieldAPERS", ["gm_minestatic_ap_dm31"]] call _fnc_saveToTemplate;
+
+#include "GM_Vehicle_Attributes.sqf"
 
 /////////////////////
 ///  Identities   ///

--- a/A3A/addons/core/Templates/Templates/GM/GM_AI_NVA.sqf
+++ b/A3A/addons/core/Templates/Templates/GM/GM_AI_NVA.sqf
@@ -19,19 +19,16 @@
 
 ["vehiclesBasic", ["gm_gc_army_p601"]] call _fnc_saveToTemplate;
 ["vehiclesLightUnarmed", ["gm_gc_army_uaz469_cargo"]] call _fnc_saveToTemplate;
-["vehiclesLightArmed",["gm_gc_army_uaz469_dshkm"]] call _fnc_saveToTemplate;
-["vehiclesTrucks", ["gm_gc_army_ural4320_cargo", "gm_gc_army_ural375d_cargo"]] call _fnc_saveToTemplate;
+["vehiclesLightArmed",["gm_gc_army_uaz469_dshkm", "gm_gc_army_brdm2", "gm_gc_army_uaz469_dshkm", "gm_gc_army_brdm2", "CUP_O_GAZ_Vodnik_BPPU_RU", "CUP_O_GAZ_Vodnik_KPVT_RU"]] call _fnc_saveToTemplate;
+["vehiclesTrucks", ["gm_gc_army_ural4320_cargo", "gm_gc_army_ural375d_cargo", "gm_gc_army_btr60pa"]] call _fnc_saveToTemplate;
 ["vehiclesCargoTrucks", ["gm_gc_army_ural4320_cargo", "gm_gc_army_ural44202", "gm_gc_army_ural375d_cargo"]] call _fnc_saveToTemplate;
 ["vehiclesAmmoTrucks", ["gm_gc_army_ural4320_reammo"]] call _fnc_saveToTemplate;
 ["vehiclesRepairTrucks", ["gm_gc_army_ural4320_repair"]] call _fnc_saveToTemplate;
 ["vehiclesFuelTrucks", ["gm_gc_army_ural375d_refuel"]] call _fnc_saveToTemplate;
 ["vehiclesMedical", ["gm_gc_army_ural375d_medic"]] call _fnc_saveToTemplate;
-["vehiclesAPCs", ["gm_pl_army_ot64a", "gm_gc_army_brdm2", "gm_gc_army_btr60pb", "CUP_O_BTR80_CAMO_RU", "CUP_O_GAZ_Vodnik_BPPU_RU", "CUP_O_GAZ_Vodnik_KPVT_RU"]] call _fnc_saveToTemplate;
-
-["vehiclesLightAPCs", ["gm_gc_army_brdm2um", "gm_gc_army_btr60pa", "gm_gc_army_btr60pu12", 
-    "CUP_O_GAZ_Vodnik_Unarmed_RU", "CUP_O_GAZ_Vodnik_PK_RU", "CUP_O_GAZ_Vodnik_AGS_RU"]] call _fnc_saveToTemplate;
-["vehiclesIFVs", ["gm_gc_army_bmp1sp2", "CUP_O_BMP2_RU", "CUP_O_BMP3_RU", "CUP_O_BTR80A_CAMO_RU"]] call _fnc_saveToTemplate;
-
+["vehiclesLightAPCs", ["gm_gc_army_btr60pb", "gm_gc_army_btr60pb", "CUP_O_GAZ_Vodnik_Unarmed_RU", "CUP_O_GAZ_Vodnik_PK_RU", "CUP_O_GAZ_Vodnik_AGS_RU"]] call _fnc_saveToTemplate;
+["vehiclesAPCs", ["gm_pl_army_ot64a", "CUP_O_BTR80_CAMO_RU", "gm_gc_army_bmp1sp2"]] call _fnc_saveToTemplate;
+["vehiclesIFVs", ["gm_gc_army_bmp1sp2", "CUP_O_BMP2_RU", "CUP_O_BMP3_RU"]] call _fnc_saveToTemplate;
 ["vehiclesTanks", ["gm_gc_army_pt76b", "gm_gc_army_t55", "gm_gc_army_t55a", "gm_gc_army_t55ak", "gm_gc_army_t55am2", "gm_gc_army_t55am2b"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["gm_gc_army_zsu234v1"]] call _fnc_saveToTemplate;
 
@@ -76,6 +73,8 @@
 //Minefield definition
 ["minefieldAT", ["gm_minestatic_at_tm46"]] call _fnc_saveToTemplate;
 ["minefieldAPERS", ["gm_minestatic_ap_pfm1"]] call _fnc_saveToTemplate;
+
+#include "GM_Vehicle_Attributes.sqf"
 
 /////////////////////
 ///  Identities   ///

--- a/A3A/addons/core/Templates/Templates/GM/GM_AI_NVA.sqf
+++ b/A3A/addons/core/Templates/Templates/GM/GM_AI_NVA.sqf
@@ -18,7 +18,7 @@
 ["equipmentBox", "Box_NATO_Equip_F"] call _fnc_saveToTemplate; //Changeing this from default will require you to define logistics attachement offset for the box type
 
 ["vehiclesBasic", ["gm_gc_army_p601"]] call _fnc_saveToTemplate;
-["vehiclesLightUnarmed", ["gm_gc_army_uaz469_cargo"]] call _fnc_saveToTemplate;
+["vehiclesLightUnarmed", ["gm_gc_army_uaz469_cargo", "gm_gc_army_uaz469_cargo", "gm_gc_army_btr60pu12"]] call _fnc_saveToTemplate;
 ["vehiclesLightArmed",["gm_gc_army_uaz469_dshkm", "gm_gc_army_brdm2", "gm_gc_army_uaz469_dshkm", "gm_gc_army_brdm2", "CUP_O_GAZ_Vodnik_BPPU_RU", "CUP_O_GAZ_Vodnik_KPVT_RU"]] call _fnc_saveToTemplate;
 ["vehiclesTrucks", ["gm_gc_army_ural4320_cargo", "gm_gc_army_ural375d_cargo", "gm_gc_army_btr60pa"]] call _fnc_saveToTemplate;
 ["vehiclesCargoTrucks", ["gm_gc_army_ural4320_cargo", "gm_gc_army_ural44202", "gm_gc_army_ural375d_cargo"]] call _fnc_saveToTemplate;
@@ -27,7 +27,7 @@
 ["vehiclesFuelTrucks", ["gm_gc_army_ural375d_refuel"]] call _fnc_saveToTemplate;
 ["vehiclesMedical", ["gm_gc_army_ural375d_medic"]] call _fnc_saveToTemplate;
 ["vehiclesLightAPCs", ["gm_gc_army_btr60pb", "gm_gc_army_btr60pb", "CUP_O_GAZ_Vodnik_Unarmed_RU", "CUP_O_GAZ_Vodnik_PK_RU", "CUP_O_GAZ_Vodnik_AGS_RU"]] call _fnc_saveToTemplate;
-["vehiclesAPCs", ["gm_pl_army_ot64a", "CUP_O_BTR80_CAMO_RU", "gm_gc_army_bmp1sp2"]] call _fnc_saveToTemplate;
+["vehiclesAPCs", ["gm_pl_army_ot64a", "CUP_O_BTR80_CAMO_RU", "CUP_O_BTR80A_CAMO_RU", "gm_gc_army_bmp1sp2"]] call _fnc_saveToTemplate;
 ["vehiclesIFVs", ["gm_gc_army_bmp1sp2", "CUP_O_BMP2_RU", "CUP_O_BMP3_RU"]] call _fnc_saveToTemplate;
 ["vehiclesTanks", ["gm_gc_army_pt76b", "gm_gc_army_t55", "gm_gc_army_t55a", "gm_gc_army_t55ak", "gm_gc_army_t55am2", "gm_gc_army_t55am2b"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["gm_gc_army_zsu234v1"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/GM/GM_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/GM/GM_Vehicle_Attributes.sqf
@@ -1,0 +1,26 @@
+["attributesVehicles", [
+
+    // CUP/GM IFVs are all too fragile to get the full value
+    ["CUP_O_BMP3_RU", ["cost", 120], ["threat", 150]],
+    ["CUP_O_BMP2_RU", ["cost", 120], ["threat", 150]],
+    ["gm_gc_army_bmp1sp2", ["cost", 120], ["threat", 150]],
+    ["gm_ge_army_marder1a1plus", ["cost", 120], ["threat", 150]],
+    ["gm_ge_army_marder1a1a", ["cost", 120], ["threat", 150]],
+    ["gm_ge_army_marder1a2", ["cost", 120], ["threat", 150]],
+    ["CUP_B_M2Bradley_USA_W", ["cost", 120], ["threat", 150]],
+
+    // Autocannons in light-armed
+    ["CUP_O_GAZ_Vodnik_BPPU_RU", ["cost", 75], ["threat", 120]],
+    ["gm_ge_army_luchsa1", ["cost", 75], ["threat", 120]],
+    ["gm_ge_army_luchsa2", ["cost", 75], ["threat", 120]],
+
+    // Fragile tanks
+    ["gm_dk_army_m113a2dk", ["cost", 120], ["threat", 150]],
+    ["gm_ge_army_Leopard1a1", ["cost", 170], ["threat", 230]],
+    ["gm_ge_army_Leopard1a1a1", ["cost", 170], ["threat", 230]],
+    ["gm_ge_army_Leopard1a1a2", ["cost", 170], ["threat", 230]],
+    ["gm_ge_army_Leopard1a3", ["cost", 170], ["threat", 230]],
+    ["gm_ge_army_Leopard1a3a1", ["cost", 170], ["threat", 230]],
+    ["gm_ge_army_Leopard1a5", ["cost", 170], ["threat", 230]]
+
+]] call _fnc_saveToTemplate;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Changes that I forgot earlier to bring the GM in line with the other factions and ensure attack/support is using the vehicles somewhat correctly:
- Vehicles that don't seat troops moved out of lightAPC/APC/IFV.
- Some scout-ish cannon-armed vehicles moved to light armed with increased cost.
- Reduced cost of vehicles that are fragile for their class.
    
### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
