### PR TITLE
Remove unintentional enemy skill dependence on resource balance setting

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_NATOinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_NATOinit.sqf
@@ -87,7 +87,7 @@ _unit addEventHandler ["Deleted", A3A_fnc_enemyUnitDeletedEH];
 
 //Calculates the skill of the given unit
 //private _skill = (0.15 * skillMult) + (0.04 * difficultyCoef) + (0.02 * tierWar);
-private _skill = (0.1 * A3A_enemySkillMul) + (0.15 * A3A_balancePlayerScale) + (0.01 * tierWar);
+private _skill = (0.1 * A3A_enemySkillMul) + (0.07 * (1 max A3A_activePlayerCount^0.5)) + (0.01 * tierWar);
 private _regularFaces = (_faction get "faces");
 private _regularVoices = (_faction get "voices");
 private ["_face", "_voice"];


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The enemy skill calculation had an unintentional dependence on the resource balance setting, so setting resource balance to Hard would increase enemy skill substantially for high player counts. This PR fixes this by calculating directly from active player count instead.

The calculation works out pretty close to previous values (at Normal) for most of the player count range, with a small reduction at very high player counts.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
