### PR TITLE
Fix trailing comma and missing AA plane in ION Temperate

### DIFF
--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_ION_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_ION_Temperate.sqf
@@ -27,7 +27,7 @@
 ["vehiclesFuelTrucks", ["UK3CB_ION_B_Desert_T810_Refuel"]] call _fnc_saveToTemplate;
 ["vehiclesMedical", ["UK3CB_ION_B_Desert_Hilux_Ambulance", "UK3CB_ION_B_Desert_M113_AMB", "UK3CB_ION_B_Desert_Transit_Medevac"]] call _fnc_saveToTemplate;
 ["vehiclesLightAPCs", ["UK3CB_B_LAV25_HQ_US_WDL", "UK3CB_ION_B_Desert_M113_M2", "UK3CB_ION_B_Desert_M113_MK19", "UK3CB_KDF_B_MTLB_KPVT", "UK3CB_KRG_B_MTLB_PKT"]] call _fnc_saveToTemplate;
-["vehiclesAPCs", ["UK3CB_B_LAV25_US_WDL", "UK3CB_B_LAV25_US_WDL", "UK3CB_B_AAV_US_WDL", "UK3CB_B_AAV_US_WDL", "RHS_M2A2_wd", "UK3CB_KDF_B_MTLB_BMP", "UK3CB_KDF_B_MTLB_Cannon",]] call _fnc_saveToTemplate;
+["vehiclesAPCs", ["UK3CB_B_LAV25_US_WDL", "UK3CB_B_LAV25_US_WDL", "UK3CB_B_AAV_US_WDL", "UK3CB_B_AAV_US_WDL", "RHS_M2A2_wd", "UK3CB_KDF_B_MTLB_BMP", "UK3CB_KDF_B_MTLB_Cannon"]] call _fnc_saveToTemplate;
 ["vehiclesIFVs", ["RHS_M2A2_wd"]] call _fnc_saveToTemplate;
 ["vehiclesTanks", ["UK3CB_KDF_B_T55", "UK3CB_KDF_B_T72A", "UK3CB_KDF_B_T72BM"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["RHS_M6_wd", "UK3CB_KRG_B_M270_Avenger"]] call _fnc_saveToTemplate;
@@ -37,7 +37,7 @@
 ["vehiclesAmphibious", ["UK3CB_B_AAV_US_WDL"]] call _fnc_saveToTemplate;
 
 ["vehiclesPlanesCAS", ["UK3CB_KDF_B_Su25SM_CAS"]] call _fnc_saveToTemplate;
-["vehiclesPlanesAA", ["UK3CB_KDF_B_L39_PYLON"]] call _fnc_saveToTemplate;
+["vehiclesPlanesAA", ["UK3CB_KDF_B_MIG29SM"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesTransport", ["RHS_C130J"]] call _fnc_saveToTemplate;
 
 ["vehiclesHelisLight", ["UK3CB_ION_B_Desert_Bell412_Utility", "UK3CB_ION_B_Desert_MELB_H6M", "UK3CB_ION_B_Desert_UH1H", "UK3CB_ION_B_Desert_Unarmed_MH9"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/functions/Base/fn_setPlaneLoadout.sqf
+++ b/A3A/addons/core/functions/Base/fn_setPlaneLoadout.sqf
@@ -262,6 +262,7 @@ if (_type == "AA") then
         case "UK3CB_TKA_O_MIG29SM";
         case "UK3CB_CW_SOV_O_LATE_MIG29S";
         case "UK3CB_LDF_B_MIG29SM";
+        case "UK3CB_KDF_B_MIG29SM";
         case "UK3CB_AAF_O_MIG29S":
         {
             _loadout = ["rhs_mag_R73M_APU73","rhs_mag_R73M_APU73","rhs_mag_R73M_APU73","rhs_mag_R73M_APU73","rhs_mag_R77_AKU170_MIG29","rhs_mag_R77_AKU170_MIG29","","rhs_BVP3026_CMFlare_Chaff_Magazine_x2"];


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed some bugs in the ION Temperate template:
- Trailing comma in vehiclesAPCs.
- No L39s in KDF as far as I can tell. Put a MiG 29 in there instead.

There are cluster MLRS launchers in these templates. Not sure if there are supposed to be anymore as they were too strong?

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Maybe make a note to test this template for 3.3.