### PR TITLE
Bugfix (Duplicate rebel vehicles/unarmed AFRF tigr) #2779 #2765

### DIFF
--- a/A3A/addons/core/Templates/Templates/RHS/RHS_AI_AFRF_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/RHS/RHS_AI_AFRF_Arid.sqf
@@ -56,7 +56,7 @@
 ["uavsPortable", ["rhs_pchela1t_vvsc"]] call _fnc_saveToTemplate;
 
 //Config special vehicles - militia vehicles are mostly used in the early game, police cars are being used by troops around cities -- Example:
-["vehiclesMilitiaLightArmed", ["rhs_tigr_m_vv", "rhs_tigr_m_vv"]] call _fnc_saveToTemplate;
+["vehiclesMilitiaLightArmed", ["rhs_tigr_sts_vv"]] call _fnc_saveToTemplate;
 ["vehiclesMilitiaTrucks", ["rhs_zil131_vv", "RHS_Ural_VV_01", "RHS_Ural_Open_VV_01", "rhs_zil131_open_vv", "rhs_kraz255b1_cargo_open_vv"]] call _fnc_saveToTemplate;
 ["vehiclesMilitiaCars", ["rhs_uaz_vv", "rhs_uaz_open_vv", "rhs_tigr_vv", "rhs_tigr_3camo_vv"]] call _fnc_saveToTemplate;
 

--- a/A3A/addons/core/Templates/Templates/RHS/RHS_AI_AFRF_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/RHS/RHS_AI_AFRF_Temperate.sqf
@@ -56,7 +56,7 @@
 ["uavsPortable", ["rhs_pchela1t_vvsc"]] call _fnc_saveToTemplate;
 
 //Config special vehicles - militia vehicles are mostly used in the early game, police cars are being used by troops around cities -- Example:
-["vehiclesMilitiaLightArmed", ["rhs_tigr_m_vv", "rhs_tigr_m_vv"]] call _fnc_saveToTemplate;
+["vehiclesMilitiaLightArmed", ["rhs_tigr_sts_vv"]] call _fnc_saveToTemplate;
 ["vehiclesMilitiaTrucks", ["rhs_zil131_vv", "RHS_Ural_VV_01", "RHS_Ural_Open_VV_01", "rhs_zil131_open_vv", "rhs_kraz255b1_cargo_open_vv"]] call _fnc_saveToTemplate;
 ["vehiclesMilitiaCars", ["rhs_uaz_vv", "rhs_uaz_open_vv", "rhs_tigr_vv", "rhs_tigr_3camo_vv"]] call _fnc_saveToTemplate;
 

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
@@ -19,7 +19,7 @@ private _vehicleAA = [];
 
 ["vehiclesPlane", ["I_C_Plane_Civil_01_F"]] call _fnc_saveToTemplate;
 
