### PR TITLE
Add CAS planes used by chdkz to setPlaneLoadout

### DIFF
--- a/A3A/addons/core/functions/Base/fn_setPlaneLoadout.sqf
+++ b/A3A/addons/core/functions/Base/fn_setPlaneLoadout.sqf
@@ -61,6 +61,7 @@ if (_type == "CAS") then
             _plane setVariable ["rocketLauncher", ["rhs_weap_FFARLauncher"]];
             _plane setVariable ["missileLauncher", ["rhs_weap_agm65d"]];
         };
+        case "RHS_Su25SM_vvsc";
         case "RHS_Su25SM_CAS_vvs";
         case "rhsgref_cdf_b_su25";
         case "UK3CB_TKA_B_Su25SM_CAS";
@@ -263,6 +264,7 @@ if (_type == "AA") then
             _loadout = ["rhs_mag_aim9m","rhs_mag_aim120","rhs_mag_aim120","rhs_mag_zpl20_mixed","rhs_mag_aim120","rhs_mag_aim120","rhs_mag_aim9m","rhsusf_ANALE40_CMFlare_Chaff_Magazine_x2"];
         };
         //RHS Russian Air superiority
+        case "rhs_mig29sm_vvs";
         case "rhs_mig29s_vvs";
         case "rhsgref_cdf_b_mig29s";
         case "UK3CB_TKA_O_MIG29SM";


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
New chdkz template is using plane versions that don't have a loadout definition. This PR fixes them.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)
