### PR TITLE
Add member & guest lock limits to garage

### DIFF
--- a/A3A/addons/garage/CfgFunctions.hpp
+++ b/A3A/addons/garage/CfgFunctions.hpp
@@ -14,6 +14,7 @@ class CfgFunctions
             class execForGarageUsers {};
             class genVehUID {};
             class getCatIndex {};
+            class getLockCount {};
             class onLoad {};
             class onUnload {};
             class reciveBroadcast {};

--- a/A3A/addons/garage/Core/fn_getLockCount.sqf
+++ b/A3A/addons/garage/Core/fn_getLockCount.sqf
@@ -1,0 +1,33 @@
+/*
+    [Description]
+        Return number of non-source vehicles locked by a player
+
+    Arguments:
+    0. <String> Player UID to check
+
+    Return Value:
+    <Int> Number of locked non-source vehicles
+
+    Scope: Server
+    Environment: Any
+    Public: [No]
+    Dependencies:
+
+    Example: _numLocked = [_playerUID] call HR_GRG_fnc_getLockCount;
+
+    License: APL-ND
+*/
+
+params ["_playerUID"];
+
+private _lockCount = 0;
+private _allSources = flatten HR_GRG_Sources;
+{
+    {
+        if (_y#2 != _playerUID) then { continue };            // not locked by this player;
+        if (_x in _allSources) then { continue };             // don't count sources
+        _lockCount = _lockCount + 1;
+    } forEach _x;                            // vehicles within category, hashmap
+} forEach HR_GRG_Vehicles;                   // categories array
+
+_lockCount;

--- a/A3A/addons/garage/Core/fn_toggleLock.sqf
+++ b/A3A/addons/garage/Core/fn_toggleLock.sqf
@@ -32,17 +32,20 @@ private _cat = HR_GRG_Vehicles#_catIndex;
 private _veh = _cat get _vehUID;
 private _lock = _veh#2;
 private _owner = _veh#5;
-_succes = call {
+_success = call {
     if ( _lock isEqualTo "" ) exitWith { true };
     if ( _lock isEqualTo _UID) exitWith { _UID = ""; true };
     if (_player call HR_GRG_isCmdClient) exitWith { _UID = ""; Info_5("Commander unlock | Vehicle ID: %1 | Owner: %2 [%3] | Commander: %4 [%5]", _vehUID, _owner, _lock, name _player, _UID); true };
     false
 };
+if (!_success) exitWith { Trace("Failed to toggle lock") };
 
-if (_succes) exitWith {
-    _veh set [2, _UID];
-    _veh set [5, [name _player, ""] select (_UID isEqualTo "")];
-    [_UID, nil, _catIndex, _vehUID, _player, false] call HR_GRG_fnc_broadcast;
-    Info_3("Lock state toggled for Vehicle ID: %1 | By: %2 | Locked: %3", _vehUID, name _player, (_UID isNotEqualTo ""));
+// If we're trying to lock a non-source vehicle, check player isn't at the lock limit
+if (_lock isEqualTo "" && !(_vehUID in flatten HR_GRG_Sources) && {[_UID] call HR_GRG_fnc_getLockCount >= _player call HR_GRG_getLockLimit}) exitWith {
+    ["STR_HR_GRG_Feedback_toggleLock_limit"] remoteExecCall ["HR_GRG_fnc_Hint", _player];
 };
-Trace("Failed to toggle lock");
+
+_veh set [2, _UID];
+_veh set [5, [name _player, ""] select (_UID isEqualTo "")];
+[_UID, nil, _catIndex, _vehUID, _player, false] call HR_GRG_fnc_broadcast;
+Info_3("Lock state toggled for Vehicle ID: %1 | By: %2 | Locked: %3", _vehUID, name _player, (_UID isNotEqualTo ""));

--- a/A3A/addons/garage/Public/config.inc
+++ b/A3A/addons/garage/Public/config.inc
@@ -37,8 +37,17 @@ HR_GRG_Cnd_canAccessAir = {
     count (airportsX select {(sidesX getVariable [_x,sideUnknown] == teamPlayer) and (HR_GRG_accessPoint inArea _x)}) > 0
 };
 
+// Return lock limit for specified player
+HR_GRG_getLockLimit = {
+    [HR_GRG_LockLimit_Guest, HR_GRG_LockLimit_Member] select (_this call A3A_fnc_isMember);
+};
+
 //Lock on garaged vehicles ( Values: [{""}, { getPlayerUID player }] )
 HR_GRG_dLock = {""};
+
+//Member & guest lock limits
+if (isNil "HR_GRG_LockLimit_Member") then { HR_GRG_LockLimit_Member = 3 };
+if (isNil "HR_GRG_LockLimit_Guest") then { HR_GRG_LockLimit_Guest = 2 };
 
 HR_GRG_renderPlacementRays = false;
 
@@ -59,6 +68,7 @@ HR_GRG_blackListCamo = ["IDAP", "African Desert Extremists", "African Desert Ext
 "Middle East Extremists 3", "Middle East Extremists 4", "Middle East Extremists 5", "Middle East Extremists 6",
 "Middle East Extremists 01", "Middle East Extremists 02", "Middle East Extremists 03", "Middle East Extremists 04", "Middle East Extremists 05", "Middle East Extremists 06"];
 //proxies"Middle East Extremists 01"
+
 HR_GRG_fnc_Hint = {
     params ["_key", ["_arguments", []]];
     ["Garage",
@@ -86,6 +96,11 @@ if (isClass (configfile >> "CBA_Extended_EventHandlers")) then {
     ["HR_GRG_dLock", "CHECKBOX", ["Lock on garage", "Lock vehicles when garaged"], [HR_GRG_Prefix,"Garage"], (HR_GRG_dLock isEqualTo {getPlayerUID player}), false, {
         HR_GRG_dLock = [{""}, { getPlayerUID player }] select _this;
     }] call CBA_fnc_addSetting;
+
+    ["HR_GRG_LockLimit_Member", "SLIDER", ["Member lock limit", "Maximum vehicles that can be locked by a member"], [HR_GRG_Prefix,"Garage"],
+        [0, 10, HR_GRG_LockLimit_Member, 0], true] call CBA_fnc_addSetting;
+    ["HR_GRG_LockLimit_Guest", "SLIDER", ["Guest lock limit", "Maximum vehicles that can be locked by a guest"], [HR_GRG_Prefix,"Garage"],
+        [0, 10, HR_GRG_LockLimit_Guest, 0], true] call CBA_fnc_addSetting;
 
     ["HR_GRG_Pylons_Enabled", "CHECKBOX", ["Allow pylon editing", "Allows player to configure pylons in the garage"], [HR_GRG_Prefix,"Garage"], true, true, {
         HR_GRG_Pylons_Enabled = _this;

--- a/A3A/addons/garage/Public/fn_addVehicle.sqf
+++ b/A3A/addons/garage/Public/fn_addVehicle.sqf
@@ -164,6 +164,11 @@ private _addVehicle = {
     ];
     private _sourceIndex = _source find true;
 
+    //Disable locking if the player is already at the lock limit
+    if (_sourceIndex == -1 && _lockUID != "" && {[_lockUID] call HR_GRG_fnc_getLockCount >= _player call HR_GRG_getLockLimit}) then {
+        _lockUID = ""; _lockName = "";
+    };
+
     private _stateData = [_this] call HR_GRG_fnc_getState;
     private _customisation = [_this] call BIS_fnc_getVehicleCustomization;
 

--- a/A3A/addons/garage/Stringtable.xml
+++ b/A3A/addons/garage/Stringtable.xml
@@ -524,6 +524,9 @@
         <Italian>Nessun veicolo selezionato</Italian>
         <Polish>Nie wybrano pojazdu</Polish>
       </Key>
+      <Key ID="STR_HR_GRG_Feedback_toggleLock_limit">
+        <Original>You have too many vehicles locked</Original>
+      </Key>
       <Key ID="STR_HR_GRG_Feedback_addVehicle_SATow">
         <Original>You can't garage a Vehicle with your Tow Rope out or a Vehicle attached</Original>
         <French>Vous ne pouvez pas garer un véhicule avec votre câble de remorquage hors d'un véhicule attaché</French>


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Heavily-requested community feature. Adds CBA-configurable member and guest limits to garage vehicle locks. It ignores source vehicles, as they are effectively public resources that should be managed by the commander.

Issue that needs resolving: Garage is currently rendered on top of customHint. Not sure why yet.

### Please specify which Issue this PR Resolves.
closes #2823

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Need to fix the UI rendering order issue.
