### PR TITLE
Support/resource balance tweaks:

### DIFF
--- a/A3A/addons/core/Params.hpp
+++ b/A3A/addons/core/Params.hpp
@@ -187,16 +187,16 @@ class Params
     class A3A_enemyBalanceMul
     {
         title = "Overall enemy resource balance";
-        values[] = {3,5,7,10,14,20,28};
-        texts[] =  {"Trivial","Very Easy","Easy","Normal","Hard","Very Hard","Extreme"};
+        values[] = {4,6,8,10,12,14,17,20,24,28};
+        texts[] =  {"0.4x","0.6x","0.8x","1.0x","1.2x","1.4x","1.7x","2.0x","2.4x","2.8x"};
         default = 10;
     };
     class A3A_enemyAttackMul
     {
         attr[] = {"server"};
         title = "Enemy attack resource balance (relative to overall balance)";
-        values[] = {3,5,7,10,14,20,28};
-        texts[] =  {"Trivial","Very Easy","Easy","Normal","Hard","Very Hard","Extreme"};
+        values[] = {4,6,8,10,12,14,17,20,24,28};
+        texts[] =  {"0.4x","0.6x","0.8x","1.0x","1.2x","1.4x","1.7x","2.0x","2.4x","2.8x"};
         default = 10;
     };
     class A3A_invaderBalanceMul

--- a/A3A/addons/core/functions/Supports/fn_SUP_ASFRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_ASFRoutine.sqf
@@ -90,7 +90,7 @@ while {true} do
         _group setCurrentWaypoint _attackWP;
 
         _group reveal [_targetObj, 1.5];         // do we need to add knowledge level to target list? Only used here?
-        _group setBehaviour "COMBAT";
+        _group setBehaviourStrong "COMBAT";
         _group setCombatMode "RED";
         _plane flyInHeight -1;          // experimental
         _currentlyAttacking = true;
@@ -114,6 +114,8 @@ while {true} do
             deleteWaypoint [_group, 1];
             _group setCurrentWaypoint _loiterWP;
 
+            _group setBehaviourStrong "AWARE";
+            _group setCombatMode "YELLOW";
             //_plane flyInHeight 1000;
             _currentlyAttacking = false;
             _timeout = _timeout - 300;

--- a/A3A/addons/core/functions/Supports/fn_SUP_mortarRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_mortarRoutine.sqf
@@ -22,16 +22,16 @@ sleep _sleepTime;
 
 //Decrease number of rounds and time alive if aggro is low
 private _sideAggression = if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
-private _numberOfRounds = 32;
+private _numberOfRounds = 24;
 private _timeAlive = 1200;
 
 //If the aggro is low, the mortar will shoot less and stay longer in one spot
 if((30 + random 40) >_sideAggression) then
 {
-    _numberOfRounds = 16;
+    _numberOfRounds = 12;
     _timeAlive = 1800;
 };
-private _shotsPerVolley = _numberOfRounds / 4;
+private _shotsPerVolley = _numberOfRounds / 3;
 
 //A function to repeatedly fire onto a target without loops by using an EH
 _fn_executeMortarFire =


### PR DESCRIPTION

### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Minor resource/support tweaks for 3.3:
- Add more levels to resource difficulty params for finer tweaking. The previous 1 -> 1.4 was too large a jump for community at least.
- Take ASF out of combat mode when it returns to loiter (experimental). Thought it was in there before. Might clear up some engage-while-loitering issues. Might not.
- Reduce maximum number of volleys for mortar & artillery supports. Because the effectiveness jump from small -> large servers is too strong. The other multi-target supports (CAS, ASF) already got reduced.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
