### PR TITLE
createVehicle fix for REP_Antenna

### DIFF
--- a/A3A/addons/core/functions/Missions/fn_REP_Antenna.sqf
+++ b/A3A/addons/core/functions/Missions/fn_REP_Antenna.sqf
@@ -40,7 +40,7 @@ if (spawner getVariable _markerX != 2) then
 	_road = [getPos _antennaDead] call A3A_fnc_findNearestGoodRoad;
 	_pos = position _road;
 	_pos = _pos findEmptyPosition [1,60,"B_T_Truck_01_repair_F"];
-	_veh = createVehicle [FactionGet(occ,"vehiclesRepairTrucks"), _pos, [], 0, "NONE"];
+	_veh = createVehicle [selectRandom (FactionGet(occ,"vehiclesRepairTrucks")), _pos, [], 0, "NONE"];
 	_veh allowdamage false;
 	_veh setDir (getDir _road);
 	_nul = [_veh, Occupants] call A3A_fnc_AIVEHinit;


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
REP_Antenna mission is broken as it can't spawn repair truck due to missing pick from repair vehicles pool for `createVehicle`.    

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)