### PR TITLE
Add fancy names to the setup UI for the new maps

### DIFF
--- a/A3A/addons/gui/functions/SetupGUI/fn_setupDialog.sqf
+++ b/A3A/addons/gui/functions/SetupGUI/fn_setupDialog.sqf
@@ -114,6 +114,8 @@ switch (_mode) do
             ,["chernarus_winter", "Chernarus (W)"]
             ,["Enoch", "Livonia"]
             ,["tem_anizay", "Anizay"]
+            ,["cup_chernarus_A3", "Cherno 2020"]
+            ,["SPE_Normandy", "Normandy"]
         ];
         {
             private _realMap = _x get "map";


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Add fancy map names for the two new maps so that they don't overspill the setup UI.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

