### PR TITLE
Add the ability for carrable objects to be placed on surfaces

### DIFF
--- a/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
@@ -76,8 +76,21 @@ if (_pickUp) then {
     if !(isNull _item) then {
         _player setVelocity [0,0,0];
         detach _item;
-        _item setVelocity [0,0,0];
-        _item setPos [getPos _item # 0, getPos _item # 1, 0];
+
+	    // Some objects never lose (and even regain) their velocity when detached, becoming lethal
+	    // On a DS, object locality changes when detached, so we have to remoteexec
+	    [_item, [0,0,0]] remoteExec ["setVelocity", _item];
+
+	    // Without this, non-unit objects often hang in mid-air
+	    [_item, surfaceNormal position _item] remoteExec ["setVectorUp", _item];
+
+	    // Place on closest surface
+	    private _pos = getPosASL _item;
+	    private _intersects = lineIntersectsSurfaces [_pos, _pos vectorAdd [0,0,-100], _item];
+	    if (count _intersects > 0) then {
+	    	_item setPosASL (_intersects select 0 select 0);
+	    };
+        
         [_item, true] remoteExec ["enableSimulationGlobal", 2];
         _eventIDcarry = _player getVariable 'A3A_eventIDcarry';
         _player removeEventHandler ["GetInMan", _eventIDcarry];


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [x] Enhancement

### What have you changed and why?
Information:
    Uses code from moving hqObjects to place the objects of the surface of other objects. Allows players to place the object on top of a surface.


### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
![Screenshot 2023-03-17 135635](https://user-images.githubusercontent.com/8095345/225994135-420c6f29-2945-4692-b5f7-36b91614f8ac.png)
