### PR TITLE
Texture path fix for setObjectTextureGlobal

### DIFF
--- a/A3A/addons/core/functions/Intel/fn_searchIntelOnLaptop.sqf
+++ b/A3A/addons/core/functions/Intel/fn_searchIntelOnLaptop.sqf
@@ -18,7 +18,7 @@ private _isTrap = !(isNull _bomb);
 if(_isTrap) exitWith
 {
     _intel remoteExecCall ["removeAllActions", 0];
-    _intel setObjectTextureGlobal [0, "x\A3A\addons\core\Pictures\Intel\laptop_die.paa"];
+    _intel setObjectTextureGlobal [0, QPATHTOFOLDER(Pictures\Intel\laptop_die.paa)];
     {
         [petros,"hint","The screen says:<br/><br/>Prepare to die!", "Search Intel"] remoteExec ["A3A_fnc_commsMP",_x];
     } forEach ([50,0,_intel,teamPlayer] call A3A_fnc_distanceUnits);
@@ -97,7 +97,7 @@ if(!(_attack == "No")) then
 _intel setVariable ["ActionNeeded", false, true];
 ["", 0, 0] params ["_errorText", "_errorChance", "_enemyCounter"];
 
-_intel setObjectTextureGlobal [0, "x\A3A\addons\core\Pictures\Intel\laptop_downloading.paa"];
+_intel setObjectTextureGlobal [0, QPATHTOFOLDER(Pictures\Intel\laptop_downloading.paa)];
 private _lastTime = time;
 private _timeDiff = 0;
 while {_pointSum <= _neededPoints} do
@@ -176,7 +176,7 @@ while {_pointSum <= _neededPoints} do
                     _picturePath = "error6";
                 };
             };
-            _picturePath = format ["x\A3A\addons\core\Pictures\Intel\laptop_%1.paa", _picturePath];
+            _picturePath = format [QPATHTOFOLDER(Pictures\Intel\laptop_%1.paa), _picturePath];
             _intel setObjectTextureGlobal [0, _picturePath];
             [
                 _intel,
@@ -185,7 +185,7 @@ while {_pointSum <= _neededPoints} do
                     {
                         (_this select 0) setVariable ["ActionNeeded", false, true];
                         (_this select 0) removeAction (_this select 2);
-                        (_this select 0) setObjectTextureGlobal [0, "x\A3A\addons\core\Pictures\Intel\laptop_downloading.paa"];
+                        (_this select 0) setObjectTextureGlobal [0, QPATHTOFOLDER(Pictures\Intel\laptop_downloading.paa)];
                     },nil,4,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull])",4
                 ]
             ] remoteExec ["addAction", [teamPlayer, civilian], _intel];
@@ -238,7 +238,7 @@ _intel setVariable ["ActionNeeded", nil, true];
 
 if(_pointSum >= _neededPoints) then
 {
-    _intel setObjectTextureGlobal [0, "x\A3A\addons\core\Pictures\Intel\laptop_complete.paa"];
+    _intel setObjectTextureGlobal [0,  QPATHTOFOLDER(Pictures\Intel\laptop_complete.paa)];
     ["Large", _side] remoteExec ["A3A_fnc_selectIntel", 2];
     {
         [petros,"hint","You managed to download the intel!", "Search Intel"] remoteExec ["A3A_fnc_commsMP",_x];

--- a/A3A/addons/core/functions/Intel/fn_searchIntelOnLaptop.sqf
+++ b/A3A/addons/core/functions/Intel/fn_searchIntelOnLaptop.sqf
@@ -1,3 +1,6 @@
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+
 private _intel = _this select 0;
 private _searchAction = _this select 2;
 

--- a/A3A/addons/core/functions/Intel/fn_searchIntelOnLaptop.sqf
+++ b/A3A/addons/core/functions/Intel/fn_searchIntelOnLaptop.sqf
@@ -18,7 +18,7 @@ private _isTrap = !(isNull _bomb);
 if(_isTrap) exitWith
 {
     _intel remoteExecCall ["removeAllActions", 0];
-    _intel setObjectTextureGlobal [0, "Pictures\Intel\laptop_die.paa"];
+    _intel setObjectTextureGlobal [0, "x\A3A\addons\core\Pictures\Intel\laptop_die.paa"];
     {
         [petros,"hint","The screen says:<br/><br/>Prepare to die!", "Search Intel"] remoteExec ["A3A_fnc_commsMP",_x];
     } forEach ([50,0,_intel,teamPlayer] call A3A_fnc_distanceUnits);
@@ -97,7 +97,7 @@ if(!(_attack == "No")) then
 _intel setVariable ["ActionNeeded", false, true];
 ["", 0, 0] params ["_errorText", "_errorChance", "_enemyCounter"];
 
-_intel setObjectTextureGlobal [0, "Pictures\Intel\laptop_downloading.paa"];
+_intel setObjectTextureGlobal [0, "x\A3A\addons\core\Pictures\Intel\laptop_downloading.paa"];
 private _lastTime = time;
 private _timeDiff = 0;
 while {_pointSum <= _neededPoints} do
@@ -176,7 +176,7 @@ while {_pointSum <= _neededPoints} do
                     _picturePath = "error6";
                 };
             };
-            _picturePath = format ["Pictures\Intel\laptop_%1.paa", _picturePath];
+            _picturePath = format ["x\A3A\addons\core\Pictures\Intel\laptop_%1.paa", _picturePath];
             _intel setObjectTextureGlobal [0, _picturePath];
             [
                 _intel,
@@ -185,7 +185,7 @@ while {_pointSum <= _neededPoints} do
                     {
                         (_this select 0) setVariable ["ActionNeeded", false, true];
                         (_this select 0) removeAction (_this select 2);
-                        (_this select 0) setObjectTextureGlobal [0, "Pictures\Intel\laptop_downloading.paa"];
+                        (_this select 0) setObjectTextureGlobal [0, "x\A3A\addons\core\Pictures\Intel\laptop_downloading.paa"];
                     },nil,4,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull])",4
                 ]
             ] remoteExec ["addAction", [teamPlayer, civilian], _intel];
