### PR TITLE
Fix marker side loading

### DIFF
--- a/A3A/addons/core/functions/Save/fn_loadServer.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadServer.sqf
@@ -8,7 +8,7 @@ if (isServer) then {
 	// Set all main markers to occupant control by default, overridden by mrkSDK & mrkCSAT
 	{ 
 		if (sidesX getVariable _x != Occupants) then { sidesX setVariable [_x, Occupants, true] };
-	} forEach (markersX - controlsX);
+	} forEach (airportsX + resourcesX + factories + outposts + seaports);
 
 	A3A_saveVersion = 0;
 	["version"] call A3A_fnc_getStatVariable;

--- a/A3A/addons/core/functions/Save/fn_loadServer.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadServer.sqf
@@ -5,6 +5,11 @@ if (isServer) then {
     Info("Starting Persistent Load.");
 	petros allowdamage false;
 
+	// Set all main markers to occupant control by default, overridden by mrkSDK & mrkCSAT
+	{ 
+		if (sidesX getVariable _x != Occupants) then { sidesX setVariable [_x, Occupants, true] };
+	} forEach (markersX - controlsX);
+
 	A3A_saveVersion = 0;
 	["version"] call A3A_fnc_getStatVariable;
 	["outpostsFIA"] call A3A_fnc_getStatVariable;
@@ -56,20 +61,15 @@ if (isServer) then {
 	// obsolete since rebelGear
 	//unlockedOptics = [unlockedOptics,[],{getNumber (configfile >> "CfgWeapons" >> _x >> "ItemInfo" >> "mass")},"DESCEND"] call BIS_fnc_sortBy;
 
+	// Set enemy roadblock allegiance to match nearest main marker
+	private _mainMarkers = markersX - controlsX - outpostsFIA;
 	{
 		if (sidesX getVariable [_x,sideUnknown] != teamPlayer) then {
-			_positionX = getMarkerPos _x;
-			_nearX = [(markersX - controlsX - outpostsFIA),_positionX] call BIS_fnc_nearestPosition;
-			_sideX = sidesX getVariable [_nearX,sideUnknown];
+			private _nearX = [_mainMarkers, markerPos _x] call BIS_fnc_nearestPosition;
+			private _sideX = sidesX getVariable [_nearX,sideUnknown];
 			sidesX setVariable [_x,_sideX,true];
 		};
 	} forEach controlsX;
-
-	{
-		if (sidesX getVariable [_x,sideUnknown] == sideUnknown) then {
-			sidesX setVariable [_x,Occupants,true];
-		};
-	} forEach markersX;
 
 	{
 		[_x] call A3A_fnc_mrkUpdate


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Because the loading code only replaces invader and rebel marker sides, markers that had been changed from invader to occupant either by reb vs gov or capture were being reset to invaders on loading. This PR fixes the problem by resetting every main marker to occupants before the load.

Also fixed a perf bug in the roadblock side selection.

### Please specify which Issue this PR Resolves.
closes #2596

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Create new reb vs gov game. Save. Load.