### PR TITLE
Switch CUP rebel AA vehicle to Ural zu23 because the AIs cannot drive

### DIFF
--- a/A3A/addons/core/Templates/Templates/CUP/CUP_Reb.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_Reb.sqf
@@ -13,7 +13,7 @@
 ["vehicleLightArmed", "CUP_I_Hilux_DSHKM_NAPA"] call _fnc_saveToTemplate;
 ["vehicleTruck", "CUP_V3S_Open_NAPA"] call _fnc_saveToTemplate;
 ["vehicleAT", "CUP_I_Hilux_SPG9_NAPA"] call _fnc_saveToTemplate;
-["vehicleAA", "CUP_I_Hilux_zu23_NAPA"] call _fnc_saveToTemplate;
+["vehicleAA", "CUP_I_Ural_ZU23_NAPA"] call _fnc_saveToTemplate;             // Add back as player-only vehicle: "CUP_I_Hilux_zu23_NAPA"
 ["vehicleBoat", "I_G_Boat_Transport_01_F"] call _fnc_saveToTemplate;
 ["vehicleRepair", "CUP_I_V3S_Repair_TKG"] call _fnc_saveToTemplate;
 ["vehiclePlane", "CUP_C_DC3_CIV"] call _fnc_saveToTemplate;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Switched out the Zu23 Hilux for the Zu23 Ural in the CUP rebel template, because apparently the AIs cannot drive the Hilux without rolling it. The Hilux can come back later as a player vehicle once we have the buy menu.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
