### PR TITLE
Fix Antistasi UI layer numbers fighting with other mods

### DIFF
--- a/A3A/addons/core/functions/Base/fn_commsMP.sqf
+++ b/A3A/addons/core/functions/Base/fn_commsMP.sqf
@@ -17,7 +17,13 @@ if (_typeX == "globalChat") then
 	{
 	_unit globalChat format ["%1", _textX];
 	};
+if (_typeX == "countdown") then
+	{
+	_textX = format ["Time Remaining: %1 secs",_textX];
+	["Countdown", format ["%1",_textX]] call A3A_fnc_customHint;
+	};
 
+private _layer = ["A3A_infoRight"] call BIS_fnc_rscLayer;
 if (_typeX == "income") then
 	{
 	waitUntil {sleep 0.2; !incomeRep};
@@ -25,16 +31,11 @@ if (_typeX == "income") then
 	//playSound3D ["a3\sounds_f\sfx\beep_target.wss", player];
 	playSound "3DEN_notificationDefault";
 	//[_textX,0.8,0.5,5,0,0,2] spawn bis_fnc_dynamicText;
-	[_textX, [safeZoneX + (0.8 * safeZoneW), (0.2 * safeZoneW)], 0.5, 5, 0, 0, 2] spawn bis_fnc_dynamicText;
+	[_textX, [safeZoneX + (0.8 * safeZoneW), (0.2 * safeZoneW)], 0.5, 5, 0, 0, _layer] spawn bis_fnc_dynamicText;
 	incomeRep = false;
 	[] spawn A3A_fnc_statistics;
 	};
 
-if (_typeX == "countdown") then
-	{
-	_textX = format ["Time Remaining: %1 secs",_textX];
-	["Countdown", format ["%1",_textX]] call A3A_fnc_customHint;
-	};
 
 if (_typeX == "taxRep") then
 	{
@@ -42,7 +43,7 @@ if (_typeX == "taxRep") then
 	playSound "3DEN_notificationDefault";
 	//playSound3D ["a3\sounds_f\sfx\beep_target.wss", player];
 	//[_textX,0.8,0.5,5,0,0,2] spawn bis_fnc_dynamicText;
-	[_textX, [safeZoneX + (0.8 * safeZoneW), (0.2 * safeZoneW)], 0.5, 5, 0, 0, 2] spawn bis_fnc_dynamicText;
+	[_textX, [safeZoneX + (0.8 * safeZoneW), (0.2 * safeZoneW)], 0.5, 5, 0, 0, _layer] spawn bis_fnc_dynamicText;
 	sleep 10;
 	incomeRep = false;
 	[] spawn A3A_fnc_statistics;
@@ -55,7 +56,7 @@ if (_typeX == "tier") then
 	playSound "3DEN_notificationDefault";
 	//[_textX,0.8,0.5,5,0,0,2] spawn bis_fnc_dynamicText;
 	_textX = format ["War Level Changed<br/><br/>Current Level: %1",tierWar];
-	[_textX, [safeZoneX + (0.8 * safeZoneW), (0.2 * safeZoneW)], 0.5, 5, 0, 0, 2] spawn bis_fnc_dynamicText;
+	[_textX, [safeZoneX + (0.8 * safeZoneW), (0.2 * safeZoneW)], 0.5, 5, 0, 0, _layer] spawn bis_fnc_dynamicText;
 	incomeRep = false;
 	[] spawn A3A_fnc_statistics;
 	};

--- a/A3A/addons/core/functions/Intel/fn_showIntel.sqf
+++ b/A3A/addons/core/functions/Intel/fn_showIntel.sqf
@@ -13,4 +13,5 @@ if(_text == "") exitWith {};
 private _outText = format ["<t size='0.6' color='#C1C0BB'>Intel Found.<br/> <t size='0.5' color='#C1C0BB'><br/>"];
 _outText = format ["%1 %2", _outText, _text];
 
-[_outText, [safeZoneX, (0.2 * safeZoneW)], [0.25, 0.5], 30, 0, 0, 4] spawn bis_fnc_dynamicText;
+private _layer = ["A3A_infoLeft"] call BIS_fnc_rscLayer;
+[_outText, [safeZoneX, (0.2 * safeZoneW)], [0.25, 0.5], 30, 0, 0, _layer] spawn bis_fnc_dynamicText;

--- a/A3A/addons/core/functions/Revive/fn_respawn.sqf
+++ b/A3A/addons/core/functions/Revive/fn_respawn.sqf
@@ -7,7 +7,8 @@ if (_unit != _unit getVariable ["owner",_unit]) exitWith {};
 if (!isPlayer _unit) exitWith {};
 _unit setVariable ["respawning",true];
 //_unit enableSimulation true;
-["Respawning",0,0,3,0,0,4] spawn bis_fnc_dynamicText;
+private _layer = ["A3A_infoCenter"] call BIS_fnc_rscLayer;
+["Respawning",0,0,3,0,0,_layer] spawn bis_fnc_dynamicText;
 //titleText ["", "BLACK IN", 0];
 if (!isNil "respawnMenu") then {(findDisplay 46) displayRemoveEventHandler ["KeyDown", respawnMenu]};
 if (isMultiplayer) exitWith

--- a/A3A/addons/core/functions/Revive/fn_unconscious.sqf
+++ b/A3A/addons/core/functions/Revive/fn_unconscious.sqf
@@ -114,7 +114,8 @@ while {(time < _bleedOut) and (_unit getVariable ["incapacitated",false]) and (a
 				_textX = "<t size='0.6'>Wait until you get assistance or<t size='0.5'><br/>Hit R to Respawn";
 				};
 			};
-		[_textX,0,0,3,0,0,4] spawn bis_fnc_dynamicText;
+		private _layer = ["A3A_infoCenter"] call BIS_fnc_rscLayer;
+		[_textX,0,0,3,0,0,_layer] spawn bis_fnc_dynamicText;
 		if (_unit getVariable "respawning") exitWith {};
 		}
 	else

--- a/A3A/addons/core/functions/Undercover/fn_goUndercover.sqf
+++ b/A3A/addons/core/functions/Undercover/fn_goUndercover.sqf
@@ -55,7 +55,8 @@ if(!(_result select 0)) exitWith
     };
 };
 
-["Undercover ON", 0, 0, 4, 0, 0, 4] spawn bis_fnc_dynamicText;
+private _layer = ["A3A_infoCenter"] call BIS_fnc_rscLayer;
+["Undercover ON", 0, 0, 4, 0, 0, _layer] spawn bis_fnc_dynamicText;
 
 [player, true] remoteExec["setCaptive", 0, player];
 player setCaptive true;
@@ -217,7 +218,8 @@ if !(isNull (objectParent player)) then
     } forEach((assignedCargo(vehicle player)) + (crew(vehicle player)) - [player]);
 };
 
-["Undercover OFF", 0, 0, 4, 0, 0, 4] spawn bis_fnc_dynamicText;
+private _layer = ["A3A_infoCenter"] call BIS_fnc_rscLayer;
+["Undercover OFF", 0, 0, 4, 0, 0, _layer] spawn bis_fnc_dynamicText;
 [] spawn A3A_fnc_statistics;
 
 switch (_reason) do

--- a/A3A/addons/core/functions/init/fn_credits.sqf
+++ b/A3A/addons/core/functions/init/fn_credits.sqf
@@ -9,7 +9,7 @@ _title = if (worldName == "Tanoa") then {
 };
 
 _credits = [ [_title, [antistasiVersion]], [ "Authors:", ["Barbolani","Official AntiStasi Community"] ] ];
-_layer = "credits1" call bis_fnc_rscLayer;
+_layer = "A3A_credits1" call bis_fnc_rscLayer;
 _delay = 5;
 _duration = 5;
 {

--- a/A3A/addons/core/functions/init/fn_tags.sqf
+++ b/A3A/addons/core/functions/init/fn_tags.sqf
@@ -9,6 +9,8 @@ if (isDedicated) exitWith {};
 #define _refresh 0.34
 #define _distance 300
 
+private _layer = ["A3A_tags"] call BIS_fnc_rscLayer;
+
 while{true}do{
         #ifdef _debug
                 _initTime = diag_tickTime;
@@ -41,7 +43,7 @@ while{true}do{
 						{
 						_nameString = format ["<t size='0.5' color='#f0e68c'>%2. </t><t size='0.5' color='#f0e68c'>%1</t>",_name,_rank];
 						};
-					[_nameString,0.5,0.9,_refresh,0,0,3] spawn bis_fnc_dynamicText;
+					[_nameString,0.5,0.9,_refresh,0,0,_layer] spawn bis_fnc_dynamicText;
                 };
         };
 /*


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
See #2431. Antistasi was using fixed low numbers for UI layers, which is very bad practice as those numbers are also distributed by BIS_fnc_rscLayer, and caused it to damage the UI of other mods. This PR switches all cases I found to using BIS_fnc_rscLayer so that there will be no unexpected collisions.

Tested all of them, I think: Respawn, undercover, unconscious, showIntel, resource income, aggro change, credits, tags.

### Please specify which Issue this PR Resolves.
closes #2431

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
