### PR TITLE
Don't spam hints on top of setup UI

### DIFF
--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -48,6 +48,7 @@ if !(isServer) then {
 
 if (isNil "A3A_startupState") then { A3A_startupState = "waitserver" };
 while {true} do {
+    if (dialog) then { sleep 0.1; continue };           // don't spam hints while the setup dialog is open
     private _stateStr = localize ("STR_A3A_feedback_serverinfo_" + A3A_startupState);
     isNil { [localize "STR_A3A_feedback_serverinfo", _stateStr, true] call A3A_fnc_customHint };         // not re-entrant, apparently
     if (A3A_startupState == "completed") exitWith {};


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Players with narrow screens (mostly laptops) have had trouble seeing the setup UI behind the "Admin is setting up the game" hint. This PR stops it being refreshed while a dialog is opened. Still hangs around for 15 seconds after the dialog opens, but better than nothing.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
