### PR TITLE
🗎 Leader Intel Search Fixes

### DIFF
--- a/A3A/addons/core/functions/Base/fn_flagaction.sqf
+++ b/A3A/addons/core/functions/Base/fn_flagaction.sqf
@@ -160,7 +160,17 @@ switch _typeX do
     };
     case "Intel_Small":
     {
-        _flag addAction ["Search for Intel", A3A_fnc_searchIntelOnLeader, nil, 4, true, false, "", "isPlayer _this", 4];
+        _flag addAction [
+            "Search for Intel", 
+            A3A_fnc_searchIntelOnLeader, 
+            nil, 
+            4, 
+            true, 
+            false, 
+            "", 
+            "!([_target] call A3A_fnc_canFight) && !(_target getVariable ['intelSearchDone', false]) && isPlayer _this", 
+            4
+        ];
     };
     case "Intel_Medium":
     {

--- a/A3A/addons/core/functions/Intel/fn_searchIntelOnLeader.sqf
+++ b/A3A/addons/core/functions/Intel/fn_searchIntelOnLeader.sqf
@@ -10,7 +10,6 @@ params ["_squadLeader", "_caller", "_searchAction"];
 *       Nothing
 */
 
-[_squadLeader, _searchAction] remoteExec ["removeAction", [teamPlayer, civilian], _squadLeader];
 
 private _timeForSearch = 10 + random 15;
 private _side = _squadLeader getVariable "side";
@@ -19,7 +18,8 @@ _caller setVariable ["intelSearchTime",time + _timeForSearch];
 _caller setVariable ["intelAnimsDone",false];
 _caller setVariable ["intelFound",false];
 _caller setVariable ["cancelIntelSearch",false];
-_caller setVariable ["intelSearchDone", false];
+
+_squadLeader setVariable ["intelSearchDone", true, true];
 
 _caller playMoveNow selectRandom medicAnims;
 private _cancelAction = _caller addAction ["Cancel Search", {(_this select 1) setVariable ["cancelIntelSearch",true]},nil,6,true,true,"","(isPlayer _this)"];
@@ -69,8 +69,7 @@ if(_wasCancelled) exitWith
 {
     ["Intel", "Search cancelled."] call A3A_fnc_customHint;
     _caller setVariable ["intelFound", nil];
-    _caller setVariable ["intelSearchDone", nil];
-    [_squadLeader, "Intel_Small"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_squadLeader];
+    _squadLeader setVariable ["intelSearchDone", nil, true];
 };
 
 if(_caller getVariable ["intelFound", false]) then
@@ -86,11 +85,9 @@ if(_caller getVariable ["intelFound", false]) then
     {
         ["Intel", "Search completed, but you found nothing!"] call A3A_fnc_customHint;
     };
-
-    _squadLeader setVariable ["intelSearchDone", true, true];
 }
 else
 {
-    [_squadLeader, "Intel_Small"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_squadLeader];
+    _squadLeader setVariable ["intelSearchDone", nil, true];
 };
 _caller setVariable ["intelFound", nil];

--- a/A3A/addons/core/functions/Intel/fn_searchIntelOnLeader.sqf
+++ b/A3A/addons/core/functions/Intel/fn_searchIntelOnLeader.sqf
@@ -19,6 +19,7 @@ _caller setVariable ["intelSearchTime",time + _timeForSearch];
 _caller setVariable ["intelAnimsDone",false];
 _caller setVariable ["intelFound",false];
 _caller setVariable ["cancelIntelSearch",false];
+_caller setVariable ["intelSearchDone", false];
 
 _caller playMoveNow selectRandom medicAnims;
 private _cancelAction = _caller addAction ["Cancel Search", {(_this select 1) setVariable ["cancelIntelSearch",true]},nil,6,true,true,"","(isPlayer _this)"];
@@ -68,6 +69,7 @@ if(_wasCancelled) exitWith
 {
     ["Intel", "Search cancelled."] call A3A_fnc_customHint;
     _caller setVariable ["intelFound", nil];
+    _caller setVariable ["intelSearchDone", nil];
     [_squadLeader, "Intel_Small"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_squadLeader];
 };
 
@@ -84,6 +86,8 @@ if(_caller getVariable ["intelFound", false]) then
     {
         ["Intel", "Search completed, but you found nothing!"] call A3A_fnc_customHint;
     };
+
+    _squadLeader setVariable ["intelSearchDone", true];
 }
 else
 {

--- a/A3A/addons/core/functions/Intel/fn_searchIntelOnLeader.sqf
+++ b/A3A/addons/core/functions/Intel/fn_searchIntelOnLeader.sqf
@@ -87,7 +87,7 @@ if(_caller getVariable ["intelFound", false]) then
         ["Intel", "Search completed, but you found nothing!"] call A3A_fnc_customHint;
     };
 
-    _squadLeader setVariable ["intelSearchDone", true];
+    _squadLeader setVariable ["intelSearchDone", true, true];
 }
 else
 {


### PR DESCRIPTION
# What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
For some reason players have a "Search for Intel" action on very alive and conscious enemy leaders which does not makes sense at all. Also, there are some exploits that allows to  search intel multiple times (I don't remember exact steps to reproduce as it was fixed in Antistasi Plus for about an year, but it seems it was tied to changing conscious/unconscious state of leader by wounding and reviving him).
This PR fixes both issues.

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
1. Stay close to enemy SL with intel while being, for example, undercovered. "Search for Intel" action prompt will not appear.
2. Wound him until he will be unconscious.  "Search for Intel" action prompt should appear.
3. Perform intel search action. No additional "Search for Intel" actions will not appear as it already done on this particular SL.