### PR TITLE
Fix units being inappropriately revealed to garrisons

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_FIAinitBASES.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_FIAinitBASES.sqf
@@ -73,30 +73,10 @@ _EHkilledIdx = _unit addEventHandler ["killed", {
 		};
 	}];
 
-_revealX = false;
-if (vehicle _unit != _unit) then
-	{
-	if (_unit == gunner (vehicle _unit)) then
-		{
-			_revealX = true;
-			if (debug) then {
-                Debug_1("Unit: %1 is mounted gunner.", _unit);
-			};
-		};
-	}
-else
-	{
-	if ((secondaryWeapon _unit) in allMissileLaunchers) then {
-			_revealX = true;
-			if (debug) then {
-                Debug_2("Unit: %1 has launcher: %2.", _unit, (secondaryWeapon _unit));
-			};
-		};
-	};
-
-if (_revealX) then
-	{
-	{
-	_unit reveal [_x,1.5];
-	} forEach allUnits select {(vehicle _x isKindOf "Air") and (_x distance _unit <= distanceSPWN)};
-	};
+//Reveals all air vehicles to the unit, if it is either gunner of a vehicle or equipped with a launcher
+if (_unit == gunner objectParent _unit or {(secondaryWeapon _unit) in allAA}) then
+{
+    {
+        if (!isNull driver _x) then { _unit reveal [_x, 1.5] };
+    } forEach (_unit nearEntities ["Air", distanceSPWN*2]);
+};

--- a/A3A/addons/core/functions/CREATE/fn_NATOinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_NATOinit.sqf
@@ -245,26 +245,11 @@ else
     _unit unlinkItem (_unit call A3A_fnc_getRadio);
 };
 
-//Reveals all air vehicles to the unit, if it is either gunner of a vehicle or equipted with a launcher
-private _reveal = false;
-if !(isNull objectParent _unit) then
-{
-    if (_unit == gunner (objectParent _unit)) then
-    {
-        _reveal = true;
-    };
-}
-else
-{
-    if ((secondaryWeapon _unit) in allMissileLaunchers) then
-    {
-        _reveal = true;
-    };
-};
-if (_reveal) then
+//Reveals all air vehicles to the unit, if it is either gunner of a vehicle or equipped with a launcher
+if (_unit == gunner objectParent _unit or {(secondaryWeapon _unit) in allAA}) then
 {
     {
-        _unit reveal [_x,1.5];
-    } forEach allUnits select {(vehicle _x isKindOf "Air") and (_x distance _unit <= distanceSPWN)}
+        if (!isNull driver _x) then { _unit reveal [_x, 1.5] };
+    } forEach (_unit nearEntities ["Air", distanceSPWN*2]);
 };
 ["AIInit", [_unit, _side, _marker, _unit getVariable "spawner"]] call EFUNC(Events,triggerEvent);


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Some classic-Antistasi code that revealed air units to garrison gunners & missile launcher troops was accidentally revealing *everything* to those units due to a precedence error. This was easy to demonstrate by moving within spawn distance of an early-game (vehicle) garrison while not undercover, because those garrisons don't use UPSMON (or patcom now), so they'd use the vanilla behaviour of sending units to investigate the contact. This bug may well have had significant performance penalties in addition to some weird cheating behaviour.

Fixed it to only reveal air vehicles. Also cleaned up and improved performance of the reveal code.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
