### PR TITLE
Rebalance mission effects on enemy resources

### DIFF
--- a/A3A/addons/core/functions/Base/fn_timingCA.sqf
+++ b/A3A/addons/core/functions/Base/fn_timingCA.sqf
@@ -17,7 +17,6 @@ params ["_timeToAdd", "_side"];
 // Function is obsolete but still used by mission rewards
 // for now, fudge some effect on attack/defence resources
 
-if (_timeToAdd < 0) exitWith {};
+//if (_timeToAdd < 0) exitWith {};
 [-_timeToAdd/10, _side, "defence"] call A3A_fnc_addEnemyResources;
 [-_timeToAdd/10, _side, "attack"] call A3A_fnc_addEnemyResources;
-if (true) exitWith {};

--- a/A3A/addons/core/functions/Missions/fn_AS_Official.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_Official.sqf
@@ -15,7 +15,7 @@ _sideX = if (sidesX getVariable [_markerX,sideUnknown] == Occupants) then {Occup
 private _faction = Faction(_sideX);
 _positionX = getMarkerPos _markerX;
 
-_timeLimit = if (_difficultX) then {15} else {30};//120
+_timeLimit = if (_difficultX) then {30} else {60};//120
 if (A3A_hasIFA) then {_timeLimit = _timeLimit * 2};
 _dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + _timeLimit];
 _dateLimitNum = dateToNumber _dateLimit;
@@ -58,7 +58,7 @@ if (not alive _official) then
 		[0,600] remoteExec ["A3A_fnc_resourcesFIA",2];
 		[2400, _sideX] remoteExec ["A3A_fnc_timingCA",2];
 		{if (isPlayer _x) then {[20,_x] call A3A_fnc_playerScoreAdd}} forEach ([500,0,_positionX,teamPlayer] call A3A_fnc_distanceUnits);
-		[10,theBoss] call A3A_fnc_playerScoreAdd;
+		[20,theBoss] call A3A_fnc_playerScoreAdd;
 		[_markerX,60] call A3A_fnc_addTimeForIdle;
 		}
 	else
@@ -66,7 +66,7 @@ if (not alive _official) then
 		[0,300] remoteExec ["A3A_fnc_resourcesFIA",2];
 		[1800, _sideX] remoteExec ["A3A_fnc_timingCA",2];
 		{if (isPlayer _x) then {[10,_x] call A3A_fnc_playerScoreAdd}} forEach ([500,0,_positionX,teamPlayer] call A3A_fnc_distanceUnits);
-		[5,theBoss] call A3A_fnc_playerScoreAdd;
+		[10,theBoss] call A3A_fnc_playerScoreAdd;
 		[_markerX,30] call A3A_fnc_addTimeForIdle;
 		};
 	}
@@ -75,13 +75,13 @@ else
 	[_taskId, "AS", "FAILED"] call A3A_fnc_taskSetState;
 	if (_difficultX) then
 		{
-		[-1200, _sideX] remoteExec ["A3A_fnc_timingCA",2];
-		[-20,theBoss] call A3A_fnc_playerScoreAdd;
+		[-200, _sideX] remoteExec ["A3A_fnc_timingCA",2];
+		[-10,theBoss] call A3A_fnc_playerScoreAdd;
 		[_markerX,-60] call A3A_fnc_addTimeForIdle;
 		}
 	else
 		{
-		[-600, _sideX] remoteExec ["A3A_fnc_timingCA",2];
+		[-200, _sideX] remoteExec ["A3A_fnc_timingCA",2];
 		[-10,theBoss] call A3A_fnc_playerScoreAdd;
 		[_markerX,-30] call A3A_fnc_addTimeForIdle;
 		};

--- a/A3A/addons/core/functions/Missions/fn_AS_specOP.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_specOP.sqf
@@ -9,6 +9,7 @@ _groupContact = grpNull;
 _tsk = "";
 _positionX = getMarkerPos _markerX;
 _sideX = if (sidesX getVariable [_markerX,sideUnknown] == Occupants) then {Occupants} else {Invaders};
+_difficultX = if (random 10 < tierWar) then {true} else {false};
 _timeLimit = if (_difficultX) then {60} else {120};
 if (A3A_hasIFA) then {_timeLimit = _timeLimit * 2};
 _dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + _timeLimit];
