### PR TITLE
Fix incorrect addTimeForIdle

### DIFF
--- a/A3A/addons/core/functions/Base/fn_distance.sqf
+++ b/A3A/addons/core/functions/Base/fn_distance.sqf
@@ -119,6 +119,9 @@ private _processOccupantMarker = {
                     [[_marker], "A3A_fnc_createAIcontrols"] call A3A_fnc_scheduler;
                 };
 
+                // Prevent other routines taking spawn places 
+                [_marker, 1] call A3A_fnc_addTimeForIdle;
+
                 case (_marker in airportsX):
                 {
                     [[_marker], "A3A_fnc_createAIAirplane"] call A3A_fnc_scheduler;
@@ -303,9 +306,6 @@ private _processInvaderMarker = {
             // ENABLE this marker
             spawner setVariable [_marker, ENABLED, true];
 
-            // Prevent other routines taking spawn places 
-            [_marker, 1] call A3A_fnc_addTimeForIdle;
-
             switch (true)
             do
             {
@@ -318,6 +318,9 @@ private _processInvaderMarker = {
                 {
                     [[_marker], "A3A_fnc_createAIcontrols"] call A3A_fnc_scheduler;
                 };
+
+                // Prevent other routines taking spawn places 
+                [_marker, 1] call A3A_fnc_addTimeForIdle;
 
                 case (_marker in airportsX):
                 {


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Had an addTimeForIdle in the wrong place. Trouble is that the function breaks if called on cities, because they store different information in the same location. Didn't trigger until invaders owned a city, because I also missed the call for occupants.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)
