### PR TITLE
Fix bunkers being counted as static weapons for rebel AI manning

### DIFF
--- a/A3A/addons/core/functions/Base/fn_updateRebelStatics.sqf
+++ b/A3A/addons/core/functions/Base/fn_updateRebelStatics.sqf
@@ -30,7 +30,7 @@ if (_marker isEqualTo "") exitWith {};
 
 // Find all non-mortar statics within marker
 private _statics = staticsToSave inAreaArray _marker;
-_statics = _statics select { !(_x isKindOf "StaticMortar") };           // don't bother with mortars yet
+_statics = _statics select { _x isKindOf "StaticWeapon" and !(_x isKindOf "StaticMortar") };           // may include bunkers. Don't bother with mortars yet
 if (count _statics == 0) exitWith {};
 
 // Find unlocked & unoccupied statics


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The function that automatically moves rebel garrison riflemen into static weapons (updateRebelStatics) made the false assumption that staticsToSave only contains static weapons. As small and large bunkers are both added to staticsToSave, riflemen would be incorrectly allocated to them and act oddly.

This PR filters staticsToSave down to actual static weapons before selecting them for crewing.

### Please specify which Issue this PR Resolves.
closes #2642

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Build a sandbag bunker, buy a static, add a rifleman to the garrison. 