### PR TITLE
Remove UAVs from garbage collection

### DIFF
--- a/A3A/addons/core/functions/Base/fn_garbageCleaner.sqf
+++ b/A3A/addons/core/functions/Base/fn_garbageCleaner.sqf
@@ -25,7 +25,7 @@ private _fnc_distCheck = {
 // Cleanup rebel vehicles
 {
 	// Locked check is a hack for roadblock vehicles
-	if !(_x isKindOf "StaticWeapon" or locked _x > 1) then { [_x, 500] call _fnc_distCheck };
+	if !(_x isKindOf "StaticWeapon" or unitIsUAV _x or locked _x > 1) then { [_x, 500] call _fnc_distCheck };
 } forEach (vehicles select {_x getVariable ["ownerSide", sideUnknown] == teamPlayer});
 
 if (A3A_hasACE) then {


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Rebel UAVs were being deleted by the garbage cleaner when more than 500m away from players, even though this is reasonable behaviour for UAVs. They're already special-cased for marker spawning (they're not general spawners) so it makes sense to special-case them here.    

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
