### PR TITLE
Support response tweaks

### DIFF
--- a/A3A/addons/core/functions/Base/fn_markerChange.sqf
+++ b/A3A/addons/core/functions/Base/fn_markerChange.sqf
@@ -189,6 +189,7 @@ if (_markerX in outposts) then
 	if (_winner != teamPlayer) then
 	{
 		server setVariable [_markerX,dateToNumber date,true];
+		[_markerX,30] call A3A_fnc_addTimeForIdle;
 		if (_loser == teamPlayer) then
 		{
             Debug("aggroEvent | Rebels lost an outpost");

--- a/A3A/addons/core/functions/Supports/fn_SUP_CASApproach.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_CASApproach.sqf
@@ -189,6 +189,7 @@ private _baseSpotChance = 0.05 * (1 + _aggro / 100);
 #define STATE_REPOSITION 2
 #define STATE_APPROACH 3
 
+private _numRuns = 0;
 private _acquired = false;
 private _targetObj = objNull;
 private _lastKnownPos = [];         // PosASL
@@ -291,6 +292,11 @@ while {true} do
                 Debug_1("Ammo at end of run: %1", _ammoHM);
                 if (-1 == values _ammoHM findIf { _x > 0 }) exitWith {
                     Info_1("%1 out of ammo, returning to base", _supportName);
+                    break;
+                };
+                _numRuns = _numRuns + 1;
+                if (_numRuns >= 3) exitWith {
+                    Info_2("%1 has completed %2 attack runs, returning to base", _supportName, _numRuns);
                     break;
                 };
                 _state = STATE_REPOSITION;

--- a/A3A/addons/core/functions/Supports/fn_maxDefenceSpend.sqf
+++ b/A3A/addons/core/functions/Supports/fn_maxDefenceSpend.sqf
@@ -44,9 +44,9 @@ if (_target isEqualType objNull and {_target isKindOf "Air"}) exitWith
     // but this might need to be the concern of the airspace manager
 
     // TODO: Might need to constrain this with the strike list so that you don't get multiple supports sent against one aircraft
-
+    
     private _isArmed = typeOf _target in (FactionGet(all, "vehiclesHelisLightAttack") + FactionGet(all, "vehiclesHelisAttack") + FactionGet(all, "vehiclesPlanesCAS") + FactionGet(all, "vehiclesPlanesAA"));
-    private _maxAASpend = _maxResources * ([0.1, 0.4] select _isArmed);
+    private _maxAASpend = _maxResources * ([0.1, 0.3] select _isArmed);
     private _curAASpend = 0;
     {
         _x params ["_spSide", "_spCallPos", "_spTargPos", "_spRes", "_spTime"];

--- a/A3A/addons/core/functions/Templates/fn_compileMissionAssets.sqf
+++ b/A3A/addons/core/functions/Templates/fn_compileMissionAssets.sqf
@@ -67,7 +67,7 @@ setVar("vehiclesLightAPCs", OccAndInv("vehiclesLightAPCs"));
 setVar("vehiclesAPCs", OccAndInv("vehiclesAPCs") );
 setVar("vehiclesIFVs", OccAndInv("vehiclesIFVs") );
 setVar("vehiclesTanks", OccAndInv("vehiclesTanks"));
-setVar("vehiclesAA", OccAndInv("vehiclesAA") + Reb("vehiclesAA"));
+setVar("vehiclesAA", OccAndInv("vehiclesAA"));
 setVar("vehiclesArtillery", OccAndInv("vehiclesArtillery"));
 setVar("vehiclesTransportAir", OccAndInv("vehiclesHelisLight") + OccAndInv("vehiclesHelisTransport") + OccAndInv("vehiclesPlanesTransport") );
 setVar("vehiclesHelisLight", OccAndInv("vehiclesHelisLight"));

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -479,8 +479,9 @@ private _vehicleResourceCosts = createHashMap;
 private _groundVehicleThreat = createHashMap;
 
 { _groundVehicleThreat set [_x, 40] } forEach FactionGet(all, "staticMGs");
-{ _groundVehicleThreat set [_x, 80] } forEach FactionGet(all, "vehiclesLightArmed") + FactionGet(all, "vehiclesLightAPCs");
-{ _groundVehicleThreat set [_x, 80] } forEach FactionGet(all, "staticAA") + FactionGet(all, "staticAT") + FactionGet(all, "staticMortars") + FactionGet(Reb, "vehiclesAT");
+{ _groundVehicleThreat set [_x, 60] } forEach FactionGet(all, "vehiclesLightArmed") + FactionGet(all, "vehiclesLightAPCs");
+{ _groundVehicleThreat set [_x, 80] } forEach FactionGet(all, "staticAA") + FactionGet(all, "staticAT") + FactionGet(all, "staticMortars");
+{ _groundVehicleThreat set [_x, 80] } forEach FactionGet(Reb, "vehiclesAA") + FactionGet(Reb, "vehiclesAT");
 
 { _groundVehicleThreat set [_x, 120] } forEach FactionGet(all, "vehiclesAPCs");
 { _groundVehicleThreat set [_x, 200] } forEach FactionGet(all, "vehiclesAA") + FactionGet(all, "vehiclesArtillery") + FactionGet(all, "vehiclesIFVs");


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Minor balance tweaks and fixes to support responses:
- Reduce threat value of rebel AA trucks. They were never supposed to get the same threat as AA tanks. Should cut down on CAS requests a bit.
- Reduce maximum air defence spend to 30%. Cuts down on useless jetspam. Not like AIs can shoot competent players down anyway.
- Block outposts from sending QRFs for 30min after recapture. Bug, assumed these had the same rules as airports.
- Cap maximum CAS attack runs to three. On high-activity servers, CAS could be a little too effective due to constant availability of new targets.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
