### PR TITLE
implement undercover removal when approaching downed heli

### DIFF
--- a/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
@@ -103,15 +103,15 @@ private _text = format ["We have downed a helicopter. There is a good chance to 
 
 // Remove undercover from players that approach the crash site
 [_heli] spawn {
-	params ["_heli"];
+    params ["_heli"];
 
     private _undercoverBreakDistance = 50;
     private _initialHeliPosition = getPos _heli;
 
-	while {alive _heli && !isPlayer driver _heli} do {
+    while {alive _heli && !isPlayer driver _heli} do {
         private _nearbyPlayers = allPlayers inAreaArray [_initialHeliPosition, _undercoverBreakDistance, _undercoverBreakDistance];
         { [_x, false] remoteExec ["setCaptive", _x] } forEach _nearbyPlayers;
-	};
+    };
 };
 
 

--- a/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
@@ -91,6 +91,18 @@ private _text = format ["We have downed a helicopter. There is a good chance to 
 [[teamPlayer,civilian],_taskId,[_text,"Downed Heli",_taskMrk],_posCrashMrk,false,0,true,"Destroy",true] call BIS_fnc_taskCreate;
 [_taskId, "DES", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
+// Remove undercover from players near the crash site
+[_heli] spawn {
+	params ["_heli"];
+
+	while {alive _heli} do {
+		sleep 5;
+		private _nearbyPlayers = allPlayers inAreaArray [getPos _heli, 150, 150];
+		{ [_x, false] remoteExec ["setCaptive", _x] } forEach _nearbyPlayers;
+	};
+};
+
+
 ////////////////
 //convoy spawn//
 ////////////////

--- a/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
@@ -226,7 +226,7 @@ _pilotsWP setWaypointBehaviour "STEALTH";
 
     while {alive _heli && { _heli getVariable "ownerSide" != teamPlayer } } do {
         private _nearbyPlayers = allPlayers inAreaArray [_initialHeliPosition, _undercoverBreakDistance, _undercoverBreakDistance];
-        { if (captive _x) then [_x, false] remoteExec ["setCaptive", _x] } forEach _nearbyPlayers;
+        { if (captive _x) then { [_x, false] remoteExec ["setCaptive", _x] } } forEach _nearbyPlayers;
         sleep 5;
     };
 };

--- a/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
@@ -1,4 +1,13 @@
-//Mission: Destroy the helicopter
+/*
+    Creates a "Destroy the helicopter" type mission near input marker.
+
+    Arguments:
+        <STRING> Marker
+
+	Public: Yes
+    Example:
+        ["airport"] call A3A_fnc_DES_Heli;
+*/
 if (!isServer and hasInterface) exitWith{};
 
 private _missionOrigin = _this select 0;
@@ -49,7 +58,7 @@ Debug_2("Crash Location: %1, Aircraft: %2", _posCrash, _typeVehH);
 private _vehicles = [];
 private _groups = [];
 
-//createing crashed helicopter
+//creating crashed helicopter
 private _crater = "CraterLong" createVehicle _posCrash;
 private _heli = createVehicle [_typeVehH, [_posCrash select 0, _posCrash select 1, 0.9], [], 0, "CAN_COLLIDE"];
 private _smoke = "test_EmptyObjectForSmoke" createVehicle _posCrash; _smoke attachTo [_heli,[0,1.5,-1]];
@@ -87,7 +96,7 @@ private _dateLimitNum = dateToNumber _dateLimit;
 Info("Creating Helicopter Down mission");
 private _location = [_missionOrigin] call A3A_fnc_localizar;
 private _taskId = "DES" + str A3A_taskCount;
-private _text = format ["We have downed a helicopter. There is a good chance to destroy it before it is recovered. Do it before a recovery team from %1 reaches the crash site. MOVE QUICKLY",_location];
+private _text = format ["We have downed a helicopter. There is a good chance to destroy or capture it before it is recovered. Do it before a recovery team from %1 reaches the crash site. MOVE QUICKLY",_location];
 [[teamPlayer,civilian],_taskId,[_text,"Downed Heli",_taskMrk],_posCrashMrk,false,0,true,"Destroy",true] call BIS_fnc_taskCreate;
 [_taskId, "DES", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 

--- a/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
@@ -106,12 +106,13 @@ private _text = format ["We have downed a helicopter. There is a good chance to 
     params ["_heli"];
 
     private _undercoverBreakDistance = 50;
-    private _initialHeliPosition = getPos _heli;
+    private _initialHeliPosition = getPosATL _heli;
 
-    while {alive _heli && !isPlayer driver _heli} do {
+    while {alive _heli && _heli getVariable "ownerSide" != teamPlayer} do {
         private _nearbyPlayers = allPlayers inAreaArray [_initialHeliPosition, _undercoverBreakDistance, _undercoverBreakDistance];
-        { [_x, false] remoteExec ["setCaptive", _x] } forEach _nearbyPlayers;
-    };
+        { if (captive _x) then [_x, false] remoteExec ["setCaptive", _x] } forEach _nearbyPlayers;
+        sleep 5;
+	};
 };
 
 

--- a/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
@@ -1,5 +1,6 @@
 /*
-    Creates a "Destroy the helicopter" type mission near input marker.
+    Maintainer: Bob Murphy
+    Creates a "Destroy the helicopter" type mission in a random location near input marker.
 
     Arguments:
         <STRING> Marker
@@ -100,14 +101,16 @@ private _text = format ["We have downed a helicopter. There is a good chance to 
 [[teamPlayer,civilian],_taskId,[_text,"Downed Heli",_taskMrk],_posCrashMrk,false,0,true,"Destroy",true] call BIS_fnc_taskCreate;
 [_taskId, "DES", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
-// Remove undercover from players near the crash site
+// Remove undercover from players that approach the crash site
 [_heli] spawn {
 	params ["_heli"];
 
-	while {alive _heli} do {
-		sleep 5;
-		private _nearbyPlayers = allPlayers inAreaArray [getPos _heli, 150, 150];
-		{ [_x, false] remoteExec ["setCaptive", _x] } forEach _nearbyPlayers;
+    private _undercoverBreakDistance = 50;
+    private _initialHeliPosition = getPos _heli;
+
+	while {alive _heli && !isPlayer driver _heli} do {
+        private _nearbyPlayers = allPlayers inAreaArray [_initialHeliPosition, _undercoverBreakDistance, _undercoverBreakDistance];
+        { [_x, false] remoteExec ["setCaptive", _x] } forEach _nearbyPlayers;
 	};
 };
 

--- a/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
@@ -101,21 +101,6 @@ private _text = format ["We have downed a helicopter. There is a good chance to 
 [[teamPlayer,civilian],_taskId,[_text,"Downed Heli",_taskMrk],_posCrashMrk,false,0,true,"Destroy",true] call BIS_fnc_taskCreate;
 [_taskId, "DES", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
-// Remove undercover from players that approach the crash site
-[_heli] spawn {
-    params ["_heli"];
-
-    private _undercoverBreakDistance = 50;
-    private _initialHeliPosition = getPosATL _heli;
-
-    while {alive _heli && _heli getVariable "ownerSide" != teamPlayer} do {
-        private _nearbyPlayers = allPlayers inAreaArray [_initialHeliPosition, _undercoverBreakDistance, _undercoverBreakDistance];
-        { if (captive _x) then [_x, false] remoteExec ["setCaptive", _x] } forEach _nearbyPlayers;
-        sleep 5;
-    };
-};
-
-
 ////////////////
 //convoy spawn//
 ////////////////
@@ -231,6 +216,20 @@ _groups pushBack _pilots;
 private _pilotsWP = _pilots addWaypoint [_posCrash, 0];
 _pilotsWP setWaypointType "HOLD";
 _pilotsWP setWaypointBehaviour "STEALTH";
+
+// Remove undercover from players that approach the crash site
+[_heli] spawn {
+    params ["_heli"];
+
+    private _undercoverBreakDistance = 50;
+    private _initialHeliPosition = getPosATL _heli;
+
+    while {alive _heli && { _heli getVariable "ownerSide" != teamPlayer } } do {
+        private _nearbyPlayers = allPlayers inAreaArray [_initialHeliPosition, _undercoverBreakDistance, _undercoverBreakDistance];
+        { if (captive _x) then [_x, false] remoteExec ["setCaptive", _x] } forEach _nearbyPlayers;
+        sleep 5;
+    };
+};
 
 Debug_3("Waiting until %1 reaches origin or rebel base, gets destroyed, timer expires at %3 or %2 reaches %1", _heli, _vehR, _dateLimit);
 waitUntil

--- a/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
@@ -112,7 +112,7 @@ private _text = format ["We have downed a helicopter. There is a good chance to 
         private _nearbyPlayers = allPlayers inAreaArray [_initialHeliPosition, _undercoverBreakDistance, _undercoverBreakDistance];
         { if (captive _x) then [_x, false] remoteExec ["setCaptive", _x] } forEach _nearbyPlayers;
         sleep 5;
-	};
+    };
 };
 
 


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
- Added logic to remove undercover status when players come within 150 units of crashed heli (based on similar functionality of salvage mission)
- Updated file with standardized header

### Please specify which Issue this PR Resolves.
closes #2311 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
- Spawn mission
  - `["airport_1"] spawn A3A_fnc_DES_Heli`
- Be undercover
- Approach crash site on foot
- ~Get shot at~ lose undercover status
[helidown.webm](https://user-images.githubusercontent.com/733514/205788388-971825c2-9392-4847-8511-b58d6f8354eb.webm)

********************************************************
Notes:
