### PR TITLE
Fix setIdentity

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -739,6 +739,8 @@ class CfgFunctions
             class getAdmin {};
             class localLog {};
             class log {};
+            class setIdentity {};
+            class setIdentityLocal {};
             class setPos {};
             class vehicleTextureSync {};
             class vehicleWillCollideAtPosition {};

--- a/A3A/addons/core/functions/Base/fn_initPetros.sqf
+++ b/A3A/addons/core/functions/Base/fn_initPetros.sqf
@@ -7,8 +7,7 @@ petros setSkill 1;
 petros setVariable ["respawning",false];
 petros allowDamage false;
 
-[petros, "GreekHead_A3_01", "Male06GRE", 1.1, "Petros"] call BIS_fnc_setIdentity;
-[petros, ["Petros", "", ""]] remoteExec ["setName", 0, petros];         // because BIS_fnc_setIdentity doesn't override full name
+[petros, "GreekHead_A3_01", "Male06GRE", 1.1, "Petros"] call A3A_fnc_setIdentity;
 
 removeHeadgear petros;
 removeGoggles petros;

--- a/A3A/addons/core/functions/CREATE/fn_CIVinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_CIVinit.sqf
@@ -7,7 +7,7 @@ _unit setSkill 0;
 _unit disableAI "TARGET";
 _unit disableAI "AUTOTARGET";
 //Stops civilians from shouting out commands.
-[_unit, selectRandom (A3A_faction_civ get "faces"), "NoVoice"] call BIS_fnc_setIdentity;
+[_unit, selectRandom (A3A_faction_civ get "faces"), "NoVoice"] call A3A_fnc_setIdentity;
 _unit addEventHandler
 [
 	"HandleDamage",

--- a/A3A/addons/core/functions/CREATE/fn_NATOinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_NATOinit.sqf
@@ -121,7 +121,6 @@ default {
     _voice = selectRandom _regularVoices;
     };
 };
-Debug_3("Selected %1 and %2 for unit %3", _face, _voice, _type);
 [_unit, _face, _voice] call A3A_fnc_setIdentity;
 _unit setSkill _skill;
 

--- a/A3A/addons/core/functions/CREATE/fn_NATOinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_NATOinit.sqf
@@ -121,7 +121,8 @@ default {
     _voice = selectRandom _regularVoices;
     };
 };
-[_unit, _face, _voice] call BIS_fnc_setIdentity;
+Debug_3("Selected %1 and %2 for unit %3", _face, _voice, _type);
+[_unit, _face, _voice] call A3A_fnc_setIdentity;
 _unit setSkill _skill;
 
 //Adjusts squadleaders with improved skill and adds intel action

