### PR TITLE
Change SPE-IFA militia cars to kubelwagens, fix unarmed car navigation bug

### DIFF
--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_WEH.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_WEH.sqf
@@ -56,11 +56,11 @@
 ["uavsPortable", []] call _fnc_saveToTemplate;
 
 //Config special vehicles
-["vehiclesMilitiaLightArmed", ["SPE_US_M3_Halftrack"]] call _fnc_saveToTemplate;
+["vehiclesMilitiaLightArmed", ["LIB_Kfz1_MG42_sernyt_DLV"]] call _fnc_saveToTemplate;
 ["vehiclesMilitiaTrucks", ["SPE_ST_OpelBlitz_Open"]] call _fnc_saveToTemplate;
-["vehiclesMilitiaCars", ["SPE_ST_OpelBlitz"]] call _fnc_saveToTemplate;
+["vehiclesMilitiaCars", ["LIB_Kfz1_sernyt"]] call _fnc_saveToTemplate;
 
-["vehiclesPolice", ["SPE_ST_OpelBlitz_Open"]] call _fnc_saveToTemplate;
+["vehiclesPolice", ["LIB_Kfz1_sernyt"]] call _fnc_saveToTemplate;
 
 ["staticMGs", ["SPE_MG42_Lafette_Deployed", "SPE_MG34_Lafette_Deployed"]] call _fnc_saveToTemplate;
 ["staticAT", ["SPE_leFH18_AT", "SPE_Pak40"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_WEH.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_WEH.sqf
@@ -56,7 +56,7 @@
 ["uavsPortable", []] call _fnc_saveToTemplate;
 
 //Config special vehicles
-["vehiclesMilitiaLightArmed", ["LIB_Kfz1_MG42_sernyt_DLV"]] call _fnc_saveToTemplate;
+["vehiclesMilitiaLightArmed", ["LIB_Kfz1_MG42_sernyt"]] call _fnc_saveToTemplate;
 ["vehiclesMilitiaTrucks", ["SPE_ST_OpelBlitz_Open"]] call _fnc_saveToTemplate;
 ["vehiclesMilitiaCars", ["LIB_Kfz1_sernyt"]] call _fnc_saveToTemplate;
 

--- a/A3A/addons/core/functions/CREATE/fn_createVehicleQRFBehaviour.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createVehicleQRFBehaviour.sqf
@@ -101,6 +101,7 @@ else            // ground vehicle
         // Vehicle has no weapons(?) and small cargo, merge crew group into cargo group
         (units _crewGroup) joinSilent _cargoGroup;
         deleteGroup _crewGroup;
+        _cargoGroup selectLeader driver _vehicle;
 
         //Create the path waypoints
         private _landPos = [_posDestination, getPosATL _vehicle, false, _landPosBlacklist] call A3A_fnc_findSafeRoadToUnload;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
- Changed SPE-IFA Wehrmacht militia cars to IFA Kubelwagens (was M3 Halftrack, very obviously US).
- Fixed issue with unarmed cars that could cause them not to drive.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