-["vehiclesCivCar", ["C_Offroad_01_F", "C_Hatchback_01_F", "C_Hatchback_01_sport_F", "C_Offroad_01_F", "C_SUV_01_F"]] call _fnc_saveToTemplate;
+["vehiclesCivCar", ["C_Offroad_01_F", "C_Hatchback_01_F", "C_Hatchback_01_sport_F", "C_Offroad_02_unarmed_F", "C_SUV_01_F"]] call _fnc_saveToTemplate;
 ["vehiclesCivTruck", ["C_Van_01_transport_F", "C_Van_02_transport_F", "C_Van_02_vehicle_F"]] call _fnc_saveToTemplate;
 ["vehiclesCivHeli", ["C_Heli_Light_01_civil_F"]] call _fnc_saveToTemplate;
 ["vehiclesCivBoat", ["C_Boat_Civil_01_F", "C_Rubberboat"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
@@ -40,7 +40,7 @@ private _staticAA = ["I_static_AA_F"];
 
 if (allowDLCExpansion) then {
     _vehiclesCivCar append ["C_Offroad_02_unarmed_F"];
-}
+};
 ["vehiclesCivCar", _vehiclesCivCar] call _fnc_saveToTemplate;
 
 if (allowDLCWS) then {

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
@@ -19,7 +19,7 @@ private _vehicleAA = [];
 
 ["vehiclesPlane", ["I_C_Plane_Civil_01_F"]] call _fnc_saveToTemplate;
 
-["vehiclesCivCar", ["C_Offroad_01_F", "C_Hatchback_01_F", "C_Hatchback_01_sport_F", "C_Offroad_02_unarmed_F", "C_SUV_01_F"]] call _fnc_saveToTemplate;
+private _vehiclesCivCar = ["C_Offroad_01_F", "C_Hatchback_01_F", "C_Hatchback_01_sport_F", "C_SUV_01_F"];
 ["vehiclesCivTruck", ["C_Van_01_transport_F", "C_Van_02_transport_F", "C_Van_02_vehicle_F"]] call _fnc_saveToTemplate;
 ["vehiclesCivHeli", ["C_Heli_Light_01_civil_F"]] call _fnc_saveToTemplate;
 ["vehiclesCivBoat", ["C_Boat_Civil_01_F", "C_Rubberboat"]] call _fnc_saveToTemplate;
@@ -38,6 +38,10 @@ private _staticAA = ["I_static_AA_F"];
 ["breachingExplosivesAPC", [["DemoCharge_Remote_Mag", 1]]] call _fnc_saveToTemplate;
 ["breachingExplosivesTank", [["SatchelCharge_Remote_Mag", 1], ["DemoCharge_Remote_Mag", 2]]] call _fnc_saveToTemplate;
 
+if (allowDLCExpansion) then {
+    _vehiclesCivCar append ["C_Offroad_02_unarmed_F"];
+}
+["vehiclesCivCar", _vehiclesCivCar] call _fnc_saveToTemplate;
 
 if (allowDLCWS) then {
   _vehicleAA append ["I_Tura_Truck_02_aa_lxWS"];

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
@@ -9,17 +9,17 @@
 ["flagMarkerType", "flag_Syndicat"] call _fnc_saveToTemplate;
 
 ["vehiclesBasic", ["I_G_Quadbike_01_F"]] call _fnc_saveToTemplate;
-["vehiclesLightUnarmed", ["I_G_Offroad_01_F"]] call _fnc_saveToTemplate;
+["vehiclesLightUnarmed", ["I_G_Offroad_01_F", "I_C_Offroad_02_unarmed_F"]] call _fnc_saveToTemplate;
 ["vehiclesLightArmed", ["I_G_Offroad_01_armed_F", "I_C_Offroad_02_LMG_F"]] call _fnc_saveToTemplate;
 ["vehiclesTruck", ["I_C_Van_01_transport_F"]] call _fnc_saveToTemplate;
-["vehiclesAT", ["I_C_Offroad_02_AT_F", "I_C_Offroad_02_AT_F"]] call _fnc_saveToTemplate;
+["vehiclesAT", ["I_C_Offroad_02_AT_F", "I_G_Offroad_01_AT_F"]] call _fnc_saveToTemplate;
 private _vehicleAA = [];
 
 ["vehiclesBoat", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;
 
 ["vehiclesPlane", ["I_C_Plane_Civil_01_F"]] call _fnc_saveToTemplate;
 
-["vehiclesCivCar", ["C_Offroad_01_F", "C_Hatchback_01_F", "C_Hatchback_01_sport_F", "C_Offroad_01_F", "C_SUV_01_F"]] call _fnc_saveToTemplate;
+["vehiclesCivCar", ["C_Offroad_01_F", "C_Hatchback_01_F", "C_Hatchback_01_sport_F", "C_Offroad_02_unarmed_F", "C_SUV_01_F"]] call _fnc_saveToTemplate;
 ["vehiclesCivTruck", ["C_Van_01_transport_F", "C_Van_02_transport_F", "C_Van_02_vehicle_F"]] call _fnc_saveToTemplate;
 ["vehiclesCivHeli", ["C_Heli_Light_01_civil_F"]] call _fnc_saveToTemplate;
 ["vehiclesCivBoat", ["C_Boat_Civil_01_F", "C_Rubberboat"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
@@ -9,7 +9,7 @@
 ["flagMarkerType", "flag_Syndicat"] call _fnc_saveToTemplate;
 
 ["vehiclesBasic", ["I_G_Quadbike_01_F"]] call _fnc_saveToTemplate;
-["vehiclesLightUnarmed", ["I_G_Offroad_01_F", "I_C_Offroad_02_unarmed_F"]] call _fnc_saveToTemplate;
+["vehiclesLightUnarmed", ["I_C_Offroad_02_unarmed_F", "I_G_Offroad_01_F"]] call _fnc_saveToTemplate;
 ["vehiclesLightArmed", ["I_G_Offroad_01_armed_F", "I_C_Offroad_02_LMG_F"]] call _fnc_saveToTemplate;
 ["vehiclesTruck", ["I_C_Van_01_transport_F"]] call _fnc_saveToTemplate;
 ["vehiclesAT", ["I_C_Offroad_02_AT_F", "I_G_Offroad_01_AT_F"]] call _fnc_saveToTemplate;


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Replaced duplicate entries of vehicles in the vanilla SDK template (`I_G_Offroad_01_AT_F `listed twice)
Removed the duplicate civilian offroad from the FIA & SDK template (`C_Offroad_01_F`), replaced by the jeep

Replaced the unarmed Tigr (`rhs_tigr_m_vv`) used for militia light armed with an armed Tigr (`rhs_tigr_sts_vv`)

### Please specify which Issue this PR Resolves.
closes #2779, #2765

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
The armed Tigr (`rhs_tigr_sts_vv`) has both a PK and an AGS, if that is too powerful either for the enemy or too powerful for the ease of access for the rebels then the Tigr could be replaced by a lighter vehicle (NAPA has plain olive green, armed UAZs which could be borrowed)