### PR TITLE
Fix missing semicolon in cfgfunctions

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -123,7 +123,7 @@ class CfgFunctions
             class distance {};
             class distanceUnits {};
             class FIAradio {};
-            class findAttackTargets {}
+            class findAttackTargets {};
             class findBasesForConvoy {};
             class findNearestGoodRoad {};
             class flagaction {};


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    The support left out some semicolons in cfg functions. Which might explain something, somewhere.

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
