### PR TITLE
HC Mortar faction key fix

### DIFF
--- a/A3A/addons/core/functions/REINF/fn_spawnHCGroup.sqf
+++ b/A3A/addons/core/functions/REINF/fn_spawnHCGroup.sqf
@@ -111,7 +111,7 @@ switch _special do {
         _cost = _cost + ([FactionGet(reb,"staticMG")] call A3A_fnc_vehiclePrice);
     };
     case "Mortar": {
-        private _backpacks = getArray (configFile/"CfgVehicles"/FactionGet(reb,"StaticMortar")/"assembleInfo"/"dissasembleTo");
+        private _backpacks = getArray (configFile/"CfgVehicles"/FactionGet(reb,"staticMortar")/"assembleInfo"/"dissasembleTo");
         (_units # (_countUnits - 1)) addBackpackGlobal (_backpacks#1);
         (_units # _countUnits) addBackpackGlobal (_backpacks#0);
         _cost = _cost + ([FactionGet(reb,"staticMortar")] call A3A_fnc_vehiclePrice);


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
HC mortar squads are not working due to faction hashmap key typo. This PR fixes that.     

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 