### PR TITLE
Fix darkMapFix whiteout after alt-tab

### DIFF
--- a/A3A/addons/core/functions/ModsAndDLC/fn_darkMapFix.sqf
+++ b/A3A/addons/core/functions/ModsAndDLC/fn_darkMapFix.sqf
@@ -27,6 +27,7 @@ A3A_darkMapFixRunning = true;
 Info("Installing dark map fix");
 while {A3A_darkMapFixRunning} do {
     call {
+        if (!isGameFocused) exitWith {};
         private _lightBrightness = getLighting select 1;
 
         if (4 < _lightBrightness && _lightBrightness < 120) exitWith {


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Apparently getLighting returns 0 brightness when Arma is tabbed out, at least in fullscreen. This causes darkMapFix to overbrighten the screen for 15 seconds after tabbing back in. Seemed minor to me, but multiple people did complain, so may as well fix it.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Run game on CamLaoNam. Alt tab for >15 seconds. Tab back in.
