### PR TITLE
Fix bug where guests could take limited magazines by loading a loadout

### DIFF
--- a/A3A/addons/JeroenArsenal/JNA/fn_arsenal_loadInventory.sqf
+++ b/A3A/addons/JeroenArsenal/JNA/fn_arsenal_loadInventory.sqf
@@ -159,17 +159,14 @@ _itemCounts =+ _availableItems;
 	_index = _foreachindex;
 	_subArray = _x;
 	_isMagArray = (_index == IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG) || (_index == IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL);
+	_arrayMin = jna_minItemMember select _index;
 	{
 		_item = _x select 0;
 		_amount = (_x select 1);
 		if (_amount != -1 && !_isMember) then {
-			if !(_isMagArray) then { _amount = _amount - minWeaps }
-			else {
-				// Magazines are counted in bullets
-				_ammoCount = getNumber (configfile >> "CfgMagazines" >> _item >> "count");
-				_amount = _amount - memberOnlyMagLimit * _ammoCount;
-			};
-			_subArray set [_foreachindex, [_item,_amount]];
+			_itemMin = A3A_arsenalLimits getOrDefault [_item, _arrayMin];
+			if (_isMagArray) then { _itemMin = _itemMin * getNumber (configfile >> "CfgMagazines" >> _item >> "count") };
+			_subArray set [_foreachindex, [_item, (_amount - _itemMin) max 0]];
 		};
 	} forEach _subArray;
 	_availableItems set [_index, _subArray];
@@ -265,9 +262,9 @@ _weapons = [_inventory select 6,_inventory select 7,_inventory select 8];
 					_arrayMissing = [_arrayMissing,[_itemMag,_amountMag]] call jn_fnc_arsenal_addToArray;
 					_amountMag = _amountMagAvailable max 0;
 				};
-			[_arrayTaken,_indexMag,_itemMag,_amountMag] call _addToArray;
-			[_availableItems,_indexMag,_itemMag,_amountMag] call _removeFromArray;
-			player addMagazine [_itemMag, _amountMag];
+				[_arrayTaken,_indexMag,_itemMag,_amountMag] call _addToArray;
+				[_availableItems,_indexMag,_itemMag,_amountMag] call _removeFromArray;
+				player addMagazine [_itemMag, _amountMag];
 			} else {
 				_arrayMissing = [_arrayMissing,[_itemMag,_amountMag]] call jn_fnc_arsenal_addToArray;
 			};


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The loadout loading code wasn't updated along with other guest-limit changes. It was using a now-undefined variable (memberOnlyMagLimit), so I'm not sure why it wasn't throwing client RPT errors. Whatever. Result seems to be that it was possible to take member-only mags from the arsenal by loading a loadout. This PR fixes it, along with an old issue where the displayed missing item count could be too high.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

I've tested what I could think of, but players get twitchy as hell when it comes to the arsenal, so this might not be a candidate for a speed merge.
