### PR TITLE
Workaround some bad GL configs

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
@@ -39,6 +39,11 @@ private _categoryOverrideTable = [
 ["rhs_weap_m32", ["GrenadeLaunchers","Weapons"]],
 ["rhs_weap_m79", ["GrenadeLaunchers","Weapons"]],
 
+// These have a rifle grenade muzzle but with no magazines or wells defined
+["rhs_weap_m70b1", ["Rifles","Weapons"]],
+["rhs_weap_m70b1n", ["Rifles","Weapons"]],
+["rhs_weap_m70ab2", ["Rifles","Weapons"]],
+
 ["B_rhsusf_B_BACKPACK", ["Unknown","Items"]],		// Drone backpack
 ["UK3CB_BAF_L103A2", ["Unknown","Items"]],			// Drill practice rifle, no mags
 

--- a/A3A/addons/core/functions/Ammunition/fn_randomRifle.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_randomRifle.sqf
@@ -47,6 +47,7 @@ if ("GrenadeLaunchers" in _categories && {"Rifles" in _categories} ) then {
     // lookup real underbarrel GL magazine, because not everything is 40mm
     private _config = configFile >> "CfgWeapons" >> _weapon;
     private _glmuzzle = getArray (_config >> "muzzles") select 1;		// guaranteed by category
+    _glmuzzle = configName (_config >> _glmuzzle);                      // bad-case fix. compatibleMagazines is case-sensitive as of 2.12
     private _glmag = compatibleMagazines [_weapon, _glmuzzle] select 0;
     _unit addMagazines [_glmag, 5];
 };


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
- compatibleMagazines [weapon, muzzle] is case-sensitive on the muzzle. This is a bug. "UK3CB_G3KA4_GL" has bad casing on the grenade launcher muzzle. This is a bug. We have to deal with it because it's our shit that it breaks.

- Some RHS M70 rifles have a rifle grenade muzzle which has no compatible magazines. categoryOverrides it is.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
