### PR TITLE
Fix unarmed militia vehicles being used in roadblocks

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_createAIcontrols.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIcontrols.sqf
@@ -157,7 +157,7 @@ if (_isControl) then
 		}
 	else
 		{
-		_typeVehX = selectRandom (_faction get "vehiclesMilitiaCars");
+		_typeVehX = selectRandom (_faction get "vehiclesMilitiaLightArmed");
 		_veh = _typeVehX createVehicle getPos (_roads select 0);
 		_veh setDir _dirveh + 90;
 		[_veh, _sideX] call A3A_fnc_AIVEHinit;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Code accidentally introduced with the SPE roadblock changes switched the militia roadblock vehicles from vehiclesMilitiaLightArmed to VehiclesMilitiaCars, causing unarmed vehicles to show up in roadblocks for all modsets. This PR fixes it.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
