### PR TITLE
Fix airport mortars

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_createAIAirplane.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIAirplane.sqf
@@ -34,7 +34,7 @@ for "_i" from 1 to _max do
 {
 	//_pos = [_positionX, 50, _size, 10, 0, 0.3, 0] call BIS_Fnc_findSafePos;
 	//_pos = _positionX findEmptyPosition [_size - 200,_size+50,_typeVehX];
-	_spawnParameter = [_markerX, "Vehicle"] call A3A_fnc_findSpawnPosition;
+	private _spawnParameter = [_markerX, "Vehicle"] call A3A_fnc_findSpawnPosition;
 
 	if (_spawnParameter isEqualType []) then
 	{
@@ -139,13 +139,18 @@ if (_patrol) then
 };
 _countX = 0;
 
+// Mortar spawning
 _groupX = createGroup _sideX;
 _groups pushBack _groupX;
-_spawnParameter = [_markerX, "Mortar"] call A3A_fnc_findSpawnPosition;
-{
+_typeUnit = _faction get "unitStaticCrew";
+while {true} do {
+	private _spawnParameter = [_markerX, "Mortar"] call A3A_fnc_findSpawnPosition;
+	if (_spawnParameter isEqualType 0) exitWith {};
+	if ((_spawnParameter select 0) nearObjects ["StaticWeapon", 5] isNotEqualTo []) then { continue };		// hack, already a (support?) mortar on the point
+
+	_typeVehX = selectRandom (_faction get "staticMortars");
 	_veh = _typeVehX createVehicle (_spawnParameter select 0);
 	_veh setDir (_spawnParameter select 1);
-	//_veh setPosATL (_spawnParameter select 0);
 	_nul=[_veh] execVM QPATHTOFOLDER(scripts\UPSMON\MON_artillery_add.sqf);//TODO need delete UPSMON link
 	_unit = [_groupX, _typeUnit, _positionX, [], 0, "CAN_COLLIDE"] call A3A_fnc_createUnit;
 	[_unit,_markerX] call A3A_fnc_NATOinit;
@@ -153,7 +158,6 @@ _spawnParameter = [_markerX, "Mortar"] call A3A_fnc_findSpawnPosition;
 	_soldiers pushBack _unit;
 	_vehiclesX pushBack _veh;
 	[_veh, _sideX] call A3A_fnc_AIVEHinit;
-	_spawnParameter = [_markerX, "Mortar"] call A3A_fnc_findSpawnPosition;
 	sleep 1;
 };
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Some pieces of the airfield mortar spawning code went missing, probably in #2047, which made airfields rather too easy. This PR restores them.

Also added a workaround to avoid spawning airfield mortars on top of support mortars. Seems to work.

### Please specify which Issue this PR Resolves.
closes #2317

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Tests run:
- Move near airbase, check the mortars spawn (Therisa airbase on Altis has two).
- Move away from airbase until it despawns. Fire up a mortar support on the airbase:
`["MORTAR", Occupants, "defence", 500, objNull, markerPos "Therisa", 0.8, 0] call A3A_fnc_createSupport;`
(needs a bit of luck or retrying, as it picks randomly). Then spawn in the airport and check that no mortar spawns on top of the support mortar.
- Convince mortars to actually shoot at you. Seems kinda random whether they bother, but I think the UPSMON stuff is working.