### PR TITLE
Workaround Arma bug with moveInAny

### DIFF
--- a/A3A/addons/core/functions/REINF/fn_spawnHCGroup.sqf
+++ b/A3A/addons/core/functions/REINF/fn_spawnHCGroup.sqf
@@ -56,6 +56,8 @@ private _bypassAI = true;
 private _initInfVeh = {
     if (isNull _vehicle) exitWith {};
     leader _group moveInDriver _vehicle;
+    // Required because moveInAny is bugged for gunners (eg. GM trucks) and breaks the driving AI
+    if (fullCrew [_vehicle, "gunner", true] isNotEqualTo []) then { (units _group # 1) moveInGunner _vehicle };
     call _initVeh;
     ["Recruit Squad", "Vehicle Purchased"] call A3A_fnc_customHint;
     petros directSay "SentGenBaseUnlockVehicle";


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
spawnHCGroup used moveInAny to board every unit except the driver for rebel infantry trucks. Unfortunately this is bugged, and moveInAny somehow breaks driving AI when used to move an AI into a gunner seat, such that they'll refuse to drive anywhere, or occasionally act like they have a brick wall in front. setEffectiveCommander to the driver will allow them to drive again, but setting it back to gunner (which is default) will block them again. You can do moveInDriver + moveInGunner and it's fine, while moveInDriver + moveInAny will break. Tested with Hunter HMG, Marshall and a couple of GM armed trucks.

Currently this is only an identified problem with GM rebel trucks, so that's what I've fixed. Other usage of moveInAny should be checked, however.

### Please specify which Issue this PR Resolves.
closes #2647

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Need to check other uses of moveInAny.
