### PR TITLE
Fix tow ropes exploits and remove towing init network spam

### DIFF
--- a/A3A/addons/core/Scripts/fn_advancedTowingInit.sqf
+++ b/A3A/addons/core/Scripts/fn_advancedTowingInit.sqf
@@ -51,8 +51,6 @@ if( count (ropeAttachedObjects _vehicle) == 0 ) then { \
 	_cargo = ((ropeAttachedObjects _vehicle) select 0) getVariable ["SA_Cargo",objNull]; \
 };
 
-SA_Advanced_Towing_Install = {
-
 // Prevent advanced towing from installing twice
 if(!isNil "SA_TOW_INIT") exitWith {};
 scriptName "fn_advancedTowingInit.sqf";
@@ -393,7 +391,6 @@ SA_Attach_Tow_Ropes = {
 };
 
 SA_Take_Tow_Ropes = {
-	if (captive player) then {player setCaptive false};//by Barbolani to avoid undercover exploits
 	params ["_vehicle","_player"];
 	if(local _vehicle) then {
 		diag_log format ["Take Tow Ropes Called %1", _this];
@@ -836,49 +833,4 @@ SA_RemoteExecServer = {
 	};
 };
 
-if (isServer) then {
-
-	// Adds support for exile network calls (Only used when running exile) //
-
-	SA_SUPPORTED_REMOTEEXECSERVER_FUNCTIONS = ["SA_Set_Owner","SA_Hide_Object_Global"];
-
-	ExileServer_AdvancedTowing_network_AdvancedTowingRemoteExecServer = {
-		params ["_sessionId", "_messageParameters",["_isCall",false]];
-		_messageParameters params ["_params","_functionName"];
-		if (_functionName in SA_SUPPORTED_REMOTEEXECSERVER_FUNCTIONS) then {
-			if (_isCall) then {
-				_params call (missionNamespace getVariable [_functionName,{}]);
-			} else {
-				_params spawn (missionNamespace getVariable [_functionName,{}]);
-			};
-		};
-	};
-
-	SA_SUPPORTED_REMOTEEXECCLIENT_FUNCTIONS = ["SA_Simulate_Towing","SA_Attach_Tow_Ropes","SA_Take_Tow_Ropes","SA_Put_Away_Tow_Ropes","SA_Pickup_Tow_Ropes","SA_Drop_Tow_Ropes","SA_Hint"];
-
-	ExileServer_AdvancedTowing_network_AdvancedTowingRemoteExecClient = {
-		params ["_sessionId", "_messageParameters"];
-		_messageParameters params ["_params","_functionName","_target",["_isCall",false]];
-		if (_functionName in SA_SUPPORTED_REMOTEEXECCLIENT_FUNCTIONS) then {
-			if (_isCall) then {
-				_params remoteExecCall [_functionName, _target];
-			} else {
-				_params remoteExec [_functionName, _target];
-			};
-		};
-	};
-
-	// Install Advanced Towing on all clients (plus JIP) //
-
-	publicVariable "SA_Advanced_Towing_Install";
-	remoteExecCall ["SA_Advanced_Towing_Install", -2,true];
-
-};
-
 Info("Loaded advanced towing");
-
-};
-
-if (isServer) then {
-	[] call SA_Advanced_Towing_Install;
-};

--- a/A3A/addons/core/functions/Undercover/fn_canGoUndercover.sqf
+++ b/A3A/addons/core/functions/Undercover/fn_canGoUndercover.sqf
@@ -53,10 +53,15 @@ if !(isNull (objectParent player)) then
         ["Undercover", "You are not in a civilian vehicle."] call A3A_fnc_customHint;
         _result = [false, "In non civilian vehicle"];
     };
-    if ((objectParent player) getVariable ["A3A_reported", false]) then
+    if ((objectParent player) getVariable ["A3A_reported", false]) exitWith
     {
         ["Undercover", "This vehicle has been reported to the enemy. Change or renew your vehicle in the Garage to go Undercover."] call A3A_fnc_customHint;
         _result = [false, "In reported vehicle"];
+    };
+    if ((objectParent player) getVariable ["SA_Tow_Ropes", []] isNotEqualTo []) exitWith
+    {
+        ["Undercover", "This vehicle cannot go undercover while it has tow ropes attached"] call A3A_fnc_customHint;
+        _result = [false, "In vehicle with tow ropes attached"];
     };
 }
 else
@@ -104,6 +109,12 @@ else
         _text = format ["%1<br/>Being naked. Thats what you think is unsuspicious?", _text];
         _result set [0, false];
         _result pushBack "No clothes";
+    };
+    if (!isNull (player getVariable ["SA_Tow_Ropes_Vehicle", objNull])) then
+    {
+        _text = format ["%1<br/>Holding tow ropes.", _text];
+        _result set [0, false];
+        _result pushBack "Holding tow ropes";
     };
     if !(_result select 0) then
     {

--- a/A3A/addons/core/functions/Undercover/fn_goUndercover.sqf
+++ b/A3A/addons/core/functions/Undercover/fn_goUndercover.sqf
@@ -104,6 +104,11 @@ while {_reason == ""} do
             _reason = "VCompromised"
         };
 
+        if (_veh getVariable ["SA_Tow_Ropes", []] isNotEqualTo []) exitWith
+        {
+            _reason = "VTowRopes"
+        };
+
         if (A3A_hasACE) then
         {
             if (((position player nearObjects["DemoCharge_Remote_Ammo", 5]) select 0) mineDetectedBy Occupants) exitWith
@@ -161,6 +166,10 @@ while {_reason == ""} do
         if (dateToNumber date < (player getVariable ["compromised", 0])) exitWith
         {
             _reason = "Compromised";
+        };
+        if (!isNull (player getVariable ["SA_Tow_Ropes_Vehicle", objNull])) exitWith
+        {
+            _reason = "TowRopes";
         };
     };
     if (_reason != "") exitWith {};
@@ -228,6 +237,14 @@ switch (_reason) do
     case "VCompromised":
     {
         ["Undercover", "You entered a reported vehicle!"] call A3A_fnc_customHint;
+    };
+    case "VTowRopes":
+    {
+        ["Undercover", "You cannot be undercover while tow ropes are attached to your vehicle!"] call A3A_fnc_customHint;
+    };
+    case "TowRopes":
+    {
+        ["Undercover", "You cannot be undercover and use tow ropes!"] call A3A_fnc_customHint;
     };
     case "SpotBombTruck":
     {

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -22,6 +22,8 @@ enableEnvironment [false, true];
 if !(isServer) then {
     call A3A_fnc_initVarCommon;
 
+    [] execVM QPATHTOFOLDER(Scripts\fn_advancedTowingInit.sqf);
+
     Info("Running client JNA preload");
     ["Preload"] call jn_fnc_arsenal;
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement
4. [X] Performance

### What have you changed and why?
Fixed a range of undercover towing exploits with both a single player and multiple players. Moved the checks to the undercover routines so that they indicate the reasons.

Also cleaned up some old weirdness where the advancing towing routines initialized on client by publicVariable spamming the entire function over the network.

### Please specify which Issue this PR Resolves.
closes #2806

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
