### PR TITLE
Fix inmuneConvoy running its bridge hack after reaching its objective

### DIFF
--- a/A3A/addons/core/functions/AI/fn_inmuneConvoy.sqf
+++ b/A3A/addons/core/functions/AI/fn_inmuneConvoy.sqf
@@ -28,12 +28,12 @@ while {alive _veh} do
 			_veh setVariable ["revealed",false,true];
 			};
 		};
-	_pos = getPos _veh;
+	_pos = getPosATL _veh;
 	sleep 60;
-	_newPos = getPos _veh;
+	_newPos = getPosATL _veh;
 
 	_driverX = driver _veh;
-	if (_stuckHacks and (_newPos distance _pos < 5) and (_text != "Supply Box") and !(isNull _driverX)) then
+	if (_stuckHacks and {(_newPos distance _pos < 5) and (_text != "Supply Box") and !(isNull _driverX)}) then
 		{
 		if (_veh isKindOf "Air") then
 			{
@@ -50,6 +50,10 @@ while {alive _veh} do
 			{
 			if (not(_veh isKindOf "Ship")) then
 				{
+				if (currentWaypoint (group _driverX) >= count waypoints (group _driverX)) exitWith {
+					// Stop running this shit once we reached the destination
+					_stuckHacks = false;
+				};
 				if ({_x distance _newPos < 500} count (allPlayers - (entities "HeadlessClient_F")) == 0) then
 					{
 					_bridges = nearestObjects [_newPos, ["Land_Bridge_01_PathLod_F","Land_Bridge_Asphalt_PathLod_F","Land_Bridge_Concrete_PathLod_F","Land_Bridge_HighWay_PathLod_F","Land_BridgeSea_01_pillar_F","Land_BridgeWooden_01_pillar_F"], 50];


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The ancient inmuneConvoy function has an anti-bridge hack that continues running after the vehicle reaches its final waypoint. If it stops near a bridge and not within 500m of players, this causes it to throw a divide-by-zero error because it's trying to teleport to the next waypoint position. Rare but degenerate. Definitely don't want this running after the vehicle runs out of waypoints anyway.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Still waiting for the test convoy.
