### PR TITLE
Fix Face-Voice Typo in CUP Templates

### DIFF
--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_TKA_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_TKA_Arid.sqf
@@ -72,8 +72,8 @@
 ///  Identities   ///
 /////////////////////
 
-["voices", ["CUP_D_Male01_TK","CUP_D_Male02_TK","CUP_D_Male03_TK","CUP_D_Male04_TK","CUP_D_Male05_TK"]] call _fnc_saveToTemplate;
 ["faces", ["PersianHead_A3_01","PersianHead_A3_02","PersianHead_A3_03"]] call _fnc_saveToTemplate;
+["voices", ["CUP_D_Male01_TK","CUP_D_Male02_TK","CUP_D_Male03_TK","CUP_D_Male04_TK","CUP_D_Male05_TK"]] call _fnc_saveToTemplate;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Arid.sqf
@@ -73,13 +73,13 @@
 ///  Identities   ///
 /////////////////////
 
-["voices", ["Barklem","GreekHead_A3_05","GreekHead_A3_06",
+["faces", ["Barklem","GreekHead_A3_05","GreekHead_A3_06",
 "GreekHead_A3_09","Sturrock","WhiteHead_02","WhiteHead_04",
 "WhiteHead_05","WhiteHead_06","WhiteHead_09","WhiteHead_10",
 "WhiteHead_11","WhiteHead_12","WhiteHead_13","WhiteHead_14",
 "WhiteHead_15","WhiteHead_17","WhiteHead_18","WhiteHead_19",
 "WhiteHead_20","WhiteHead_21"]] call _fnc_saveToTemplate;
-["faces", ["Male01ENG","Male02ENG","Male03ENG","Male04ENG","Male06ENG","Male07ENG","Male08ENG","Male09ENG","Male10ENG","Male11ENG","Male12ENG"]] call _fnc_saveToTemplate;
+["voices", ["Male01ENG","Male02ENG","Male03ENG","Male04ENG","Male06ENG","Male07ENG","Male08ENG","Male09ENG","Male10ENG","Male11ENG","Male12ENG"]] call _fnc_saveToTemplate;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Temperate.sqf
@@ -73,13 +73,13 @@
 ///  Identities   ///
 /////////////////////
 
-["voices", ["Barklem","GreekHead_A3_05","GreekHead_A3_06",
+["faces", ["Barklem","GreekHead_A3_05","GreekHead_A3_06",
 "GreekHead_A3_09","Sturrock","WhiteHead_02","WhiteHead_04",
 "WhiteHead_05","WhiteHead_06","WhiteHead_09","WhiteHead_10",
 "WhiteHead_11","WhiteHead_12","WhiteHead_13","WhiteHead_14",
 "WhiteHead_15","WhiteHead_17","WhiteHead_18","WhiteHead_19",
 "WhiteHead_20","WhiteHead_21"]] call _fnc_saveToTemplate;
-["faces", ["Male01ENG","Male02ENG","Male03ENG","Male04ENG","Male06ENG","Male07ENG","Male08ENG","Male09ENG","Male10ENG","Male11ENG","Male12ENG"]] call _fnc_saveToTemplate;
+["voices", ["Male01ENG","Male02ENG","Male03ENG","Male04ENG","Male06ENG","Male07ENG","Male08ENG","Male09ENG","Male10ENG","Male11ENG","Male12ENG"]] call _fnc_saveToTemplate;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Marine_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Marine_Arid.sqf
@@ -76,13 +76,13 @@
 ///  Identities   ///
 /////////////////////
 
-["voices", ["Barklem","GreekHead_A3_05","GreekHead_A3_06",
+["faces", ["Barklem","GreekHead_A3_05","GreekHead_A3_06",
 "GreekHead_A3_09","Sturrock","WhiteHead_02","WhiteHead_04",
 "WhiteHead_05","WhiteHead_06","WhiteHead_09","WhiteHead_10",
 "WhiteHead_11","WhiteHead_12","WhiteHead_13","WhiteHead_14",
 "WhiteHead_15","WhiteHead_17","WhiteHead_18","WhiteHead_19",
 "WhiteHead_20","WhiteHead_21"]] call _fnc_saveToTemplate;
-["faces", ["Male01ENG","Male02ENG","Male03ENG","Male04ENG","Male06ENG","Male07ENG","Male08ENG","Male09ENG","Male10ENG","Male11ENG","Male12ENG"]] call _fnc_saveToTemplate;
+["voices", ["Male01ENG","Male02ENG","Male03ENG","Male04ENG","Male06ENG","Male07ENG","Male08ENG","Male09ENG","Male10ENG","Male11ENG","Male12ENG"]] call _fnc_saveToTemplate;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Marine_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Marine_Temperate.sqf
@@ -76,13 +76,13 @@
 ///  Identities   ///
 /////////////////////
 
-["voices", ["Barklem","GreekHead_A3_05","GreekHead_A3_06",
+["faces", ["Barklem","GreekHead_A3_05","GreekHead_A3_06",
 "GreekHead_A3_09","Sturrock","WhiteHead_02","WhiteHead_04",
 "WhiteHead_05","WhiteHead_06","WhiteHead_09","WhiteHead_10",
 "WhiteHead_11","WhiteHead_12","WhiteHead_13","WhiteHead_14",
 "WhiteHead_15","WhiteHead_17","WhiteHead_18","WhiteHead_19",
 "WhiteHead_20","WhiteHead_21"]] call _fnc_saveToTemplate;
-["faces", ["Male01ENG","Male02ENG","Male03ENG","Male04ENG","Male06ENG","Male07ENG","Male08ENG","Male09ENG","Male10ENG","Male11ENG","Male12ENG"]] call _fnc_saveToTemplate;
+["voices", ["Male01ENG","Male02ENG","Male03ENG","Male04ENG","Male06ENG","Male07ENG","Male08ENG","Male09ENG","Male10ENG","Male11ENG","Male12ENG"]] call _fnc_saveToTemplate;
 
 //////////////////////////
 //       Loadouts       //


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Apparently there was a little Line Skipper and we had Faces assigned as Voices and the other way Around.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Any Unit from the Factions should have the Right Faces and Voices.

A Wrong Entry will just use "Default Face" and English as Voice.
********************************************************
Notes:
