### PR TITLE
Undercover fixes

### DIFF
--- a/A3A/addons/core/functions/Undercover/fn_goUndercover.sqf
+++ b/A3A/addons/core/functions/Undercover/fn_goUndercover.sqf
@@ -47,8 +47,7 @@ if(!(_result select 0)) exitWith
             {
                 if ((isPlayer _x) && (captive _x)) then
                 {
-                    [_x, false] remoteExec["setCaptive"];
-                    _x setCaptive false;
+                    [_x, false] remoteExec["setCaptive", _x];
                 };
             } forEach ((crew(objectParent player)) + (assignedCargo(objectParent player)) - [player]);
         };
@@ -58,7 +57,6 @@ if(!(_result select 0)) exitWith
 private _layer = ["A3A_infoCenter"] call BIS_fnc_rscLayer;
 ["Undercover ON", 0, 0, 4, 0, 0, _layer] spawn bis_fnc_dynamicText;
 
-[player, true] remoteExec["setCaptive", 0, player];
 player setCaptive true;
 [] spawn A3A_fnc_statistics;
 if (player == leader group player) then
@@ -73,7 +71,7 @@ if (player == leader group player) then
 
 private _roadblocks = controlsX select {isOnRoad(getMarkerPos _x)};
 private _secureBases = airportsX + outposts + seaports + _roadblocks;
-private _isInRoadblock = false;
+private _lastBaseInside = "";
 private _reason = "";
 ["Undercover", [""]] call EFUNC(Events,triggerEvent);
 
@@ -125,7 +123,7 @@ while {_reason == ""} do
             _reason = "NoFly";
         };
 
-        if (!(_vehType in FactionGet(reb,"vehiclesCivHeli")) && (!(_vehType in FactionGet(reb,"vehiclesCivBoat")))) then
+        if (_vehType isKindOf "Land") then
         {
             if (!(isOnRoad position _veh) && {count (_veh nearRoads 50) == 0}) then
             {
@@ -133,40 +131,6 @@ while {_reason == ""} do
                 {
                     _reason = "Highway";
                 };
-            };
-
-            if(_reason != "") exitWith {};
-
-            private _base = [_secureBases, player] call BIS_fnc_nearestPosition;
-            private _onDetectionMarker = (detectionAreas findIf {player inArea _x} != -1);
-            private _onBaseMarker = (player inArea _base);
-            private _baseSide = (sidesX getVariable [_base, sideUnknown]);
-            if ((_onBaseMarker || _onDetectionMarker) && (_baseSide != teamPlayer)) then
-            {
-                if !(_isInRoadblock) then
-                {
-                    private _aggro = if (_baseSide == Occupants) then {aggressionOccupants + (tierWar * 10)} else {aggressionInvaders + (tierWar * 10)};
-                    //Probability of being spotted. Unless we're in an airfield - then we're always spotted.
-                    if (_base in airportsX || _onDetectionMarker || random 100 < _aggro) then
-                    {
-                        if (_base in _roadblocks) then
-                        {
-                            _reason = "distanceX";
-                        }
-                        else
-                        {
-                            _reason = "Control";
-                        };
-                    }
-                    else
-                    {
-                        _isInRoadblock = true;
-                    };
-                };
-            }
-            else
-            {
-                _isInRoadblock = false;
             };
         };
     }
@@ -199,11 +163,33 @@ while {_reason == ""} do
             _reason = "Compromised";
         };
     };
+    if (_reason != "") exitWith {};
+
+    // Don't do location checks on air vehicles. AirspaceControl handles that.
+    if (!isNull _veh and { _veh isKindOf "Air" }) then { continue };
+
+    private _base = [_secureBases, player] call BIS_fnc_nearestPosition;
+    private _onDetectionMarker = detectionAreas findIf {player inArea _x} != -1;
+    private _onBaseMarker = player inArea _base;
+    private _baseSide = sidesX getVariable [_base, sideUnknown];
+    if ((_onBaseMarker || _onDetectionMarker) && (_baseSide != teamPlayer) && (_base != _lastBaseInside)) then
+    {
+        if (_base in airportsX || _onDetectionMarker) exitWith
+        {
+            _reason = "Airport";
+        };
+
+        private _aggro = if (_baseSide == Occupants) then {aggressionOccupants + (tierWar * 10)} else {aggressionInvaders + (tierWar * 10)};
+        if (random 100 < _aggro) exitWith
+        {
+            _reason = ["Outpost", "Roadblock"] select (_base in _roadblocks);
+        };
+        _lastBaseInside = _base;            // Don't check this base again once we passed the check
+    };
 };
 
 if (captive player) then
 {
-    [player, false] remoteExec["setCaptive"];
     player setCaptive false;
 };
 
@@ -212,8 +198,7 @@ if !(isNull (objectParent player)) then
     {
         if (isPlayer _x) then
         {
-            [_x, false] remoteExec["setCaptive", 0, _x];
-            _x setCaptive false;
+            [_x, false] remoteExec["setCaptive", _x];
         }
     } forEach((assignedCargo(vehicle player)) + (crew(vehicle player)) - [player]);
 };
@@ -276,9 +261,15 @@ switch (_reason) do
     {
         ["Undercover", "You left your vehicle and you are still on the Wanted List!"] call A3A_fnc_customHint;
     };
-    case "distanceX":
+    case "Airport"; case "Roadblock"; case "Outpost":
     {
-        ["Undercover", "You have gotten too close to an enemy Base, Outpost or Roadblock!"] call A3A_fnc_customHint;
+        private _text = switch (_reason) do {
+            case "Airport": {"You have trespassed on an enemy airbase!"};
+            case "Outpost": {"An enemy outpost or seaport has detected you!"};
+            case "Roadblock": {"An enemy roadblock has detected you!"};
+        };
+        ["Undercover", _text] call A3A_fnc_customHint;
+
         if !(isNull objectParent player) then
         {
             (objectParent player) setVariable ["A3A_reported", true, true];
@@ -295,11 +286,6 @@ switch (_reason) do
         ["Undercover", format ["You have violated the airspace of %1!", [_detectedBy] call A3A_fnc_localizar]] call A3A_fnc_customHint;
         _veh setVariable ["A3A_reported", true, true];
         _veh setVariable ["NoFlyZoneDetected", nil, true];
-    };
-    case "Control":
-    {
-        ["Undercover", "The Installation Garrison has recognised you!"] call A3A_fnc_customHint;
-        (objectParent player) setVariable ["A3A_reported", true, true];
     };
     default
     {


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Turns out that you could freely walk onto enemy airbases when on foot, making it trivial to steal armoured vehicles. Fixed some other shit while I was in there:
- Fix a corner case where you could enter an airfield undercover through another marker.
- Fix civilian planes doing the road proximity check.
- Clean up unnecessary setCaptive remoteExecs and JIP spam.
- Improve text hints for detection by enemy bases.

### Please specify which Issue this PR Resolves.
closes #2729

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Probably needs some live-server testing just in case there's some reason to spam remoteExecs on setCaptive that I missed.