### PR TITLE
Allow rebels to purchase AT and AA missile launcher troops

### DIFF
--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -443,6 +443,12 @@
         <Spanish>Reclutar AT</Spanish>
         <Polish>Rekrutuj Celowniczego PPANC</Polish>
       </Key>
+      <Key ID="STR_antistasi_dialogs_garrison_spawn_atmissile_text">
+        <Original>Recruit AT Missile</Original>
+      </Key>
+      <Key ID="STR_antistasi_dialogs_garrison_spawn_aamissile_text">
+        <Original>Recruit AA Missile</Original>
+      </Key>
     </Container>
     <Container name="dialog_build_minefield">
       <Key ID="STR_antistasi_dialogs_minefield_frame_text">
@@ -628,7 +634,7 @@
         <Polish>Rekrutuj Strzelca Wyborowego</Polish>
       </Key>
       <Key ID="STR_antistasi_dialogs_unit_recruit_antitank_text">
-        <Original>Recruit Antitank Solider</Original>
+        <Original>Recruit Antitank Soldier</Original>
         <French>Recruter un Soldat Antichar</French>
         <Russian>Гранатомётчик</Russian>
         <German>Panzerabwehrsoldat rekrutieren</German>
@@ -638,6 +644,12 @@
         <Italian>Recluta Soldato Anticarro</Italian>
         <Spanish>Reclutar AT</Spanish>
         <Polish>Rekrutuj Celowniczego PPANC</Polish>
+      </Key>
+      <Key ID="STR_antistasi_dialogs_unit_recruit_atmissile_text">
+        <Original>Recruit AT Missile Soldier</Original>
+      </Key>
+      <Key ID="STR_antistasi_dialogs_unit_recruit_aamissile_text">
+        <Original>Recruit AA Missile Soldier</Original>
       </Key>
     </Container>
     <Container name="dialog_generic">

