### PR TITLE
Unarmed key fix in fn_createAction

### DIFF
--- a/A3A/addons/core/functions/Convoy/fn_createAIAction.sqf
+++ b/A3A/addons/core/functions/Convoy/fn_createAIAction.sqf
@@ -556,7 +556,7 @@ if(_type == "convoy") then
         {
           for "_i" from 1 to (1 + round (random 11)) do
           {
-            _typeGroup pushBack FactionGet(reb,"Unarmed");
+            _typeGroup pushBack FactionGet(reb,"unitUnarmed");
           };
         };
         _crew = [_typeVehObj, _crewUnits] call A3A_fnc_getVehicleCrew;


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
fn_createAIAction uses wrong rebel faction hashmap key.

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)