### PR TITLE
Fix original save detection

### DIFF
--- a/A3A/addons/core/functions/Save/fn_collectSaveData.sqf
+++ b/A3A/addons/core/functions/Save/fn_collectSaveData.sqf
@@ -27,13 +27,12 @@ private _saveList = [profileNamespace getVariable "antistasiSavedGames"] param [
 
 } forEach _saveList;
 
-// Original saves
-private _oldCampaignID = profileNameSpace getVariable "ss_CampaignID";
-A3A_saveTarget = [_serverID, _oldCampaignID, worldName];
-if (!isNil "_campaignID" and {!(_oldCampaignID in _campaignIDs)}) then {
-    if (call _fnc_gameMissing) then { A3A_saveTarget set [0, ""] };			// might work for original saves after running community
+private _oldCampaignID = profileNameSpace getVariable ["ss_CampaignID", ""];
+if !(_oldCampaignID in _campaignIDs) then {
+    A3A_saveTarget = [_serverID, _oldCampaignID, worldName];                          // Pre 2.3 saves
+    if (call _fnc_gameMissing) then { A3A_saveTarget set [1, ""] };			          // Original saves (no campaign ID)
     if (call _fnc_gameMissing) exitWith {};
-    _saveData pushBack (createHashMapFromArray [["serverID", ""], ["gameID", _oldCampaignID], ["map", worldName]]);
+    _saveData pushBack (createHashMapFromArray [["serverID", _serverID], ["gameID", A3A_saveTarget#1], ["map", worldName]]);
 };
 
 // missionProfileNamespace saves

--- a/A3A/addons/core/functions/Save/fn_collectSaveData.sqf
+++ b/A3A/addons/core/functions/Save/fn_collectSaveData.sqf
@@ -30,9 +30,9 @@ private _saveList = [profileNamespace getVariable "antistasiSavedGames"] param [
 private _oldCampaignID = profileNameSpace getVariable ["ss_CampaignID", ""];
 if !(_oldCampaignID in _campaignIDs) then {
     A3A_saveTarget = [_serverID, _oldCampaignID, worldName];                          // Pre 2.3 saves
-    if (call _fnc_gameMissing) then { A3A_saveTarget set [1, ""] };			          // Original saves (no campaign ID)
+    if (call _fnc_gameMissing) then { A3A_saveTarget set [1, ""] };                   // Original saves (no campaign ID)
     if (call _fnc_gameMissing) exitWith {};
-    _saveData pushBack (createHashMapFromArray [["serverID", _serverID], ["gameID", A3A_saveTarget#1], ["map", worldName]]);
+    _saveData pushBack createHashMapFromArray [["serverID", _serverID], ["gameID", A3A_saveTarget#1], ["map", worldName]];
 };
 
 // missionProfileNamespace saves


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The original & old community save detection code had a few bugs:
- Error-throwing use of undefined campaignID var in cases with no previous save.
- Wrong variable name in the conditional bypassed the whole section.
- Misread of original code: CampaignID is the new one, ServerID is original.

Fixed, everything probably works now. Original saves even appear to load correctly.

### Please specify which Issue this PR Resolves.
closes #2602

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
