### PR TITLE
Rework Petros death handling

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -155,6 +155,7 @@ class CfgFunctions
             class onPlayerDisconnect {};
             class outpostDialog {};
             class patrolDestinations {};
+            class petrosDeathMonitor {};
             class placementSelection {};
             class playableUnits {};
             class getSideRadioTowerInfluence {};

--- a/A3A/addons/core/functions/Base/fn_createPetros.sqf
+++ b/A3A/addons/core/functions/Base/fn_createPetros.sqf
@@ -1,26 +1,23 @@
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
-params [["_location", []]];
+params ["_location"];
 
-private _oldPetros = if (isNil "petros") then {objNull} else {petros};
-private _groupPetros = if (!isNull _oldPetros && {side group _oldPetros == teamPlayer}) then {group _oldPetros} else {createGroup teamPlayer};
+private _groupPetros = if (isNull petros or {side group petros != teamPlayer}) then {createGroup teamPlayer} else {group petros};
 
-// Hack-fix for bugged case where petros is killed by enemy while being moved
-if (count _location > 0 && count units _groupPetros > 1) then { _groupPetros = createGroup teamPlayer };
+// Don't re-use group if petros was killed by enemy while being moved
+if (!isNil "_location" && count units _groupPetros > 1) then { _groupPetros = createGroup teamPlayer };
 