@@ -34,12 +35,13 @@ if (dateToNumber date > _dateLimitNum) then
 }
 else
 {
+	private _bonus = [1, 1.5] select _difficultX;
 	[_taskId, "AS", "SUCCEEDED"] call A3A_fnc_taskSetState;
-	[0,200] remoteExec ["A3A_fnc_resourcesFIA",2];
+	[0,200*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
 	[0,5,_positionX] remoteExec ["A3A_fnc_citySupportChange",2];
-	[600, _sideX] remoteExec ["A3A_fnc_timingCA",2];
-	{if (isPlayer _x) then {[10,_x] call A3A_fnc_playerScoreAdd}} forEach ([500,0,_positionX,teamPlayer] call A3A_fnc_distanceUnits);
-	[10,theBoss] call A3A_fnc_playerScoreAdd;
+	[800*_bonus, _sideX] remoteExec ["A3A_fnc_timingCA",2];
+	{if (isPlayer _x) then {[10*_bonus,_x] call A3A_fnc_playerScoreAdd}} forEach ([500,0,_positionX,teamPlayer] call A3A_fnc_distanceUnits);
+	[10*_bonus,theBoss] call A3A_fnc_playerScoreAdd;
     [_sideX, 10, 60] remoteExec ["A3A_fnc_addAggression", 2];
 	["TaskFailed", ["", format ["SpecOp Team decimated at a %1",_nameDest]]] remoteExec ["BIS_fnc_showNotification",_sideX];
 };

--- a/A3A/addons/core/functions/Missions/fn_AS_specOP.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_specOP.sqf
@@ -3,7 +3,6 @@ if (!isServer and hasInterface) exitWith{};
 
 _markerX = _this select 0;
 
-_difficultX = if (random 10 < tierWar) then {true} else {false};
 _leave = false;
 _contactX = objNull;
 _groupContact = grpNull;
@@ -27,42 +26,22 @@ private _taskId = "AS" + str A3A_taskCount;
 waitUntil  {sleep 5; (dateToNumber date > _dateLimitNum) or (sidesX getVariable [_markerX,sideUnknown] == teamPlayer)};
 
 if (dateToNumber date > _dateLimitNum) then
-	{
+{
 	[_taskId, "AS", "FAILED"] call A3A_fnc_taskSetState;
-	if (_difficultX) then
-		{
-		[10,0,_positionX] remoteExec ["A3A_fnc_citySupportChange",2];
-		[-1200, _sideX] remoteExec ["A3A_fnc_timingCA",2];
-		[-20,theBoss] call A3A_fnc_playerScoreAdd;
-		}
-	else
-		{
-		[5,0,_positionX] remoteExec ["A3A_fnc_citySupportChange",2];
-		[-600, _sideX] remoteExec ["A3A_fnc_timingCA",2];
-		[-10,theBoss] call A3A_fnc_playerScoreAdd;
-		};
-	}
+	[5,0,_positionX] remoteExec ["A3A_fnc_citySupportChange",2];
+	[-200, _sideX] remoteExec ["A3A_fnc_timingCA",2];
+	[-10,theBoss] call A3A_fnc_playerScoreAdd;
+}
 else
-	{
+{
 	[_taskId, "AS", "SUCCEEDED"] call A3A_fnc_taskSetState;
-	if (_difficultX) then
-		{
-		[0,400] remoteExec ["A3A_fnc_resourcesFIA",2];
-		[0,10,_positionX] remoteExec ["A3A_fnc_citySupportChange",2];
-		[1200, _sideX] remoteExec ["A3A_fnc_timingCA",2];
-		{if (isPlayer _x) then {[20,_x] call A3A_fnc_playerScoreAdd}} forEach ([500,0,_positionX,teamPlayer] call A3A_fnc_distanceUnits);
-		[20,theBoss] call A3A_fnc_playerScoreAdd;
-		}
-	else
-		{
-		[0,200] remoteExec ["A3A_fnc_resourcesFIA",2];
-		[0,5,_positionX] remoteExec ["A3A_fnc_citySupportChange",2];
-		[600, _sideX] remoteExec ["A3A_fnc_timingCA",2];
-		{if (isPlayer _x) then {[10,_x] call A3A_fnc_playerScoreAdd}} forEach ([500,0,_positionX,teamPlayer] call A3A_fnc_distanceUnits);
-		[10,theBoss] call A3A_fnc_playerScoreAdd;
-		};
+	[0,200] remoteExec ["A3A_fnc_resourcesFIA",2];
+	[0,5,_positionX] remoteExec ["A3A_fnc_citySupportChange",2];
+	[600, _sideX] remoteExec ["A3A_fnc_timingCA",2];
+	{if (isPlayer _x) then {[10,_x] call A3A_fnc_playerScoreAdd}} forEach ([500,0,_positionX,teamPlayer] call A3A_fnc_distanceUnits);
+	[10,theBoss] call A3A_fnc_playerScoreAdd;
     [_sideX, 10, 60] remoteExec ["A3A_fnc_addAggression", 2];
 	["TaskFailed", ["", format ["SpecOp Team decimated at a %1",_nameDest]]] remoteExec ["BIS_fnc_showNotification",_sideX];
-	};
+};
 
 [_taskId, "AS", 1200] spawn A3A_fnc_taskDelete;

--- a/A3A/addons/core/functions/Missions/fn_CON_Outpost.sqf
+++ b/A3A/addons/core/functions/Missions/fn_CON_Outpost.sqf
@@ -45,14 +45,12 @@ if (dateToNumber date > _dateLimitNum) then
 	[_taskId, "CON", "FAILED"] call A3A_fnc_taskSetState;
 	if (_difficultX) then
 		{
-		[10,0,_positionX] remoteExec ["A3A_fnc_citySupportChange",2];
-		[-1200, _markerSide] remoteExec ["A3A_fnc_timingCA",2];
-		[-20,theBoss] call A3A_fnc_playerScoreAdd;
+		[-200, _markerSide] remoteExec ["A3A_fnc_timingCA",2];
+		[-10,theBoss] call A3A_fnc_playerScoreAdd;
 		}
 	else
 		{
-		[5,0,_positionX] remoteExec ["A3A_fnc_citySupportChange",2];
-		[-600, _markerSide] remoteExec ["A3A_fnc_timingCA",2];
+		[-200, _markerSide] remoteExec ["A3A_fnc_timingCA",2];
 		[-10,theBoss] call A3A_fnc_playerScoreAdd;
 		};
 	}
@@ -63,16 +61,14 @@ else
 	if (_difficultX) then
 		{
 		[0,400] remoteExec ["A3A_fnc_resourcesFIA",2];
-		[-10,0,_positionX] remoteExec ["A3A_fnc_citySupportChange",2];
-		[1200, _markerSide] remoteExec ["A3A_fnc_timingCA",2];
+		[800, _markerSide] remoteExec ["A3A_fnc_timingCA",2];
 		{if (isPlayer _x) then {[20,_x] call A3A_fnc_playerScoreAdd}} forEach ([500,0,_positionX,teamPlayer] call A3A_fnc_distanceUnits);
 		[20,theBoss] call A3A_fnc_playerScoreAdd;
 		}
 	else
 		{
 		[0,200] remoteExec ["A3A_fnc_resourcesFIA",2];
-		[-5,0,_positionX] remoteExec ["A3A_fnc_citySupportChange",2];
-		[600, _markerSide] remoteExec ["A3A_fnc_timingCA",2];
+		[400, _markerSide] remoteExec ["A3A_fnc_timingCA",2];
 		{if (isPlayer _x) then {[10,_x] call A3A_fnc_playerScoreAdd}} forEach ([500,0,_positionX,teamPlayer] call A3A_fnc_distanceUnits);
 		[10,theBoss] call A3A_fnc_playerScoreAdd;
 		};

