### PR TITLE
Fix guest commander leash issues

### DIFF
--- a/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -54,7 +54,7 @@ if (count _positionTel > 0) then
 	//if (_base in outpostsFIA) exitWith {hint "You cannot Fast Travel to roadblocks and watchposts"; openMap [false,false]};
 
 	if ([getMarkerPos _base] call A3A_fnc_enemyNearCheck) exitWith {["Fast Travel", "You cannot Fast Travel to an area under attack or with enemies in the surrounding."] call A3A_fnc_customHint; openMap [false,false]};
-	if (!([player] call A3A_fnc_isMember) && {!([_positionTel] call A3A_fnc_playerLeashCheckPosition)}) exitWith {["Fast Travel", format ["There are no members nearby the target location. You need to be within %1 km of HQ or a member.", ceil (memberDistance/1e3)]] call A3A_fnc_customHint;};
+	if (!(player call A3A_fnc_isMember || player == theBoss) && {!([_positionTel] call A3A_fnc_playerLeashCheckPosition)}) exitWith {["Fast Travel", format ["There are no members near the target location. You need to be within %1 km of HQ, an attack, commander or a member.", ceil (memberDistance/1e3)]] call A3A_fnc_customHint;};
 
 	if (_positionTel distance getMarkerPos _base < 50) then
 		{

--- a/A3A/addons/core/functions/OrgPlayers/fn_playerLeash.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_playerLeash.sqf
@@ -1,7 +1,6 @@
 /*
 Maintainer: Caleb Serafin
     If the current player is not a member, it will loop every 60 seconds to check the distance from the player to HQ or any member.
-    However, if there are no members online, it will allow the player unlimited distance from HQ.
     If there is a member online, it will warn the player and begin a 61 second countdown
     See playerLeashRefresh for teleportation compatibility.
 
@@ -39,11 +38,12 @@ if (memberDistance <= 0 || !membershipEnabled) exitWith {};
 
 // Membership is rechecked in the case that a temporary membership is granted.
 while {!([player] call A3A_fnc_isMember) || _debugMode} do {
-    private _nearestLeashCentre = getPos player;  // Only 2D pos is evaluated. Default to player position when no members or ff punishment is the exemption.
+    private _nearestLeashCentre = getPosATL player;  // Only 2D pos is evaluated. Default to player position when no members or ff punishment is the exemption.
     private _withinLeash = switch (true) do {
         case (!isNil "A3A_FFPun_Jailed" && {(getPlayerUID player) in A3A_FFPun_Jailed}): { true };
+        case (player == theBoss): { true };             // covered in playerLeashCheckPosition, but shortcut
         // Add leash exemptions here.
-        default { [getPos player,_nearestLeashCentre] call A3A_fnc_playerLeashCheckPosition };
+        default { [getPosATL player,_nearestLeashCentre] call A3A_fnc_playerLeashCheckPosition };
     };
 
     if (_withinLeash) then {

--- a/A3A/addons/core/functions/OrgPlayers/fn_playerLeashCheckPosition.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_playerLeashCheckPosition.sqf
@@ -44,7 +44,5 @@ _nearestLeashCentre = [_leashCentres,_targetPos] call BIS_fnc_nearestPosition;
 _out_nearestLeashCentre set [0,_nearestLeashCentre #0];
 _out_nearestLeashCentre set [1,_nearestLeashCentre #1];
 
-// If there are no members online, allow unlimited distance.
-if (count _memberPositions == 0 && !_debugMode) exitWith {true};
 // By this point no leash exemptions were found.
 _targetPos distance2D _nearestLeashCentre <= memberDistance;  // Final return of whether the player is within leash


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
I didn't read the leash/FT code sufficiently and missed a couple of things:
- Guest commander was unintentionally still blocked from fast travelling to far locations.
- Previous behaviour removed all leash restrictions when there were no members online. This is no longer desired behaviour now that we have guest commanders with leash privileges.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
You can become a guest as localhost by running this:
```
membershipEnabled = true;
membersX = [];
[] spawn A3A_fnc_playerLeash;
```
The playerLeash call is necessary because the leash loop currently exits as soon as the player becomes a member.