--- a/A3A/addons/core/functions/CREATE/fn_invaderPunish.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_invaderPunish.sqf
@@ -74,7 +74,7 @@ while {count _civilians < _numCiv} do
     for "_i" from 1 to (4 min (_numCiv - count _civilians)) do
     {
         private _civ = [_groupCivil, FactionGet(reb, "unitUnarmed"), _pos, [], 0, "NONE"] call A3A_fnc_createUnit;
-        [_civ, selectRandom (A3A_faction_civ get "faces"), "NoVoice"] call BIS_fnc_setIdentity;
+        [_civ, selectRandom (A3A_faction_civ get "faces"), "NoVoice"] call A3A_fnc_setIdentity;
         _civ forceAddUniform selectRandom (A3A_faction_civ get "uniforms");
         _civ addHeadgear selectRandom (A3A_faction_civ get "headgear");
         [_civ, selectRandom _civWeapons, 5, 0] call BIS_fnc_addWeapon;

--- a/A3A/addons/core/functions/Missions/fn_RES_Prisoners.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RES_Prisoners.sqf
@@ -65,7 +65,7 @@ _grpPOW = createGroup teamPlayer;
 for "_i" from 0 to _countX do
 	{
 	_unit = [_grpPOW, FactionGet(reb,"unitUnarmed"), (_posHouse select _i), [], 0, "NONE"] call A3A_fnc_createUnit;
-	[_unit, selectRandom (A3A_faction_reb get "faces"), selectRandom (A3A_faction_reb get "voices")] call BIS_fnc_setIdentity;
+	[_unit, selectRandom (A3A_faction_reb get "faces"), selectRandom (A3A_faction_reb get "voices")] call A3A_fnc_setIdentity;
 	_unit allowDamage false;
 	_unit setCaptive true;
 	_unit disableAI "MOVE";

--- a/A3A/addons/core/functions/Missions/fn_RES_Refugees.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RES_Refugees.sqf
@@ -51,7 +51,7 @@ _groupPOW = createGroup teamPlayer;
 for "_i" from 1 to (((count _posHouse) - 1) min 15) do
 	{
 	_unit = [_groupPOW, FactionGet(reb,"unitUnarmed"), _posHouse select _i, [], 0, "NONE"] call A3A_fnc_createUnit;
-	[_unit, selectRandom (A3A_faction_reb get "faces"), selectRandom (A3A_faction_reb get "voices")] call BIS_fnc_setIdentity;
+	[_unit, selectRandom (A3A_faction_reb get "faces"), selectRandom (A3A_faction_reb get "voices")] call A3A_fnc_setIdentity;
 	_unit allowdamage false;
 	_unit disableAI "MOVE";
 	_unit disableAI "AUTOTARGET";

--- a/A3A/addons/core/functions/Missions/fn_convoy.sqf
+++ b/A3A/addons/core/functions/Missions/fn_convoy.sqf
@@ -189,7 +189,7 @@ if (_convoyType == "Prisoners") then
     for "_i" from 1 to (1+ round (random 11)) do
     {
         private _unit = [_grpPOW, FactionGet(reb,"unitUnarmed"), _posSpawn, [], 0, "NONE"] call A3A_fnc_createUnit;
-        [_unit, selectRandom (A3A_faction_reb get "faces"), selectRandom (A3A_faction_reb get "voices")] call BIS_fnc_setIdentity;
+        [_unit, selectRandom (A3A_faction_reb get "faces"), selectRandom (A3A_faction_reb get "voices")] call A3A_fnc_setIdentity;
         _unit setCaptive true;
         _unit disableAI "MOVE";
         _unit setBehaviour "CARELESS";

--- a/A3A/addons/core/functions/REINF/fn_FIAinit.sqf
+++ b/A3A/addons/core/functions/REINF/fn_FIAinit.sqf
@@ -28,7 +28,7 @@ _unit setUnitTrait ["audibleCoef",0.8];
 // FIAinit is called for liberated refugees/hostages. Don't equip them.
 if !(_typeX isEqualTo FactionGet(reb,"unitUnarmed")) then {
 	[_unit, [0,1] select (leader _unit != player)] call A3A_fnc_equipRebel;
-	[_unit, selectRandom (A3A_faction_reb get "faces"), selectRandom (A3A_faction_reb get "voices")] call BIS_fnc_setIdentity;
+	[_unit, selectRandom (A3A_faction_reb get "faces"), selectRandom (A3A_faction_reb get "voices")] call A3A_fnc_setIdentity;
 };
 _unit selectWeapon (primaryWeapon _unit);
 

--- a/A3A/addons/core/functions/Utility/fn_setIdentity.sqf
+++ b/A3A/addons/core/functions/Utility/fn_setIdentity.sqf
@@ -17,4 +17,9 @@ params ["_unit"];           // Don't care about the other params here
 
 if (isNull _unit) exitWith {};
 private _JIPID = "identity_" + netId _unit;
-[_JIPID] + _this remoteExec ["A3A_fnc_setIdentityLocal", 0, _JIPID];
+([_JIPID] + _this) remoteExec ["A3A_fnc_setIdentityLocal", 0, _JIPID];
+
+// This won't be 100% reliable because it's only installed locally, but it'll avoid remoteExec spam on connection
+_unit addEventHandler ["Deleted", {
+    remoteExec ["", "identity_" + netId _unit];
+}];

--- a/A3A/addons/core/functions/Utility/fn_setIdentity.sqf
+++ b/A3A/addons/core/functions/Utility/fn_setIdentity.sqf
@@ -1,0 +1,20 @@
+/*
+    Set face, voice, pitch and name of unit. Global effect and JIP-safe.
+
+Scope: Any
+Environment: Any
+Public: Yes
+
+Arguments:
+    <OBJECT> Object to set identity for
+    <STRING> Optional: Face of unit
+    <STRING> Optional: Voice/speaker of unit
+    <STRING> Optional: (Voice) pitch of unit
+    <STRING> Optional: Name of unit
+*/
+
+params ["_unit"];           // Don't care about the other params here
+
+if (isNull _unit) exitWith {};
+private _JIPID = "identity_" + netId _unit;
+[_JIPID] + _this remoteExec ["A3A_fnc_setIdentityLocal", 0, _JIPID];

--- a/A3A/addons/core/functions/Utility/fn_setIdentityLocal.sqf
+++ b/A3A/addons/core/functions/Utility/fn_setIdentityLocal.sqf
@@ -1,0 +1,25 @@
+/*
+    Set face, voice, pitch and name of unit locally, and clear JIP if no longer present
+
+Scope: Any
+Environment: Any
+Public: No, should only be called by setIdentity
+
+Arguments:
+    <STRING> JIP ID of operation
+    <OBJECT> Object to set identity for
+    <STRING> Optional: Face of unit
+    <STRING> Optional: Voice/speaker of unit
+    <STRING> Optional: (Voice) pitch of unit
+    <STRING> Optional: Name of unit
+*/
+
+params ["_JIPID", "_unit", "_face", "_speaker", "_pitch", "_name"];
+
+// isRemoteExecutedJIP is not trustworthy from HC->client, so just do it anyway
+if (isNull _unit) exitWith { remoteExec ["", _JIPID] };
+
+if !(isNil "_face") then { _unit setFace _face };
+if !(isNil "_speaker") then { _unit setSpeaker _speaker };
+if !(isNil "_pitch") then { _unit setPitch _pitch };
+if !(isNil "_name") then { _unit setName [_name, "", ""] };

--- a/A3A/addons/core/functions/Utility/fn_setIdentityLocal.sqf
+++ b/A3A/addons/core/functions/Utility/fn_setIdentityLocal.sqf
@@ -1,5 +1,5 @@
 /*
-    Set face, voice, pitch and name of unit locally, and clear JIP if no longer present
+    Sets specified identity of unit locally. Clears JIP if unit no longer present
 
 Scope: Any
 Environment: Any

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -108,7 +108,7 @@ stragglers = creategroup teamPlayer;
 (group player) enableAttack false;
 
 if (isNil "ace_noradio_enabled" or {!ace_noradio_enabled}) then {
-    [player, nil, selectRandom (A3A_faction_reb get "voices")] call BIS_fnc_setIdentity
+    [player, nil, selectRandom (A3A_faction_reb get "voices")] call A3A_fnc_setIdentity
 };
 //Give the player the base loadout.
 [player] call A3A_fnc_dress;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
We used BIS_fnc_setIdentity to set voices and faces globally, but it didn't work correctly because it assumes that the initial call returns false for `isRemoteExecuted`. Because the remote execution flag is passed through spawns (wtf BIS), most Antistasi code actually returns true.

Rewrote with an explicit global/local split. Also skips the reflection-to-server, as that wasn't necessary. You can run JIP remoteExecs from anywhere.

Also changed the name code to use the proper function rather than the one that only sets first/last names, so we no longer need the hack for Petros and future unit naming code will be easier.

One somewhat unwanted effect inherited from the original code is that it continually grows the JIP queue until someone new connects and clears out the dead JIPs. A lot of work to fix though.

Cases tested:
1. Units created on client sync correctly to server. Should also apply to HCs as all isRemoteExecuted checks were removed.
2. Units created on server sync correctly to client.
3. Units sync correctly on JIP, regardless of creation location.
4. JIP clearance for deleted units works.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
