### PR TITLE
Childproof 3CBBAF

### DIFF
--- a/A3A/addons/core/Templates/Templates.hpp
+++ b/A3A/addons/core/Templates/Templates.hpp
@@ -391,7 +391,7 @@ class Templates
 
     class 3CBBAF_Base
     {
-        requiredAddons[] = {"UK3CB_BAF_Weapons","UK3CB_BAF_Vehicles","UK3CB_BAF_Units_Common","UK3CB_BAF_Equipment"};
+        requiredAddons[] = {"UK3CB_BAF_Weapons","UK3CB_BAF_Vehicles","UK3CB_BAF_Units_Common","UK3CB_BAF_Equipment","rhsgref_main"};
         //requiredAddons[] = {"UK3CB_BAF_Units_Common"};              // has weapons/equipment/vehicles dependencies
         basepath = QPATHTOFOLDER(Templates\Templates\3CB);
         logo = "\UK3CB_BAF_Weapons\addons\UK3CB_BAF_Weapons_Ammo\data\ui\logo_small_3cb_ca.paa";


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
The 3CB BAF Templates are written with the RHS Vehicles Dependency in Mind, not loading RHSUSAF will result in Instant Wins for Ammo Truck Missions, and Lack of other Vehicles etc.
### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Load 3CB BAF without RHS and with, it should only be selectable with RHS.
********************************************************
Notes:
