### PR TITLE
Fix freak case where mrkWIN can flip the wrong marker

### DIFF
--- a/A3A/addons/core/functions/Base/fn_mrkWIN.sqf
+++ b/A3A/addons/core/functions/Base/fn_mrkWIN.sqf
@@ -30,7 +30,7 @@ if (_caller isNotEqualTo player) exitWith {
 };
 private _flagX = _target;
 
-private _markerX = [markersX, getPos _flagX] call BIS_fnc_nearestPosition;
+private _markerX = [airportsX + resourcesX + factories + outposts + seaports, getPosATL _flagX] call BIS_fnc_nearestPosition;
 private _markerPos = getMarkerPos _markerX;
 private _outpostGridSquare = ((_markerPos#0 toFixed 0) call A3A_fnc_pad_3Digits) + ((_markerPos#1 toFixed 0) call A3A_fnc_pad_3Digits);  // NB: Check if this is the right order for pos-> grid square
 


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
There may be literally one case on the entire map set where this is possible (outpost_14 on Chernarus summer), but it's possible to have a hill marker and outpost marker close together, which can cause the wrong marker to flip when the flag action is used.

This PR removes roadblocks, hill markers and cities from the mrkWIN lookup as they're not supposed to be flipped with a flag action. Fixes the issue and maybe some other rare cases.

### Please specify which Issue this PR Resolves.
Immediate fix for #2732 but the other half of it needs maps checking.

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
