### PR TITLE
Disable lambs danger when it is loaded

### DIFF
--- a/.github/workflows/publishBranchToSteam.yml
+++ b/.github/workflows/publishBranchToSteam.yml
@@ -17,7 +17,7 @@ jobs:
         node ./tools/incrementVersion.js -b ${{github.sha}}
 
     - name: Build addons
-      run: '.\tools\Builder\buildAddons.ps1 -WorkshopID ${{github.event.inputs.workshopid}}'
+      run: '.\tools\Builder\buildAddons.ps1 -WorkshopID ${{secrets.WORKSHOPID}}'
 
     - name: Upload build addon artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/publishBranchToSteam.yml
+++ b/.github/workflows/publishBranchToSteam.yml
@@ -17,7 +17,7 @@ jobs:
         node ./tools/incrementVersion.js -b ${{github.sha}}
 
     - name: Build addons
-      run: '.\tools\Builder\buildAddons.ps1 -WorkshopID ${{secrets.WORKSHOPID}}'
+      run: '.\tools\Builder\buildAddons.ps1 -WorkshopID ${{github.event.inputs.workshopid}}'
 
     - name: Upload build addon artifact
       uses: actions/upload-artifact@v2

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -35,6 +35,15 @@ if !(isServer) then {
         waitUntil { sleep 0.1; !isNil "serverInitDone" };			// addNodesNearMarkers needs marker lists
         call A3A_fnc_addNodesNearMarkers;
     };
+
+    if (isClass (configfile >> "CfgPatches" >> "lambs_danger")) then {
+        // disable lambs danger fsm entrypoint
+        ["CAManBase", "InitPost", {
+            params ["_unit"];
+            (group _unit) setVariable ["lambs_danger_disableGroupAI", true];
+            _unit setVariable ["lambs_danger_disableAI", true];
+        }] call CBA_fnc_addClassEventHandler;
+    };
 };
 
 if (isNil "A3A_startupState") then { A3A_startupState = "waitserver" };

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -36,7 +36,8 @@ if !(isServer) then {
         call A3A_fnc_addNodesNearMarkers;
     };
 
-    if (isClass (configfile >> "CfgPatches" >> "lambs_danger")) then {
+    if (isClass (configfile >> "CBA_Extended_EventHandlers")) && {
+        isClass (configfile >> "CfgPatches" >> "lambs_danger")}) then {
         // disable lambs danger fsm entrypoint
         ["CAManBase", "InitPost", {
             params ["_unit"];

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -289,4 +289,13 @@ savingServer = false;           // enable saving
     };
 };
 
+if (isClass (configfile >> "CfgPatches" >> "lambs_danger")) then {
+    // disable lambs danger fsm entrypoint
+    ["CAManBase", "InitPost", {
+        params ["_unit"];
+        (group _unit) setVariable ["lambs_danger_disableGroupAI", true];
+        _unit setVariable ["lambs_danger_disableAI", true];
+    }] call CBA_fnc_addClassEventHandler;
+};
+
 Info("initServer completed");

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -289,7 +289,8 @@ savingServer = false;           // enable saving
     };
 };
 
-if (isClass (configfile >> "CfgPatches" >> "lambs_danger")) then {
+if (isClass (configfile >> "CBA_Extended_EventHandlers")) && {
+    isClass (configfile >> "CfgPatches" >> "lambs_danger")}) then {
     // disable lambs danger fsm entrypoint
     ["CAManBase", "InitPost", {
         params ["_unit"];


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information:
This enhancement will disable lambs danger when it is loaded despite warnings to NOT load it.
It needs CBA, but that should be a requirement anyways already.

********************************************************
Notes:
I have gotten multiple people asking me about lambs and antistasi compat. Since lambs tries to integrate like vanilla AI, just with another FSM it is often seen that a mission should have an implementation to deal with it.
The Antistasi docs make it clear that lambs is not to be loaded and is not supported. As far as I could tell, it keeps happening that people do it anyways. So here ya go, it just disables all danger AI features from lambs without additional network cost. Problem solved.
