### PR TITLE
making moveHQObjects non-lethal

### DIFF
--- a/A3A/addons/core/functions/Dialogs/fn_moveHQObject.sqf
+++ b/A3A/addons/core/functions/Dialogs/fn_moveHQObject.sqf
@@ -25,6 +25,9 @@ _thingX setVariable ["objectBeingMoved", true];
 if !(_isStatic) then { _thingX removeAction _id };
 if (_isStatic) then { _thingX lock true };
 
+if (isNil {_thingX getVariable "A3A_originalMass"}) then { _thingX setVariable ["A3A_originalMass", getMass _thingX] };
+[_thingX, 1e-12] remoteExecCall ["setMass", 0]; 
+
 private _spacing = 2 max (1 - (boundingBoxReal _thingX select 0 select 1));
 private _height = 0.1 - (boundingBoxReal _thingX select 0 select 2);
 _thingX attachTo [_playerX, [0, _spacing, _height]];
@@ -72,6 +75,8 @@ private _fnc_placeObject = {
 	if (_thingX isKindOf "StaticWeapon") then { _thingX lock false };
 
 	_thingX setVariable ["objectBeingMoved", false];
+
+	[_thingX, _thingX getVariable "A3A_originalMass"] remoteExecCall ["setMass", _thingX];
 };
 
 private _actionX = _playerX addAction ["Drop Here", {


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    sets the mass of the object to be close to zero, to prevent damage. Same method as the other carry code. Maybe on day we will merge all the carry code.

### Please specify which Issue this PR Resolves.
closes #2593

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
