### PR TITLE
Fix ASF loiter altitude

### DIFF
--- a/A3A/addons/core/functions/Supports/fn_SUP_ASFRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_ASFRoutine.sqf
@@ -47,6 +47,7 @@ private _loiterWP = _group addWaypoint [_suppCenter, 0];
 _loiterWP setWaypointSpeed "NORMAL";
 _loiterWP setWaypointType "Loiter";
 _loiterWP setWaypointLoiterRadius 2000;
+_loiterWP setWaypointLoiterAltitude 700;
 _group setCurrentWaypoint _loiterWP;
 Debug_2("%1 underway from %2", _supportName, _airport);
 
@@ -81,7 +82,6 @@ while {true} do
         };
         Debug_2("Next target for %2 is %1", _suppTarget, _supportName);
         _timeout = _timeout + 300;              // make sure it has some time to kill
-        _remTargets = _remTargets - 1;
 
         private _attackWP = _group addWaypoint [_targetObj, 0];
         _attackWP setWaypointType "DESTROY";
@@ -102,7 +102,7 @@ while {true} do
         // TODO: better evasion mechanics?
         if (!alive _targetObj or {_targetObj distance2D _suppCenter > _suppRadius and _targetObj distance2D _plane > 3000}) then
         {
-            _remTargets = _remTargets + 1;
+            _remTargets = _remTargets - 1;
             _suppTarget resize 0;           // clear target array so support routines can add the next
 
             if !(alive _targetObj) then {


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The ASF (CAP) supports didn't set the altitude for the loiter waypoint, and the default behaviour is... very weird. L-39s fly around at 100m. F-22s will go into orbit, and then spin down to their deaths once given an attack order.

This PR sets the loiter altitude to 700m. Also fixes an old bug with the maximum targets count which probably never triggers anyway.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
