### PR TITLE
Rewrite spawn positions so QRFs and garrisons coexist

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -226,6 +226,7 @@ class CfgFunctions
             class CIVinit {};
             class civVEHinit {};
             class cleanserVeh {};
+            class countFreeSpawnPositions {};
             class createAIAirplane {};
             class createAICities {};
             class createAIcontrols {};

--- a/A3A/addons/core/functions/Base/fn_distance.sqf
+++ b/A3A/addons/core/functions/Base/fn_distance.sqf
@@ -303,6 +303,9 @@ private _processInvaderMarker = {
             // ENABLE this marker
             spawner setVariable [_marker, ENABLED, true];
 
+            // Prevent other routines taking spawn places 
+            [_marker, 1] call A3A_fnc_addTimeForIdle;
+
             switch (true)
             do
             {

--- a/A3A/addons/core/functions/CREATE/fn_availableBasesLand.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_availableBasesLand.sqf
@@ -23,15 +23,20 @@ params ["_side", "_target", ["_returnAll", false]];
 private _lowAir = Faction(_side) getOrDefault ["attributeLowAir", false];
 private _nearMarkers = [_target, _lowAir] call A3A_fnc_findLandSupportMarkers;
 
+// Just go simple here for the moment. Point is not to spawn at a site that's under attack
+private _rebelSpawners = units teamPlayer select { _x getVariable ["spawner", false] };
+
 private _freeBases = [];
 private _weights = [];
 {
     _x params ["_marker", "_navDist"];
     if (sidesX getVariable [_marker, sideUnknown] != _side) then {continue};
     if (dateToNumber date < server getVariable [_marker, 0]) then {continue};       // addTimeForIdle
-    if (spawner getVariable _marker != 2) then {continue};                           // spawn places dangerous if spawned
+    //if (spawner getVariable _marker == 0) then {continue};                           // spawn places should coexist now...
+    if ([_marker, "Vehicle"] call A3A_fnc_countFreeSpawnPositions == 0) then {continue};             // maybe request by required place count?
     if (count (garrison getVariable [_marker,[]]) < 16) then {continue};
- 
+    if (_rebelSpawners inAreaArray [markerPos _marker, 700, 700] isNotEqualTo []) then {continue};
+
     _freeBases pushBack _marker;
     _weights pushBack (1 / _navDist^2);
 } forEach _nearMarkers;

--- a/A3A/addons/core/functions/CREATE/fn_countFreeSpawnPositions.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_countFreeSpawnPositions.sqf
@@ -1,0 +1,16 @@
+/*  Count empty spawn positions on marker of a specific type
+
+Environment: Any. Has network timing risks which should be mitigated using addTimeForIdle
+
+Arguments:
+    <STRING> Marker name to search
+    <STRING> Type of spawn place to search, "vehicle", "mortar", "heli" or "plane"
+
+Return Value:
+    <NUMBER> Number of spawn positions of that type available to use
+*/
+
+params ["_marker", "_type"];
+private _varName = format ["%1_%2_used", _marker, tolower _type];
+private _used = spawner getVariable [_varName, []];
+{ !_x } count _used;

--- a/A3A/addons/core/functions/CREATE/fn_createAIResources.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIResources.sqf
@@ -19,6 +19,7 @@ _soldiers = [];
 private _dogs = [];
 _groups = [];
 _vehiclesX = [];
+private _spawnsUsed = [];
 
 _frontierX = [_markerX] call A3A_fnc_isFrontline;
 
@@ -163,6 +164,7 @@ if (not(_markerX in destroyedSites)) then
 private _spawnParameter = [_markerX, "Vehicle"] call A3A_fnc_findSpawnPosition;
 if (_spawnParameter isEqualType []) then
 {
+	_spawnsUsed pushBack _spawnParameter#2;
 	private _typeVehX = call {
 		if (FactionGet(civ,"vehiclesCivRepair") isEqualTo [] and random 1 < 0.1) exitWith { selectRandom (_faction get "vehiclesRepairTrucks") };
 		if (FactionGet(civ,"vehiclesCivFuel") isEqualTo [] and random 1 < 0.1) exitWith { selectRandom (_faction get "vehiclesFuelTrucks") };
@@ -171,8 +173,10 @@ if (_spawnParameter isEqualType []) then
 		if (count _types == 0) then { (_faction get "vehiclesCargoTrucks") } else { _types };
 		selectRandom _types;
 	};
-	_veh = createVehicle [_typeVehX, (_spawnParameter select 0), [], 0, "NONE"];
-	_veh setDir (_spawnParameter select 1);
+	isNil {
+		_veh = createVehicle [_typeVehX, (_spawnParameter select 0), [], 0, "NONE"];
+		_veh setDir (_spawnParameter select 1);
+	};
 	_vehiclesX pushBack _veh;
 	[_veh, _sideX] call A3A_fnc_AIVEHinit;
 	sleep 1;
@@ -219,7 +223,7 @@ for "_i" from 0 to (count _array - 1) do
 
 waitUntil {sleep 1; (spawner getVariable _markerX == 2)};
 
-[_markerX] call A3A_fnc_freeSpawnPositions;
+_spawnsUsed call A3A_fnc_freeSpawnPositions;
 
 deleteMarker _mrk;
 

--- a/A3A/addons/core/functions/CREATE/fn_createAttackForceLand.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAttackForceLand.sqf
@@ -44,7 +44,9 @@ for "_i" from 1 to _vehCount do {
     private _vehType = selectRandomWeighted ([_supportPool, _transportPool] select _isTransport);
 
     private _vehData = [_vehType, "Normal", _resPool, _landPosBlacklist, _side, _base, _targPos] call A3A_fnc_createAttackVehicle;
-    if !(_vehData isEqualType []) exitWith {};          // couldn't create for some reason, assume we're out of spawn places?
+    if !(_vehData isEqualType []) exitWith {
+        Error_1("Failed to spawn land vehicle at marker %1" _base);
+    };          // couldn't create for some reason, assume we're out of spawn places?
 
     _vehicles pushBack (_vehData#0);
     if (!isNull (_vehData#1)) then { _crewGroups pushBack (_vehData#1) };
@@ -61,11 +63,13 @@ for "_i" from 1 to _vehCount do {
     sleep 10;
 };
 
-
-// TODO: Sort out the spawn positions API or don't use it
-_base spawn {
+_vehicles spawn {
     sleep 60;
-    if (spawner getVariable _this == 2) then { [_this] call A3A_fnc_freeSpawnPositions };
+    // Free spawn places for any vehicles that still exist
+    private _vehicles = _this select { !isNull _x };
+    private _spawnPlaces = _vehicles apply { _x getVariable "spawnPlace" };
+    _spawnPlaces call A3A_fnc_freeSpawnPositions;
+    { _x setVariable ["spawnPlace", nil] } forEach _vehicles;
 };
 
 [_resourcesSpent, _vehicles, _crewGroups, _cargoGroups];

--- a/A3A/addons/core/functions/CREATE/fn_createAttackForceMixed.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAttackForceMixed.sqf
@@ -65,7 +65,7 @@ if (_landCount > 0) then
 
     while { !isNil "_landBase" } do
     {
-        [_landBase, 5] call A3A_fnc_addTimeForIdle;
+        [_landBase, 1] call A3A_fnc_addTimeForIdle;
         private _attackCount = round (_landCount * (0.25 + random 0.2));
         private _troops = ["Normal", "SpecOps"] select ("specops" in _modifiers and random 1 > 0.5);
         ServerDebug_3("Attempting to spawn %1 land vehicles including %2 attack from %3", _landCount, _attackCount, _landBase);

--- a/A3A/addons/core/functions/CREATE/fn_findSpawnPosition.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_findSpawnPosition.sqf
@@ -1,112 +1,40 @@
+/*  Find an empty spawn position on marker of a specific type
+
+Environment: Any. Has network timing risks which should be mitigated using addTimeForIdle
+
+Arguments:
+    <STRING> Marker name to search
+    <STRING> Type of spawn place to search, "vehicle", "mortar", "heli" or "plane"
+
+Return Value:
+    <ARRAY<
+        <POSAGL> Central position of spawn place
+        <NUMBER> Direction of spawn place 
+        <ARRAY> Data to pass to freeSpawnPositions to free this spawn place
+    >>
+    or false if no empty spawn positions of that type were found
+*/
+
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
-#define VEH               0
-#define HELI              1
-#define PLANE             2
-#define MORTAR            3
 
 params ["_marker", "_type"];
 
-_result = getMarkerPos _marker;
+// check marker lockout?
 
-//Debug_2("Searching spawn position on %1 for %2", _marker, _type);
-_spawns = spawner getVariable [format ["%1_spawns", _marker], -1];
-if(_spawns isEqualType -1) exitWith
-{
-  Error_1("%1 does not have any spawn positions set!", _marker);
-  -1;
-};
-//DebugArray("Spawnpoints", _spawns);
-
-_selection = -1;
-switch (_type) do
-{
-  case ("Group") :
-  {
-    //Not yet implemented
-  };
-  case ("Crew"):
-  {
-    //Not yet implemented
-  };
-  case ("Vehicle"):
-  {
-    _selection = VEH;
-  };
-  case ("Heli"):
-  {
-    _selection = HELI;
-  };
-  case ("Plane"):
-  {
-    _selection = PLANE;
-  };
-  case ("Mortar"):
-  {
-    _selection = MORTAR;
-  };
+private _varName = format ["%1_%2", _marker, tolower _type];
+private _varNameUsed = _varName + "_used";
+private _used = spawner getVariable [_varNameUsed, []];
+private _index = _used find false;
+if (_index == -1) exitWith {
+    Info_1("%1 has no remaining spawn positions of type %2", _marker, _type);
+    false;
 };
 
-if (_selection == -1) exitWith {};
+_used set [_index, true];
+spawner setVariable [_varNameUsed, _used, true];
+private _return = spawner getVariable (_varName + "_places") select _index;
+_return pushBack [_varNameUsed, _index];
 
-_possible = (_spawns select _selection) select {!(_x select 1)};
-
-if(count _possible > 0) then
-{
-  _result = selectRandom _possible;
-  _index = (_spawns select _selection) findIf {_x isEqualTo _result};
-  //Debug_2("Result is %1, Index is %2", _result, _index);
-  ((_spawns select _selection) select _index) set [1, true];
-
-  _result = _result select 0;
-
-}
-else
-{
-  _result = -1;
-};
-
-Debug_1("Result is %1", _result);
-_result;
-
-
-/*params ["_marker", "_vehicleType"];
-
-private ["_pos", "_spawnPos", "_spawnDir", "_result"];
-
-_pos = getMarkerPos _marker;
-
-_spawnPos = [];
-_spawnDir = 0;
-
-switch (true) do
-{
-  case (_vehicleType isKindOf "Plane"):
-  {
-    //Find a runway or a hangar
-  };
-  case (_vehicleType isKindOf "Helicopter"):
-  {
-    //Find a heli pad
-  };
-  case (_vehicleType isKindOf "StaticWeapon"):
-  {
-    //Find a position for in a bunker or a open space for a mortar
-  };
-  case (_vehicleType isKindOf "Man"):
-  {
-    //Find a building to spawn in
-  };
-  default
-  {
-    //Find a good place near a road or something
-
-    //Debug option to get it working
-    _spawnPos = _pos;
-  };
-};
-
-_result = [_spawnPos, _spawnDir];
-
-_result;
-*/
+Debug_2("Used place with varname %1 and index %2", _varName, _index);
+_return;

--- a/A3A/addons/core/functions/CREATE/fn_freeSpawnPositions.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_freeSpawnPositions.sqf
@@ -1,25 +1,29 @@
+/*  Free an array of spawn positions (data returned by findSpawnPosition)
+
+Environment: Any.
+
+Arguments:
+    <ARRAY<
+        <STRING> Var name for spawn places
+        <NUMBER> Index of spawn place
+    >>
+*/
+
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
-params ["_marker"];
 
-/* Unlocks all locked vehicle slots of a marker
-*****/
-
-_spawns = spawner getVariable [format ["%1_spawns", _marker], [[],[],[],[]]];
-if(_spawns isEqualTo [[],[],[],[]]) exitWith
 {
-    Error_1("Marker %1 has no spawn places defined!", _marker);
-};
-
-DebugArray("Spawn places for "+_marker, _spawns);
-
-for "_i" from 0 to 3 do
-{
-  _places = _spawns select _i;
-  {
-    if(_x select 1) then
-    {
-      _x set [1, false];
-    }
-  } forEach _places;
-};
+    if !(_x isEqualTypeArray ["", 0]) then {
+        Error_1("Invalid data provided: %1", _x);
+        continue;
+    };
+    _x params ["_varName", "_index"];
+    private _used = spawner getVariable [_varName, []];
+    if (count _used <= _index) then {
+        Error_3("Invalid index %3 provided for varname %1", _varName, _index);
+        continue;
+    };
+    _used set [_index, false];
+    spawner setVariable [_varName, _used, true];
+    Debug_2("Freed place with varname %1 and index %2", _varName, _index);
+} forEach _this;

--- a/A3A/addons/core/functions/CREATE/fn_milBuildings.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_milBuildings.sqf
@@ -15,6 +15,7 @@ _frontierX = _this select 3;
 
 _vehiclesX = [];
 _soldiers = [];
+private _spawnsUsed = [];
 
 _groupX = createGroup _sideX;
 _typeUnit = _faction get "unitStaticCrew";
@@ -22,16 +23,17 @@ _typeUnit = _faction get "unitStaticCrew";
 //New system to place helis, does not care about heli types currently
 private _helicopterTypes = [];
 _helicopterTypes append (_faction get "vehiclesHelisLight");
-private _spawnParameter = [_markerX, "Heli"] call A3A_fnc_findSpawnPosition;
 private _count = 1 + round (random 3); //Change these numbers as you want, first number is minimum, max is first plus second number
-while {_spawnParameter isEqualType [] && {_count > 0}} do
+while {_count > 0} do
 {
     if (_helicopterTypes isEqualTo []) exitWith {}; //no helis to pick from
     _typeVehX = selectRandom _helicopterTypes;
+    private _spawnParameter = [_markerX, "Heli"] call A3A_fnc_findSpawnPosition;
+    if !(_spawnParameter isEqualType []) exitWith {};       // out of spawn places
+    _spawnsUsed pushBack _spawnParameter#2;
     _veh = createVehicle [_typeVehX, (_spawnParameter select 0), [],0, "CAN_COLLIDE"];
     _veh setDir (_spawnParameter select 1);
     _vehiclesX pushBack _veh;
-    _spawnParameter = [_markerX, "Heli"] call A3A_fnc_findSpawnPosition;
     _count = _count - 1;
 };
 
@@ -251,4 +253,4 @@ for "_i" from 0 to (count _buildings) - 1 do
 
 
 
-[_groupX,_vehiclesX,_soldiers]
+[_groupX,_vehiclesX,_soldiers,_spawnsUsed]

--- a/A3A/addons/core/functions/CREATE/fn_patrolReinf.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_patrolReinf.sqf
@@ -37,6 +37,7 @@ private _crewGroup = [_side, _vehicle] call A3A_fnc_createVehicleCrew;
 { [_x, nil, false, "legacy"] call A3A_fnc_NATOinit } forEach (units _crewGroup);
 [_vehicle, _side, "legacy"] call A3A_fnc_AIVEHinit;				// don't pay up-front for reinf vehicles/crew, assumed to return
 
+
 private _expectedCargo = ([_vehicleType, true] call BIS_fnc_crewCount) - ([_vehicleType, false] call BIS_fnc_crewCount);
 if (_expectedCargo < count _groupType) then { _groupType resize _expectedCargo };           // trim to cargo seat count
 private _cargoGroup = [_posOrigin, _side, _groupType, true, false] call A3A_fnc_spawnGroup;         // force spawn, should be pre-checked
@@ -62,6 +63,14 @@ if (_isLand) then {
 
 	private _reinfWP = _cargoGroup addWaypoint [_posDest, 0];
 	_reinfWP setWaypointBehaviour "AWARE";
+
+	// Free the spawn position after 60 seconds
+	_vehicle spawn {
+		sleep 60;
+		if (isNull _this) exitWith {};
+		[_this getVariable "spawnPlace"] call A3A_fnc_freeSpawnPositions;
+		_this setVariable ["spawnPlace", nil];
+	};
 }
 else
 {

--- a/A3A/addons/core/functions/CREATE/fn_spawnVehicleAtMarker.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_spawnVehicleAtMarker.sqf
@@ -16,6 +16,7 @@ params
 
     Returns:
         OBJECT : The vehicle object, objNull if spawn wasnt possible
+        If it was a land vehicle, the spawnPlace variable on it is set to the spawn place used
 */
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
@@ -39,8 +40,11 @@ private _spawnParams = [_marker, "Vehicle"] call A3A_fnc_findSpawnPosition;
 if(_spawnParams isEqualType []) then
 {
     //Place found spawn in vehicle now
-    _vehicleObj = createVehicle [_vehicle, (_spawnParams select 0), [], 0, "CAN_COLLIDE"];
-    _vehicleObj setDir (_spawnParams select 1);
+    isNil {
+        _vehicleObj = createVehicle [_vehicle, (_spawnParams select 0), [], 0, "CAN_COLLIDE"];
+        _vehicleObj setDir (_spawnParams select 1);
+    };
+    _vehicleObj setVariable ["spawnPlace", _spawnParams select 2];
 };
 
 _vehicleObj;

--- a/A3A/addons/core/functions/EventHandler/fn_vehicleDeletedEH.sqf
+++ b/A3A/addons/core/functions/EventHandler/fn_vehicleDeletedEH.sqf
@@ -6,6 +6,9 @@ params ["_veh"];
 private _landingPad = _veh getVariable "LandingPad";
 if (!isNil "_landingPad") then { deleteVehicle _landingPad };
 
+private _spawnPlace = _veh getVariable "spawnPlace";
+if (!isNil "_spawnPlace") then { _spawnPlace call A3A_fnc_freeSpawnPositions };
+
 private _side = _veh getVariable ["ownerSide", teamPlayer];
 private _vehCost = A3A_vehicleResourceCosts getOrDefault [typeof _veh, 0];
 if (!alive _veh || (_side != Occupants && _side != Invaders) || _vehCost == 0) exitWith {};

--- a/A3A/addons/core/functions/Missions/fn_convoy.sqf
+++ b/A3A/addons/core/functions/Missions/fn_convoy.sqf
@@ -28,7 +28,7 @@ private _displayTime = [_startDate] call A3A_fnc_dateToTimeString;
 
 private _nameDest = [_mrkDest] call A3A_fnc_localizar;
 private _nameOrigin = [_mrkOrigin] call A3A_fnc_localizar;
-[_mrkOrigin, _startDelay + 5] call A3A_fnc_addTimeForIdle;
+[_mrkOrigin, _startDelay + 1] call A3A_fnc_addTimeForIdle;      // best not to try driving past this stuff
 
 
 // Determine convoy type from destination

--- a/A3A/addons/core/functions/Supports/fn_SUP_QRFAir.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_QRFAir.sqf
@@ -40,7 +40,7 @@ private _aggro = [aggressionOccupants, aggressionInvaders] select (_side == Inva
 if (_delay < 0) then { _delay = (0.5 + random 1) * (300 - 15*tierWar - 1*_aggro) };
 
 //Set idle times for marker, just so that stuff doesn't spawn on top? Carrier will ignore anyway
-[_airbase, 5+_delay/60] call A3A_fnc_addTimeForIdle;
+//[_airbase, 5+_delay/60] call A3A_fnc_addTimeForIdle;
 
 // kinda epic but whatever
 [[_suppName, _side, _resPool, _delay, _targPos, _airbase, true, _vehCount, _attackCount, _estResources], "A3A_fnc_SUP_QRFRoutine"] call A3A_fnc_scheduler;

--- a/A3A/addons/core/functions/Supports/fn_SUP_QRFLand.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_QRFLand.sqf
@@ -24,8 +24,8 @@ params ["_suppName", "_side", "_resPool", "_maxSpend", "_target", "_targPos", "_
 private _base = [_side, _targPos] call A3A_fnc_availableBasesLand;
 if (isNil "_base") exitWith { Info("QRF cancelled because no land bases available"); -1 };
 
-//Set idle times for marker, just so that stuff doesn't spawn on top
-[_base, 10] call A3A_fnc_addTimeForIdle;
+// Prevent ground QRFs spawning on top of each other. Should be gone after a minute.
+[_base, 1] call A3A_fnc_addTimeForIdle;
 
 private _vehCount = 3 min ceil (_maxSpend / A3A_balanceVehicleCost);
 private _attackCount = [0, 0, round random 1, 1] select _vehCount;

--- a/A3A/addons/core/functions/Supports/fn_SUP_mortar.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_mortar.sqf
@@ -46,12 +46,12 @@ private _spawnDir = 0;
     private _spawnParams = [_x, "Mortar"] call A3A_fnc_findSpawnPosition;
     if (_spawnParams isEqualType []) exitWith
     {
-        //Will occupy a mortar spawn position until the outpost spawnes in and despawns again (Currently we dont spawn mortars at outposts anyways)
+        // Spawn position cleared by vehicleDeleted EH
         _spawnRadius = 0;
         _spawnPos = _spawnParams select 0;
         _spawnDir = _spawnParams select 1;
+        _vehicle setVariable ["spawnPlace", _spawnParams#2];
     };
-    [_x] spawn A3A_fnc_freeSpawnPositions;
 } forEach _possibleBases;
 
 if (_spawnPos isEqualTo []) then 

--- a/A3A/addons/core/functions/init/fn_prepareMarkerArrays.sqf
+++ b/A3A/addons/core/functions/init/fn_prepareMarkerArrays.sqf
@@ -108,7 +108,7 @@ fnc_sortPlacementMarker =
 
 // Autogenerate stuff like helipad placements for markers that don't have any defined spawn places
 {
-    private _spawnStr = format ["%1_spawns", _x];
+    private _spawnStr = format ["%1_vehicle_used", _x];
     if (isNil { spawner getVariable _spawnStr }) then {
         Debug_1("Generating additional spawn places for %1", _x);
         [_x, []] call A3A_fnc_initSpawnPlaces;


### PR DESCRIPTION

### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Previously ground QRFs could not spawn at any spawned marker. This was a rather severe and exploitable restriction, as once a marker spawns in, it remains spawned as long as any spawning unit is within 1.3km (assuming 1km spawn distance). On some map regions this made land QRFs excessively rare, causing the AI to use more air QRFs and artillery instead.

I rewrote the spawn places system in the process, as the old one required publishing the entire spawn places array for a marker every time a spawn place was allocated or freed. The new one splits the place data and used-place flags and stores a separate array per place type. This doesn't use many extra variables because most locations only have vehicle places anyway. addTimeForIdle is now almost strictly used for limiting consecutive ground vehicle spawning, so that networked variable fighting is highly unlikely.

Additional related fixes:
- Fix some vehicles not spawning correctly on spawn places.
- Fix spawn-placed vehicles destroying each other due to scheduler break.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

General testing should do.

### How can the changes be tested?
Ping around the map with Zeus to spawn markers in and out.

Call land QRFs like this:
`["QRFLAND", Invaders, "defence", 500, player, getPosATL player, 1, 0] call A3A_fnc_createSupport;`

Ground parts of attacks use the same vehicle placement code as land QRFs so shouldn't need separate testing.
