### PR TITLE
Rewrite playerMarkers so that it works

### DIFF
--- a/A3A/addons/core/functions/init/fn_playerMarkers.sqf
+++ b/A3A/addons/core/functions/init/fn_playerMarkers.sqf
@@ -1,70 +1,70 @@
-private ["_playersX","_playerX","_mrk","_veh","_sideX"];
-_sideX = side group player;
+
 while {true} do
-	{
-	waitUntil {sleep 0.5; (visibleMap or visibleGPS) and ([player] call A3A_fnc_hasRadio)};
-	_playersX = [];
-	_markersX = [];
-	while {visibleMap or visibleGPS} do
-		{
-		{
-		_playerX = _x getVariable ["owner",_x];
-		if ((not(_playerX in _playersX)) and ((side group _playerX == _sideX))) then
-			{
-			_playersX pushBack _playerX;
-			_mrk = createMarkerLocal [format ["%1",_playerX],position _playerX];
-			_mrk setMarkerTypeLocal "mil_triangle";
-			_mrk setMarkerColorLocal "ColorWhite";
-			_mrk setMarkerTextLocal format ["%1",name _playerX];
-			_markersX pushBack _mrk;
-			};
-		} forEach (call A3A_fnc_playableUnits);
-		if (count _playersX > 0) then
-			{
-			{
-			_playerX = _x;
-			_mrk = format ["%1",_playerX];
-			if (vehicle _playerX == _playerX) then
-				{
-				_mrk setMarkerAlphaLocal 1;
-				_mrk setMarkerPosLocal position _playerX;
-				_mrk setMarkerDirLocal getDir _playerX;
-				if (_playerX getVariable ["incapacitated",false] || _playerX getVariable ["ACE_isUnconscious",false]) then
-					{
-					_mrk setMarkerTextLocal format ["%1 Injured",name _playerX];
-					_mrk setMarkerColorLocal "ColorRed";
-					}
-				else
-					{
-					_mrk setMarkerTextLocal format ["%1",name _playerX];
-					_mrk setMarkerColorLocal "ColorWhite";
-					};
-				}
-			else
-				{
-				_veh = vehicle _playerX;
-				if ((!isPlayer driver _veh) or (driver _veh == _playerX)) then
-					{
-					_mrk setMarkerAlphaLocal 1;
-					_mrk setMarkerPosLocal position _veh;
-					_mrk setMarkerDirLocal getDir _veh;
-					_textX = format ["%1 (%2)/",name _playerX,getText(configFile>>"CfgVehicles">>typeOf _veh>>"DisplayName")];
-					{
-					if ((_x!=_playerX) and (vehicle _x == _veh)) then
-						{
-						_textX = format ["%1%2/",_textX,name _x];
-						};
-					} forEach (call A3A_fnc_playableUnits);
-					_mrk setMarkerTextLocal _textX;
-					}
-				else
-					{
-					_mrk setMarkerAlphaLocal 0;
-					};
-				};
-			} forEach _playersX;
-			};
-		sleep 1;
-		};
-	{deleteMarkerLocal _x} forEach _markersX;
-	};
+{
+    waitUntil {sleep 0.5; (visibleMap or visibleGPS) and ([player] call A3A_fnc_hasRadio)};
+    private _markedIDs = [];
+
+    while {visibleMap or visibleGPS} do
+    {
+        // Delete markers for inactive IDs
+        private _activePlayers = call A3A_fnc_playableUnits;        // Note: does not include dead players
+        private _activeIDs = _activePlayers apply { getPlayerID _x };
+        {
+            deleteMarkerLocal format ["A3A_playerMrk_%1", _x];
+        } forEach (_markedIDs - _activeIDs);
+
+        // Create/update active players
+        {
+            private _ID = getPlayerID _x;
+            private _realUnit = _x getVariable ["owner", _x];
+            private _name = name _x;
+            private _mrk = format ["A3A_playerMrk_%1", _ID];
+
+            if !(_ID in _markedIDs) then
+            {
+                createMarkerLocal [_mrk, getPosATL _realUnit];
+                _mrk setMarkerTypeLocal "mil_triangle";
+                _mrk setMarkerColorLocal "ColorWhite";
+                _mrk setMarkerTextLocal format ["%1", _name];
+            };
+
+            if (vehicle _realUnit == _realUnit) then
+            {
+                _mrk setMarkerAlphaLocal 1;
+                _mrk setMarkerPosLocal getPosATL _realUnit;
+                _mrk setMarkerDirLocal getDir _realUnit;
+                if (_realUnit getVariable ["incapacitated",false]) then
+                {
+                    _mrk setMarkerTextLocal format ["%1 Injured", _name];
+                    _mrk setMarkerColorLocal "ColorRed";
+                }
+                else
+                {
+                    _mrk setMarkerTextLocal format ["%1", _name];
+                    _mrk setMarkerColorLocal "ColorWhite";
+                };
+            }
+            else
+            {
+                private _veh = vehicle _realUnit;
+                // This isn't perfect due to inability to check some units for remote controlling, but close enough
+                private _crew = crew _veh select { _realUnit == _x or ((theBoss == _x or isPlayer _x) and alive _x) };
+                if (count _crew == 0 or {_crew#0 != _realUnit}) exitWith { _mrk setMarkerAlphaLocal 0 };
+
+                _mrk setMarkerAlphaLocal 1;
+                _mrk setMarkerPosLocal getPosATL _veh;
+                _mrk setMarkerDirLocal getDir _veh;
+                private _textX = format ["%1 (%2)", _name, getText (configFile >> "CfgVehicles" >> typeOf _veh >> "DisplayName")];
+                if (count _crew > 1) then { _textX = format ["%1/%2", _textX, name (_crew#1)] };
+                if (count _crew > 2) then { _textX = format ["%1+%2", _textX, count _crew - 2] };
+                _mrk setMarkerTextLocal _textX;
+            };
+
+        } forEach _activePlayers;
+        _markedIDs = _activeIDs;			// should now match the marker list
+
+        sleep 1;
+    };
+
+    { deleteMarkerLocal format ["A3A_playerMrk_%1", _x] } forEach _markedIDs;
+};


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The player markers logic was very bad and didn't correctly handle players respawning or changing group. I rewrote it. Features are mostly the same, although it now contracts players in a vehicle to the format "player1/player2+N". Perf should be somewhat better.

Method uses `getPlayerID` as a persistent tracking value. I originally used `getPlayerUID` which probably worked but was impossible to test due to loopback players having the same UID.

### Please specify which Issue this PR Resolves.
closes #2590

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Couldn't test with more than two players. Not enough RAM.

### How can the changes be tested?
You're gonna need some players.