### PR TITLE
Fix typos in lightAPC & IFV categorization

### DIFF
--- a/A3A/addons/core/functions/Base/fn_getVehiclesGroundTransport.sqf
+++ b/A3A/addons/core/functions/Base/fn_getVehiclesGroundTransport.sqf
@@ -32,7 +32,7 @@ private _ifvWeight =       [ 0,  0,  2,  4,  6,  8, 12, 16, 20, 25] select _leve
 
 // Assumption is that at least one of APC or battle bus exists
 if (_faction get "vehiclesIFVs" isEqualTo []) then { _apcWeight = _apcWeight + _ifvWeight };
-if (_faction get "vehiclesAPCs" isEqualTo []) then { _bbWeight = _bbWeight + _apcWeight };
+if (_faction get "vehiclesAPCs" isEqualTo []) then { _lapcWeight = _lapcWeight + _apcWeight };
 if (_faction get "vehiclesLightAPCs" isEqualTo []) then { _apcWeight = _apcWeight + _lapcWeight/2; _truckWeight = _truckWeight + _lapcWeight/2; };
 
 // only occupants use militia vehicle types?

--- a/A3A/addons/core/functions/Templates/fn_compileMissionAssets.sqf
+++ b/A3A/addons/core/functions/Templates/fn_compileMissionAssets.sqf
@@ -136,7 +136,8 @@ private _vehArmor =
 getVar("vehiclesTanks")
 + getVar("vehiclesAA")
 + getVar("vehiclesArtillery")
-+ getVar("vehiclesAPCs");
++ getVar("vehiclesLightAPCs")
++ getVar("vehiclesAPCs")
 + getVar("vehiclesIFVs");
 setVar("vehiclesArmor", _vehArmor);
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Light APCs were missing from the vehiclesArmor list and IFVs were blocked by a rogue semicolon, with the following effects:
- Not breachable.
- Labelled as MRAP on map.
- Crew bailing out inappropriately.
- CAS not using missiles against them.

Also fixed a related typo in currently-unused vehicle selection code.

### Please specify which Issue this PR Resolves.
closes #2824

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
