### PR TITLE
Dedicated Server/Headless client air tables fix

### DIFF
--- a/A3A/addons/core/functions/Intel/fn_placeIntel.sqf
+++ b/A3A/addons/core/functions/Intel/fn_placeIntel.sqf
@@ -151,8 +151,8 @@ private _ehId = _building addEventHandler ["Killed", {
 		deleteVehicle _intel;
 	};
 
-	if (!isNull _desk) then {
-		_desk enableSimulation true;
+	if (!isNull _desk && {!simulationEnabled _desk}) then {
+		[_desk, true] remoteExec ["enableSimulationGlobal",2];
 	};
 
 	_building removeEventHandler ["Killed",_thisEventHandler];


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Seems that `enabledSimulation` is not enough to unfreeze tables on network-complicated environments. The fix includes `enableSimulationGlobal` execution on server which will do the rest (the same way as it used in the same circumstances in the codebase)

![image](https://user-images.githubusercontent.com/6746043/212748449-76fe74d1-ccaa-4a5e-80a3-9eb3c9abfd47.png)


### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
-