### PR TITLE
🚚(cont.)Bank/Convoy truck convertation to template variable

### DIFF
--- a/A3A/addons/core/Templates/Templates/#Examples/RebelExample.sqf
+++ b/A3A/addons/core/Templates/Templates/#Examples/RebelExample.sqf
@@ -25,7 +25,7 @@
 ["vehiclesCivHeli", []] call _fnc_saveToTemplate;
 ["vehiclesCivBoat", []] call _fnc_saveToTemplate;
 ["vehiclesCivPlane", []] call _fnc_saveToTemplate;
-
+["vehiclesCivSupply", []] call _fnc_saveToTemplate;
 
 ["staticMGs", []] call _fnc_saveToTemplate;
 ["staticAT", []] call _fnc_saveToTemplate;
@@ -113,7 +113,7 @@ private _squadLeaderTemplate = {
 private _riflemanTemplate = {
     ["uniforms"] call _fnc_setUniform;
     ["facewear"] call _fnc_setFacewear;
-    
+
     ["maps"] call _fnc_addMap;
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;

--- a/A3A/addons/core/Templates/Templates/FactionDefaults/RebelDefaults.sqf
+++ b/A3A/addons/core/Templates/Templates/FactionDefaults/RebelDefaults.sqf
@@ -15,6 +15,8 @@
 ["vehiclesPlane", []] call _fnc_saveToTemplate;
 ["vehiclesMedical", []] call _fnc_saveToTemplate;
 
+["vehiclesCivSupply", ["C_Van_01_box_F"]] call _fnc_saveToTemplate;
+
 ["vehicleLightSource", "Land_LampShabby_F"] call _fnc_saveToTemplate;
 ["vehicleFuelDrum", ["FlexibleTank_01_forest_F", 150]] call _fnc_saveToTemplate;
 ["vehicleFuelTank", ["B_Slingload_01_Fuel_F", 1000]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/functions/Convoy/fn_createAIAction.sqf
+++ b/A3A/addons/core/functions/Convoy/fn_createAIAction.sqf
@@ -467,14 +467,14 @@ if(_type == "convoy") then
       		_text = format ["A truck plenty of money is being moved from %1 to %3, and it's about to depart at %2. Steal that truck and bring it to HQ. Those funds will be very welcome.",_nameOrigin,_displayTime,_nameDest];
       		_taskTitle = "Money Convoy";
       		_taskIcon = "move";
-      		_typeVehObj = "C_Van_01_box_F"; //ToDo: replace with templated vehicles, no hard coded classes
+      		_typeVehObj = selectRandom (FactionGet(reb, "vehiclesCivSupply"));
       	};
       	case "Supplies":
       	{
       		_text = format ["A truck with medical supplies destination %3 it's about to depart at %2 from %1. Steal that truck bring it to %3 and let people in there know it is %4 who's giving those supplies.",_nameOrigin,_displayTime,_nameDest,FactionGet(reb,"name")];
       		_taskTitle = "Supply Convoy";
       		_taskIcon = "heal";
-      		_typeVehObj = "C_Van_01_box_F"; //ToDo: replace with templated vehicles, no hard coded classes
+      		_typeVehObj = selectRandom (FactionGet(reb, "vehiclesCivSupply"));
       	};
         default
         {

--- a/A3A/addons/core/functions/Missions/fn_LOG_Bank.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Bank.sqf
@@ -31,9 +31,11 @@ _mrkFinal setMarkerShape "ICON";
 //_mrkFinal setMarkerColor "ColorBlue";
 //_mrkFinal setMarkerText "Bank";
 
-_pos = (getMarkerPos respawnTeamPlayer) findEmptyPosition [1,50,"C_Van_01_box_F"];
+private _bankVehicleClass = selectRandom (FactionGet(reb, "vehiclesCivSupply"));
 
-_truckX = "C_Van_01_box_F" createVehicle _pos;
+_pos = (getMarkerPos respawnTeamPlayer) findEmptyPosition [1,50,_bankVehicleClass];
+
+_truckX = _bankVehicleClass createVehicle _pos;
 {_x reveal _truckX} forEach (allPlayers - (entities "HeadlessClient_F"));
 [_truckX, teamPlayer] call A3A_fnc_AIVEHinit;
 _truckX setVariable ["destinationX",_nameDest,true];

--- a/A3A/addons/core/functions/Missions/fn_LOG_Supplies.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Supplies.sqf
@@ -28,7 +28,7 @@ private _taskId = "SUPP" + str A3A_taskCount;
 [_taskId, "SUPP", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
 //Creating the box
-_pos = (getMarkerPos respawnTeamPlayer) findEmptyPosition [1,50,"C_Van_01_box_F"];
+_pos = (getMarkerPos respawnTeamPlayer) findEmptyPosition [1,50,"C_Van_01_box_F"]; //special case for bigger object search to make sure that it has enough free space around it
 _truckX = "Land_FoodSacks_01_cargo_brown_F" createVehicle _pos;
 _truckX enableRopeAttach true;
 _truckX allowDamage false;

--- a/A3A/addons/core/functions/Missions/fn_convoy.sqf
+++ b/A3A/addons/core/functions/Missions/fn_convoy.sqf
@@ -96,14 +96,14 @@ switch (tolower _convoyType) do
         _textX = format ["A truck with plenty of money is being moved from %1 to %3, and it's about to depart at %2. Steal that truck and bring it to HQ. Those funds will be very welcome.",_nameOrigin,_displayTime,_nameDest];
         _taskTitle = "Money Convoy";
         _taskIcon = "move";
-        _typeVehObj = "C_Van_01_box_F"; //ToDo: make this templated, no hard coded classnames
+        _typeVehObj = selectRandom (FactionGet(reb, "vehiclesCivSupply"));
     };
     case "supplies":
     {
         _textX = format ["A truck with medical supplies destination %3 it's about to depart at %2 from %1. Steal that truck bring it to %3 and let people in there know it is %4 who's giving those supplies.",_nameOrigin,_displayTime,_nameDest,FactionGet(reb,"name")];
         _taskTitle = "Supply Convoy";
         _taskIcon = "heal";
-        _typeVehObj = "C_Van_01_box_F"; //ToDo: make this templated, no hard coded classnames
+        _typeVehObj = selectRandom (FactionGet(reb, "vehiclesCivSupply"));
     };
 };
 

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -142,7 +142,7 @@ _arrayEst = [];
 	_veh = _x;
 	_typeVehX = typeOf _veh;
 	if ((_veh distance getMarkerPos respawnTeamPlayer < 50) and !(_veh in staticsToSave) and !(_typeVehX in ["ACE_SandbagObject","Land_FoodSacks_01_cargo_brown_F","Land_Pallet_F"])) then {
-		if (((not (_veh isKindOf "StaticWeapon")) and (not (_veh isKindOf "ReammoBox")) and (not (_veh isKindOf "ReammoBox_F")) and (not(_veh isKindOf "Building"))) and (not (_typeVehX == "C_Van_01_box_F")) and (count attachedObjects _veh == 0) and (alive _veh) and ({(alive _x) and (!isPlayer _x)} count crew _veh == 0) and (not(_typeVehX == "WeaponHolderSimulated"))) then {
+		if (((not (_veh isKindOf "StaticWeapon")) and (not (_veh isKindOf "ReammoBox")) and (not (_veh isKindOf "ReammoBox_F")) and (not(_veh isKindOf "Building"))) and (not (_typeVehX in (A3A_faction_reb get "vehiclesCivSupply"))) and (count attachedObjects _veh == 0) and (alive _veh) and ({(alive _x) and (!isPlayer _x)} count crew _veh == 0) and (not(_typeVehX == "WeaponHolderSimulated"))) then {
 			_posVeh = getPosWorld _veh;
 			_xVectorUp = vectorUp _veh;
 			_xVectorDir = vectorDir _veh;

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -142,7 +142,7 @@ _arrayEst = [];
 	_veh = _x;
 	_typeVehX = typeOf _veh;
 	if ((_veh distance getMarkerPos respawnTeamPlayer < 50) and !(_veh in staticsToSave) and !(_typeVehX in ["ACE_SandbagObject","Land_FoodSacks_01_cargo_brown_F","Land_Pallet_F"])) then {
-		if (((not (_veh isKindOf "StaticWeapon")) and (not (_veh isKindOf "ReammoBox")) and (not (_veh isKindOf "ReammoBox_F")) and (not(_veh isKindOf "Building"))) and (not (_typeVehX in (A3A_faction_reb get "vehiclesCivSupply"))) and (count attachedObjects _veh == 0) and (alive _veh) and ({(alive _x) and (!isPlayer _x)} count crew _veh == 0) and (not(_typeVehX == "WeaponHolderSimulated"))) then {
+		if (((not (_veh isKindOf "StaticWeapon")) and (not (_veh isKindOf "ReammoBox")) and (not (_veh isKindOf "ReammoBox_F")) and (not(_veh isKindOf "Building"))) and (count attachedObjects _veh == 0) and (alive _veh) and ({(alive _x) and (!isPlayer _x)} count crew _veh == 0) and (not(_typeVehX == "WeaponHolderSimulated"))) then {
 			_posVeh = getPosWorld _veh;
 			_xVectorUp = vectorUp _veh;
 			_xVectorDir = vectorDir _veh;

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -390,9 +390,9 @@ for "_i" from 0 to (count _civVehiclesWeighted - 2) step 2 do {
 	_civVehicles pushBack (_civVehiclesWeighted select _i);
 };
 
-_civVehicles append FactionGet(reb,"vehiclesCivCar"); 
-_civVehicles append FactionGet(reb,"vehiclesCivTruck");			// Civ car/truck from rebel template, in case they're different
-_civVehicles pushBackUnique "C_Van_01_box_F";		// Box van from bank mission. TODO: Define in rebel template
+_civVehicles append FactionGet(reb,"vehiclesCivCar");
+_civVehicles append FactionGet(reb,"vehiclesCivTruck");
+_civVehicles append FactionGet(reb,"vehiclesCivSupply");  // Box van from bank mission. TODO: Define in rebel template
 
 DECLARE_SERVER_VAR(arrayCivVeh, _civVehicles);
 DECLARE_SERVER_VAR(civVehiclesWeighted, _civVehiclesWeighted);
@@ -490,7 +490,7 @@ private _groundVehicleThreat = createHashMap;
 // Rebel vehicle cost
 private _rebelVehicleCosts = createHashMap;
 
-_fnc_setPriceIfValid = 
+_fnc_setPriceIfValid =
 {
 	_this params ["_hashMap", "_className", "_price"];
 	private _configClass = configFile >> "CfgVehicles" >> _className;
@@ -498,7 +498,7 @@ _fnc_setPriceIfValid =
 		_hashMap set [_className, _price];
 	};
 };
- 
+
 { [_rebelVehicleCosts, _x, 50] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesBasic");
 { [_rebelVehicleCosts, _x, 200] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesCivCar") + FactionGet(reb, "vehiclesCivBoat");
 { [_rebelVehicleCosts, _x, 600] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesCivTruck") + FactionGet(reb, "vehiclesMedical");
@@ -510,8 +510,8 @@ _fnc_setPriceIfValid =
 { [_rebelVehicleCosts, _x, 1200] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesAA");
 { [_rebelVehicleCosts, _x, 5000] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesCivHeli");
 { [_rebelVehicleCosts, _x, 5000] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesPlane") + FactionGet(reb, "vehiclesCivPlane");
- 
- 
+
+
 // Template overrides
 private _overrides = FactionGet(Reb, "attributesVehicles") + FactionGet(Occ, "attributesVehicles") + FactionGet(Inv, "attributesVehicles");
 {
@@ -527,7 +527,7 @@ private _overrides = FactionGet(Reb, "attributesVehicles") + FactionGet(Occ, "at
 		};
 	} forEach _x;
 } forEach _overrides;
- 
+
 DECLARE_SERVER_VAR(A3A_vehicleResourceCosts, _vehicleResourceCosts);
 DECLARE_SERVER_VAR(A3A_groundVehicleThreat, _groundVehicleThreat);
 DECLARE_SERVER_VAR(A3A_rebelVehicleCosts, _rebelVehicleCosts);


### PR DESCRIPTION
Original PR By: @igorkis-scrts; `Igorkis-scrts-feature/box-vehicle-template-var`
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information:
Direct usage of `C_Van_01_box_F` classname has been replaced with template variable which will allow to redefine Bank/Convoy missions vehicle for specific modsets.

### Please specify which Issue this PR Resolves.
continues #2562

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
- Spawn the supply mission.
- Confirm that the supply vehicle is created.
- Confirm that the supply vehicle is not persisted after a save/load (As per [(not (_typeVehX in (A3A_faction_reb get "vehiclesCivSupply")))](https://github.com/official-antistasi-community/A3-Antistasi/blob/63537e45ac03f0f4f70b2fbd1fe622916ef87bf7/A3A/addons/core/functions/Save/fn_saveLoop.sqf#L145))

********************************************************
Notes:
@igorkis-scrts, @killerswin2 Because the original branch is now in a read-only repo, this branch will PR directy to Antistasi unstable. 

tl;dr: single vehicleCivSupply -> array vehiclesCivSupply. Merge branch 'feature/box-vehicle-template-var' of https://github.com/igorkis-scrts/A3-Antistasi-Plus into igorkis-scrts-feature/box-vehicle-template-var