### PR TITLE
Fix early battle menu key use

### DIFF
--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -448,6 +448,7 @@ if (isNil "placementDone") then {
     };
 };
 
+initClientDone = true;
 Info("initClient completed");
 
 if(!isMultiplayer) then

--- a/A3A/addons/core/keybinds/fn_keyActions.sqf
+++ b/A3A/addons/core/keybinds/fn_keyActions.sqf
@@ -4,6 +4,13 @@ params ["_key"];
 if !(isClass (missionConfigFile/"A3A")) exitWith {}; //not a3a mission
 
 switch (_key) do {
+    case QGVAR(customHintDismiss): {
+        [] call A3A_fnc_customHintDismiss;
+    };
+
+    // Actions below here aren't valid until the game is started and client init is complete
+    if (isNil "initClientDone") exitWith {};
+
     case QGVAR(battleMenu): {
         if (player getVariable ["incapacitated",false]) exitWith {};
         if (player getVariable ["owner",player] != player) exitWith {};
@@ -58,10 +65,6 @@ switch (_key) do {
                 ["Ear Plugs", "You've inserted your ear plugs.", true] call A3A_fnc_customHint;
             };
         };
-    };
-
-    case QGVAR(customHintDismiss): {
-        [] call A3A_fnc_customHintDismiss;
     };
 
     Default {


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
With the setup UI, I overlooked the ability to use various Antistasi hotkeys before associated systems were initialized, causing errors with uninitialized data. This PR disables those hotkeys until client init is complete.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
