### PR TITLE
Fix garage static weapon vehicle swap exploit

### DIFF
--- a/A3A/addons/garage/Extras/fn_reloadMounts.sqf
+++ b/A3A/addons/garage/Extras/fn_reloadMounts.sqf
@@ -31,7 +31,7 @@ private _cat = HR_GRG_vehicles#4;
 } forEach attachedObjects HR_GRG_previewVeh;
 
 //remove unticked statics
-private _toRemove = [];
+/*private _toRemove = [];
 for "_i" from 0 to (lbSize _ctrl) -1 do {
     private _class = _ctrl lbData _i;
     private _UID = _ctrl lbValue _i;
@@ -39,6 +39,8 @@ for "_i" from 0 to (lbSize _ctrl) -1 do {
     if ( (checkboxTextures find (_ctrl lbPicture _i)) isEqualTo 0 ) then {_toRemove pushBack [_class, _UID]}; // if not checked
 };
 HR_GRG_Mounts = HR_GRG_Mounts - _toRemove;
+*/
+HR_GRG_Mounts = [];
 
 //add new statics to the list
 for "_i" from 0 to (lbSize _ctrl) -1 do {

--- a/A3A/addons/garage/Extras/fn_reloadMounts.sqf
+++ b/A3A/addons/garage/Extras/fn_reloadMounts.sqf
@@ -30,28 +30,21 @@ private _cat = HR_GRG_vehicles#4;
     deleteVehicle _x;
 } forEach attachedObjects HR_GRG_previewVeh;
 
-//remove unticked statics
-/*private _toRemove = [];
-for "_i" from 0 to (lbSize _ctrl) -1 do {
-    private _class = _ctrl lbData _i;
-    private _UID = _ctrl lbValue _i;
-    Trace_4("Checking mount list | Index: %1 | Class: %2 | UID: %3 | Not checked: %4", _i, _class, _UID, (checkboxTextures find (_ctrl lbPicture _i)) isEqualTo 0 );
-    if ( (checkboxTextures find (_ctrl lbPicture _i)) isEqualTo 0 ) then {_toRemove pushBack [_class, _UID]}; // if not checked
-};
-HR_GRG_Mounts = HR_GRG_Mounts - _toRemove;
-*/
-HR_GRG_Mounts = [];
-
-//add new statics to the list
+//read ticked statics from UI
+private _newMounts = [];
 for "_i" from 0 to (lbSize _ctrl) -1 do {
     private _UID = _ctrl lbValue _i;
-    if (HR_GRG_Mounts findIf {_UID isEqualTo (_x#1)} isEqualTo -1) then { //not in list
-        if ( (checkboxTextures find (_ctrl lbPicture _i)) isEqualTo 1 ) then { //and checked
-            HR_GRG_Mounts pushBackUnique [_ctrl lbData _i, _UID];
-        };
+    if ( (checkboxTextures find (_ctrl lbPicture _i)) isEqualTo 1 ) then { //and checked
+        _newMounts pushBack [_ctrl lbData _i, _UID];
     };
 };
+
+// Preserve previous array order if elements exist in both
+HR_GRG_Mounts = HR_GRG_Mounts select { _x in _newMounts };
+HR_GRG_Mounts append (_newMounts - HR_GRG_Mounts);
+
 Trace_1("reloadMounts - Remaining mounts | %1", HR_GRG_Mounts);
+
 
 //add new statics
 private _lockedSeats = 0;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
As described in #2620, there's an exploit where if you use the garage to mount a static weapon in a vehicle and then swap the vehicle to one that cannot load it, placing the vehicle will then spawn a free copy of the weapon.

As far as I can tell, reloadMounts is just overcomplex: On a refresh operation, it starts with the old list of statics, removes those that are unticked (but not those that are no longer in the UI list, hence the bug), and then adds those that are newly ticked. However, as there's no attempt to preserve the objects themselves, this is all unnecessary and the list can simply be rebuilt from the ticked boxes.

I left the original code intact in case I missed something, although I don't think I did. Everything seems to work correctly now.

### Please specify which Issue this PR Resolves.
closes #2620

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Someone else should sanity-check this in case I'm missing some garage functionality.
