### PR TITLE
Discounted rebel 7.62 and 5.56 vics & statics

### DIFF
--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Reb_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Reb_Vehicle_Attributes.sqf
@@ -13,11 +13,19 @@
     ["UK3CB_C_Ural_Open", ["rebCost", 650]], //15 Seats 76 Speed
     ["UK3CB_C_Ural_Recovery", ["rebCost", 1200]],
     ["UK3CB_C_V3S_Recovery", ["rebCost", 1000]],
-    //Rebell Boats
+    //Rebel Boats
     ["UK3CB_I_G_Fishing_Boat_SPG9", ["rebCost", 800]],
     ["UK3CB_CHD_I_Fishing_Boat_Zu23_front", ["rebCost", 1000]],
-    //Rebell Light Armed
+	
+    //Rebel Light Unarmed
+    ["UK3CB_ION_B_Winter_M998_2DR", ["rebCost", 500]],
+	
+    //Rebel Light Armed
     ["UK3CB_ION_B_Winter_M1025_M2", ["rebCost", 900]],
     ["UK3CB_ION_B_Winter_SUV_Armed", ["rebCost", 1000]],
-    ["UK3CB_ION_B_Winter_M998_2DR", ["rebCost", 500]]
+	
+	//Rebel Static
+    ["UK3CB_FIA_I_M240_High", ["rebCost", 300]],
+    ["UK3CB_FIA_I_M240_Low", ["rebCost", 300]],
+    ["UK3CB_MEI_I_PKM_Low", ["rebCost", 300]]
 ]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_Reb_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_Reb_Vehicle_Attributes.sqf
@@ -1,4 +1,7 @@
 ["attributesVehicles", [
+    // light armed stuff
+    ["CUP_I_Datsun_PK", ["rebCost", 600]],
+	
     // heavy armed stuff
     ["CUP_I_Hilux_UB32_NAPA", ["rebCost", 6000]],
     ["CUP_I_Hilux_MLRS_NAPA", ["rebCost", 12000]],

--- a/A3A/addons/core/Templates/Templates/UNS/UNS_Reb_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/UNS/UNS_Reb_Vehicle_Attributes.sqf
@@ -1,2 +1,4 @@
 ["attributesVehicles", [
+    ["uns_Type55_LMG", ["rebCost", 600]],
+    ["uns_pk_high_VC", ["rebCost", 300]]
 ]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/VN/VN_Reb_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_Reb_Vehicle_Attributes.sqf
@@ -1,5 +1,7 @@
 ["attributesVehicles", [
     ["vn_o_air_mig19_gun", ["rebCost", 999999]],
+	
+    ["vn_i_static_m60_high", ["rebCost", 300]],//7.62 static
 	//Civ Cars
     ["vn_c_car_01_01", ["rebCost", 150]], //No Cargo, 4 Seats, 121 speed
     ["vn_c_car_03_01", ["rebCost", 150]], //No Cargo 4 Seats 130 speed

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_Vehicle_Attributes.sqf
@@ -1,2 +1,3 @@
 ["attributesVehicles", [
+    ["I_C_Offroad_02_LMG_F", ["cost", 500]]
 ]] call _fnc_saveToTemplate;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Across all rebel templates:
Discounted vehicles with 7.62 MG's by 100$
Discounted static 7.62 MG's by 100$
Discounted vehicles with 5.56 MG's by 200$ (SDK)
    

### Please specify which Issue this PR Resolves.
closes #2803

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
There were a lot fewer vehicles that this was applicable for than expected, perhaps the rebels could get some additional vehicles in the future.

For VN and UNS their discounts may not make sense due to their earlier technology setting where 7.62 MGs might be a lot better compared to the equipment it is up against

