### PR TITLE
Rewrite radioJam, improve perf and fix last-tower bug

### DIFF
--- a/A3A/addons/core/functions/OrgPlayers/fn_radioJam.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_radioJam.sqf
@@ -1,45 +1,38 @@
-private _jammed = false;
-private _sideX = side player;
-_rad = 1000;
-_strength = 49;
-_isJammed = false;
-_interference = 1;
-_sendInterference = 1;
+#define JAM_RADIUS 1000
+#define JAM_STRENGTH 49
+
+// Pre-generate antenna -> base mappings to save scanning
+private _sideX = side group player;
 private _bases = outposts + airportsx + seaports;
+private _antennaBases = createHashMap;
+{
+    private _base = [_bases, _x] call BIS_fnc_nearestPosition;
+    _antennaBases set [netId _x, _base];
+} forEach (antennas + antennasDead);
+
+private _fnc_setInterference = {
+    params ["_recInterference", "_sendInterference"];
+    player setVariable ["tf_receivingDistanceMultiplicator", _recInterference];
+    player setVariable ["tf_sendingDistanceMultiplicator", _sendInterference];
+};
+
 while {true} do
-	{
-	private _antennas = [];
-	{
-	_outpost = [_bases,_x] call BIS_fnc_nearestPosition;
-	if (sidesX getVariable [_outpost,sideUnknown] != _sideX) then {_antennas pushBack _x};
-	} forEach antennas;
-	if !(_antennas isEqualTo []) then
-		{
-		_jammer = [_antennas,player] call BIS_fnc_nearestPosition;
-		_dist = player distance _jammer;
-	    _distPercent = _dist / _rad;
+{
+    sleep 10;
 
-	    if (_dist < _rad) then
-	    	{
-			_interference = _strength - (_distPercent * _strength) + 1; // Calculate the recieving interference, which has to be above 1 to have any effect.
-			_sendInterference = 1/_interference; //Calculate the sending interference, which needs to be below 1 to have any effect.
-			if (!_isJammed) then {_isJammed = true};
-			player setVariable ["tf_receivingDistanceMultiplicator", _interference];
-			player setVariable ["tf_sendingDistanceMultiplicator", _sendInterference];
-	    	}
-	    else
-	    	{
-	    	if (_isJammed) then
-	    		{
-	    		_isJammed = false;
-	    		_interference = 1;
-				_sendInterference = 1;
-				player setVariable ["tf_receivingDistanceMultiplicator", _interference];
-				player setVariable ["tf_sendingDistanceMultiplicator", _sendInterference];
-	    		};
-	    	};
-	    // Set the TF receiving and sending distance multipliers
+    private _jammers = antennas inAreaArray [getPosATL player, JAM_RADIUS, JAM_RADIUS];
+    _jammers = _jammers select { sidesX getVariable (_antennaBases get netId _x) != _sideX };
 
-		};
-	sleep 10;
-	};
+    // No live enemy antennas within range
+    if (_jammers isEqualTo []) then {
+        [1, 1] call _fnc_setInterference;
+        continue;
+    };
+
+    private _jammer = [_jammers, player] call BIS_fnc_nearestPosition;
+    private _dist = player distance _jammer;
+
+    // Receiving interference >1 has effect, sending interference <1 has effect
+    private _interference = 1 + JAM_STRENGTH * (1 - _dist/JAM_RADIUS);
+    [_interference, 1/_interference] call _fnc_setInterference;
+};


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement
4. [X] Performance

### What have you changed and why?
Fixed a bug in radioJam where jamming could persist after the last radio tower was destroyed or captured, as jamming was only changed if there were enemy towers present.

The code also did a full N(radio towers) * M(outposts+airports+seaports) distance scan on every check so I rewrote it. 

### Please specify which Issue this PR Resolves.
closes #2630

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Can be tested without TFAR running. After setup, load the jam script with:
`[] spawn A3A_fnc_radioJam`

Then do something like this to observe the effects:
```
onEachFrame {
  hint str (player getVariable "tf_receivingDistanceMultiplicator");
};
```