### PR TITLE
Ensure cargo turrets (eg. door guns) are crewed

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_createAttackVehicle.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAttackVehicle.sqf
@@ -28,7 +28,9 @@ private _vehicle = [_markerOrigin, _vehicleType] call A3A_fnc_spawnVehicleAtMark
 
 if(isNull _vehicle) exitWith {objNull};
 
-private _crewGroup = [_side, _vehicle] call A3A_fnc_createVehicleCrew;
+// Fill cargo turrets with crew for attack helis
+private _isAttackHeli = _vehicleType in FactionGet(all, "vehiclesHelisAttack") + FactionGet(all, "vehiclesHelisLightAttack");
+private _crewGroup = [_side, _vehicle, nil, _isAttackHeli] call A3A_fnc_createVehicleCrew;
 {
     [_x, nil, nil, _resPool] call A3A_fnc_NATOinit
 } forEach (units _crewGroup);
@@ -36,11 +38,8 @@ private _crewGroup = [_side, _vehicle] call A3A_fnc_createVehicleCrew;
 
 private _cargoGroup = grpNull;
 private _expectedCargo = ([_vehicleType, true] call BIS_fnc_crewCount) - ([_vehicleType, false] call BIS_fnc_crewCount);
-if (_expectedCargo >= 2) then
+if (_expectedCargo >= 2 and !_isAttackHeli) then
 {
-    // These types won't let the cargo group disembark, so they're a waste of units even if they have spare seats
-    if (_vehicleType in FactionGet(all, "vehiclesHelisAttack") + FactionGet(all, "vehiclesHelisLightAttack")) exitWith {};
-
     //Vehicle is able to transport units
     private _groupType = call {
         if (_troopType == "Normal") exitWith { [_vehicleType, _side] call A3A_fnc_cargoSeats };
@@ -48,12 +47,30 @@ if (_expectedCargo >= 2) then
         if (_troopType == "Air") exitWith { _faction get "groupAA" };
         if (_troopType == "Tank") exitWith { _faction get "groupAT" };
     };
-    
+
+    // Find turret paths that count as cargo seats
+    private _fnc_addCargoTurrets = {
+        params ["_config", ["_path", []]];
+        {
+            private _turretPath = _path + [_forEachIndex];
+            [_x, _turretPath] call _fnc_addCargoTurrets;                // Handle nested turrets
+            if (getNumber (_x >> "showAsCargo") != 0) then { _cargoTurrets pushBack _turretPath };
+        } forEach ("true" configClasses (_config >> "Turrets"));
+    };
+    private _cargoTurrets = [];
+    [configFile >> "CfgVehicles" >> _vehicleType] call _fnc_addCargoTurrets;
+
     if (_expectedCargo < count _groupType) then { _groupType resize _expectedCargo };           // trim to cargo seat count
     _cargoGroup = [getMarkerPos _markerOrigin, _side, _groupType, true, false] call A3A_fnc_spawnGroup;         // force spawn, should be pre-checked
     {
-        _x assignAsCargo _vehicle;
-        _x moveInCargo _vehicle;
+        if (_cargoTurrets isNotEqualTo []) then {
+            private _turretPath = _cargoTurrets deleteAt 0;
+            _x assignAsTurret [_vehicle, _turretPath];
+            _x moveInTurret [_vehicle, _turretPath];
+        } else {
+            _x assignAsCargo _vehicle;
+            _x moveInCargo _vehicle;
+        };
         [_x, nil, nil, _resPool] call A3A_fnc_NATOinit;
     } forEach units _cargoGroup;
 };

--- a/A3A/addons/core/functions/CREATE/fn_createVehicleCrew.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createVehicleCrew.sqf
@@ -12,6 +12,7 @@
 		_group - Existing group to add units to, or side to create group on [GROUP/SIDE]
 		_vehicle - Vehicle to create crew for [OBJECT]
 		_unitType - Type of unit to create [STRING]
+		_fillCargoTurrets - Optional, default false. True to fill turrets marked as cargo [BOOL]
 
     Returns:
 		_group - Group with crew members [GROUP]
@@ -20,7 +21,7 @@
 		[west, _myVehicle, FactionGet(occ,"crew")] call A3A_fnc_createVehicleCrew;
 */
 
-params ["_group", "_vehicle", "_unitType"];
+params ["_group", "_vehicle", "_unitType", ["_fillCargoTurrets", false]];
 
 private _newGroup = false;
 if (_group isEqualType sideUnknown) then {
@@ -56,7 +57,7 @@ private _fnc_addCrewToTurrets = {
 		[_turretConfig, _turretPath] call _fnc_addCrewToTurrets;
 
 		if (getNumber (_turretConfig >> "hasGunner") == 0 || getNumber (_turretConfig >> "dontCreateAI") != 0) then { continue };
-		if (getNumber (_turretConfig >> "showAsCargo") > 0) then { continue };
+		if (!_fillCargoTurrets and getNumber (_turretConfig >> "showAsCargo") > 0) then { continue };
 		if (isNull (_vehicle turretUnit _turretPath)) then {
 			private _gunner = [_group, _unitType, getPos _vehicle, [], 10] call A3A_fnc_createUnit;
 			_gunner assignAsTurret [_vehicle, _turretPath];


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
In 3.0, createVehicleCrew is prevented from filling "showAsCargo" turrets with crew units. This is because BIS_fnc_crewCount counts these turrets as cargo, and hence the cargo capacity calculations would return incorrect results if they were filled with crew. However, in some cases (eg. various RHS Mi-8 doorguns) these turrets weren't filled with cargo either, unintentionally nerfing the vehicles.

This PR forces the cargo turrets to be filled: With cargo units in the case of transport vehicles, and with crew in the case of attack helicopters. For some transport helis this is questionable, as they have plenty of other cargo seats and dismounting the door gunners may not be ideal. However it is what the mod specifies, and in some cases we'd need to change vehicle categories and/or rewrite BIS_fnc_crewCount otherwise. Also putting pilots in door gunner seats looks a bit odd.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Testing has so far been rather narrow, although the changes should be safe.
