### PR TITLE
Statics to save

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -239,6 +239,7 @@ class CfgFunctions
             class createAttackVehicle {};
             class createCIV {};
             class createFIAOutposts2 {};
+            class createObjects {};
             class createSDKGarrisons {};
             class createSDKgarrisonsTemp {};
             class createUnit {};
@@ -526,10 +527,12 @@ class CfgFunctions
             class FIAskillAdd {};
             class garrisonAdd {};
             class garrisonDialog {};
+            class getObjectList {};
             class NATObomb {};
             class postmortem {};
             class reDress {};
             class reinfPlayer {};
+            class removeObjectFromBuildSave {};
             class spawnHCGroup {};
             class vehiclePrice {};
             class vehStats {};

--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -509,6 +509,7 @@ class CfgFunctions
             class addBombRun {};
             class addFIAsquadHC {};
             class addFIAveh {};
+            class addObjectToBuildSave {};
             class addSquadVeh {};
             class addToGarrison {};
             class autoGarrison {};

--- a/A3A/addons/core/functions/AI/fn_landThreatEval.sqf
+++ b/A3A/addons/core/functions/AI/fn_landThreatEval.sqf
@@ -10,6 +10,7 @@ _markerX = _this select 0;
 _sideX = _this select 1;
 if (_markerX isEqualType []) then {_positionX = _markerX} else {_positionX = getMarkerPos _markerX};
 _threat = _threat + 2 * ({(isOnRoad getMarkerPos _x) and (getMarkerPos _x distance _positionX < distanceSPWN)} count outpostsFIA);
