### PR TITLE
Fix arsenal loadout loading broken by SPE fakemag check  

### DIFF
--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_itemType.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_itemType.sqf
@@ -181,7 +181,7 @@ private _itemCategory = switch true do {
 			// Everything else
 			default {
 				// haaaaack
-				if (_item isKindOf ["SPE_MUZZLE_FAKEMAG", configFile >> "CfgMagazines"]) exitWith {"junk"};
+				if (_item isKindOf ["SPE_MUZZLE_FAKEMAG", configFile >> "CfgMagazines"]) exitWith {"Junk"};
 				"Magazine";
 			};
 		};
@@ -195,9 +195,10 @@ private _itemCategory = switch true do {
 	case (isClass (configFile >> "CfgGlasses" >> _item)): {
 		"Glasses";
 	};
+	default { "Junk" };			// Loadout code can send empty strings. Possibly other rubbish.
 };
 
-if (_itemCategory == "junk") exitWith {-1};
+if (_itemCategory == "Junk") exitWith {-1};
 
 INITTYPES
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The arsenal itemType check for fake SPE mags broke on an old bug where the loadout code sends empty strings to ItemType which caused _itemCategory to have the wrong type. This broke loadout loading. 

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
