### PR TITLE
Fix syntax for adding WS CDLC static AA to rebel templates

### DIFF
--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
@@ -41,7 +41,7 @@ private _staticAA = ["I_static_AA_F"];
 
 if (allowDLCWS) then {
   _vehicleAA append ["I_Tura_Truck_02_aa_lxWS"];
-  _staticAA insert [0, "I_Tura_ZU23_lxWS"];
+  _staticAA insert [0, ["I_Tura_ZU23_lxWS"]];
 };
 ["vehiclesAA", _vehicleAA] call _fnc_saveToTemplate;
 ["staticAA", _staticAA] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
@@ -41,7 +41,7 @@ private _staticAA = ["I_static_AA_F"];
 
 if (allowDLCWS) then {
   _vehicleAA append ["I_Tura_Truck_02_aa_lxWS"];
-  _staticAA insert [0, "I_Tura_ZU23_lxWS"];
+  _staticAA insert [0, ["I_Tura_ZU23_lxWS"]];
 };
 ["vehiclesAA", _vehicleAA] call _fnc_saveToTemplate;
 ["staticAA", _staticAA] call _fnc_saveToTemplate;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The syntax for adding the WS ZU23 static AA was incorrect in the vanilla rebel templates, causing them to be unpurchasable. This PR probably fixes it.

New bug in 3.2.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Need someone else to test this as I don't have WS.

### How can the changes be tested?
Start campaigns with vanilla FIA and SDK rebels with WS DLC enabled in the factions page. Check that the static zu23 is available to purchase in the vehicle buy menu.
