### PR TITLE
Test-fix for establishing a roadblock using remote control

### DIFF
--- a/A3A/addons/core/functions/Base/fn_createOutpostsFIA.sqf
+++ b/A3A/addons/core/functions/Base/fn_createOutpostsFIA.sqf
@@ -51,10 +51,11 @@ if ({(alive _x) and (_x distance _positionTel < 10)} count units _groupX > 0) th
 		_owner = (leader _groupX) getVariable ["owner",leader _groupX];
 		(leader _groupX) remoteExec ["removeAllActions",leader _groupX];
 		_owner remoteExec ["selectPlayer",leader _groupX];
-		(leader _groupX) setVariable ["owner",_owner,true];
-		{[_x] joinsilent group _owner} forEach units group _owner;
-		[group _owner, _owner] remoteExec ["selectLeader", _owner];
+		//(leader _groupX) setVariable ["owner",_owner,true];
+		//{[_x] joinsilent group _owner} forEach units group _owner;
+		//[group _owner, _owner] remoteExec ["selectLeader", _owner];
 		waitUntil {!(isPlayer leader _groupX)};
+		sleep 5;			// Give client & server time to resolve the selectPlayer before we delete anything
 		};
 	outpostsFIA = outpostsFIA + [_mrk]; publicVariable "outpostsFIA";
 	sidesX setVariable [_mrk,teamPlayer,true];


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
There have been several cases of players breaking badly by completing a roadblock using remote control, including Arma crashes and broken player objects. Couldn't replicate, maybe because a dedicated server with significant latency is required.

The roadblock code has specific logic for this, which is bad but shouldn't cause this sort of problem. My best guess is that the problem is that the roadblock code deletes the units immediately after, and this can outpace some selectPlayer functionality. Added a short delay and removed some redundant operations that wouldn't have worked correctly anyway due to remoteExec order.

### Please specify which Issue this PR Resolves.
maybe closes #1964

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

See if there are no further reports within six months or so.