### PR TITLE
addonVics ref correct config class, and loading is fixed along with a…

### DIFF
--- a/A3A/addons/core/functions/Templates/fn_loadAddon.sqf
+++ b/A3A/addons/core/functions/Templates/fn_loadAddon.sqf
@@ -18,15 +18,22 @@ Example: [civilian, "Templates\AddonVics\rds_Civ.sqf"] call A3A_fnc_loadAddon;
 
 License: MIT License
 */
-params ["_side", "_path"];
-private _factionPrefix = ["occ", "inv", "reb", "civ"] # ([west,east,resistance,civilian] find _side);
+#include "..\..\script_component.hpp"
+params [["_side","",[""]], ["_path","",[""]]];
+_side = toLower _side;
+if !(fileExists _path) exitWith {
+    Error_2("File missing! - Side: %1 File: %2", _side, _path);
+};
+if !(_side in ["occ", "inv", "reb", "civ"]) exitWith {
+    Error_2("Invalid side of addon - Side: %1 File: %2", _side, _path);
+};
 
 //get the addon data
 private _addon = createHashMap;
 call compile preprocessFileLineNumbers _path;
 
 //add the addon data to the faction data
-private _faction = missionNamespace getVariable ["A3A_faction_"+_factionPrefix, createHashMap];
+private _faction = missionNamespace getVariable ["A3A_faction_"+_side, createHashMap];
 {
     _faction set [_x, (_faction get _x) + _y];
 } forEach _addon;

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -320,7 +320,7 @@ private _logisticsFiles = [QPATHTOFOLDER(Templates\Templates\Vanilla\Vanilla_Log
 } forEach (_saveData get "factions");
 
 {
-	private _cfg = configFile/"A3A"/"Templates"/_x;
+	private _cfg = configFile/"A3A"/"AddonVics"/_x;
 	private _basepath = getText (_cfg/"path") + "\";
 	{
 		Info_2("Loading addon file %1 for side %2", _x#1, _x#0);


### PR DESCRIPTION
…dded safeguards agains errors

## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    initVarServer refrenced wrong class for data about the addonVics, i fixed this so now it will be able to get the file path etc.
    loadAddon expected side as a parameter, we provided the side text, changed loadAddon to expect this as it was less work
    added a few error safeguards with logging to loadAddon

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: start a game with a pack enabled and check one of the arrays it would be expanding, for example with rhs it would add "RDS_Old_bike_Civ_01" to "vehiclesCivCar" in the civ faction

********************************************************
Notes:
