### PR TITLE
Double Click to Load Save + Empty Row Fix

### DIFF
--- a/A3A/addons/GUI/dialogues/setupDialog.hpp
+++ b/A3A/addons/GUI/dialogues/setupDialog.hpp
@@ -134,6 +134,7 @@ class A3A_SetupDialog : A3A_TabbedDialog
                 {
                     idc = A3A_IDC_SETUP_SAVESLISTBOX;
                     onMouseButtonUp = "['saveListClick', _this] call A3A_fnc_setupLoadgameTab";
+                    onMouseButtonDblClick = "['saveListDoubleClick', _this] call A3A_fnc_setupLoadgameTab";
                     x = 4 * GRID_W;
                     y = 12 * GRID_H;
                     w = 118 * GRID_W;

--- a/A3A/addons/GUI/functions/SetupGUI/fn_setupLoadgameTab.sqf
+++ b/A3A/addons/GUI/functions/SetupGUI/fn_setupLoadgameTab.sqf
@@ -124,7 +124,7 @@ switch (_mode) do
         if (_rowIndex > count A3A_setup_saveData) exitWith {};                      // ignore clicks below saves
         if (_rowIndex == _listboxCtrl getVariable "rowIndex") exitWith {};          // ignore if already selected       
         private _data = A3A_setup_saveData select _rowIndex;
-        if (isNil "_data") exitWith {};                                             //empty row fix
+        if (isNil "_data") exitWith {};                                             // ignore if there is no actual data
 
         ["selectSave", [_rowIndex]] call A3A_fnc_setupLoadgameTab;
     };

--- a/A3A/addons/GUI/functions/SetupGUI/fn_setupLoadgameTab.sqf
+++ b/A3A/addons/GUI/functions/SetupGUI/fn_setupLoadgameTab.sqf
@@ -122,8 +122,22 @@ switch (_mode) do
         if (_mpos#0 > (ctrlPosition _listBoxCtrl # 2) - 2*GRID_W) exitWith {};      // ignore scroll-bar region
         private _rowIndex = floor (_mpos#1 / (4*GRID_H));
         if (_rowIndex > count A3A_setup_saveData) exitWith {};                      // ignore clicks below saves
-        if (_rowIndex == _listboxCtrl getVariable "rowIndex") exitWith {};          // ignore if already selected 
+        if (_rowIndex == _listboxCtrl getVariable "rowIndex") exitWith {};          // ignore if already selected       
+        private _data = A3A_setup_saveData select _rowIndex;
+        if (isNil "_data") exitWith {};                                             //empty row fix
+
         ["selectSave", [_rowIndex]] call A3A_fnc_setupLoadgameTab;
+    };
+
+    case ("saveListDoubleClick"): 
+    {
+        if (_params#1 != 0) exitWith {};                                            // ignore non-LMB clicks
+        private _mpos = ctrlMousePosition _listBoxCtrl;
+        if (_mpos#0 > (ctrlPosition _listBoxCtrl # 2) - 2*GRID_W) exitWith {};      // ignore scroll-bar region
+        private _rowIndex = floor (_mpos#1 / (4*GRID_H));
+        if (_rowIndex > count A3A_setup_saveData) exitWith {};                      // ignore clicks below saves
+        if (cbChecked _newGameCtrl) exitWith {};                                    // ignore new game clicks
+        ["startGame"] call A3A_fnc_setupLoadgameTab;
     };
 
     case ("selectSave"):


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
This PR adds nice touch to overall UI/UX (less cursor travel time, intuitive listbox experience inline with traditional ones etc) of startup menu - player is now allowed to open dialog to load selected save via double click on selected row.

Also, this PR fixes bug with empty row without data select that's for some reason exists there:
![20221116182128_1](https://user-images.githubusercontent.com/6746043/202229623-ed85a4de-c679-4310-92c0-e4a500e1b4be.jpg)

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
1. Start mission.
2. Double click on desired save slot.
********************************************************
Notes:
