### PR TITLE
Prevent use of ACE grenade throwing near HQ

### DIFF
--- a/A3A/addons/core/functions/Punishment/fn_punishment_FF_AddEH.sqf
+++ b/A3A/addons/core/functions/Punishment/fn_punishment_FF_AddEH.sqf
@@ -63,6 +63,10 @@ if (A3A_hasACE) then {
         params ["_explosive","_dir","_pitch","_unit"];
         [_unit,"Put",_explosive] call A3A_fnc_punishment_FF_checkNearHQ;
     }] call CBA_fnc_addEventHandler;
+    ["ace_throwableThrown", {
+        params ["_unit", "_throwable"];
+        [_unit,"Throw",_throwable] call A3A_fnc_punishment_FF_checkNearHQ;
+    }] call CBA_fnc_addEventHandler;
 } else {
     _unit addEventHandler ["FiredMan", {
         params ["_unit", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile", "_vehicle"];


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
The punishment system didn't detect ACE grenade throwing (shift-G default). Now it does.

### Please specify which Issue this PR Resolves.
closes #1690

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
