### PR TITLE
Move the controls defined in setupDialog.hpp to control.hpp

### DIFF
--- a/A3A/addons/GUI/dialogues/controls.hpp
+++ b/A3A/addons/GUI/dialogues/controls.hpp
@@ -1134,3 +1134,34 @@ class A3A_DefaultControlsGroup : A3A_ControlsGroupNoScrollbars
     w = DIALOG_W * GRID_W;
     h = DIALOG_H * GRID_H;
 };
+
+class A3A_Text_Small : A3A_text
+{
+    sizeEx = GUI_TEXT_SIZE_SMALL;
+};
+
+class A3A_Listbox_Small : A3A_Listbox
+{
+    rowHeight = GUI_TEXT_SIZE_SMALL;
+    sizeEx = GUI_TEXT_SIZE_SMALL;
+};
+
+class A3A_ComboBox : A3A_ListBox
+{
+    type = CT_COMBO;
+    class ComboScrollBar: ScrollBar {};
+    style = ST_MULTI;   // + ST_NO_RECT;          // ?
+
+    arrowEmpty = "\A3\ui_f\data\GUI\RscCommon\rsccombo\arrow_combo_ca.paa";
+    arrowFull = "\A3\ui_f\data\GUI\RscCommon\rsccombo\arrow_combo_active_ca.paa";
+    soundExpand[] = { "\A3\ui_f\data\sound\RscCombo\soundExpand", 0.1, 1 };
+    soundCollapse[] = { "\A3\ui_f\data\sound\RscCombo\soundCollapse", 0.1, 1 };
+    wholeHeight = 1; // ??
+    maxHistoryDelay = 0.2;      // Do values <1 actually work? pretty annoying if you can't quick open-close these
+};
+
+class A3A_ComboBox_Small : A3A_ComboBox
+{
+    sizeEx = GUI_TEXT_SIZE_SMALL;
+    rowHeight = GUI_TEXT_SIZE_SMALL;
+};

--- a/A3A/addons/GUI/dialogues/setupDialog.hpp
+++ b/A3A/addons/GUI/dialogues/setupDialog.hpp
@@ -1,36 +1,4 @@
 
-
-class A3A_Text_Small : A3A_text
-{
-    sizeEx = GUI_TEXT_SIZE_SMALL;
-};
-
-class A3A_Listbox_Small : A3A_Listbox
-{
-    rowHeight = GUI_TEXT_SIZE_SMALL;
-    sizeEx = GUI_TEXT_SIZE_SMALL;
-};
-
-class A3A_ComboBox : A3A_ListBox
-{
-    type = CT_COMBO;
-    class ComboScrollBar: ScrollBar {};
-    style = ST_MULTI;   // + ST_NO_RECT;          // ?
-
-    arrowEmpty = "\A3\ui_f\data\GUI\RscCommon\rsccombo\arrow_combo_ca.paa";
-    arrowFull = "\A3\ui_f\data\GUI\RscCommon\rsccombo\arrow_combo_active_ca.paa";
-    soundExpand[] = { "\A3\ui_f\data\sound\RscCombo\soundExpand", 0.1, 1 };
-    soundCollapse[] = { "\A3\ui_f\data\sound\RscCombo\soundCollapse", 0.1, 1 };
-    wholeHeight = 1; // ??
-    maxHistoryDelay = 0.2;      // Do values <1 actually work? pretty annoying if you can't quick open-close these
-};
-
-class A3A_ComboBox_Small : A3A_ComboBox
-{
-    sizeEx = GUI_TEXT_SIZE_SMALL;
-    rowHeight = GUI_TEXT_SIZE_SMALL;
-};
-
 class A3A_SetupDialog : A3A_TabbedDialog
 {
     idd = A3A_IDD_SETUPDIALOG;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    Move the controls that John defined into control.hpp so that if we need a combobox or one of the other defines we don't have to double define stuff. 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