--- a/A3A/addons/core/dialogs.hpp
+++ b/A3A/addons/core/dialogs.hpp
@@ -253,18 +253,18 @@ class garrison_recruit 			{
 			idc = 101;
 			text = $STR_antistasi_dialogs_generic_box_text;
 			x = 0.244979 * safezoneW + safezoneX;
-			y = 0.223941 * safezoneH + safezoneY;
+			y = 0.173941 * safezoneH + safezoneY;
 			w = 0.445038 * safezoneW;
-			h = 0.492103 * safezoneH;
+			h = 0.592103 * safezoneH;
 		};
 		class HQ_frame: A3A_core_BattleMenuFrame
 		{
 			idc = 102;
 			text = $STR_antistasi_dialogs_garrison_recruit_frame_text;
 			x = 0.254979 * safezoneW + safezoneX;
-			y = 0.233941 * safezoneH + safezoneY;
+			y = 0.183941 * safezoneH + safezoneY;
 			w = 0.425038 * safezoneW;
-			h = 0.462103 * safezoneH;
+			h = 0.562103 * safezoneH;
 		};
 		class HQ_button_back: A3A_core_BattleMenuRedButton
 		{
@@ -272,7 +272,7 @@ class garrison_recruit 			{
 			text = $STR_antistasi_dialogs_generic_button_back_text;
 			tooltip = $STR_antistasi_dialogs_generic_button_back_tooltip;
 			x = 0.61 * safezoneW + safezoneX;
-			y = 0.251941 * safezoneH + safezoneY;
+			y = 0.201941 * safezoneH + safezoneY;
 			w = 0.06 * safezoneW;//0.175015
 			h = 0.05 * safezoneH;
 			action = "closeDialog 0;_nul = createDialog ""build_menu"";";
@@ -282,7 +282,7 @@ class garrison_recruit 			{
 			idc = 104;
 			text = $STR_antistasi_dialogs_garrison_spawn_rifleman_text;
 			x = 0.272481 * safezoneW + safezoneX;
-			y = 0.317959 * safezoneH + safezoneY;
+			y = 0.267959 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			action = "nul = [A3A_faction_reb get 'unitRifle'] spawn A3A_fnc_garrisonAdd";
@@ -292,7 +292,7 @@ class garrison_recruit 			{
 			idc = 105;
 			text = $STR_antistasi_dialogs_garrison_spawn_autorifleman_text;
 			x = 0.272481 * safezoneW + safezoneX;
-			y = 0.415981 * safezoneH + safezoneY;
+			y = 0.365981 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			action = "nul = [A3A_faction_reb get 'unitMG'] spawn A3A_fnc_garrisonAdd";
@@ -302,7 +302,7 @@ class garrison_recruit 			{
 			idc = 126;
 			text = $STR_antistasi_dialogs_garrison_spawn_medic_text;
 			x = 0.272481 * safezoneW + safezoneX;
-			y = 0.514003 * safezoneH + safezoneY;
+			y = 0.464003 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			action = "nul = [A3A_faction_reb get 'unitMedic'] spawn A3A_fnc_garrisonAdd";
@@ -312,7 +312,7 @@ class garrison_recruit 			{
 			idc = 107;
 			text = $STR_antistasi_dialogs_garrison_spawn_squad_lead_text;
 			x = 0.482498 * safezoneW + safezoneX;
-			y = 0.317959 * safezoneH + safezoneY;
+			y = 0.267959 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			action = "nul = [A3A_faction_reb get 'unitSL'] spawn A3A_fnc_garrisonAdd";
@@ -322,7 +322,7 @@ class garrison_recruit 			{
 			idc = 108;
 			text = $STR_antistasi_dialogs_garrison_spawn_mortar_text;
 			x = 0.482498 * safezoneW + safezoneX;
-			y = 0.514003 * safezoneH + safezoneY;
+			y = 0.464003 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			action = "nul = [A3A_faction_reb get 'unitCrew'] spawn A3A_fnc_garrisonAdd";
@@ -332,7 +332,7 @@ class garrison_recruit 			{
 			idc = 109;
 			text = $STR_antistasi_dialogs_garrison_spawn_grenadier_text;
 			x = 0.482498 * safezoneW + safezoneX;
-			y = 0.415981 * safezoneH + safezoneY;
+			y = 0.365981 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			action = "nul = [A3A_faction_reb get 'unitGL'] spawn A3A_fnc_garrisonAdd";
@@ -342,21 +342,40 @@ class garrison_recruit 			{
 			idc = 110;
 			text = $STR_antistasi_dialogs_garrison_spawn_marksman_text;
 			x = 0.272481 * safezoneW + safezoneX;
-			y = 0.612025 * safezoneH + safezoneY;
+			y = 0.562025 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			action = "nul = [A3A_faction_reb get 'unitSniper'] spawn A3A_fnc_garrisonAdd";
 		};
-
-		class HQ_button_AT: A3A_core_BattleMenuRedButton
+		class HQ_button_LAT: A3A_core_BattleMenuRedButton
 		{
 			idc = 111;
 			text = $STR_antistasi_dialogs_garrison_spawn_at_text;
 			x = 0.482498 * safezoneW + safezoneX;
-			y = 0.612025 * safezoneH + safezoneY;
+			y = 0.562025 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			action = "nul = [A3A_faction_reb get 'unitLAT'] spawn A3A_fnc_garrisonAdd";
+		};
+		class HQ_button_AT: A3A_core_BattleMenuRedButton
+		{
+			idc = 112;
+			text = $STR_antistasi_dialogs_garrison_spawn_atmissile_text;
+			x = 0.272481 * safezoneW + safezoneX;
+			y = 0.660047 * safezoneH + safezoneY;
+			w = 0.175015 * safezoneW;
+			h = 0.0560125 * safezoneH;
+			action = "nul = [A3A_faction_reb get 'unitAT'] spawn A3A_fnc_garrisonAdd";
+		};
+		class HQ_button_AA: A3A_core_BattleMenuRedButton
+		{
+			idc = 113;
+			text = $STR_antistasi_dialogs_garrison_spawn_aamissile_text;
+			x = 0.482498 * safezoneW + safezoneX;
+			y = 0.660047 * safezoneH + safezoneY;
+			w = 0.175015 * safezoneW;
+			h = 0.0560125 * safezoneH;
+			action = "nul = [A3A_faction_reb get 'unitAA'] spawn A3A_fnc_garrisonAdd";
 		};
 	};
 };										//slots: 8
@@ -437,25 +456,25 @@ class unit_recruit 		{
 			idc = 101;
 			text = $STR_antistasi_dialogs_generic_box_text;
 			x = 0.244979 * safezoneW + safezoneX;
-			y = 0.223941 * safezoneH + safezoneY;
+			y = 0.173941 * safezoneH + safezoneY;
 			w = 0.445038 * safezoneW;
-			h = 0.492103 * safezoneH;
+			h = 0.592103 * safezoneH;
 		};
 		class HQ_frame: A3A_core_BattleMenuFrame
 		{
 			idc = 102;
 			text = $STR_antistasi_dialogs_unit_recruit_frame_text;
 			x = 0.254979 * safezoneW + safezoneX;
-			y = 0.233941 * safezoneH + safezoneY;
+			y = 0.183941 * safezoneH + safezoneY;
 			w = 0.425038 * safezoneW;
-			h = 0.462103 * safezoneH;
+			h = 0.562103 * safezoneH;
 		};
 		class HQ_button_back: A3A_core_BattleMenuRedButton
 		{
 			idc = 103;
 			text = $STR_antistasi_dialogs_generic_button_back_text;
 			x = 0.61 * safezoneW + safezoneX;
-			y = 0.251941 * safezoneH + safezoneY;
+			y = 0.201941 * safezoneH + safezoneY;
 			w = 0.06 * safezoneW;//0.175015
 			h = 0.05 * safezoneH;
 			action = "closeDialog 0";
@@ -465,7 +484,7 @@ class unit_recruit 		{
 			idc = 104;
 			text = $STR_antistasi_dialogs_unit_recruit_militiaman_text;
 			x = 0.272481 * safezoneW + safezoneX;
-			y = 0.317959 * safezoneH + safezoneY;
+			y = 0.267959 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			action = "nul = [A3A_faction_reb get 'unitRifle'] spawn A3A_fnc_reinfPlayer";
@@ -475,7 +494,7 @@ class unit_recruit 		{
 			idc = 105;
 			text = $STR_antistasi_dialogs_unit_recruit_mg_text;
 			x = 0.272481 * safezoneW + safezoneX;
-			y = 0.415981 * safezoneH + safezoneY;
+			y = 0.365981 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			action = "nul = [A3A_faction_reb get 'unitMG'] spawn A3A_fnc_reinfPlayer";
@@ -485,7 +504,7 @@ class unit_recruit 		{
 			idc = 126;
 			text = $STR_antistasi_dialogs_unit_recruit_medic_text;
 			x = 0.272481 * safezoneW + safezoneX;
-			y = 0.514003 * safezoneH + safezoneY;
+			y = 0.464003 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			action = "nul = [A3A_faction_reb get 'unitMedic'] spawn A3A_fnc_reinfPlayer";
@@ -495,7 +514,7 @@ class unit_recruit 		{
 			idc = 107;
 			text = $STR_antistasi_dialogs_unit_recruit_engineer_text;
 			x = 0.482498 * safezoneW + safezoneX;
-			y = 0.317959 * safezoneH + safezoneY;
+			y = 0.267959 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			action = "nul = [A3A_faction_reb get 'unitEng'] spawn A3A_fnc_reinfPlayer";
@@ -505,7 +524,7 @@ class unit_recruit 		{
 			idc = 108;
 			text = $STR_antistasi_dialogs_unit_recruit_explosive_text;
 			x = 0.482498 * safezoneW + safezoneX;
-			y = 0.514003 * safezoneH + safezoneY;
+			y = 0.464003 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			action = "nul = [A3A_faction_reb get 'unitExp'] spawn A3A_fnc_reinfPlayer";
@@ -515,7 +534,7 @@ class unit_recruit 		{
 			idc = 109;
 			text = $STR_antistasi_dialogs_unit_recruit_grenadier_text;
 			x = 0.482498 * safezoneW + safezoneX;
-			y = 0.415981 * safezoneH + safezoneY;
+			y = 0.365981 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			action = "nul = [A3A_faction_reb get 'unitGL'] spawn A3A_fnc_reinfPlayer";
@@ -525,21 +544,40 @@ class unit_recruit 		{
 			idc = 110;
 			text = $STR_antistasi_dialogs_unit_recruit_marksman_text;
 			x = 0.272481 * safezoneW + safezoneX;
-			y = 0.612025 * safezoneH + safezoneY;
+			y = 0.562025 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			action = "nul = [A3A_faction_reb get 'unitSniper'] spawn A3A_fnc_reinfPlayer";
 		};
-
-		class HQ_button_AT: A3A_core_BattleMenuRedButton
+		class HQ_button_LAT: A3A_core_BattleMenuRedButton
 		{
 			idc = 111;
 			text = $STR_antistasi_dialogs_unit_recruit_antitank_text;
 			x = 0.482498 * safezoneW + safezoneX;
-			y = 0.612025 * safezoneH + safezoneY;
+			y = 0.562025 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			action = "nul = [A3A_faction_reb get 'unitLAT'] spawn A3A_fnc_reinfPlayer";
+		};
+		class HQ_button_AT: A3A_core_BattleMenuRedButton
+		{
+			idc = 112;
+			text = $STR_antistasi_dialogs_unit_recruit_atmissile_text;
+			x = 0.272481 * safezoneW + safezoneX;
+			y = 0.660047 * safezoneH + safezoneY;
+			w = 0.175015 * safezoneW;
+			h = 0.0560125 * safezoneH;
+			action = "nul = [A3A_faction_reb get 'unitAT'] spawn A3A_fnc_reinfPlayer";
+		};
+		class HQ_button_AA: A3A_core_BattleMenuRedButton
+		{
+			idc = 113;
+			text = $STR_antistasi_dialogs_unit_recruit_aamissile_text;
+			x = 0.482498 * safezoneW + safezoneX;
+			y = 0.660047 * safezoneH + safezoneY;
+			w = 0.175015 * safezoneW;
+			h = 0.0560125 * safezoneH;
+			action = "nul = [A3A_faction_reb get 'unitAA'] spawn A3A_fnc_reinfPlayer";
 		};
 	};
 };

--- a/A3A/addons/core/functions/Base/fn_garrisonInfo.sqf
+++ b/A3A/addons/core/functions/Base/fn_garrisonInfo.sqf
@@ -10,7 +10,7 @@ private _estatic = if (_siteX in outpostsFIA) then {"Technicals"} else {"Mortars
 private _limit = [_siteX] call A3A_fnc_getGarrisonLimit;
 
 //sort garrison into unit types
-private _units = [ [],[],[],[],[],[],[],[],[] ];
+private _units = [ [],[],[],[],[],[],[],[],[],[],[] ];
 {
     _units # (switch _x do {
         case (FactionGet(reb,"unitSL")): {0};
@@ -21,12 +21,14 @@ private _units = [ [],[],[],[],[],[],[],[],[] ];
         case (FactionGet(reb,"unitGL")): {5};
         case (FactionGet(reb,"unitSniper")): {6};
         case (FactionGet(reb,"unitLAT")): {7};
-        default {8};
+        case (FactionGet(reb,"unitAT")): {8};
+        case (FactionGet(reb,"unitAA")): {9};
+        default {10};
     }) pushBack _x;
 } forEach _garrison;
 
 _textX = format [
-    "<br/><br/>Garrison units: %1%13<br/><br/>Squad Leaders: %2<br/>%12: %3<br/>Riflemen: %4<br/>Autoriflemen: %5<br/>Medics: %6<br/>Grenadiers: %7<br/>Marksmen: %8<br/>AT Men: %9<br/>Other: %10<br/>Static Weap: %11"
+    "<br/><br/>Garrison units: %1%15<br/><br/>Squad Leaders: %2<br/>%14: %3<br/>Riflemen: %4<br/>Autoriflemen: %5<br/>Medics: %6<br/>Grenadiers: %7<br/>Marksmen: %8<br/>AT Men: %9<br/>AT Missile Men: %10<br />AA Missile Men: %11<br />Other: %12<br/>Static Weap: %13"
     , count _garrison
     , count (_units#0)
     , count (_units#1)
@@ -37,6 +39,8 @@ _textX = format [
     , count (_units#6)
     , count (_units#7)
     , count (_units#8)
+    , count (_units#9)
+    , count (_units#10)
     , {_x distance _positionX < _size} count staticsToSave
     , _estatic
     , if (_limit != -1) then {format ["/%1", _limit]} else {""}

--- a/A3A/addons/core/functions/Dialogs/fn_unit_recruit.sqf
+++ b/A3A/addons/core/functions/Dialogs/fn_unit_recruit.sqf
@@ -32,4 +32,8 @@ if (str (_display) != "no display") then
 	_ChildControl  ctrlSetTooltip format ["Cost: %1 €",server getVariable FactionGet(reb,"unitSniper")];
 	_ChildControl = _display displayCtrl 111;
 	_ChildControl  ctrlSetTooltip format ["Cost: %1 €",server getVariable FactionGet(reb,"unitLAT")];
+	_ChildControl = _display displayCtrl 112;
+	_ChildControl  ctrlSetTooltip format ["Cost: %1 €",server getVariable FactionGet(reb,"unitAT")];
+	_ChildControl = _display displayCtrl 113;
+	_ChildControl  ctrlSetTooltip format ["Cost: %1 €",server getVariable FactionGet(reb,"unitAA")];
 };

--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -139,6 +139,18 @@ switch (true) do
 //			[_unit, "LIB_PTRD", 100] call _addSecondaryAndMags;
 //		};
     };
+    case (_unitType isEqualTo FactionGet(reb,"unitAT")): {
+        [_unit, "Rifles", 40] call A3A_fnc_randomRifle;
+
+        private _launcher = selectRandomWeighted (A3A_rebelGear get "MissileLaunchersAT");
+        if !(isNil "_launcher") then { [_unit, _launcher, 100] call _fnc_addSecondaryAndMags };
+    };
+    case (_unitType isEqualTo FactionGet(reb,"unitAA")): {
+        [_unit, "Rifles", 40] call A3A_fnc_randomRifle;
+
+        private _launcher = selectRandomWeighted (A3A_rebelGear get "MissileLaunchersAA");
+        if !(isNil "_launcher") then { [_unit, _launcher, 100] call _fnc_addSecondaryAndMags };
+    };
     case (_unitType isEqualTo FactionGet(reb,"unitSL")): {
         [_unit, "Rifles", 50] call A3A_fnc_randomRifle;
         if (_smokes isNotEqualTo []) then { _unit addMagazines [selectRandomWeighted _smokes, 2] };

--- a/A3A/addons/core/functions/REINF/fn_garrisonAdd.sqf
+++ b/A3A/addons/core/functions/REINF/fn_garrisonAdd.sqf
@@ -38,6 +38,7 @@ if (_limit != -1 && {count _garrison >= _limit}) exitWith {
 	[localize "STR_A3A_garrisons_header", localize "STR_A3A_garrison_reached_limit"] call A3A_fnc_customHint;
 };
 
+
 _nul = [-1,-_costs] remoteExec ["A3A_fnc_resourcesFIA",2];
 
 private _countX = count _garrison;

--- a/A3A/addons/core/functions/REINF/fn_garrisonDialog.sqf
+++ b/A3A/addons/core/functions/REINF/fn_garrisonDialog.sqf
@@ -136,5 +136,9 @@ else
 		_ChildControl  ctrlSetTooltip format ["Cost: %1 €",server getVariable FactionGet(reb,"unitSniper")];
 		_ChildControl = _display displayCtrl 111;
 		_ChildControl  ctrlSetTooltip format ["Cost: %1 €",server getVariable FactionGet(reb,"unitLAT")];
+		_ChildControl = _display displayCtrl 112;
+		_ChildControl  ctrlSetTooltip format ["Cost: %1 €",server getVariable FactionGet(reb,"unitAT")];
+		_ChildControl = _display displayCtrl 113;
+		_ChildControl  ctrlSetTooltip format ["Cost: %1 €",server getVariable FactionGet(reb,"unitAA")];
 		};
 	};

--- a/A3A/addons/core/functions/REINF/fn_reinfPlayer.sqf
+++ b/A3A/addons/core/functions/REINF/fn_reinfPlayer.sqf
@@ -20,6 +20,18 @@ if (_costs > _resourcesFIA) exitWith {["AI Recruitment", format ["You do not hav
 
 if ((count units group player) + (count units stragglers) > 9) exitWith {["AI Recruitment", "Your squad is full or you have too many scattered units with no radio contact."] call A3A_fnc_customHint;};
 
+private _weaponHM = createHashMapFromArray [
+	[A3A_faction_reb get "unitSniper", "SniperRifles"],
+	[A3A_faction_reb get "unitLAT", "RocketLaunchers"],
+	[A3A_faction_reb get "unitMG", "MachineGuns"],
+	[A3A_faction_reb get "unitGL", "GrenadeLaunchers"],
+	[A3A_faction_reb get "unitAA", "MissileLaunchersAA"],
+	[A3A_faction_reb get "unitAT", "MissileLaunchersAT"]];
+
+if (A3A_rebelGear getOrDefault [_weaponHM getOrDefault [_typeUnit, ""], false] isEqualTo []) exitWith {
+	["AI Recruitment", "You don't have enough weapons to equip this type of unit."] call A3A_fnc_customHint;
+};
+
 private _unit = [group player, _typeUnit, position player, [], 0, "NONE"] call A3A_fnc_createUnit;
 
 if (!isMultiPlayer) then {

--- a/A3A/addons/core/functions/Templates/fn_compileGroups.sqf
+++ b/A3A/addons/core/functions/Templates/fn_compileGroups.sqf
@@ -175,6 +175,8 @@ _faction set ["unitGL", unit(militia, "Grenadier")];
 _faction set ["unitRifle", unit(militia, "Rifleman")];
 _faction set ["unitSL", unit(militia, "SquadLeader")];
 _faction set ["unitEng", unit(militia, "Engineer")];
+_faction set ["unitAA", unit(militia, "AA")];
+_faction set ["unitAT", unit(militia, "AT")];
 
 //groups
 _faction set ["groupMedium", [_faction get "unitSL", _faction get "unitGL", _faction get "unitMG", _faction get "unitRifle"]];
@@ -212,7 +214,7 @@ _faction set ["groupSquadSupp", [
 _faction set ["groupSniper", double( _faction get "unitSniper" )];
 _faction set ["groupSentry", [_faction get "unitGL", _faction get "unitRifle"]];
 
-_faction set ["unitsSoldiers", (_faction get "groupSquadEng") + [_faction get "unitSniper", _faction get "unitCrew"]];
+_faction set ["unitsSoldiers", (_faction get "groupSquadEng") + [_faction get "unitSniper", _faction get "unitCrew", _faction get "unitAA", _faction get "unitAT"]];
 
 };
 

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -557,6 +557,7 @@ Info("Creating pricelist");
 {server setVariable [_x,75,true]} forEach [FactionGet(reb,"unitMG"), FactionGet(reb,"unitGL"), FactionGet(reb,"unitLAT")];
 {server setVariable [_x,100,true]} forEach [FactionGet(reb,"unitMedic"), FactionGet(reb,"unitExp"), FactionGet(reb,"unitEng")];
 {server setVariable [_x,150,true]} forEach [FactionGet(reb,"unitSL"), FactionGet(reb,"unitSniper")];
+{server setVariable [_x,500,true]} forEach [FactionGet(reb,"unitAT"), FactionGet(reb,"unitAA")];
 
 {
 	server setVariable [_x, _y, true];


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
There was an old feature where if you had missile launchers set to unlockable, recruiting engineers to your squad or riflemen to garrisons would equip them with a missile launcher. This was removed with the rebelGear/no-unlocks update, but the intention was that it'd be replaced by directly purchasable (but expensive) missile launcher troops in the new UI. As this still isn't finished and people are complaining about it, I've jammed new buttons into the unit recruit and garrison recruit UIs.

It's a bit questionable whether we should be allowing direct purchase of missile launcher AIs, but:
1. They're expensive at 500+ per unit.
2. AIs are idiots and usually stand in the wrong place to use the things.
3. Zu23s are relatively overpowered against aircraft already, so it's mostly a vanilla balance change.

Also added a feature that blocks players from buying units for their personal squad when you don't have enough of the right weapons. This isn't applied to garrisons, because eventually those units would be equipped.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
3. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
