### PR TITLE
Check client vs server version on init

### DIFF
--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -5105,6 +5105,9 @@
         <Portuguese>Informaçao Servior</Portuguese>
         <Spanish>Información de Servidor</Spanish>
       </Key>
+      <Key ID="STR_A3A_feedback_serverinfo_mismatch">
+        <Original>Version mismatch error:&lt;br/&gt;&lt;br/&gt;Server: %1&lt;br/&gt;Client: %2</Original>
+      </Key>
       <Key ID="STR_A3A_feedback_serverinfo_starting">
         <Original>Starting game...</Original>
         <Czech>Spouštím hru...</Czech>

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -6,6 +6,7 @@ FIX_LINE_NUMBERS()
 if (isNil "logLevel") then { logLevel = 2; A3A_logDebugConsole = 1 };
 
 Info("initClient started");
+A3A_clientVersion = QUOTE(VERSION);
 Info_1("Client version: %1", QUOTE(VERSION_FULL));
 
 // *************************** Client pre-setup init *******************************
@@ -46,6 +47,15 @@ if !(isServer) then {
     };
 };
 
+// Server/client version check
+waitUntil { sleep 0.1; !isNil "initZonesDone" };
+if (isNil "A3A_serverVersion") then { A3A_serverVersion = "pre-3.3" };
+if (A3A_clientVersion != A3A_serverVersion) exitWith {
+    private _errorStr = format [localize "STR_A3A_feedback_serverinfo_mismatch", A3A_serverVersion, A3A_clientVersion];
+    [localize "STR_A3A_feedback_serverinfo", _errorStr] call A3A_fnc_customHint;
+};
+
+// Show server startup state hints
 if (isNil "A3A_startupState") then { A3A_startupState = "waitserver" };
 while {true} do {
     if (dialog) then { sleep 0.1; continue };           // don't spam hints while the setup dialog is open

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -6,6 +6,7 @@ logLevel = "LogLevel" call BIS_fnc_getParamValue; publicVariable "logLevel"; //S
 A3A_logDebugConsole = "A3A_logDebugConsole" call BIS_fnc_getParamValue; publicVariable "A3A_logDebugConsole";
 
 Info("Server init started");
+A3A_serverVersion = QUOTE(VERSION); publicVariable "A3A_serverVersion";
 Info_1("Server version: %1", QUOTE(VERSION_FULL));
 
 // ********************** Pre-setup init ****************************************************


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Checks server against client versions on client init, throws an error and quits if they're different. Also works correctly with older versions that don't publish a version number.

Wrote a lot of trash to check whether multiple Antistasi mods were loaded as well, but this doesn't seem to be necessary or useful unless the server & client versions are different, so I stripped it out.

Didn't update the version number yet so the display will be kinda weird with 3.2 server versus unstable client.

### Please specify which Issue this PR Resolves.
closes #2784

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

