### PR TITLE
Prevent HC squads reboarding to travel after an explicit dismount order

### DIFF
--- a/A3A/addons/core/functions/AI/fn_attackDrillAI.sqf
+++ b/A3A/addons/core/functions/AI/fn_attackDrillAI.sqf
@@ -312,7 +312,7 @@ while {true} do
 					{[_x] spawn A3A_fnc_autoRearm; sleep 1} forEach (_movable select {!(_x getVariable ["maneuvering",false])});
 					};
 				};
-			if !(isNull(_groupX getVariable ["transporte",objNull])) then
+			if (!isNull(_groupX getVariable ["transporte",objNull]) and !(_groupX getVariable ["A3A_forceDismount",false])) then
 				{
 				(units _groupX select {vehicle _x == _x}) allowGetIn true;
 				};

--- a/A3A/addons/core/functions/REINF/fn_vehStats.sqf
+++ b/A3A/addons/core/functions/REINF/fn_vehStats.sqf
@@ -28,11 +28,13 @@ if (_this select 0 == "mount") exitWith
 				{
 				_textX = format ["%2%1 dismounting<br/>",groupID _groupX,_textX];
 				{[_x] orderGetIn false; [_x] allowGetIn false} forEach units _groupX;
+				_groupX setVariable ["A3A_forceDismount", true];
 				}
 			else
 				{
 				_textX = format ["%2%1 boarding<br/>",groupID _groupX,_textX];
 				{[_x] orderGetIn true; [_x] allowGetIn true} forEach units _groupX;
+				_groupX setVariable ["A3A_forceDismount", nil];
 				};
 			}
 		else
@@ -40,6 +42,7 @@ if (_this select 0 == "mount") exitWith
 			if (leader _groupX in _veh) then
 				{
 				_textX = format ["%2%1 dismounting<br/>",groupID _groupX,_textX];
+				_groupX setVariable ["A3A_forceDismount", true];
 				if (canMove _veh) then
 					{
 					{[_x] orderGetIn false; [_x] allowGetIn false} forEach assignedCargo _veh;
@@ -54,6 +57,7 @@ if (_this select 0 == "mount") exitWith
 				{
 				_textX = format ["%2%1 boarding<br/>",groupID _groupX,_textX];
 				{[_x] orderGetIn true; [_x] allowGetIn true} forEach units _groupX;
+				_groupX setVariable ["A3A_forceDismount", nil];
 				};
 			};
 		};


### PR DESCRIPTION
## What type of PR is this.
1. [?] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
After giving a high command squad a Y-menu dismount order, they'd still board a vehicle if ordered to travel more than 200m with no enemies visible. This was generally not how commanders wanted the order to work.

This PR changes the logic so that HC squads won't reboard after a Y-menu dismount order unless given a mount order. They can still reboard if they decided to get out on their own, for example due to enemy contact.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