--- a/A3A/addons/core/functions/Missions/fn_DES_Antenna.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Antenna.sqf
@@ -37,19 +37,16 @@ _bonus = if (_difficultX) then {2} else {1};
 if (dateToNumber date > _dateLimitNum) then
 	{
 	[_taskId, "DES", "FAILED"] call A3A_fnc_taskSetState;
-	//[5,0,_positionX] remoteExec ["A3A_fnc_citySupportChange",2];
 	[-10*_bonus,theBoss] call A3A_fnc_playerScoreAdd;
-    [_side, -5, 60] remoteExec ["A3A_fnc_addAggression", 2];
 	}
 else
 	{
 	sleep 15;
 	[_taskId, "DES", "SUCCEEDED"] call A3A_fnc_taskSetState;
-	//[-5,0,_positionX] remoteExec ["A3A_fnc_citySupportChange",2];
-    [_side, 15, 90] remoteExec ["A3A_fnc_addAggression", 2];
-	[600*_bonus, _side] remoteExec ["A3A_fnc_timingCA",2];
+    [_side, 10, 120] remoteExec ["A3A_fnc_addAggression", 2];
+	[400*_bonus, _side] remoteExec ["A3A_fnc_timingCA",2];
 	{if (_x distance _positionX < 500) then {[10*_bonus,_x] call A3A_fnc_playerScoreAdd}} forEach (allPlayers - (entities "HeadlessClient_F"));
-	[5*_bonus,theBoss] call A3A_fnc_playerScoreAdd;
+	[10*_bonus,theBoss] call A3A_fnc_playerScoreAdd;
 	};
 
 deleteMarker _mrkFinal;

--- a/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
@@ -351,16 +351,15 @@ if ((not alive _heli) || (_heli distance (getMarkerPos respawnTeamPlayer) < 100)
     };
     [_taskId, "DES", "SUCCEEDED"] call A3A_fnc_taskSetState;
     [0,300*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
-    [1800*_bonus, _sideX] remoteExec ["A3A_fnc_timingCA",2];
+    [600*_bonus, _sideX] remoteExec ["A3A_fnc_timingCA",2];
     {if (_x distance _heli < 500) then {[10*_bonus,_x] call A3A_fnc_playerScoreAdd}} forEach (allPlayers - (entities "HeadlessClient_F"));
-    [5*_bonus,theBoss] call A3A_fnc_playerScoreAdd;
-    if (_isAttackHeli) then {[600*_bonus, _sideX] remoteExec ["A3A_fnc_timingCA",2]};
+    [10*_bonus,theBoss] call A3A_fnc_playerScoreAdd;
 } else {
     Debug_2("%1 was successfully recovered by %2, mission failed", _heli, _sideX);
     [_taskId, "DES", "FAILED"] call A3A_fnc_taskSetState;
-    [-600*_bonus, _sideX] remoteExec ["A3A_fnc_timingCA",2];
+    [-200, _sideX] remoteExec ["A3A_fnc_timingCA",2];
     [-10*_bonus,theBoss] call A3A_fnc_playerScoreAdd;
-    if (_isAttackHeli) then {[-600*_bonus, _sideX] remoteExec ["A3A_fnc_timingCA",2]};
+    if (_isAttackHeli) then {[-200, _sideX] remoteExec ["A3A_fnc_timingCA",2]};
 };
 Info("Downed Heli mission completed");
 ////////////

