### PR TITLE
Don't place units or statics on destroyed buildings

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_milBuildings.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_milBuildings.sqf
@@ -70,7 +70,7 @@ for "_i" from 0 to (count _buildings) - 1 do
     private _typeB = typeOf _building;
 
     call {
-        if (isObjectHidden _building) exitWith {};			// don't put statics on destroyed buildings
+        if (damage _building >= 1 or isObjectHidden _building) exitWith {};			// don't put statics on destroyed buildings
         if 	((_typeB == "Land_Cargo_Patrol_V1_F") or (_typeB == "Land_Cargo_Patrol_V2_F") or (_typeB == "Land_Cargo_Patrol_V3_F") or (_typeB == "Land_Cargo_Patrol_V4_F")) exitWith
         {
             private _type = selectRandom (_faction get "staticMGs");

--- a/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
@@ -39,6 +39,8 @@ if (count _buildings == 0) then {
     _buildings = [_position, _radius] call A3A_fnc_patrolEnterableBuildings;
 };
 
+// don't place units on destroyed buildings
+_buildings = _buildings select { damage _x < 1 && !isObjectHidden _x };
 _buildings = _buildings call BIS_fnc_arrayShuffle;
 
 {


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The Patcom garrison AI code wasn't checking whether buildings were destroyed before placing units on them, which could cause units to fall to their deaths on spawn, or possibly spawn underground in some cases.

Also fixed an oversight in the enemy garrison static placement code where statics could be placed underground on a building destroyed in the current session. Apparently buildings are not set hidden when they're destroyed.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