-private _position = if (count _location > 0) then {
-	_location
-} else {
-	if (getPos _oldPetros isEqualTo [0,0,0]) then {
-		getMarkerPos respawnTeamPlayer
+if (isNil "_location") then {
+	if (count units _groupPetros > 1) then {
+		_location = getPosATL petros
 	} else {
-		getPos _oldPetros
+		_location = getMarkerPos respawnTeamPlayer
 	};
 };
 
-petros = [_groupPetros, FactionGet(reb,"unitPetros"), _position, [], 10, "NONE"] call A3A_fnc_createUnit;
+private _oldPetros = petros;
+petros = [_groupPetros, FactionGet(reb,"unitPetros"), _location, [], 10, "NONE"] call A3A_fnc_createUnit;
 publicVariable "petros";
-
 deleteVehicle _oldPetros;		// Petros should now be leader unless there's a player in the group
 
 call A3A_fnc_initPetros;

--- a/A3A/addons/core/functions/Base/fn_initPetros.sqf
+++ b/A3A/addons/core/functions/Base/fn_initPetros.sqf
@@ -76,38 +76,21 @@ petros addEventHandler
 petros addMPEventHandler ["mpkilled",
 {
     removeAllActions petros;
-    _killer = _this select 1;
-    if (isServer) then
-	{
-        if ((side _killer == Invaders) or (side _killer == Occupants) and !(isPlayer _killer) and !(isNull _killer)) then
-		{
-			_nul = [] spawn {
-				garrison setVariable ["Synd_HQ",[],true];
-				_hrT = server getVariable "hr";
-				_resourcesFIAT = server getVariable "resourcesFIA";
-				[-1*(round(_hrT*0.9)),-1*(round(_resourcesFIAT*0.9))] remoteExec ["A3A_fnc_resourcesFIA",2];
-				waitUntil {count allPlayers > 0};
-				if (!isNull theBoss) then {
-					[] remoteExec ["A3A_fnc_placementSelection",theBoss];
-				} else {
-					private _playersWithRank =
-						(call A3A_fnc_playableUnits)
-						select {(side (group _x) == teamPlayer) && isPlayer _x && _x == _x getVariable ["owner", _x]}
-						apply {[([_x] call A3A_fnc_numericRank) select 0, _x]};
-					_playersWithRank sort false;
+    if (!isServer) exitWith {};
 
-					 [] remoteExec ["A3A_fnc_placementSelection", _playersWithRank select 0 select 1];
-				};
-			};
-			{
-				if (side _x == Occupants) then {_x setPos (getMarkerPos respawnOccupants)};
-			} forEach (call A3A_fnc_playableUnits);
-		}
-        else
-		{
-            [] call A3A_fnc_createPetros;
-		};
-	};
+    _killer = _this select 1;
+    if ((side _killer == Invaders) or (side _killer == Occupants) and !(isPlayer _killer) and !(isNull _killer)) then
+    {
+        garrison setVariable ["Synd_HQ", [], true];
+        _hr = server getVariable "hr";
+        _res = server getVariable "resourcesFIA";
+        [-1*(round(_hr*0.9)), -1*(round(_res*0.9))] spawn A3A_fnc_resourcesFIA;
+        [] spawn A3A_fnc_petrosDeathMonitor;
+    }
+    else
+    {
+        [] call A3A_fnc_createPetros;
+    };
 }];
 [] spawn {sleep 120; petros allowDamage true;};
 

--- a/A3A/addons/core/functions/Base/fn_petrosDeathMonitor.sqf
+++ b/A3A/addons/core/functions/Base/fn_petrosDeathMonitor.sqf
@@ -1,0 +1,36 @@
+/*  Routine to handle distribution of petros post-death placement "UI" to clients
+
+Environment: Server, spawned
+
+Arguments: None
+
+*/
+
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+
+Info("Petros death monitor started");
+
+A3A_playerPlacingPetros = "";           // this is a playerID
+
+while {!alive petros} do {
+    private _userInfo = getUserInfo A3A_playerPlacingPetros;
+    if (_userInfo isEqualTo [] or {_userInfo # 6 != 10}) then {          // client state number
+        // Don't bother trying to open the interface until we have an alive & conscious commander
+        if (!alive theBoss or {theBoss getVariable ["incapacitated", false]}) exitWith {};
+
+        // In case commander is remote controlling...
+        private _index = allPlayers findIf { _x getVariable ["owner", _x] == theBoss };
+        if (_index == -1) exitWith { Error("Uh, boss has no owner?") };
+        private _bossPlayer = allPlayers select _index;
+
+        Info_1("Selected player %1 to place petros", name _bossPlayer);
+
+        A3A_playerPlacingPetros = getPlayerID _bossPlayer;
+        publicVariable "A3A_playerPlacingPetros";
+        [] remoteExec ["A3A_fnc_placementSelection", _bossPlayer];
+    };
+    sleep 5;
+};
+
+Info("Petros successfully placed");

--- a/A3A/addons/core/functions/Base/fn_placementselection.sqf
+++ b/A3A/addons/core/functions/Base/fn_placementselection.sqf
@@ -69,8 +69,11 @@ while {_positionIsInvalid} do {
 	sleep 0.1;
 };
 
+player allowDamage true;
+
+{deleteMarkerLocal _x} forEach _mrkDangerZone;
+
 //If we're still in the map, we chose a place.
-// Should be impossible to close it without picking now? No new-game case anymore.
 if (visiblemap) then {
 	_controlsX = controlsX select {!(isOnRoad (getMarkerPos _x))};
 	{
@@ -81,8 +84,10 @@ if (visiblemap) then {
 	[_positionClicked] remoteExec ["A3A_fnc_createPetros", 2];
 	[_positionClicked, false] remoteExec ["A3A_fnc_relocateHQObjects", 2];
 	openmap [false,false];
+
+	// Make sure petros is actually placed before we signal that we're done placing
+	sleep 5;
 };
 
-player allowDamage true;
-
-{deleteMarkerLocal _x} forEach _mrkDangerZone;
+A3A_playerPlacingPetros = "";
+publicVariableServer "A3A_playerPlacingPetros";


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Petros post-death placement handling wasn't reliable. If a player managed to exit the placement interface (eg. by dying or disconnecting) then no-one would have access to the placement control.

With this PR, a petros death instead triggers a monitor loop that triggers the placement UI on suitable commanders. It survives both commander deaths and disconnections, and any other map close actions.

### Please specify which Issue this PR Resolves.
closes #2701

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

- Consider disabling the debug petros respawn. That might cause more issues than it fixes now.