--- a/A3A/addons/core/functions/Missions/fn_DES_Vehicle.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Vehicle.sqf
@@ -77,27 +77,17 @@ if (spawner getVariable _markerX == 0) then
 			["TaskFailed", ["", format ["AA Stolen in %1",_nameDest]]] remoteExec ["BIS_fnc_showNotification",_sideX];
 			};
 		[0,300*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
-        [_sideX, 10, 60] remoteExec ["A3A_fnc_addAggression", 2];
-		if (_sideX == Invaders) then
-        {
-            [0,10*_bonus,_positionX] remoteExec ["A3A_fnc_citySupportChange",2]
-        }
-        else
-        {
-            [0,5*_bonus,_positionX] remoteExec ["A3A_fnc_citySupportChange",2]
-        };
-		[1200*_bonus, _sideX] remoteExec ["A3A_fnc_timingCA",2];
+        [_sideX, 5, 60] remoteExec ["A3A_fnc_addAggression", 2];
+		[400*_bonus, _sideX] remoteExec ["A3A_fnc_timingCA",2];
 		{if (_x distance _veh < 500) then {[10*_bonus,_x] call A3A_fnc_playerScoreAdd}} forEach (allPlayers - (entities "HeadlessClient_F"));
-		[5*_bonus,theBoss] call A3A_fnc_playerScoreAdd;
+		[10*_bonus,theBoss] call A3A_fnc_playerScoreAdd;
 		};
 	}
 else
 	{
     [_taskId, "DES", "FAILED"] call A3A_fnc_taskSetState;
-	[-5*_bonus,-100*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
-	[5*_bonus,0,_positionX] remoteExec ["A3A_fnc_citySupportChange",2];
-	[-600*_bonus, _sideX] remoteExec ["A3A_fnc_timingCA",2];
-	[-10*_bonus,theBoss] call A3A_fnc_playerScoreAdd;
+	[-200, _sideX] remoteExec ["A3A_fnc_timingCA",2];
+	[-10,theBoss] call A3A_fnc_playerScoreAdd;
 	};
 
 [_taskId, "DES", 1200] spawn A3A_fnc_taskDelete;

--- a/A3A/addons/core/functions/Missions/fn_LOG_Ammo.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Ammo.sqf
@@ -98,24 +98,24 @@ if ((spawner getVariable _markerX != 2) and !(sidesX getVariable [_markerX,sideU
 	if (dateToNumber date > _dateLimitNum) then
 		{
 		[_taskId, "LOG", "FAILED"] call A3A_fnc_taskSetState;
-		[-1200*_bonus, _sideX] remoteExec ["A3A_fnc_timingCA",2];
-		[-10*_bonus,theBoss] call A3A_fnc_playerScoreAdd;
+		[-200, _sideX] remoteExec ["A3A_fnc_timingCA",2];
+		[-10, theBoss] call A3A_fnc_playerScoreAdd;
 		};
 	if ((not alive _truckX) or (call _fnc_truckReturnedToBase)) then
 		{
 
 			[_taskId, "LOG", "SUCCEEDED"] call A3A_fnc_taskSetState;
 			[0,300*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
-			[1200*_bonus, _sideX] remoteExec ["A3A_fnc_timingCA",2];
+			[400*_bonus, _sideX] remoteExec ["A3A_fnc_timingCA",2];
 			{if (_x distance _truckX < 500) then {[10*_bonus,_x] call A3A_fnc_playerScoreAdd}} forEach (allPlayers - (entities "HeadlessClient_F"));
-			[5*_bonus,theBoss] call A3A_fnc_playerScoreAdd;
+			[10*_bonus,theBoss] call A3A_fnc_playerScoreAdd;
 		};
 	}
 else
 	{
 	[_taskId, "LOG", "FAILED"] call A3A_fnc_taskSetState;
-	[-1200*_bonus, _sideX] remoteExec ["A3A_fnc_timingCA",2];
-	[-10*_bonus,theBoss] call A3A_fnc_playerScoreAdd;
+	[-200, _sideX] remoteExec ["A3A_fnc_timingCA",2];
+	[-10, theBoss] call A3A_fnc_playerScoreAdd;
 	};
 
 [_taskId, "LOG", 1200] spawn A3A_fnc_taskDelete;

--- a/A3A/addons/core/functions/Missions/fn_LOG_Bank.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Bank.sqf
@@ -76,8 +76,8 @@ _bonus = if (_difficultX) then {2} else {1};
 if ((dateToNumber date > _dateLimitNum) or (!alive _truckX)) then
 	{
 	[_taskId, "LOG", "FAILED"] call A3A_fnc_taskSetState;
-	[-1800*_bonus, Occupants] remoteExec ["A3A_fnc_timingCA",2];
-	[-10*_bonus,theBoss] call A3A_fnc_playerScoreAdd;
+	[-200, Occupants] remoteExec ["A3A_fnc_timingCA",2];
+	[-10,theBoss] call A3A_fnc_playerScoreAdd;
 	}
 else
 	{
@@ -130,10 +130,10 @@ if ((_truckX distance _posbase < 50) and (dateToNumber date < _dateLimitNum)) th
 	[_taskId, "LOG", "SUCCEEDED"] call A3A_fnc_taskSetState;
 	[0,5000*_bonus] remoteExec ["A3A_fnc_resourcesFIA",2];
     Debug("aggroEvent | Rebels won a bank mission");
-	[Occupants, 20 * _bonus, 120] remoteExec ["A3A_fnc_addAggression",2];
-	[1800*_bonus, Occupants] remoteExec ["A3A_fnc_timingCA",2];
+	[Occupants, 10, 120] remoteExec ["A3A_fnc_addAggression",2];
+	[400*_bonus, Occupants] remoteExec ["A3A_fnc_timingCA",2];
 	{if (_x distance _truckX < 500) then {[10*_bonus,_x] call A3A_fnc_playerScoreAdd}} forEach (allPlayers - (entities "HeadlessClient_F"));
-	[5*_bonus,theBoss] call A3A_fnc_playerScoreAdd;
+	[10*_bonus,theBoss] call A3A_fnc_playerScoreAdd;
 	waitUntil {sleep 1; speed _truckX == 0};
 
 	[_truckX] call A3A_fnc_empty;
@@ -141,8 +141,7 @@ if ((_truckX distance _posbase < 50) and (dateToNumber date < _dateLimitNum)) th
 if (!alive _truckX) then
 	{
 	[_taskId, "LOG", "FAILED"] call A3A_fnc_taskSetState;
-	[1800*_bonus, Occupants] remoteExec ["A3A_fnc_timingCA",2];
-	[-10*_bonus,theBoss] call A3A_fnc_playerScoreAdd;
+	//[400*_bonus, Occupants] remoteExec ["A3A_fnc_timingCA",2];
 	};
 
 

--- a/A3A/addons/core/functions/Missions/fn_REP_Antenna.sqf
+++ b/A3A/addons/core/functions/Missions/fn_REP_Antenna.sqf
@@ -63,9 +63,9 @@ if (spawner getVariable _markerX != 2) then
 		[_taskId, "REP", "SUCCEEDED"] call A3A_fnc_taskSetState;
         [Occupants, 15, 90] remoteExec ["A3A_fnc_addAggression", 2];
         [Invaders, 5, 60] remoteExec ["A3A_fnc_addAggression", 2];
-		[1200, Occupants] remoteExec ["A3A_fnc_timingCA",2];
+		[500, Occupants] remoteExec ["A3A_fnc_timingCA",2];
 		{if (_x distance _veh < 500) then {[10,_x] call A3A_fnc_playerScoreAdd}} forEach (allPlayers - (entities "HeadlessClient_F"));
-		[5,theBoss] call A3A_fnc_playerScoreAdd;
+		[10,theBoss] call A3A_fnc_playerScoreAdd;
 		};
 	};
 if (dateToNumber date > _dateLimitNum) then
@@ -75,15 +75,15 @@ if (dateToNumber date > _dateLimitNum) then
 		[_taskId, "REP", "SUCCEEDED"] call A3A_fnc_taskSetState;
         [Occupants, 15, 90] remoteExec ["A3A_fnc_addAggression", 2];
         [Invaders, 5, 60] remoteExec ["A3A_fnc_addAggression", 2];
-		[1200, Occupants] remoteExec ["A3A_fnc_timingCA",2];
+		[500, Occupants] remoteExec ["A3A_fnc_timingCA",2];
 		{if (_x distance _veh < 500) then {[10,_x] call A3A_fnc_playerScoreAdd}} forEach (allPlayers - (entities "HeadlessClient_F"));
-		[5,theBoss] call A3A_fnc_playerScoreAdd;
+		[10,theBoss] call A3A_fnc_playerScoreAdd;
 		}
 	else
 		{
 		[_taskId, "REP", "FAILED"] call A3A_fnc_taskSetState;
 		//[5,0,_positionX] remoteExec ["A3A_fnc_citySupportChange",2];
-		[-600, Occupants] remoteExec ["A3A_fnc_timingCA",2];
+		[-200, Occupants] remoteExec ["A3A_fnc_timingCA",2];
 		[-10,theBoss] call A3A_fnc_playerScoreAdd;
 		};
 	[_antennaDead] remoteExec ["A3A_fnc_rebuildRadioTower", 2];


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
I realized that the mission rewards that reduced enemy resources were unbalanced enough to be throwing the whole resource system, so this could do with a relatively fast fix.

Principles:
- Most missions have direct effects on enemy resources (especially convoys when destroyed), so they shouldn't have large additional effects. The main exception is AS_official.
- Failure results generally shouldn't be dependent on mission difficulty.
- Increased commander score reward for completed missions, as they were lagging hard in most cases.
- Stripped out some weird/unnecessary city support change rewards.
- Removed aggro reductions for failing missions.

If this is too much for 3.3 I'll have to make another PR to disable timingCA until the next version.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Should probably get a couple of days on the servers. I've executed each mission but not tested all of the result cases.