### PR TITLE
Various one-liner fixes

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
@@ -17,7 +17,7 @@ if (isNil "_veh") exitWith {};
 if !(isNil { _veh getVariable "ownerSide" }) exitWith
 {
 	// vehicle already initialized, just swap side and exit
-	[_veh, _side] call A3A_fnc_vehKilledOrCaptured;
+	[_veh, _side, true] call A3A_fnc_vehKilledOrCaptured;
 };
 
 _veh setVariable ["originalSide", _side, true];
@@ -41,6 +41,7 @@ if (_side == teamPlayer) then
 
 // Sync the vehicle textures if necessary
 _veh call A3A_fnc_vehicleTextureSync;
+
 
 private _typeX = typeOf _veh;
 if (_veh isKindOf "Car" or _veh isKindOf "Tank") then

--- a/A3A/addons/core/functions/Missions/fn_REP_Antenna.sqf
+++ b/A3A/addons/core/functions/Missions/fn_REP_Antenna.sqf
@@ -94,5 +94,6 @@ if (dateToNumber date > _dateLimitNum) then
 waitUntil {sleep 1; (spawner getVariable _markerX == 2)};
 
 // could make these guys return home, too much work atm
+if (isNil "_groupX") exitWith {};
 [_groupX] spawn A3A_fnc_groupDespawner;
 [_veh] spawn A3A_fnc_vehDespawner;

--- a/A3A/addons/core/functions/Missions/fn_convoy.sqf
+++ b/A3A/addons/core/functions/Missions/fn_convoy.sqf
@@ -150,7 +150,7 @@ private _fnc_spawnConvoyVehicle = {
     _veh allowDamage false;
 
     private _group = [_sideX, _veh] call A3A_fnc_createVehicleCrew;
-    { [_x, nil, nil, _resPool] call A3A_fnc_NATOinit; _x allowDamage false; } forEach (units _group);
+    { [_x, nil, nil, _resPool] call A3A_fnc_NATOinit; _x allowDamage false; _x disableAI "MINEDETECTION" } forEach (units _group);
     _soldiers append (units _group);
     (driver _veh) stop true;
     deleteWaypoint [_group, 0];													// groups often start with a bogus waypoint

--- a/A3A/addons/core/functions/REINF/fn_addFIAsquadHC.sqf
+++ b/A3A/addons/core/functions/REINF/fn_addFIAsquadHC.sqf
@@ -98,7 +98,7 @@ private _vehiclePlacementMethod = if (getMarkerPos respawnTeamPlayer distance pl
         private _vehicle = _vehType createVehicle _spawnPos;
 
         if (_mounts isNotEqualTo []) then {
-            private _static = staticAAteamPlayer createVehicle _spawnPos;
+            private _static = FactionGet(reb,"staticAA") createVehicle _spawnPos;
             private _nodes = [_vehicle, _static] call A3A_fnc_logistics_canLoad;
             if (_nodes isEqualType 0) exitWith {};
             (_nodes + [true]) call A3A_fnc_logistics_load;

--- a/A3A/addons/core/functions/REINF/fn_spawnHCGroup.sqf
+++ b/A3A/addons/core/functions/REINF/fn_spawnHCGroup.sqf
@@ -62,7 +62,7 @@ private _initInfVeh = {
 };
 
 private _initVeh = {
-    [_vehicle, teamPlayer] call A3A_fnc_AIVEHinit;
+    [_vehicle, teamPlayer] call A3A_fnc_AIVEHinit;          // Already called by HR_GRG_fnc_vehInit, but make sure
     _group addVehicle _vehicle;
     _vehicle setVariable ["owner",_group,true];
     driver _vehicle action ["engineOn", _vehicle];

--- a/A3A/addons/core/functions/Supports/fn_SUP_mortarRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_mortarRoutine.sqf
@@ -99,6 +99,7 @@ while {time < _timeout} do
     _mortar setVariable ["FireOrder", _subTargets];
     [_mortar] spawn _fn_executeMortarFire;
     _numberOfRounds = _numberOfRounds - _shotsPerVolley;
+    _timeout = _timeout max (time + 60);                // don't cleanup until the volley is done
 
     //Makes sure that all units escape before attacking
     // [_side, _targetMarker] spawn A3A_fnc_clearTargetArea;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
- Fixed an issue where rebel troops were exiting their vehicle after spawning, and possibly other issues. AIVEHinit is called twice on rebel high command spawned vehicles, and the second one was causing it to be reported as destroyed due to an incorrect parameter.
- Fixed an issue where vanilla AA vehicles spawned without their missile launcher when remote-spawned. From #2047.
- Fixed an issue where the antenna repair mission could throw an error when exiting without having spawned the group or vehicle.
- Probably fixed an issue where mortarRoutine could throw errors due to the main loop timing out and cleaning up the mortar while it was still firing.
- Disabled mine detection AI on convoy vehicles. Already done for most combat vehicles, as they're too good at it.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
