### PR TITLE
Fix static crew simulation bug

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_createAIAirplane.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIAirplane.sqf
@@ -81,9 +81,9 @@ if (_frontierX) then
 		_veh setPos _pos;
 		_typeUnit = _faction get "unitStaticCrew";
 		_unit = [_groupX, _typeUnit, _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
+		_unit moveInGunner _veh;
 		[_unit,_markerX] call A3A_fnc_NATOinit;
 		[_veh, _sideX] call A3A_fnc_AIVEHinit;
-		_unit moveInGunner _veh;
 		_soldiers pushBack _unit;
 	};
 };
@@ -154,11 +154,11 @@ while {true} do {
 	//_veh setPosATL (_spawnParameter select 0);
 	_nul=[_veh] spawn UPSMON_fnc_artillery_add;//TODO need delete UPSMON link
 	_unit = [_groupX, _typeUnit, _positionX, [], 0, "CAN_COLLIDE"] call A3A_fnc_createUnit;
-	[_unit,_markerX] call A3A_fnc_NATOinit;
 	_unit moveInGunner _veh;
+	[_unit,_markerX] call A3A_fnc_NATOinit;
+	[_veh, _sideX] call A3A_fnc_AIVEHinit;
 	_soldiers pushBack _unit;
 	_vehiclesX pushBack _veh;
-	[_veh, _sideX] call A3A_fnc_AIVEHinit;
 	sleep 1;
 };
 

--- a/A3A/addons/core/functions/CREATE/fn_createAIOutposts.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIOutposts.sqf
@@ -107,8 +107,8 @@ if ((_frontierX) and (_markerX in outposts)) then
 		_veh = _typeVehX createVehicle (_spawnParameter select 0);
 		_nul=[_veh] spawn UPSMON_fnc_artillery_add;//TODO need delete UPSMON link
 		_unit = [_groupX, _typeUnit, _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
-		[_unit,_markerX] call A3A_fnc_NATOinit;
 		_unit moveInGunner _veh;
+		[_unit,_markerX] call A3A_fnc_NATOinit;
 		_groups pushBack _groupX;
 		_soldiers pushBack _unit;
 		_vehiclesX pushBack _veh;
@@ -226,9 +226,9 @@ else
 			_veh setDir _dirVeh + 180;
 			_typeUnit = _faction get "unitStaticCrew";
 			_unit = [_groupX, _typeUnit, _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
+			_unit moveInGunner _veh;
 			[_unit,_markerX] call A3A_fnc_NATOinit;
 			[_veh, _sideX] call A3A_fnc_AIVEHinit;
-			_unit moveInGunner _veh;
 			_soldiers pushBack _unit;
 		};
 	};

--- a/A3A/addons/core/functions/CREATE/fn_createAIResources.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIResources.sqf
@@ -65,9 +65,9 @@ if (_frontierX) then
 		_veh setDir _dirVeh + 180;
 		_typeUnit = _faction get "unitStaticCrew";
 		_unit = [_groupX, _typeUnit, _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
+		_unit moveInGunner _veh;
 		[_unit,_markerX] call A3A_fnc_NATOinit;
 		[_veh, _sideX] call A3A_fnc_AIVEHinit;
-		_unit moveInGunner _veh;
 		_soldiers pushBack _unit;
 	};
 };

--- a/A3A/addons/core/functions/CREATE/fn_milBuildings.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_milBuildings.sqf
@@ -42,8 +42,8 @@ private _fnc_spawnStatic = {
     private _veh = createVehicle [_type, _pos, [], 0, "CAN_COLLIDE"];
     if (!isNil "_dir") then { _veh setDir _dir };
     private _unit = [_groupX, _typeUnit, _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
-    [_unit,_markerX] call A3A_fnc_NATOinit;
     _unit moveInGunner _veh;
+    [_unit,_markerX] call A3A_fnc_NATOinit;
     _soldiers pushBack _unit;
     _vehiclesX pushBack _veh;
     _veh;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Static crew could be created with simulation disabled due to their creation code running NATOinit before moving them into the static weapon. Because static crew are assumed to have simulation enabled, they'd remain disabled, making them invulnerable to damage.

This PR fixes the issues by moving the NATOinit calls after moveInGunner. Structure is generally bad but I'll probably be reworking garrisons soon-ish so it'll do for now.

### Please specify which Issue this PR Resolves.
closes #2666

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
In theory you can trigger the original issue by moving within spawn distance of a marker and then immediately moving out again, so that at least some of the NATOinit calls for static crew are executed with the spawn state at DISABLED (1). Haven't bothered trying that though. Should be possible because there's a 1-second sleep for each 2-man patrol generated before any statics are spawned, and distance.sqf typically runs once per second.
