### PR TITLE
Fix crate transfer not updating arsenal unlocks with new items

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_arsenalManage.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_arsenalManage.sqf
@@ -4,7 +4,7 @@ if (!isServer) exitWith {};
 private _updated = "";
 private _item = objNull;
 private _cateogry = objNull;
-["buttonInvToJNA"] call jn_fnc_arsenal;
+[boxX] call jn_fnc_arsenal_cargoToArsenal;
 
 if (minWeaps < 0) exitWith {""};		// no unlocks
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
When crate or vehicle contents were transferred to the arsenal, it would run an unlock check (arsenalManage) but before adding the new items due to timing issues. This PR fixes the problem by removing the last server->server remoteExec in the way.

Would have been a lot harder to fix before, but another blocking issue with arsenal_addItem timing was fixed relatively recently.   

Items may or may not unlock immediately for players who are already viewing the arsenal. Shouldn't be an issue.

### Please specify which Issue this PR Resolves.
closes #885

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
