### PR TITLE
Fix Unsung radio detection

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_hasARadio.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_hasARadio.sqf
@@ -20,5 +20,5 @@ Example: _unit call A3A_fnc_hasRadio;
 
 License: MIT License
 */
-assignedItems _this findIf { _x == "ItemRadio" || {"tf_" in _x} || {"TFAR_" in _x} || {"item_radio" in _x} } > -1
+assignedItems _this findIf { _x == "ItemRadio" || {"tf_" in _x} || {"TFAR" in _x} || {"item_radio" in _x} } > -1
 || { backpack _this in allBackpacksRadio }


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Unsung handheld radios weren't being detected by hasARadio because the Unsung radios are named xxx_TFAR which fails the check.

Did a dumb fix for it, because getSlotItemName is apparently being added in Arma 2.14 and we can improve the function then.

### Please specify which Issue this PR Resolves.
closes #2655

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
