### PR TITLE
Add ACE Hearing reset to Vehicle Box

### DIFF
--- a/A3A/addons/core/functions/Base/fn_vehicleBoxRestore.sqf
+++ b/A3A/addons/core/functions/Base/fn_vehicleBoxRestore.sqf
@@ -47,6 +47,9 @@ private _rebelPlayers = allUnits select {side _x in [teamPlayer, civilian] && {_
     if (A3A_hasACEMedical) then {
         [_x, _x] call ace_medical_treatment_fnc_fullHeal;
     };
+    if (A3A_hasACEHearing) then {
+        [{ace_hearing_deafnessDV = 0;}] remoteExec ["call", _x];
+    };
     _x setDamage 0;
     _x setVariable ["incapacitated",false,true];
     _x setVariable ["compromised", 0, true];


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Added the ability for the Vehicle Box to restore hearing while running ACE with the Hearing module enabled.
    

### Please specify which Issue this PR Resolves.
closes #2688 and removes the need for #2313 (abandoned)

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Run the changes on a server with more than one player and see if it works for multiple players