### PR TITLE
Balance utility trucks in cases where the civ factions lacks them

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_createAIOutposts.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIOutposts.sqf
@@ -237,17 +237,15 @@ else
 _spawnParameter = [_markerX, "Vehicle"] call A3A_fnc_findSpawnPosition;
 if (_spawnParameter isEqualType []) then
 {
-	_typeVehX = if (_sideX == Occupants) then
-	{
+	private _typeVehX = call {
+		if (FactionGet(civ,"vehiclesCivRepair") isEqualTo [] and random 1 < 0.1) exitWith { selectRandom (_faction get "vehiclesRepairTrucks") };
+		if (FactionGet(civ,"vehiclesCivFuel") isEqualTo [] and random 1 < 0.1) exitWith { selectRandom (_faction get "vehiclesFuelTrucks") };
 		private _types = if (!_isFIA) then {(_faction get "vehiclesTrucks") + (_faction get "vehiclesCargoTrucks")} else {_faction get "vehiclesMilitiaTrucks"};
 		_types = _types select { _x in FactionGet(all,"vehiclesCargoTrucks") };
 		if (count _types == 0) then { (_faction get "vehiclesCargoTrucks") } else { _types };
-	}
-	else
-	{
-		(_faction get "vehiclesTrucks")
+		selectRandom _types;
 	};
-	_veh = createVehicle [selectRandom _typeVehX, (_spawnParameter select 0), [], 0, "NONE"];
+	_veh = createVehicle [_typeVehX, (_spawnParameter select 0), [], 0, "NONE"];
 	_veh setDir (_spawnParameter select 1);
 	_vehiclesX pushBack _veh;
 	_nul = [_veh, _sideX] call A3A_fnc_AIVEHinit;

--- a/A3A/addons/core/functions/CREATE/fn_createAIResources.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIResources.sqf
@@ -163,17 +163,15 @@ if (not(_markerX in destroyedSites)) then
 private _spawnParameter = [_markerX, "Vehicle"] call A3A_fnc_findSpawnPosition;
 if (_spawnParameter isEqualType []) then
 {
-	_typeVehX = if (_sideX == Occupants) then
-	{
+	private _typeVehX = call {
+		if (FactionGet(civ,"vehiclesCivRepair") isEqualTo [] and random 1 < 0.1) exitWith { selectRandom (_faction get "vehiclesRepairTrucks") };
+		if (FactionGet(civ,"vehiclesCivFuel") isEqualTo [] and random 1 < 0.1) exitWith { selectRandom (_faction get "vehiclesFuelTrucks") };
 		private _types = if (!_isFIA) then {(_faction get "vehiclesTrucks") + (_faction get "vehiclesCargoTrucks")} else {_faction get "vehiclesMilitiaTrucks"};
 		_types = _types select { _x in FactionGet(all,"vehiclesCargoTrucks") };
 		if (count _types == 0) then { (_faction get "vehiclesCargoTrucks") } else { _types };
-	}
-	else
-	{
-		(_faction get "vehiclesTrucks")
+		selectRandom _types;
 	};
-	_veh = createVehicle [selectRandom _typeVehX, (_spawnParameter select 0), [], 0, "NONE"];
+	_veh = createVehicle [_typeVehX, (_spawnParameter select 0), [], 0, "NONE"];
 	_veh setDir (_spawnParameter select 1);
 	_vehiclesX pushBack _veh;
 	[_veh, _sideX] call A3A_fnc_AIVEHinit;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
One of the main complaints about the Unsung modset was that it was much harder to acquire fuel and repair trucks due to the lack of civilian vehicles. This PR attempts to balance that out by adding a chance of picking military fuel and repair vehicles instead of the static cargo trucks at bases. It's exploitable by spawn/despawn but no more so than the civ spawns in other modsets.

Also clears up some old/broken occupant/invader asymmetry on usage of cargo trucks.

Note that createAIOutposts is also used for seaports, and createAIResources is also used for factories. Airports already have a chance of spawning utility trucks so I didn't touch those.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
I think the only current civ faction without fuel/repair vehicles is Unsung, although you can test like this with other factions:
```
A3A_faction_civ set ["vehiclesCivRepair", []];
A3A_faction_civ set ["vehiclesCivFuel", []];
```