+private _hashMap = sidesX getVariable ["OBJ_DATA"];
 
 {
 if (getMarkerPos _x distance _positionX < distanceSPWN) then
@@ -18,10 +19,12 @@ if (getMarkerPos _x distance _positionX < distanceSPWN) then
 	_garrison = garrison getVariable [_analyzed,[]];
 	_threat = _threat + (floor((count _garrison)/8));
 	//_size = [_analyzed] call A3A_fnc_sizeMarker;
-	_staticsX = staticsToSave select {_x inArea _analyzed};
+	private _analyzedHash = _hashmap getOrDefault [_analyzed, nil];
+	if (isNil "_analyzedHash") then {continue};
+	_staticsX = _analyzedHash getOrDefault ["StaticWeaponData", []];
 	if (count _staticsX > 0) then
 		{
-		_threat = _threat + ({typeOf _x in FactionGet(reb,"staticMortars")} count _staticsX) + (2*({typeOf _x in FactionGet(reb,"staticAT")} count _staticsX))
+		_threat = _threat + ({typeOf (_x # 0) in FactionGet(reb,"staticMortars")} count _staticsX) + (2*({typeOf (_x # 0) in FactionGet(reb,"staticAT")} count _staticsX))
 		};
 	};
 } forEach (markersX - citiesX - controlsX - outpostsFIA) select {sidesX getVariable [_x,sideUnknown] != _sideX};

--- a/A3A/addons/core/functions/Base/fn_findAttackTargets.sqf
+++ b/A3A/addons/core/functions/Base/fn_findAttackTargets.sqf
@@ -34,7 +34,7 @@ if (count _possibleTargets == 0 || count _possibleStartBases == 0) exitWith {
 };
 Debug_2("%1 possible targets for attack found, possible start points are %2", count _possibleTargets, _possibleStartBases);
 
-
+private _hashMap = sidesX getVariable ["OBJ_DATA"];
 //**************** Data preparation *************************************************************
 
 // Build X/Y/threat array for all enemy locations
@@ -48,7 +48,10 @@ private _maxThreatDist = distanceForAirAttack + 1000;
 
     private _threat = 10 * count (garrison getVariable [_x, []]);
     if (_markerSide == teamPlayer) then {
-        _threat = _threat + 50 * count (staticsToSave inAreaArray _x);
+        private _analyzedHash = _hashmap getOrDefault [_x, nil];
+        if (isNil "_analyzedHash") then {continue};
+        _staticsX = _analyzedHash getOrDefault ["StaticWeaponData", []];
+        _threat = _threat + 50 * count (_staticsX);
     } else {
         // based on typical static count
         _threat = _threat + call {

--- a/A3A/addons/core/functions/Base/fn_garrisonInfo.sqf
+++ b/A3A/addons/core/functions/Base/fn_garrisonInfo.sqf
@@ -37,7 +37,7 @@ _textX = format [
     , count (_units#6)
     , count (_units#7)
     , count (_units#8)
-    , {_x distance _positionX < _size} count staticsToSave
+    , {_x distance _positionX < _size} count ([_siteX, 3] call A3A_fnc_getObjectList)
     , _estatic
     , if (_limit != -1) then {format ["/%1", _limit]} else {""}
 ];

--- a/A3A/addons/core/functions/Base/fn_markerChange.sqf
+++ b/A3A/addons/core/functions/Base/fn_markerChange.sqf
@@ -283,17 +283,13 @@ Debug_1("Notification and points done for marker change at %1", _markerX);
 if (_winner == teamPlayer) then
 {
 	[] call A3A_fnc_tierCheck;
-
 	//Convert all of the static weapons to teamPlayer, essentially. Make them mannable by AI.
 	//Make the size larger, as rarely does the marker cover the whole outpost.
 	private _staticWeapons = nearestObjects [_positionX, ["StaticWeapon"], _size * 1.5, true];
 	{
 		[_x, teamPlayer, true] call A3A_fnc_vehKilledOrCaptured;
-		if !(_x in staticsToSave) then {
-			staticsToSave pushBack _x;
-		};
+		[_x, _markerX] call A3A_fnc_addObjectToBuildSave;
 	} forEach _staticWeapons;
-	publicVariable "staticsToSave";
 
 	if (!isNull _flagX) then
 	{
@@ -314,8 +310,10 @@ else
 	{
 	//Remove static weapons near the marker from the saved statics array
 	private _staticWeapons = nearestObjects [_positionX, ["StaticWeapon"], _size * 1.5, true];
-	staticsToSave = staticsToSave - _staticWeapons;
-	publicVariable "staticsToSave";
+	{
+		[_x, _markerX] call A3A_fnc_removeObjectFromBuildSave;
+		
+	} forEach _staticWeapons;
 	{
 		[_x, _winner, true] call A3A_fnc_vehKilledOrCaptured;
 	} forEach _staticWeapons;
@@ -324,7 +322,7 @@ else
 	[_staticWeapons, _markerX] spawn {
 		params ["_statics", "_markerX"];
 		waitUntil { sleep 1; spawner getVariable _markerX == 2 };
-		{ deleteVehicle _x } forEach (_statics - staticsToSave);
+		{ deleteVehicle _x } forEach (_statics);
 	};
 
 	if (!isNull _flagX) then

--- a/A3A/addons/core/functions/Base/fn_sellVehicle.sqf
+++ b/A3A/addons/core/functions/Base/fn_sellVehicle.sqf
@@ -119,7 +119,9 @@ _costs = round (_costs * (1-damage _veh));
 
 [0,_costs] remoteExec ["A3A_fnc_resourcesFIA",2];
 
-if (_veh in staticsToSave) then {staticsToSave = staticsToSave - [_veh]; publicVariable "staticsToSave"};
+
+// try to remove from save 
+if ((_veh isKindOf "StaticWeapon") or (_veh isKindOf "Building")) then {[_veh] call A3A_fnc_removeObjectFromBuildSave;};
 
 [_veh,true] call A3A_fnc_empty;
 

--- a/A3A/addons/core/functions/Base/fn_updateRebelStatics.sqf
+++ b/A3A/addons/core/functions/Base/fn_updateRebelStatics.sqf
@@ -29,7 +29,7 @@ if !(_target isEqualType "") then
 if (_marker isEqualTo "") exitWith {};
 
 // Find all non-mortar statics within marker
-private _statics = staticsToSave inAreaArray _marker;
+private _statics =  ([_marker, 3] call A3A_fnc_getObjectList); 
 _statics = _statics select { _x isKindOf "StaticWeapon" and !(_x isKindOf "StaticMortar") };           // may include bunkers. Don't bother with mortars yet
 if (count _statics == 0) exitWith {};
 

--- a/A3A/addons/core/functions/CREATE/fn_createObjects.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createObjects.sqf
@@ -18,6 +18,7 @@ private _buildingArray = [];
 private _staticArray = [];
 {
     private _key = _x;
+    if !(_key in ["BuildingData", "StaticWeaponData"]) then {continue};
     {
         //[typeOf _veh, getPosWorld _veh, vectorUp _veh, vectorDir _veh];
         _x params ["_typeVehX", "_posVeh", "_xVectorUp", "_xVectorDir"];
@@ -25,7 +26,7 @@ private _staticArray = [];
         _veh setPosWorld _posVeh;
         _veh setVectorDirAndUp [_xVectorDir,_xVectorUp];
         [_veh, teamPlayer] call A3A_fnc_AIVEHinit;
-        if (_key isEqualTo "Building") then {
+        if (_key isEqualTo "BuildingData") then {
             _buildingArray pushBackUnique _veh;
         } else {
             _staticArray pushBackUnique _veh;

--- a/A3A/addons/core/functions/CREATE/fn_createObjects.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createObjects.sqf
@@ -1,0 +1,40 @@
+systemChat "called createObject?";
+
+params [["_markerKey", ""]];
+if(_markerKey isEqualTo "") exitWith {};
+
+private _objMap = sidesX getVariable ["OBJ_DATA", nil];
+if (isNil "_objMap") exitWith {};
+private _hashmap = _objMap getOrDefault [_markerKey, nil];
+if (isNil "_hashmap") exitWith {};
+
+
+//check that we aren't double building!
+if (
+	(_hashmap getOrDefault ["Building", []]) isNotEqualTo [] ||
+	(_hashmap getOrDefault ["StaticWeapon", []]) isNotEqualTo [] ) exitwith { systemChat "Not empty";};
+
+private _buildingArray = [];
+private _staticArray = [];
+{
+    private _key = _x;
+    {
+        //[typeOf _veh, getPosWorld _veh, vectorUp _veh, vectorDir _veh];
+        _x params ["_typeVehX", "_posVeh", "_xVectorUp", "_xVectorDir"];
+        private _veh = createVehicle [_typeVehX,[0,0,1000],[], 0,"CAN_COLLIDE"];
+        _veh setPosWorld _posVeh;
+        _veh setVectorDirAndUp [_xVectorDir,_xVectorUp];
+        [_veh, teamPlayer] call A3A_fnc_AIVEHinit;
+        if (_key isEqualTo "Building") then {
+            _buildingArray pushBackUnique _veh;
+        } else {
+            _staticArray pushBackUnique _veh;
+        };
+    } forEach _y; // arrays of data
+    
+} forEach _hashmap;
+
+_hashmap set ["Building", _buildingArray];
+_hashmap set ["StaticWeapon", _staticArray];
+_objMap set [_markerKey, _hashmap];
+sidesX setVariable ["OBJ_DATA", _objMap, true];

--- a/A3A/addons/core/functions/CREATE/fn_createSDKgarrisons.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createSDKgarrisons.sqf
@@ -64,8 +64,11 @@ if (_markerX != "Synd_HQ") then
 	};
 };
 
+// spawn in statics and buildings
+[_markerX] call A3A_fnc_createObjects;
+
 private _size = [_markerX] call A3A_fnc_sizeMarker;
-_staticsX = staticsToSave select {_x distance2D _positionX < _size};
+_staticsX = ([_markerX, 3] call A3A_fnc_getObjectList); 
 
 _garrison = [];
 _garrison = _garrison + (garrison getVariable [_markerX,[]]);
@@ -167,5 +170,5 @@ waitUntil {sleep 1; (spawner getVariable _markerX == 2)};
 deleteGroup _groupStatics;
 deleteGroup _groupMortars;
 
-{if (!(_x in staticsToSave)) then {deleteVehicle _x}} forEach _vehiclesX;
+{deleteVehicle _x} forEach _vehiclesX + ([_markerX, 3] call A3A_fnc_getObjectList);
 ["locationSpawned", [_markerX, "RebelOutpost", false]] call EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/CREATE/fn_cycleSpawn.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_cycleSpawn.sqf
@@ -197,13 +197,4 @@ deleteMarker _patrolMarker;
 	deleteGroup _x
 } forEach _allGroups;
 
-{
-	if (!(_x in staticsToSave)) then
-	{
-		if ((!([distanceSPWN, 1, _x, teamPlayer] call A3A_fnc_distanceUnits))) then
-		{
-			deleteVehicle _x;
-		};
-	};
-} forEach _allVehicles;
 */

--- a/A3A/addons/core/functions/REINF/fn_addObjectToBuildSave.sqf
+++ b/A3A/addons/core/functions/REINF/fn_addObjectToBuildSave.sqf
@@ -1,0 +1,58 @@
+/*
+Author: [Killerswin2]
+    adds objects to the save/build system for tracking
+Arguments:
+0.  <object>    object to add
+1.  <string>    key name for hashmap
+
+Return Value:
+    <nil>
+
+Scope: Clients
+Environment: scheduled
+Public: yes
+Dependencies:
+
+Example:
+    [_veh, _markerKey] call A3A_fnc_addObjectToBuildSave;
+*/
+
+
+
+params [["_veh", objNull], ["_markerKey", ""]];
+
+if(isNull _veh) then {};
+
+if(_markerKey isEqualTo "") then {
+	_sites = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
+	_markerKey = [_sites, getPosATL player] call BIS_fnc_nearestPosition;
+
+	//TODO check distance encase this was wrongly called
+};
+
+private _type = "";
+
+switch (true) do {
+	case (_veh isKindOf "StaticWeapon"): { _type = "StaticWeapon";};
+	case (_veh isKindOf "Building"): { _type = "Building";};
+	default { };
+};
+
+private _objMap = sidesX getVariable ["OBJ_DATA", nil];
+if (isNil "_objMap") exitWith {};
+private _hashmap = _objMap getOrDefault [_markerKey, nil];
+if (isNil "_hashmap") then {_hashmap = createHashMap};
+
+private _objectsToSave = _hashmap getOrDefault [_type, []];
+_objectsToSave pushBackUnique _veh;
+private _objectsData = _hashmap getOrDefault [(_type + "Data"), []];
+
+_objectsData pushBack [typeOf _veh, getPosWorld _veh, vectorUp _veh, vectorDir _veh];
+
+
+_hashmap set [_type, _objectsToSave];
+_hashmap set [(_type + "Data"), _objectsData];
+
+_objMap set [_markerKey, _hashmap];
+
+sidesX setVariable ["OBJ_DATA", _objMap, true];

--- a/A3A/addons/core/functions/REINF/fn_addObjectToBuildSave.sqf
+++ b/A3A/addons/core/functions/REINF/fn_addObjectToBuildSave.sqf
@@ -21,7 +21,7 @@ Example:
 
 params [["_veh", objNull], ["_markerKey", ""]];
 
-if(isNull _veh) then {};
+if(isNull _veh) exitWith {};
 
 if(_markerKey isEqualTo "") then {
 	_sites = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
@@ -38,6 +38,8 @@ switch (true) do {
 	default { };
 };
 
+systemChat str [_veh, _type];
+
 private _objMap = sidesX getVariable ["OBJ_DATA", nil];
 if (isNil "_objMap") exitWith {};
 private _hashmap = _objMap getOrDefault [_markerKey, nil];
@@ -47,7 +49,7 @@ private _objectsToSave = _hashmap getOrDefault [_type, []];
 _objectsToSave pushBackUnique _veh;
 private _objectsData = _hashmap getOrDefault [(_type + "Data"), []];
 
-_objectsData pushBack [typeOf _veh, getPosWorld _veh, vectorUp _veh, vectorDir _veh];
+_objectsData pushBackUnique [typeOf _veh, getPosWorld _veh, vectorUp _veh, vectorDir _veh];
 
 
 _hashmap set [_type, _objectsToSave];

--- a/A3A/addons/core/functions/REINF/fn_buildCreateVehicleCallback.sqf
+++ b/A3A/addons/core/functions/REINF/fn_buildCreateVehicleCallback.sqf
@@ -91,8 +91,6 @@ _veh enableSimulationGlobal false;
 if ((build_type == "SB") or (build_type == "CB")) exitWith
 {
 	[_veh, build_nearestFriendlyMarker] call A3A_fnc_addObjectToBuildSave;
-	//staticsToSave pushBackUnique _veh;
-	//publicVariable "staticsToSave"
 };
 
 

--- a/A3A/addons/core/functions/REINF/fn_buildCreateVehicleCallback.sqf
+++ b/A3A/addons/core/functions/REINF/fn_buildCreateVehicleCallback.sqf
@@ -90,8 +90,9 @@ _veh enableSimulationGlobal false;
 
 if ((build_type == "SB") or (build_type == "CB")) exitWith
 {
-	staticsToSave pushBackUnique _veh;
-	publicVariable "staticsToSave"
+	[_veh, build_nearestFriendlyMarker] call A3A_fnc_addObjectToBuildSave;
+	//staticsToSave pushBackUnique _veh;
+	//publicVariable "staticsToSave"
 };
 
 

--- a/A3A/addons/core/functions/REINF/fn_getObjectList.sqf
+++ b/A3A/addons/core/functions/REINF/fn_getObjectList.sqf
@@ -1,0 +1,39 @@
+/*
+Author: [Killerswin2]
+    adds objects to the save/build system for tracking
+Arguments:
+0.  <object>    object to add
+1.  <string>    key name for hashmap
+
+Return Value:
+    <nil>
+
+Scope: Clients
+Environment: scheduled
+Public: yes
+Dependencies:
+
+Example:
+    [_veh, _markerKey] call A3A_fnc_addObjectToBuildSave;
+*/
+
+
+params [["_markerKey", ""], ["_type", 1]];
+
+private _key = "";
+if(_type == 1) then {_key = "StaticWeapon";} else {_key = "Building";};
+
+
+private _objMap = sidesX getVariable ["OBJ_DATA", nil];
+if (isNil "_objMap") exitWith {[]};
+private _hashmap = _objMap getOrDefault [_markerKey, nil];
+if (isNil "_hashmap") exitWith {[]};
+
+private _objectsToSave = _hashmap getOrDefault [_key, []];
+private _return = +_objectsToSave;
+// if we need both do this
+if (_type > 2) then {
+	_return append (_hashmap getOrDefault ["StaticWeapon", []]);
+};
+
+_return

--- a/A3A/addons/core/functions/REINF/fn_postmortem.sqf
+++ b/A3A/addons/core/functions/REINF/fn_postmortem.sqf
@@ -17,12 +17,6 @@ if (isnull _victim)exitwith{Error("Function failed called with null param.")};
 if (isNull _group) then
 {
     Debug_1("Group for victim :: %1, no group found! Removing from Statics list.",_victim);
-
-	if (_victim in staticsToSave) then
-    {
-        staticsToSave = staticsToSave - [_victim];
-        publicVariable "staticsToSave";
-    };
 };
 
 Debug_3("Pausing for %1 minutes before cleaning victim: %2 and group: %3", round cleantime/60, _victim, _group);

--- a/A3A/addons/core/functions/REINF/fn_removeObjectFromBuildSave.sqf
+++ b/A3A/addons/core/functions/REINF/fn_removeObjectFromBuildSave.sqf
@@ -1,0 +1,58 @@
+/*
+Author: [Killerswin2]
+    removes objects from the save/build system
+Arguments:
+0.  <object>    object to remove
+1.  <string>    key name for hashmap
+
+Return Value:
+    <nil>
+
+Scope: Clients
+Environment: scheduled
+Public: yes
+Dependencies:
+
+Example:
+    [_veh, _marker] call A3A_fnc_removeObjectFromBuildSave;
+*/
+
+
+
+params [["_veh", objNull], ["_markerKey", ""]];
+
+if(isNull _veh) then {};
+
+if(_markerKey isEqualTo "") then {
+	_sites = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
+	_markerKey = [_sites, getPosATL player] call BIS_fnc_nearestPosition;
+
+	//TODO check distance encase this was wrongly called
+};
+
+private _type = "";
+
+switch (true) do {
+	case (_veh isKindOf "StaticWeapon"): { _type = "StaticWeapon";};
+	case (_veh isKindOf "Building"): { _type = "Building";};
+	default { };
+};
+
+private _objMap = sidesX getVariable ["OBJ_DATA", nil];
+if (isNil "_objMap") exitWith {};
+private _hashmap = _objMap getOrDefault [_markerKey, nil];
+if (isNil "_hashmap") exitWith {};
+
+private _objectsToSave = _hashmap getOrDefault [_type, []];
+_objectsToSave deleteAt (_objectsToSave find _veh);
+private _objectsData = _hashmap getOrDefault [(_type + "Data"), []];
+
+_objectsData deleteAt (_objectsData find [typeOf _veh, getPosWorld _veh, vectorUp _veh, vectorDir _veh]);
+
+
+_hashmap set [_type, _objectsToSave];
+_hashmap set [(_type + "Data"), _objectsData];
+
+_objMap set [_markerKey, _hashmap];
+
+sidesX setVariable ["OBJ_DATA", _objMap, true];

--- a/A3A/addons/core/functions/Save/fn_deleteSave.sqf
+++ b/A3A/addons/core/functions/Save/fn_deleteSave.sqf
@@ -46,7 +46,7 @@ private _savedPlayers = _namespace getVariable ["savedPlayers" + _postfix, []];
 	"outpostsFIA", "tasks", "idlebases", "idleassets", "killZones", "controlsSDK", "params",
 	"attackCountdownOccupants", "attackCountdownInvaders", "prestigeNATO", "prestigeCSAT",
 	"savedPlayers", "testingTimerIsActive", "HR_Garage", "A3A_fuelAmountleftArray", "HQKnowledge", "enemyResources",
-	"version", "name", "saveTime", "ended", "factions", "addonVics", "DLC"];
+	"version", "name", "saveTime", "ended", "factions", "addonVics", "DLC", "objData"];
 
 
 // Remove this campaign from the save list, if present

--- a/A3A/addons/core/functions/Save/fn_loadServer.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadServer.sqf
@@ -96,6 +96,7 @@ if (isServer) then {
 	["posHQ"] call A3A_fnc_getStatVariable;
 	["nextTick"] call A3A_fnc_getStatVariable;
 	["staticsX"] call A3A_fnc_getStatVariable;
+	["objData"] call A3A_fnc_getStatVariable;
 
 	{_x setPos getMarkerPos respawnTeamPlayer} forEach ((call A3A_fnc_playableUnits) select {side _x == teamPlayer});
 	_sites = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};

--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -53,7 +53,7 @@ private _specialVarLoads = [
     "garrison","tasks","membersX","vehInGarage","destroyedBuildings","idlebases",
     "chopForest","weather","killZones","jna_dataList","controlsSDK","mrkCSAT","nextTick",
     "bombRuns","wurzelGarrison","aggressionOccupants", "aggressionInvaders", "enemyResources", "HQKnowledge",
-    "testingTimerIsActive", "version", "HR_Garage", "A3A_fuelAmountleftArray"
+    "testingTimerIsActive", "version", "HR_Garage", "A3A_fuelAmountleftArray", "objData"
 ];
 
 private _varName = _this select 0;
@@ -327,6 +327,34 @@ if (_varName in _specialVarLoads) then {
             vehicleBox setPos ((_varValue select 5) select 1);
         };
         {_x setPos _posHQ} forEach ((call A3A_fnc_playableUnits) select {side _x == teamPlayer});
+    };
+
+    if (_varname == 'objData') then 
+    {
+        private _hqMap = _varValue get "Synd_HQ";
+        private _buildingArray = [];
+        private _staticArray = [];
+        {
+            {
+                //[typeOf _veh, getPosWorld _veh, vectorUp _veh, vectorDir _veh];
+                _x params ["_typeVehX", "_posVeh", "_xVectorUp", "_xVectorDir"];
+                private _veh = createVehicle [_typeVehX,[0,0,1000],[],0,"CAN_COLLIDE"];
+                _veh setPosWorld _posVeh;
+                _veh setVectorDirAndUp [_xVectorDir,_xVectorUp];
+                [_veh, teamPlayer] call A3A_fnc_AIVEHinit;
+                if (_x isEqualTo "Building") then {
+                    _buildingArray pushBackUnique _veh;
+                } else {
+                    _staticArray pushBackUnique _veh;
+                };
+            } forEach _y; // arrays of data
+            
+        } forEach _hqMap;
+        
+        _hqMap set ["Building", _buildingArray];
+        _hqMap set ["StaticWeapon", _staticArray];
+        _varValue set ["Synd_HQ", _hqMap];
+        sidesX setVariable ["OBJ_DATA", _varValue, true];
     };
     if (_varname == 'staticsX') then {
         for "_i" from 0 to (count _varvalue) - 1 do {

--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -337,6 +337,7 @@ if (_varName in _specialVarLoads) then {
         private _staticArray = [];
         {
             private _key = _x;
+            if !(_key in ["BuildingData", "StaticWeaponData"]) then {continue};
             {
                 systemChat str _key;
                 //[typeOf _veh, getPosWorld _veh, vectorUp _veh, vectorDir _veh];

--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -331,18 +331,26 @@ if (_varName in _specialVarLoads) then {
 
     if (_varname == 'objData') then 
     {
+        copyToClipboard str _varValue;
         private _hqMap = _varValue get "Synd_HQ";
         private _buildingArray = [];
         private _staticArray = [];
         {
+            private _key = _x;
             {
+                systemChat str _key;
                 //[typeOf _veh, getPosWorld _veh, vectorUp _veh, vectorDir _veh];
-                _x params ["_typeVehX", "_posVeh", "_xVectorUp", "_xVectorDir"];
+                _x params [
+                    ["_typeVehX", "", [""]],
+                    ["_posVeh", [0,0,0], [[]]],
+                    ["_xVectorUp", [0,0,0], [[]]],
+                    ["_xVectorDir", [0,0,0], [[]]]
+                ];
                 private _veh = createVehicle [_typeVehX,[0,0,1000],[],0,"CAN_COLLIDE"];
                 _veh setPosWorld _posVeh;
                 _veh setVectorDirAndUp [_xVectorDir,_xVectorUp];
                 [_veh, teamPlayer] call A3A_fnc_AIVEHinit;
-                if (_x isEqualTo "Building") then {
+                if (_key isEqualTo "BuildingData") then {
                     _buildingArray pushBackUnique _veh;
                 } else {
                     _staticArray pushBackUnique _veh;
@@ -370,15 +378,11 @@ if (_varName in _specialVarLoads) then {
                 _veh setVectorDirAndUp [_xVectorDir,_xVectorUp];
             };
             [_veh, teamPlayer] call A3A_fnc_AIVEHinit;
-            if ((_veh isKindOf "StaticWeapon") or (_veh isKindOf "Building")) then {
-                staticsToSave pushBack _veh;
-            }
-            else {
-                if (!isNil "_state") then {
-                    [_veh, _state] call HR_GRG_fnc_setState;
-                };
-                [_veh] spawn A3A_fnc_vehDespawner;
+ 
+            if (!isNil "_state") then {
+                [_veh, _state] call HR_GRG_fnc_setState;
             };
+            [_veh] spawn A3A_fnc_vehDespawner;
 
         //this is less flexible than buyItem is but is fine for the specific use case of fuel drums and light sources
         //future objects that needs initialising needs another unique handler here which might eventually become troublessome
@@ -403,7 +407,7 @@ if (_varName in _specialVarLoads) then {
             };
          */
         };
-        publicVariable "staticsToSave";
+
     };
     if (_varname == 'tasks') then {
 /*

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -114,12 +114,10 @@ _vehInGarage = _vehInGarage + vehInGarage;
 				if (vehicle _friendX != _friendX) then {
 					_veh = vehicle _friendX;
 					_typeVehX = typeOf _veh;
-					if (not(_veh in staticsToSave)) then {
-						if ((_veh isKindOf "StaticWeapon") or (driver _veh == _friendX)) then {
-							if ((group _friendX in (hcAllGroups theBoss)) or (!isMultiplayer)) then {
-								_resourcesBackground = _resourcesBackground + ([_typeVehX] call A3A_fnc_vehiclePrice);
-								if (count attachedObjects _veh != 0) then {{_resourcesBackground = _resourcesBackground + ([typeOf _x] call A3A_fnc_vehiclePrice)} forEach attachedObjects _veh};
-							};
+					if ((_veh isKindOf "StaticWeapon") or (driver _veh == _friendX)) then {
+						if ((group _friendX in (hcAllGroups theBoss)) or (!isMultiplayer)) then {
+							_resourcesBackground = _resourcesBackground + ([_typeVehX] call A3A_fnc_vehiclePrice);
+							if (count attachedObjects _veh != 0) then {{_resourcesBackground = _resourcesBackground + ([typeOf _x] call A3A_fnc_vehiclePrice)} forEach attachedObjects _veh};
 						};
 					};
 				};
@@ -141,7 +139,7 @@ _arrayEst = [];
 {
 	_veh = _x;
 	_typeVehX = typeOf _veh;
-	if ((_veh distance getMarkerPos respawnTeamPlayer < 50) and !(_veh in staticsToSave) and !(_typeVehX in ["ACE_SandbagObject","Land_FoodSacks_01_cargo_brown_F","Land_Pallet_F"])) then {
+	if ((_veh distance getMarkerPos respawnTeamPlayer < 50) and !(_veh in (["Synd_HQ", 3] call A3A_fnc_getObjectList)) and !(_typeVehX in ["ACE_SandbagObject","Land_FoodSacks_01_cargo_brown_F","Land_Pallet_F"])) then {
 		if (((not (_veh isKindOf "StaticWeapon")) and (not (_veh isKindOf "ReammoBox")) and (not (_veh isKindOf "ReammoBox_F")) and (not(_veh isKindOf "Building"))) and (count attachedObjects _veh == 0) and (alive _veh) and ({(alive _x) and (!isPlayer _x)} count crew _veh == 0) and (not(_typeVehX == "WeaponHolderSimulated"))) then {
 			_posVeh = getPosWorld _veh;
 			_xVectorUp = vectorUp _veh;
@@ -158,30 +156,13 @@ _arrayEst = [];
 		};
 	};
 } forEach vehicles - [boxX,flagX,fireX,vehicleBox,mapX];
-
-// _sites = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
-// {
-// 	_positionX = position _x;
-// 	if ((alive _x) and !(surfaceIsWater _positionX) and !(isNull _x)) then {
-// 		_arrayEst pushBack [typeOf _x,getPosWorld _x,vectorUp _x, vectorDir _x];
-// 	};
-// } forEach staticsToSave;
-
 ["staticsX", _arrayEst] call A3A_fnc_setStatVariable;
 
-private _hashmap = createHashMap;
+private _hashmap = +(sidesX getVariable ["OBJ_DATA", nil]);
 {
-	private _nestedHashmap = createHashMap;
-	private _keys = keys _y;
-	private _indexKey = [];
-	{
-		if ((_x find "Data") isNotEqualTo -1) then {
-			_nestedHashmap set [_x, _y get _x];
-		};
-	} forEach _keys;
-
-	_hashmap set [_x, _nestedHashmap];
-} forEach (sidesX getVariable ["OBJ_DATA", nil]);
+	_y deleteAt "StaticWeapon";
+	_y deleteAt "Building";
+} forEach _hashmap;
 
 ["objData", _hashmap] call A3A_fnc_setStatVariable;
 

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -159,15 +159,32 @@ _arrayEst = [];
 	};
 } forEach vehicles - [boxX,flagX,fireX,vehicleBox,mapX];
 
-_sites = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
-{
-	_positionX = position _x;
-	if ((alive _x) and !(surfaceIsWater _positionX) and !(isNull _x)) then {
-		_arrayEst pushBack [typeOf _x,getPosWorld _x,vectorUp _x, vectorDir _x];
-	};
-} forEach staticsToSave;
+// _sites = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
+// {
+// 	_positionX = position _x;
+// 	if ((alive _x) and !(surfaceIsWater _positionX) and !(isNull _x)) then {
+// 		_arrayEst pushBack [typeOf _x,getPosWorld _x,vectorUp _x, vectorDir _x];
+// 	};
+// } forEach staticsToSave;
 
 ["staticsX", _arrayEst] call A3A_fnc_setStatVariable;
+
+private _hashmap = createHashMap;
+{
+	private _nestedHashmap = createHashMap;
+	private _keys = keys _y;
+	private _indexKey = [];
+	{
+		if ((_x find "Data") isNotEqualTo -1) then {
+			_nestedHashmap set [_x, _y get _x];
+		};
+	} forEach _keys;
+
+	_hashmap set [_x, _nestedHashmap];
+} forEach (sidesX getVariable ["OBJ_DATA", nil]);
+
+["objData", _hashmap] call A3A_fnc_setStatVariable;
+
 [] call A3A_fnc_arsenalManage;
 
 _jna_dataList = [];

--- a/A3A/addons/core/functions/Save/fn_savePlayer.sqf
+++ b/A3A/addons/core/functions/Save/fn_savePlayer.sqf
@@ -67,7 +67,7 @@ if (_globalSave) then
 				_totalMoney = _totalMoney + _unitPrice;
 			};
 			private _veh = vehicle _x;
-			if (_veh == _x || {_veh in staticsToSave}) exitWith {};
+			if (_veh == _x) exitWith {};
 			if (_x == driver _veh || {_x == gunner _veh && _veh isKindOf "StaticWeapon"}) then {
 				private _vehPrice = [typeof _veh] call A3A_fnc_vehiclePrice;
 				_totalMoney = _totalMoney + _vehPrice;

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -234,10 +234,7 @@ player addEventHandler ["WeaponAssembled", {
     private _veh = _this select 1;
     [_veh, teamPlayer] call A3A_fnc_AIVEHinit;		// will flip/capture if already initialized
     if (_veh isKindOf "StaticWeapon") then {
-        if (not(_veh in staticsToSave)) then {
-            staticsToSave pushBack _veh;
-            publicVariable "staticsToSave";
-        };
+        //TODO: add staticweapon to thing again
         _markersX = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
         _pos = position _veh;
         [_veh] call A3A_Logistics_fnc_addLoadAction;

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -99,8 +99,6 @@ bookedSlots = floor ((memberSlots/100) * (playableSlotsNumber teamPlayer)); publ
 
 // create the new statics save system.
 private _hashMap = createHashMap;
-private _nestedHashmap = createHashMap;
-_hashMap set ["Synd_HQ", _nestedHashmap];
 sidesX setVariable ["OBJ_DATA", _hashMap, true];
 
 // ****************** Load save data or create new *********************************

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -97,6 +97,11 @@ if (gameMode != 1) then {
 };
 bookedSlots = floor ((memberSlots/100) * (playableSlotsNumber teamPlayer)); publicVariable "bookedSlots";
 
+// create the new statics save system.
+private _hashMap = createHashMap;
+private _nestedHashmap = createHashMap;
+_hashMap set ["Synd_HQ", _nestedHashmap];
+sidesX setVariable ["OBJ_DATA", _hashMap, true];
 
 // ****************** Load save data or create new *********************************
 

--- a/A3A/addons/core/functions/proxy/fn_onPlayerRespawn.sqf
+++ b/A3A/addons/core/functions/proxy/fn_onPlayerRespawn.sqf
@@ -211,10 +211,7 @@ if (side group player == teamPlayer) then
 			private _veh = _this select 1;
 			[_veh, teamPlayer] call A3A_fnc_AIVEHinit;		// will flip/capture if already initialized
 			if (_veh isKindOf "StaticWeapon") then {
-				if (not(_veh in staticsToSave)) then {
-					staticsToSave pushBack _veh;
-					publicVariable "staticsToSave";
-				};
+				//TODO: add static weapon to location
 				_markersX = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
 				_pos = position _veh;
 				if (_markersX findIf {_pos inArea _x} != -1) then {["Static Deployed", "Static weapon has been deployed for use in a nearby zone, and will be used by garrison militia if you leave it here the next time the zone spawns."] call A3A_fnc_customHint;};

--- a/A3A/addons/garage/Public/config.inc
+++ b/A3A/addons/garage/Public/config.inc
@@ -66,7 +66,7 @@ HR_GRG_fnc_Hint = {
     ] call A3A_fnc_customHint;
 };
 HR_GRG_fnc_vehInit = {
-    if (_this isKindOf "StaticWeapon") then {staticsToSave pushBack _this; publicVariable "staticsToSave"};
+    if (_this isKindOf "StaticWeapon") then {[_this] call A3A_fnc_addObjectToBuildSave};
     _this setVariable ["ownerX",getPlayerUID player,true];
     [_this, TeamPlayer] call A3A_fnc_AIVEHinit;
 }; //is passed vehicle as _this

--- a/A3A/addons/garage/Public/fn_addVehicle.sqf
+++ b/A3A/addons/garage/Public/fn_addVehicle.sqf
@@ -117,13 +117,9 @@ if (
     && {count (airportsX select {(sidesX getVariable [_x,sideUnknown] == teamPlayer) and (_player inArea _x)}) < 1} //no airports
 ) exitWith {["STR_HR_GRG_Feedback_addVehicle_airBlocked", [FactionGet(reb,"name")]] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
 
-//here to allow adaption of external Antistasi system without needing to addapt code under APL-ND
-private _broadcastReportedVehsAndStaticsToSave = {
-    publicVariable "staticsToSave";
-};
 //_this is vehicle
-private _deleteFromReportedVehsAndStaticsToSave = {
-    staticsToSave deleteAt (staticsToSave find _this);
+private _deleteFromReportedVehsAndStatics = {
+    [_this] call A3A_fnc_removeObjectFromBuildSave;
 };
 //_this is vehicle
 private _transferToArsenal = {
@@ -175,7 +171,7 @@ private _addVehicle = {
 
     //Antistasi adaptions
     _this call _transferToArsenal;
-    _this call _deleteFromReportedVehsAndStaticsToSave;
+    _this call _deleteFromReportedVehsAndStatics;
     _this call _unloadAceCargo;
 
     deleteVehicle _this;
@@ -202,7 +198,6 @@ private _catsRequiringUpdate = [];
 } forEach attachedObjects _vehicle;
 _vehicle call _addVehicle;
 
-if (_catsRequiringUpdate isNotEqualTo []) then _broadcastReportedVehsAndStaticsToSave;
 
 //refresh category for active users
 private _refreshCode = {


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [x] Enhancement

### What have you changed and why?
Information:
    Removes statics to save and replaces it with a hashmap location binning. Designed to replace staticsToSave, so that we can move the spawning of statics and buildings to the scheduler. Mainly down to drop spawned entity counts. This may or may not work. I got testing done with Lan, so this could break for multiplayer. 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
********************************************************
Notes:
