### PR TITLE
Fix HQ position desync

### DIFF
--- a/A3A/addons/core/functions/Base/fn_buildHQ.sqf
+++ b/A3A/addons/core/functions/Base/fn_buildHQ.sqf
@@ -18,6 +18,5 @@ petros setBehaviour "SAFE";
 
 [getPos petros, false] remoteExec ["A3A_fnc_relocateHQObjects", 2];
 
-if (isNil "placementDone") then {placementDone = true; publicVariable "placementDone"};
 sleep 5;
 ["HQPlaced", [getPos petros]] call EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/Base/fn_placementselection.sqf
+++ b/A3A/addons/core/functions/Base/fn_placementselection.sqf
@@ -1,17 +1,10 @@
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
 scriptName "fn_placementSelection.sqf";
-private _newGame = isNil "placementDone";
 private _disabledPlayerDamage = false;
 
-if (_newGame) then {
-    Info("New session selected");
-	"Initial HQ Placement Selection" hintC ["Click on the Map Position you want to start the Game.","Close the map with M to start in the default position.","Don't select areas with enemies nearby!!\n\nGame experience changes a lot on different starting positions."];
-} else {
-	player allowDamage false;
-	_disabledPlayerDamage = true;
-	format ["%1 is Dead",name petros] hintC format ["%1 has been killed. You lost part of your assets and need to select a new HQ position far from the enemies.",name petros];
-};
+player allowDamage false;
+format ["%1 is Dead",name petros] hintC format ["%1 has been killed. You lost part of your assets and need to select a new HQ position far from the enemies.",name petros];
 
 hintC_arr_EH = findDisplay 72 displayAddEventHandler ["unload",{
 	0 = _this spawn {
@@ -21,16 +14,10 @@ hintC_arr_EH = findDisplay 72 displayAddEventHandler ["unload",{
 }];
 
 private _markersX = markersX select {sidesX getVariable [_x,sideUnknown] != teamPlayer};
+_markersX = _markersX - (controlsX select {!isOnRoad (getMarkerPos _x)});
+openMap [true,true];
 
-if (_newGame) then {
-	_markersX = _markersX - controlsX;
-	openMap true;
-} else {
-	_markersX = _markersX - (controlsX select {!isOnRoad (getMarkerPos _x)});
-	openMap [true,true];
-};
 private _mrkDangerZone = [];
-
 {
 	_mrk = createMarkerLocal [format ["%1dumdum", count _mrkDangerZone], getMarkerPos _x];
 	_mrk setMarkerShapeLocal "ELLIPSE";
@@ -74,7 +61,7 @@ while {_positionIsInvalid} do {
 		_positionIsInvalid = true;
 	};
 
-	if (!_positionIsInvalid && !_newGame) then {
+	if (!_positionIsInvalid) then {
 		//Invalid if enemies nearby
 		_positionIsInvalid = (allUnits findIf {(side _x == Occupants || side _x == Invaders) && {_x distance _positionClicked < 500}}) > -1;
 		if (_positionIsInvalid) then {["HQ Position", "There are enemies in the surroundings of that area, please select another."] call A3A_fnc_customHint;};
@@ -83,31 +70,19 @@ while {_positionIsInvalid} do {
 };
 
 //If we're still in the map, we chose a place.
+// Should be impossible to close it without picking now? No new-game case anymore.
 if (visiblemap) then {
-	if (_newGame) then {
-		{
-			if (getMarkerPos _x distance _positionClicked < distanceSPWN) then {
-				sidesX setVariable [_x,teamPlayer,true];
-			};
-		} forEach controlsX;
-		petros setPos _positionClicked;
-	} else {
-		_controlsX = controlsX select {!(isOnRoad (getMarkerPos _x))};
-		{
-			if (getMarkerPos _x distance _positionClicked < distanceSPWN) then {
-				sidesX setVariable [_x,teamPlayer,true];
-			};
-		} forEach _controlsX;
-		[_positionClicked] remoteExec ["A3A_fnc_createPetros", 2];
-	};
-	[_positionClicked, _newGame] remoteExec ["A3A_fnc_relocateHQObjects", 2];
+	_controlsX = controlsX select {!(isOnRoad (getMarkerPos _x))};
+	{
+		if (getMarkerPos _x distance _positionClicked < distanceSPWN) then {
+			sidesX setVariable [_x,teamPlayer,true];
+		};
+	} forEach _controlsX;
+	[_positionClicked] remoteExec ["A3A_fnc_createPetros", 2];
+	[_positionClicked, false] remoteExec ["A3A_fnc_relocateHQObjects", 2];
 	openmap [false,false];
 };
 
-if (_disabledPlayerDamage) then {player allowDamage true};
+player allowDamage true;
 
 {deleteMarkerLocal _x} forEach _mrkDangerZone;
-"Synd_HQ" setMarkerPos (getMarkerPos respawnTeamPlayer);
-posHQ = getMarkerPos respawnTeamPlayer; publicVariable "posHQ";
-if (_newGame) then {placementDone = true; publicVariable "placementDone"};
-chopForest = false; publicVariable "chopForest";

--- a/A3A/addons/core/functions/Base/fn_relocateHQObjects.sqf
+++ b/A3A/addons/core/functions/Base/fn_relocateHQObjects.sqf
@@ -23,6 +23,9 @@ isNil {
 
 respawnTeamPlayer setMarkerPos _newPosition;
 posHQ = _newPosition; publicVariable "posHQ";
+"Synd_HQ" setMarkerPos _newPosition;
+chopForest = false; publicVariable "chopForest";
+
 
 [respawnTeamPlayer, 1, teamPlayer] call A3A_fnc_setMarkerAlphaForSide;
 [respawnTeamPlayer, 1, civilian] call A3A_fnc_setMarkerAlphaForSide;
@@ -60,7 +63,4 @@ mapX hideObjectGlobal false;
 fireX hideObjectGlobal false;
 flagX hideObjectGlobal false;
 
-
-"Synd_HQ" setMarkerPos _newPosition;
-chopForest = false; publicVariable "chopForest";
 

--- a/A3A/addons/core/functions/Save/fn_loadServer.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadServer.sqf
@@ -144,7 +144,6 @@ if (isServer) then {
 	["tasks"] call A3A_fnc_getStatVariable;
 
 	statsLoaded = 0; publicVariable "statsLoaded";
-	placementDone = true; publicVariable "placementDone";
 	petros allowdamage true;
 };
 Info("loadServer Completed.");

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -432,15 +432,6 @@ _layer = ["statisticsX"] call bis_fnc_rscLayer;
 //Load the player's personal save.
 [] spawn A3A_fnc_createDialog_shouldLoadPersonalSave;
 
-// Check if we need to relocate HQ. Might happen if we leave during placement?
-// Should be replaced with server-side monitoring loop
-if (isNil "placementDone") then {
-    if (isNil "playerPlacingHQ" || {!(playerPlacingHQ in (call A3A_fnc_playableUnits))}) then {
-        playerPlacingHQ = player;
-        publicVariable "playerPlacingHQ";
-        [] spawn A3A_fnc_placementSelection;
-    };
-};
 
 initClientDone = true;
 Info("initClient completed");

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -138,7 +138,6 @@ else
     } forEach controlsX;
     petros setPos _posHQ;
     [_posHQ, true] call A3A_fnc_relocateHQObjects;         // sets all the other vars
-    placementDone = true; publicVariable "placementDone";           // do we need this now?
 };
 
 if (_startType != "load") then {


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed bug where the two HQ markers (respawnTeamPlayer and "Synd_HQ") could become desynced because placementSelection was setting one of them on the client side for some goddamned reason.

Also stripped out the new-game code from placementSelection (and associated placementDone flag stuff) that was obsoleted by the setup UI HQ placement interface.

The case where the commander disconnects while placing still hasn't been addressed. Quite a lot more work.

### Please specify which Issue this PR Resolves.
closes #2675

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Should do a DS run really as the code has a client/server split, although it should be solid.

### How can the changes be tested?
Load or start game, wait 120 seconds for petros to become vulnerable (or run `petros allowDamage true`), then get him killed by spawning units in zeus or similar.
