### PR TITLE
Fix undercover backpack exploit

### DIFF
--- a/A3A/addons/core/functions/AI/fn_undercoverAI.sqf
+++ b/A3A/addons/core/functions/AI/fn_undercoverAI.sqf
@@ -20,10 +20,11 @@ _unit setUnitPos "UP";
 _loadOut = getUnitLoadout _unit;
 removeAllItems _unit;
 removeAllAssignedItems _unit;
-removeAllWeapons _unit;
-removeHeadgear _unit;
+removeAllWeapons _unit;			// also removes magazines
 removeGoggles _unit;
 removeVest _unit;
+
+_unit addHeadgear (selectRandom (A3A_faction_civ get "headgear"));
 _unit forceAddUniform (selectRandom (A3A_faction_civ get "uniforms"));
 
 //_airportsX = airportsX + outposts;// + (controlsX select {isOnRoad getMarkerPos _x});
@@ -44,4 +45,7 @@ _unit setCombatBehaviour _oldBehaviour;
 _unit enableAI "TARGET";
 _unit enableAI "AUTOTARGET";
 _unit setUnitPos "AUTO";
+
+// Remove backpack if changed, prevents static/device dupe exploits
+if (backpack _unit != _loadOut#5#0) then { _loadOut set [5, []] };
 _unit setUnitLoadout _loadOut;

--- a/A3A/addons/core/functions/AI/fn_undercoverAI.sqf
+++ b/A3A/addons/core/functions/AI/fn_undercoverAI.sqf
@@ -47,5 +47,5 @@ _unit enableAI "AUTOTARGET";
 _unit setUnitPos "AUTO";
 
 // Remove backpack if changed, prevents static/device dupe exploits
-if (backpack _unit != _loadOut#5#0) then { _loadOut set [5, []] };
+if (_loadOut#5 isNotEqualTo [] and { backpack _unit != _loadOut#5#0 }) then { _loadOut set [5, []] };
 _unit setUnitLoadout _loadOut;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Because undercover AIs retain their backpacks but have them replaced when they lose undercover, it was possible to duplicate statics and other devices by ordering assembly while undercover. This PR fixes the problem by not restoring the unit's backpack    if it no longer matches.

Also added random civ hats to undercover AIs, as we have an array for that now.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