@@ -238,7 +238,7 @@ _intel setVariable ["ActionNeeded", nil, true];
 
 if(_pointSum >= _neededPoints) then
 {
-    _intel setObjectTextureGlobal [0, "Pictures\Intel\laptop_complete.paa"];
+    _intel setObjectTextureGlobal [0, "x\A3A\addons\core\Pictures\Intel\laptop_complete.paa"];
     ["Large", _side] remoteExec ["A3A_fnc_selectIntel", 2];
     {
         [petros,"hint","You managed to download the intel!", "Search Intel"] remoteExec ["A3A_fnc_commsMP",_x];

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -22,12 +22,8 @@ if (call A3A_fnc_modBlacklist) exitWith {};
 
 switch (toLower worldname) do {
 	case "cam_lao_nam": {};
-	case "vn_khe_sanh": {
-        mapX setObjectTextureGlobal [0, "x\A3A\addons\core\Pictures\Mission\whiteboard.paa"];
-    };
-	default {
-        mapX setObjectTextureGlobal [0, "x\A3A\addons\core\Pictures\Mission\whiteboard.jpg"];
-    };
+	case "vn_khe_sanh": {mapX setObjectTextureGlobal [0,"Pictures\Mission\whiteboard.paa"];};
+	default {mapX setObjectTextureGlobal [0,"Pictures\Mission\whiteboard.jpg"];};
 };
 
 enableSaving [false,false];

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -22,8 +22,8 @@ if (call A3A_fnc_modBlacklist) exitWith {};
 
 switch (toLower worldname) do {
 	case "cam_lao_nam": {};
-	case "vn_khe_sanh": {mapX setObjectTextureGlobal [0,"Pictures\Mission\whiteboard.paa"];};
-	default {mapX setObjectTextureGlobal [0,"Pictures\Mission\whiteboard.jpg"];};
+	case "vn_khe_sanh": {mapX setObjectTextureGlobal [0,"x\A3A\addons\core\Pictures\Mission\whiteboard.paa"];};
+	default {mapX setObjectTextureGlobal [0,"x\A3A\addons\core\Pictures\Mission\whiteboard.jpg"];};
 };
 
 enableSaving [false,false];

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -22,8 +22,8 @@ if (call A3A_fnc_modBlacklist) exitWith {};
 
 switch (toLower worldname) do {
 	case "cam_lao_nam": {};
-	case "vn_khe_sanh": {mapX setObjectTextureGlobal [0,"x\A3A\addons\core\Pictures\Mission\whiteboard.paa"];};
-	default {mapX setObjectTextureGlobal [0,"x\A3A\addons\core\Pictures\Mission\whiteboard.jpg"];};
+	case "vn_khe_sanh": {mapX setObjectTextureGlobal [0, QPATHTOFOLDER(Pictures\Mission\whiteboard.paa)];};
+	default {mapX setObjectTextureGlobal [0, QPATHTOFOLDER(Pictures\Mission\whiteboard.jpg)];};
 };
 
 enableSaving [false,false];

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -22,8 +22,12 @@ if (call A3A_fnc_modBlacklist) exitWith {};
 
 switch (toLower worldname) do {
 	case "cam_lao_nam": {};
-	case "vn_khe_sanh": {mapX setObjectTextureGlobal [0, QPATHTOFOLDER(Pictures\Mission\whiteboard.paa)];};
-	default {mapX setObjectTextureGlobal [0, QPATHTOFOLDER(Pictures\Mission\whiteboard.jpg)];};
+	case "vn_khe_sanh": {
+        mapX setObjectTextureGlobal [0, "x\A3A\addons\core\Pictures\Mission\whiteboard.paa"];
+    };
+	default {
+        mapX setObjectTextureGlobal [0, "x\A3A\addons\core\Pictures\Mission\whiteboard.jpg"];
+    };
 };
 
 enableSaving [false,false];


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Old texture paths does not work in mod environment. This PR fixes laptop and mapX texture paths.
    
![image](https://user-images.githubusercontent.com/6746043/205508834-0ee37955-c7b2-4c61-8a57-696cfe7c4e35.png)


### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)
