### PR TITLE
Improve SPE_IFA Templates

### DIFF
--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_US.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_US.sqf
@@ -21,7 +21,7 @@
 
 ["vehiclesBasic", ["LIB_US_Willys_MB"]] call _fnc_saveToTemplate;
 ["vehiclesLightUnarmed", ["LIB_US_Willys_MB", "LIB_US_Willys_MB_Hood"]] call _fnc_saveToTemplate;
-["vehiclesLightArmed", ["LIB_US_Willys_MB_M1919", "LIB_US_Scout_M3", "SPE_US_M3_Halftrack"]] call _fnc_saveToTemplate;
+["vehiclesLightArmed", ["LIB_US_Willys_MB_M1919", "LIB_US_Scout_M3", "LIB_US_Willys_MB_M1919", "LIB_US_Scout_M3", "LIB_M8_Greyhound", "LIB_M3A3_Stuart", "LIB_M5A1_Stuart"]] call _fnc_saveToTemplate;
 ["vehiclesTrucks", ["SPE_US_M3_Halftrack_Unarmed", "LIB_US_GMC_Open", "LIB_US_GMC_Tent"]] call _fnc_saveToTemplate;
 ["vehiclesCargoTrucks", ["SPE_US_M3_Halftrack_Unarmed"]] call _fnc_saveToTemplate;
 ["vehiclesAmmoTrucks", ["SPE_US_M3_Halftrack_Ammo", "LIB_US_GMC_Ammo"]] call _fnc_saveToTemplate;
@@ -29,9 +29,9 @@
 ["vehiclesFuelTrucks", ["SPE_US_M3_Halftrack_Fuel", "LIB_US_GMC_Fuel"]] call _fnc_saveToTemplate;
 ["vehiclesMedical", ["SPE_US_M3_Halftrack_Ambulance", "LIB_US_GMC_Ambulance"]] call _fnc_saveToTemplate;
 ["vehiclesLightAPCs", ["LIB_US_Scout_M3", "SPE_US_M3_Halftrack"]] call _fnc_saveToTemplate;
-["vehiclesAPCs", ["SPE_M10", "SPE_US_M3_Halftrack", "SPE_US_M16_Halftrack", "SPE_US_M3_Halftrack"]] call _fnc_saveToTemplate;
-["vehiclesIFVs", ["SPE_M18_Hellcat", "LIB_M3A3_Stuart", "LIB_M5A1_Stuart", "LIB_M8_Greyhound"]] call _fnc_saveToTemplate;
-["vehiclesTanks", ["SPE_M4A0_75_Early", "SPE_M4A0_75", "SPE_M4A1_76", "SPE_M4A1_75"]] call _fnc_saveToTemplate;
+["vehiclesAPCs", ["SPE_US_M3_Halftrack", "SPE_US_M16_Halftrack", "SPE_US_M3_Halftrack"]] call _fnc_saveToTemplate;
+["vehiclesIFVs", ["SPE_M10", "SPE_M4A0_75_Early", "SPE_M4A0_75"]] call _fnc_saveToTemplate;
+["vehiclesTanks", ["SPE_M18_Hellcat", "SPE_M4A1_76", "SPE_M4A1_75"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["SPE_US_M16_Halftrack"]] call _fnc_saveToTemplate;
 
 ["vehiclesTransportBoats", ["LIB_LCVP"]] call _fnc_saveToTemplate;
@@ -276,6 +276,10 @@ _militiaLoadoutData set ["slUniorms", []];
 _militiaLoadoutData set ["helmets", ["H_SPE_FR_Adrian", "H_SPE_FR_Adrian_ns", "H_SPE_FR_US_Helmet_ns"]];
 _militiaLoadoutData set ["medHelmets", ["H_SPE_FR_Adrian_Medic", "H_SPE_FR_Adrian_Medic_ns"]];
 _militiaLoadoutData set ["slHelmets", ["H_SPE_FR_US_Helmet_ns"]];
+
+_militiaLoadoutData set ["machineGuns", [
+    ["SPE_FM_24_M29", "", "", "", ["SPE_25Rnd_75x54"], [], ""]
+]];
 
 //////////////////////////
 //    Misc Loadouts     //

--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_US.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_US.sqf
@@ -21,7 +21,7 @@
 
 ["vehiclesBasic", ["LIB_US_Willys_MB"]] call _fnc_saveToTemplate;
 ["vehiclesLightUnarmed", ["LIB_US_Willys_MB", "LIB_US_Willys_MB_Hood"]] call _fnc_saveToTemplate;
-["vehiclesLightArmed", ["LIB_US_Willys_MB_M1919", "LIB_US_Scout_M3", "LIB_US_Willys_MB_M1919", "LIB_US_Scout_M3", "LIB_M8_Greyhound", "LIB_M3A3_Stuart", "LIB_M5A1_Stuart"]] call _fnc_saveToTemplate;
+["vehiclesLightArmed", ["LIB_US_Willys_MB_M1919", "LIB_US_Scout_M3"]] call _fnc_saveToTemplate;
 ["vehiclesTrucks", ["SPE_US_M3_Halftrack_Unarmed", "LIB_US_GMC_Open", "LIB_US_GMC_Tent"]] call _fnc_saveToTemplate;
 ["vehiclesCargoTrucks", ["SPE_US_M3_Halftrack_Unarmed"]] call _fnc_saveToTemplate;
 ["vehiclesAmmoTrucks", ["SPE_US_M3_Halftrack_Ammo", "LIB_US_GMC_Ammo"]] call _fnc_saveToTemplate;
@@ -30,8 +30,8 @@
 ["vehiclesMedical", ["SPE_US_M3_Halftrack_Ambulance", "LIB_US_GMC_Ambulance"]] call _fnc_saveToTemplate;
 ["vehiclesLightAPCs", ["LIB_US_Scout_M3", "SPE_US_M3_Halftrack"]] call _fnc_saveToTemplate;
 ["vehiclesAPCs", ["SPE_US_M3_Halftrack", "SPE_US_M16_Halftrack", "SPE_US_M3_Halftrack"]] call _fnc_saveToTemplate;
-["vehiclesIFVs", ["SPE_M10", "SPE_M4A0_75_Early", "SPE_M4A0_75"]] call _fnc_saveToTemplate;
-["vehiclesTanks", ["SPE_M18_Hellcat", "SPE_M4A1_76", "SPE_M4A1_75"]] call _fnc_saveToTemplate;
+["vehiclesIFVs", ["SPE_M18_Hellcat", "SPE_M10", "LIB_M8_Greyhound", "LIB_M3A3_Stuart", "LIB_M5A1_Stuart"]] call _fnc_saveToTemplate;
+["vehiclesTanks", ["SPE_M4A0_75_Early", "SPE_M4A0_75", "SPE_M4A1_76", "SPE_M4A1_75"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["SPE_US_M16_Halftrack"]] call _fnc_saveToTemplate;
 
 ["vehiclesTransportBoats", ["LIB_LCVP"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_US.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_US.sqf
@@ -19,23 +19,23 @@
 ["surrenderCrate", "SPE_Mine_AmmoBox_US"] call _fnc_saveToTemplate;
 ["equipmentBox", "Box_NATO_Equip_F"] call _fnc_saveToTemplate;
 
-["vehiclesBasic", []] call _fnc_saveToTemplate;
-["vehiclesLightUnarmed", ["SPE_US_M3_Halftrack_Unarmed"]] call _fnc_saveToTemplate;
-["vehiclesLightArmed", ["SPE_US_M16_Halftrack", "SPE_US_M3_Halftrack"]] call _fnc_saveToTemplate;
-["vehiclesTrucks", ["SPE_US_M3_Halftrack_Unarmed", "SPE_US_M3_Halftrack"]] call _fnc_saveToTemplate;
+["vehiclesBasic", ["LIB_US_Willys_MB"]] call _fnc_saveToTemplate;
+["vehiclesLightUnarmed", ["LIB_US_Willys_MB", "LIB_US_Willys_MB_Hood"]] call _fnc_saveToTemplate;
+["vehiclesLightArmed", ["LIB_US_Willys_MB_M1919", "SPE_US_M16_Halftrack", "SPE_US_M3_Halftrack"]] call _fnc_saveToTemplate;
+["vehiclesTrucks", ["SPE_US_M3_Halftrack_Unarmed", "LIB_US_GMC_Open", "LIB_US_GMC_Tent"]] call _fnc_saveToTemplate;
 ["vehiclesCargoTrucks", ["SPE_US_M3_Halftrack_Unarmed"]] call _fnc_saveToTemplate;
-["vehiclesAmmoTrucks", ["SPE_US_M3_Halftrack_Ammo"]] call _fnc_saveToTemplate;
-["vehiclesRepairTrucks", ["SPE_US_M3_Halftrack_Repair"]] call _fnc_saveToTemplate;
-["vehiclesFuelTrucks", ["SPE_US_M3_Halftrack_Fuel"]] call _fnc_saveToTemplate;
-["vehiclesMedical", ["SPE_US_M3_Halftrack_Ambulance"]] call _fnc_saveToTemplate;
+["vehiclesAmmoTrucks", ["SPE_US_M3_Halftrack_Ammo", "LIB_US_GMC_Ammo"]] call _fnc_saveToTemplate;
+["vehiclesRepairTrucks", ["SPE_US_M3_Halftrack_Repair", "LIB_US_GMC_Parm"]] call _fnc_saveToTemplate;
+["vehiclesFuelTrucks", ["SPE_US_M3_Halftrack_Fuel", "LIB_US_GMC_Fuel"]] call _fnc_saveToTemplate;
+["vehiclesMedical", ["SPE_US_M3_Halftrack_Ambulance", "LIB_US_GMC_Ambulance"]] call _fnc_saveToTemplate;
 ["vehiclesLightAPCs", ["SPE_US_M3_Halftrack"]] call _fnc_saveToTemplate;
-["vehiclesAPCs", ["SPE_M4A0_75_Early", "SPE_M4A0_75"]] call _fnc_saveToTemplate;
-["vehiclesIFVs", ["SPE_M10", "SPE_M18_Hellcat"]] call _fnc_saveToTemplate;
-["vehiclesTanks", ["SPE_M4A1_76", "SPE_M4A1_75"]] call _fnc_saveToTemplate;
+["vehiclesAPCs", ["SPE_M10", "SPE_US_M3_Halftrack", "SPE_US_M16_Halftrack", "SPE_US_M3_Halftrack"]] call _fnc_saveToTemplate;
+["vehiclesIFVs", ["SPE_M18_Hellcat", "LIB_M3A3_Stuart", "LIB_M5A1_Stuart", "LIB_M8_Greyhound"]] call _fnc_saveToTemplate;
+["vehiclesTanks", ["SPE_M4A0_75_Early", "SPE_M4A0_75", "SPE_M4A1_76", "SPE_M4A1_75"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["SPE_US_M16_Halftrack"]] call _fnc_saveToTemplate;
 
-["vehiclesTransportBoats", ["B_Boat_Transport_01_F"]] call _fnc_saveToTemplate;
-["vehiclesGunBoats", ["B_Boat_Transport_01_F"]] call _fnc_saveToTemplate;
+["vehiclesTransportBoats", ["LIB_LCVP"]] call _fnc_saveToTemplate;
+["vehiclesGunBoats", ["LIB_LCM3_Armed"]] call _fnc_saveToTemplate;
 ["vehiclesAmphibious", []] call _fnc_saveToTemplate;
 
 ["vehiclesPlanesCAS", ["SPE_P47"]] call _fnc_saveToTemplate;
@@ -56,11 +56,11 @@
 ["uavsPortable", []] call _fnc_saveToTemplate;
 
 //Config special vehicles
-["vehiclesMilitiaLightArmed", ["SPE_US_M3_Halftrack"]] call _fnc_saveToTemplate;
-["vehiclesMilitiaTrucks", ["SPE_US_M3_Halftrack_Unarmed"]] call _fnc_saveToTemplate;
-["vehiclesMilitiaCars", ["SPE_US_M3_Halftrack"]] call _fnc_saveToTemplate;
+["vehiclesMilitiaLightArmed", ["LIB_US_Willys_MB_M1919"]] call _fnc_saveToTemplate;
+["vehiclesMilitiaTrucks", ["LIB_US_GMC_Open"]] call _fnc_saveToTemplate;
+["vehiclesMilitiaCars", ["LIB_US_Willys_MB"]] call _fnc_saveToTemplate;
 
-["vehiclesPolice", ["SPE_FR_M3_Halftrack_Unarmed"]] call _fnc_saveToTemplate;
+["vehiclesPolice", ["LIB_US_Willys_MB_Hood"]] call _fnc_saveToTemplate;
 
 ["staticMGs", ["SPE_M1919A6_Bipod"]] call _fnc_saveToTemplate;
 ["staticAT", ["SPE_57mm_M1"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_US.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_US.sqf
@@ -21,14 +21,14 @@
 
 ["vehiclesBasic", ["LIB_US_Willys_MB"]] call _fnc_saveToTemplate;
 ["vehiclesLightUnarmed", ["LIB_US_Willys_MB", "LIB_US_Willys_MB_Hood"]] call _fnc_saveToTemplate;
-["vehiclesLightArmed", ["LIB_US_Willys_MB_M1919", "SPE_US_M16_Halftrack", "SPE_US_M3_Halftrack"]] call _fnc_saveToTemplate;
+["vehiclesLightArmed", ["LIB_US_Willys_MB_M1919", "LIB_US_Scout_M3", "SPE_US_M3_Halftrack"]] call _fnc_saveToTemplate;
 ["vehiclesTrucks", ["SPE_US_M3_Halftrack_Unarmed", "LIB_US_GMC_Open", "LIB_US_GMC_Tent"]] call _fnc_saveToTemplate;
 ["vehiclesCargoTrucks", ["SPE_US_M3_Halftrack_Unarmed"]] call _fnc_saveToTemplate;
 ["vehiclesAmmoTrucks", ["SPE_US_M3_Halftrack_Ammo", "LIB_US_GMC_Ammo"]] call _fnc_saveToTemplate;
 ["vehiclesRepairTrucks", ["SPE_US_M3_Halftrack_Repair", "LIB_US_GMC_Parm"]] call _fnc_saveToTemplate;
 ["vehiclesFuelTrucks", ["SPE_US_M3_Halftrack_Fuel", "LIB_US_GMC_Fuel"]] call _fnc_saveToTemplate;
 ["vehiclesMedical", ["SPE_US_M3_Halftrack_Ambulance", "LIB_US_GMC_Ambulance"]] call _fnc_saveToTemplate;
-["vehiclesLightAPCs", ["SPE_US_M3_Halftrack"]] call _fnc_saveToTemplate;
+["vehiclesLightAPCs", ["LIB_US_Scout_M3", "SPE_US_M3_Halftrack"]] call _fnc_saveToTemplate;
 ["vehiclesAPCs", ["SPE_M10", "SPE_US_M3_Halftrack", "SPE_US_M16_Halftrack", "SPE_US_M3_Halftrack"]] call _fnc_saveToTemplate;
 ["vehiclesIFVs", ["SPE_M18_Hellcat", "LIB_M3A3_Stuart", "LIB_M5A1_Stuart", "LIB_M8_Greyhound"]] call _fnc_saveToTemplate;
 ["vehiclesTanks", ["SPE_M4A0_75_Early", "SPE_M4A0_75", "SPE_M4A1_76", "SPE_M4A1_75"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_WEH.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_WEH.sqf
@@ -21,16 +21,16 @@
 
 ["vehiclesBasic", ["LIB_Kfz1"]] call _fnc_saveToTemplate;
 ["vehiclesLightUnarmed", ["LIB_Kfz1", "LIB_Kfz1_Hood"]] call _fnc_saveToTemplate;
-["vehiclesLightArmed", ["LIB_Kfz1_MG42", "LIB_SdKfz251"]] call _fnc_saveToTemplate;
+["vehiclesLightArmed", ["LIB_Kfz1_MG42", "LIB_SdKfz251", "SPE_ST_OpelBlitz_Flak38"]] call _fnc_saveToTemplate;
 ["vehiclesTrucks", ["SPE_ST_OpelBlitz_Open", "SPE_ST_OpelBlitz", "LIB_SdKfz_7"]] call _fnc_saveToTemplate;
 ["vehiclesCargoTrucks", ["SPE_ST_OpelBlitz_Open"]] call _fnc_saveToTemplate;
 ["vehiclesAmmoTrucks", ["SPE_ST_OpelBlitz_Ammo", "LIB_SdKfz_7_Ammo"]] call _fnc_saveToTemplate;
 ["vehiclesRepairTrucks", ["SPE_ST_OpelBlitz_Repair"]] call _fnc_saveToTemplate;
 ["vehiclesFuelTrucks", ["SPE_ST_OpelBlitz_Fuel"]] call _fnc_saveToTemplate;
 ["vehiclesMedical", ["SPE_ST_OpelBlitz_Ambulance"]] call _fnc_saveToTemplate;
-["vehiclesLightAPCs", []] call _fnc_saveToTemplate;
-["vehiclesAPCs", ["LIB_SdKfz251_FFV", "SPE_SdKfz250_1"]] call _fnc_saveToTemplate;
-["vehiclesIFVs", ["SPE_PzKpfwIII_N", "SPE_ST_OpelBlitz_Flak38", "SPE_PzKpfwIII_M", "SPE_PzKpfwIII_L"]] call _fnc_saveToTemplate;
+["vehiclesLightAPCs", ["SPE_SdKfz250_1", "LIB_SdKfz251"]] call _fnc_saveToTemplate;
+["vehiclesAPCs", ["LIB_SdKfz251_FFV", "SPE_PzKpfwIII_J"]] call _fnc_saveToTemplate;
+["vehiclesIFVs", ["SPE_PzKpfwIII_N", "SPE_PzKpfwIII_M", "SPE_PzKpfwIII_L"]] call _fnc_saveToTemplate;
 ["vehiclesTanks", ["SPE_PzKpfwVI_H1", "LIB_PzKpfwV", "SPE_PzKpfwIV_G"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["SPE_ST_OpelBlitz_Flak38", "LIB_SdKfz_7_AA", "LIB_FlakPanzerIV_Wirbelwind"]] call _fnc_saveToTemplate;
 
@@ -81,7 +81,7 @@
 /////////////////////
 
 ["faces", ["LivonianHead_6","SPE_boyartsev","SPE_bykov","SPE_Connors","SPE_DAgostino","SPE_Davidson","SPE_Elliot","SPE_Grishka","SPE_Hauptmann","SPE_Klimakov","SPE_Krueger","SPE_Kuzmin","SPE_Neumann","SPE_Oberst","SPE_OBrien","SPE_Vasiliev","SPE_Walter","SPE_Wolf","Sturrock","WhiteHead_01","WhiteHead_02","WhiteHead_03","WhiteHead_04","WhiteHead_05","WhiteHead_06","WhiteHead_08","WhiteHead_09","WhiteHead_11","WhiteHead_12","WhiteHead_13","WhiteHead_14","WhiteHead_15","WhiteHead_18","WhiteHead_19","WhiteHead_20","WhiteHead_21"]] call _fnc_saveToTemplate;
-["voices", ["Male01ENG", "Male02ENG", "Male03ENG", "Male04ENG", "Male05ENG", "Male06ENG", "Male07ENG", "Male08ENG", "Male09ENG", "Male10ENG", "Male11ENG", "Male12ENG"]] call _fnc_saveToTemplate;
+["voices", ["Male01Ger", "Male02Ger", "Male03Ger", "Male04Ger", "Male05Ger"]] call _fnc_saveToTemplate;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_WEH.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_WEH.sqf
@@ -19,20 +19,20 @@
 ["surrenderCrate", "SPE_Weaponcrate_MP40_GER"] call _fnc_saveToTemplate;
 ["equipmentBox", "Box_NATO_Equip_F"] call _fnc_saveToTemplate;
 
-["vehiclesBasic", []] call _fnc_saveToTemplate;
-["vehiclesLightUnarmed", ["SPE_ST_OpelBlitz_Open", "SPE_ST_OpelBlitz"]] call _fnc_saveToTemplate;
-["vehiclesLightArmed", ["SPE_SdKfz250_1", "SPE_SdKfz250_1", "SPE_ST_OpelBlitz_Flak38"]] call _fnc_saveToTemplate;
-["vehiclesTrucks", ["SPE_ST_OpelBlitz_Open", "SPE_ST_OpelBlitz"]] call _fnc_saveToTemplate;
+["vehiclesBasic", ["LIB_Kfz1"]] call _fnc_saveToTemplate;
+["vehiclesLightUnarmed", ["LIB_Kfz1", "LIB_Kfz1_Hood"]] call _fnc_saveToTemplate;
+["vehiclesLightArmed", ["LIB_Kfz1_MG42", "LIB_SdKfz251"]] call _fnc_saveToTemplate;
+["vehiclesTrucks", ["SPE_ST_OpelBlitz_Open", "SPE_ST_OpelBlitz", "LIB_SdKfz_7"]] call _fnc_saveToTemplate;
 ["vehiclesCargoTrucks", ["SPE_ST_OpelBlitz_Open"]] call _fnc_saveToTemplate;
-["vehiclesAmmoTrucks", ["SPE_ST_OpelBlitz_Ammo"]] call _fnc_saveToTemplate;
+["vehiclesAmmoTrucks", ["SPE_ST_OpelBlitz_Ammo", "LIB_SdKfz_7_Ammo"]] call _fnc_saveToTemplate;
 ["vehiclesRepairTrucks", ["SPE_ST_OpelBlitz_Repair"]] call _fnc_saveToTemplate;
 ["vehiclesFuelTrucks", ["SPE_ST_OpelBlitz_Fuel"]] call _fnc_saveToTemplate;
 ["vehiclesMedical", ["SPE_ST_OpelBlitz_Ambulance"]] call _fnc_saveToTemplate;
 ["vehiclesLightAPCs", []] call _fnc_saveToTemplate;
-["vehiclesAPCs", ["SPE_PzKpfwIII_N", "SPE_PzKpfwIII_M", "SPE_PzKpfwIII_L"]] call _fnc_saveToTemplate;
-["vehiclesIFVs", ["SPE_PzKpfwIII_N", "SPE_PzKpfwIII_M", "SPE_PzKpfwIII_L"]] call _fnc_saveToTemplate;
-["vehiclesTanks", ["SPE_PzKpfwVI_H1", "SPE_ST_PzKpfwIII_J", "SPE_PzKpfwIV_G"]] call _fnc_saveToTemplate;
-["vehiclesAA", ["SPE_ST_OpelBlitz_Flak38"]] call _fnc_saveToTemplate;
+["vehiclesAPCs", ["LIB_SdKfz251_FFV", "SPE_SdKfz250_1"]] call _fnc_saveToTemplate;
+["vehiclesIFVs", ["SPE_PzKpfwIII_N", "SPE_ST_OpelBlitz_Flak38", "SPE_PzKpfwIII_M", "SPE_PzKpfwIII_L"]] call _fnc_saveToTemplate;
+["vehiclesTanks", ["SPE_PzKpfwVI_H1", "LIB_PzKpfwV", "SPE_PzKpfwIV_G"]] call _fnc_saveToTemplate;
+["vehiclesAA", ["SPE_ST_OpelBlitz_Flak38", "LIB_SdKfz_7_AA", "LIB_FlakPanzerIV_Wirbelwind"]] call _fnc_saveToTemplate;
 
 ["vehiclesTransportBoats", ["B_Boat_Transport_01_F"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["B_Boat_Transport_01_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_CIV.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_CIV.sqf
@@ -3,17 +3,16 @@
 //////////////////////////    
 
 ["vehiclesCivCar", [
-    "SPE_OpelBlitz", 1
-    , "SPE_OpelBlitz_Open", 1
-    , "LIB_GazM1", 1
+    "LIB_GazM1", 1
     , "LIB_GazM1_dirty", 1
     , "LIB_GazM1_SOV_camo_sand", 1
     , "LIB_GazM1_SOV", 1
+    , "LIB_Willys_MB", 1
+    , "LIB_Willys_MB_Hood", 1
     ]] call _fnc_saveToTemplate;
 
 ["vehiclesCivIndustrial", [
-    "SPE_OpelBlitz", 1
-    , "SPE_OpelBlitz_Open", 1
+    "LIB_Zis5v", 1
 ]] call _fnc_saveToTemplate;
 
 ["vehiclesCivBoat", [
@@ -21,15 +20,15 @@
 ]] call _fnc_saveToTemplate;
 
 ["vehiclesCivRepair", [
-    "SPE_OpelBlitz_Repair", 0.1
+    "LIB_Zis6_Parm", 0.1
 ]] call _fnc_saveToTemplate;
 
 ["vehiclesCivMedical", [
-    "SPE_OpelBlitz_Ambulance", 0.1
+    "LIB_Zis5v_Med", 0.1
 ]] call _fnc_saveToTemplate;
 
 ["vehiclesCivFuel", [
-    "SPE_OpelBlitz_Fuel", 0.1
+    "LIB_Zis5v_Fuel", 0.1
 ]] call _fnc_saveToTemplate;
 
 /////////////////////

--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_REB_FFF.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_REB_FFF.sqf
@@ -26,10 +26,10 @@
 //       Vehicles       //
 //////////////////////////
 
-["vehiclesBasic", ["SPE_FFI_OpelBlitz_Open"]] call _fnc_saveToTemplate;
-["vehiclesLightUnarmed", ["LIB_Kfz1_sernyt","LIB_Kfz1_Hood_sernyt"]] call _fnc_saveToTemplate;
-["vehiclesLightArmed", ["SPE_US_M3_Halftrack","LIB_Kfz1_MG42_sernyt"]] call _fnc_saveToTemplate;
-["vehiclesTruck", ["SPE_US_M3_Halftrack_Unarmed"]] call _fnc_saveToTemplate;
+["vehiclesBasic", ["LIB_Kfz1_sernyt"]] call _fnc_saveToTemplate;
+["vehiclesLightUnarmed", ["LIB_Kfz1_Hood_sernyt","LIB_UK_Willys_MB_Hood"]] call _fnc_saveToTemplate;
+["vehiclesLightArmed", ["LIB_UK_Willys_MB_M1919","LIB_Kfz1_MG42_sernyt"]] call _fnc_saveToTemplate;
+["vehiclesTruck", ["LIB_US6_Open"]] call _fnc_saveToTemplate;
 ["vehiclesAT", []] call _fnc_saveToTemplate;
 ["vehiclesAA", ["SPE_OpelBlitz_Flak38"]] call _fnc_saveToTemplate;
 
@@ -39,7 +39,7 @@
 ["vehiclesHeli", []] call _fnc_saveToTemplate;
 
 ["vehiclesCivCar", ["LIB_GazM1","LIB_GazM1_dirty"]] call _fnc_saveToTemplate;
-["vehiclesCivTruck", ["SPE_FFI_OpelBlitz"]] call _fnc_saveToTemplate;
+["vehiclesCivTruck", ["LIB_Zis5v"]] call _fnc_saveToTemplate;
 ["vehiclesCivHeli", []] call _fnc_saveToTemplate;
 ["vehiclesCivBoat", ["B_Boat_Transport_01_F"]] call _fnc_saveToTemplate;
 ["vehiclesCivPlane", []] call _fnc_saveToTemplate;

--- a/A3A/addons/logistics/CfgLogistics.hpp
+++ b/A3A/addons/logistics/CfgLogistics.hpp
@@ -15,6 +15,7 @@ class DOUBLES(ADDON,Nodes)
     #include "Nodes\RHS.hpp"
     #include "Nodes\RNT.hpp"
     #include "Nodes\SPE.hpp"
+    #include "Nodes\IFA.hpp"
     #include "Nodes\UNS.hpp"
     #include "Nodes\Vanilla.hpp"
     #include "Nodes\VN.hpp"

--- a/A3A/addons/logistics/Nodes/IFA.hpp
+++ b/A3A/addons/logistics/Nodes/IFA.hpp
@@ -28,6 +28,7 @@
 
 "class WW2_Assets_m_Vehicles_Trucks_m_IF_Opelblitz_p3d : TRIPLES(ADDON,Nodes,Base)
 {
+	    canLoadWeapon = 0;
         class Nodes
     {
         class Node1
@@ -56,6 +57,7 @@
 
 "class WW2_Assets_m_Vehicles_Trucks_m_IF_Opelblitz_Tent_p3d : TRIPLES(ADDON,Nodes,Base)
 {
+	    canLoadWeapon = 0;
         class Nodes
     {
         class Node1
@@ -84,34 +86,7 @@
 
 "class WW2_Assets_m_Vehicles_Trucks_m_IF_Us6_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-        class Nodes
-    {
-        class Node1
-        {
-            offset[] = {0,-0.28,0.2};
-			seats[] = {1,10};
-        };
-        class Node2
-        {
-            offset[] = {0,-1.08,0.2};
-			seats[] = {2,5,6,7};
-        };
-        class Node3
-        {
-            offset[] = {0,-1.88,0.2};
-			seats[] = {3,4};
-        };
-        class Node4
-        {
-            offset[] = {0,-2.68,0.2};
-			seats[] = {8,9};
-        };
-    };
-};
-"
-
-"class WW2_Assets_m_Vehicles_Trucks_m_IF_Us6_p3d : TRIPLES(ADDON,Nodes,Base)
-{
+	    canLoadWeapon = 0;
         class Nodes
     {
         class Node1
@@ -163,34 +138,7 @@
 
 "class WW2_Assets_m_Vehicles_Trucks_m_IF_Gmc353Truck_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-        class Nodes
-    {
-        class Node1
-        {
-            offset[] = {0,-0.4,-0.6};
-			seats[] = {1,2,7,10};
-        };
-        class Node2
-        {
-            offset[] = {0,-1.2,-0.6};
-			seats[] = {5,6};
-        };
-        class Node3
-        {
-            offset[] = {0,-2,-0.6};
-			seats[] = {3,4};
-        };
-        class Node4
-        {
-            offset[] = {0,-2.8,-0.6};
-			seats[] = {8,9};
-        };
-    };
-};
-"
-
-"class WW2_Assets_m_Vehicles_Trucks_m_IF_Gmc353Truck_p3d : TRIPLES(ADDON,Nodes,Base)
-{
+	    canLoadWeapon = 0;
         class Nodes
     {
         class Node1

--- a/A3A/addons/logistics/Nodes/IFA.hpp
+++ b/A3A/addons/logistics/Nodes/IFA.hpp
@@ -1,0 +1,218 @@
+"class WW2_Assets_m_Vehicles_WheeledAPC_m_IF_SdKfz_7_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-0.5,-0.7};
+			seats[] = {2,3,4,5,9};
+        };
+        class Node2
+        {
+            offset[] = {0,-1.3,-0.7};
+			seats[] = {6,10};
+        };
+        class Node3
+        {
+            offset[] = {0,-2.1,-0.7};
+
+        };
+        class Node4
+        {
+            offset[] = {0,-2.9,-0.7};
+			seats[] = {7,8};
+        };
+    };
+};
+"
+
+"class WW2_Assets_m_Vehicles_Trucks_m_IF_Opelblitz_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-0.1,-0.04};
+			seats[] = {1,2,7,10,11};
+        };
+        class Node2
+        {
+            offset[] = {0,-0.9,-0.04};
+			seats[] = {5,6};
+        };
+        class Node3
+        {
+            offset[] = {0,-1.7,-0.04};
+			seats[] = {3,4};
+        };
+        class Node4
+        {
+            offset[] = {0,-2.5,-0.04};
+			seats[] = {8,9};
+        };
+    };
+};
+"
+
+"class WW2_Assets_m_Vehicles_Trucks_m_IF_Opelblitz_Tent_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-0.1,-0.04};
+			seats[] = {1,2,7,10,11};
+        };
+        class Node2
+        {
+            offset[] = {0,-0.9,-0.04};
+			seats[] = {5,6};
+        };
+        class Node3
+        {
+            offset[] = {0,-1.7,-0.04};
+			seats[] = {3,4};
+        };
+        class Node4
+        {
+            offset[] = {0,-2.5,-0.04};
+			seats[] = {8,9};
+        };
+    };
+};
+"
+
+"class WW2_Assets_m_Vehicles_Trucks_m_IF_Us6_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-0.28,0.2};
+			seats[] = {1,10};
+        };
+        class Node2
+        {
+            offset[] = {0,-1.08,0.2};
+			seats[] = {2,5,6,7};
+        };
+        class Node3
+        {
+            offset[] = {0,-1.88,0.2};
+			seats[] = {3,4};
+        };
+        class Node4
+        {
+            offset[] = {0,-2.68,0.2};
+			seats[] = {8,9};
+        };
+    };
+};
+"
+
+"class WW2_Assets_m_Vehicles_Trucks_m_IF_Us6_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-0.28,0.2};
+			seats[] = {1,10};
+        };
+        class Node2
+        {
+            offset[] = {0,-1.08,0.2};
+			seats[] = {2,5,6,7};
+        };
+        class Node3
+        {
+            offset[] = {0,-1.88,0.2};
+			seats[] = {3,4};
+        };
+        class Node4
+        {
+            offset[] = {0,-2.68,0.2};
+			seats[] = {8,9};
+        };
+    };
+};
+"
+
+"class WW2_Assets_m_Vehicles_Trucks_m_IF_Zis5v_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-0.2,-0.4};
+			seats[] = {1,2,3,5,10,11};
+        };
+        class Node2
+        {
+            offset[] = {0,-1,-0.4};
+			seats[] = {4,6,7};
+        };
+        class Node3
+        {
+            offset[] = {0,-1.8,-0.4};
+			seats[] = {8,9,12};
+        };
+    };
+};
+"
+
+"class WW2_Assets_m_Vehicles_Trucks_m_IF_Gmc353Truck_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-0.4,-0.6};
+			seats[] = {1,2,7,10};
+        };
+        class Node2
+        {
+            offset[] = {0,-1.2,-0.6};
+			seats[] = {5,6};
+        };
+        class Node3
+        {
+            offset[] = {0,-2,-0.6};
+			seats[] = {3,4};
+        };
+        class Node4
+        {
+            offset[] = {0,-2.8,-0.6};
+			seats[] = {8,9};
+        };
+    };
+};
+"
+
+"class WW2_Assets_m_Vehicles_Trucks_m_IF_Gmc353Truck_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-0.4,-0.6};
+			seats[] = {1,2,7,10};
+        };
+        class Node2
+        {
+            offset[] = {0,-1.2,-0.6};
+			seats[] = {5,6};
+        };
+        class Node3
+        {
+            offset[] = {0,-2,-0.6};
+			seats[] = {3,4};
+        };
+        class Node4
+        {
+            offset[] = {0,-2.8,-0.6};
+			seats[] = {8,9};
+        };
+    };
+};
+"

--- a/A3A/addons/logistics/Nodes/IFA.hpp
+++ b/A3A/addons/logistics/Nodes/IFA.hpp
@@ -1,4 +1,4 @@
-"class WW2_Assets_m_Vehicles_WheeledAPC_m_IF_SdKfz_7_p3d : TRIPLES(ADDON,Nodes,Base)
+class WW2_Assets_m_Vehicles_WheeledAPC_m_IF_SdKfz_7_p3d : TRIPLES(ADDON,Nodes,Base)
 {
         class Nodes
     {
@@ -24,9 +24,9 @@
         };
     };
 };
-"
 
-"class WW2_Assets_m_Vehicles_Trucks_m_IF_Opelblitz_p3d : TRIPLES(ADDON,Nodes,Base)
+
+class WW2_Assets_m_Vehicles_Trucks_m_IF_Opelblitz_p3d : TRIPLES(ADDON,Nodes,Base)
 {
 	    canLoadWeapon = 0;
         class Nodes
@@ -53,9 +53,9 @@
         };
     };
 };
-"
 
-"class WW2_Assets_m_Vehicles_Trucks_m_IF_Opelblitz_Tent_p3d : TRIPLES(ADDON,Nodes,Base)
+
+class WW2_Assets_m_Vehicles_Trucks_m_IF_Opelblitz_Tent_p3d : TRIPLES(ADDON,Nodes,Base)
 {
 	    canLoadWeapon = 0;
         class Nodes
@@ -82,9 +82,9 @@
         };
     };
 };
-"
 
-"class WW2_Assets_m_Vehicles_Trucks_m_IF_Us6_p3d : TRIPLES(ADDON,Nodes,Base)
+
+class WW2_Assets_m_Vehicles_Trucks_m_IF_Us6_p3d : TRIPLES(ADDON,Nodes,Base)
 {
 	    canLoadWeapon = 0;
         class Nodes
@@ -111,9 +111,9 @@
         };
     };
 };
-"
 
-"class WW2_Assets_m_Vehicles_Trucks_m_IF_Zis5v_p3d : TRIPLES(ADDON,Nodes,Base)
+
+class WW2_Assets_m_Vehicles_Trucks_m_IF_Zis5v_p3d : TRIPLES(ADDON,Nodes,Base)
 {
         class Nodes
     {
@@ -134,9 +134,9 @@
         };
     };
 };
-"
 
-"class WW2_Assets_m_Vehicles_Trucks_m_IF_Gmc353Truck_p3d : TRIPLES(ADDON,Nodes,Base)
+
+class WW2_Assets_m_Vehicles_Trucks_m_IF_Gmc353Truck_p3d : TRIPLES(ADDON,Nodes,Base)
 {
 	    canLoadWeapon = 0;
         class Nodes
@@ -163,4 +163,3 @@
         };
     };
 };
-"

--- a/A3A/addons/logistics/Nodes/IFA.hpp
+++ b/A3A/addons/logistics/Nodes/IFA.hpp
@@ -1,32 +1,63 @@
-class WW2_Assets_m_Vehicles_WheeledAPC_m_IF_SdKfz_7_p3d : TRIPLES(ADDON,Nodes,Base)
+class LIB_SdKfz_7 : TRIPLES(ADDON,Nodes,Base)
 {
         class Nodes
     {
         class Node1
         {
-            offset[] = {0,-0.5,-0.7};
+            offset[] = {0,-0.5,-0.8};
 			seats[] = {2,3,4,5,9};
         };
         class Node2
         {
-            offset[] = {0,-1.3,-0.7};
+            offset[] = {0,-1.3,-0.8};
 			seats[] = {6,10};
         };
         class Node3
         {
-            offset[] = {0,-2.1,-0.7};
+            offset[] = {0,-2.1,-0.8};
 
         };
         class Node4
         {
-            offset[] = {0,-2.9,-0.7};
+            offset[] = {0,-2.9,-0.8};
 			seats[] = {7,8};
         };
     };
 };
+class LIB_DAK_SdKfz_7 : LIB_SdKfz_7 {};
+class LIB_SdKfz_7_w : LIB_SdKfz_7 {};
 
+class LIB_OpelBlitz_Open_Y_Camo : TRIPLES(ADDON,Nodes,Base)
+{
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-0.1,-0.04};
+			seats[] = {1,2,7,10,11};
+        };
+        class Node2
+        {
+            offset[] = {0,-0.9,-0.04};
+			seats[] = {5,6};
+        };
+        class Node3
+        {
+            offset[] = {0,-1.7,-0.04};
+			seats[] = {3,4};
+        };
+        class Node4
+        {
+            offset[] = {0,-2.5,-0.04};
+			seats[] = {8,9};
+        };
+    };
+};
+class LIB_DAK_OpelBlitz_Open : LIB_OpelBlitz_Open_Y_Camo {};
+class LIB_OpelBlitz_Open_Y_Camo_w : LIB_OpelBlitz_Open_Y_Camo {};
+class LIB_OpelBlitz_Open_G_Camo_w : LIB_OpelBlitz_Open_Y_Camo {};
 
-class WW2_Assets_m_Vehicles_Trucks_m_IF_Opelblitz_p3d : TRIPLES(ADDON,Nodes,Base)
+class LIB_OpelBlitz_Tent_Y_Camo : TRIPLES(ADDON,Nodes,Base)
 {
 	    canLoadWeapon = 0;
         class Nodes
@@ -53,38 +84,10 @@ class WW2_Assets_m_Vehicles_Trucks_m_IF_Opelblitz_p3d : TRIPLES(ADDON,Nodes,Base
         };
     };
 };
+class LIB_DAK_OpelBlitz_Tent : LIB_OpelBlitz_Tent_Y_Camo {};
+class LIB_OpelBlitz_Tent_Y_Camo_w : LIB_OpelBlitz_Tent_Y_Camo {};
 
-
-class WW2_Assets_m_Vehicles_Trucks_m_IF_Opelblitz_Tent_p3d : TRIPLES(ADDON,Nodes,Base)
-{
-	    canLoadWeapon = 0;
-        class Nodes
-    {
-        class Node1
-        {
-            offset[] = {0,-0.1,-0.04};
-			seats[] = {1,2,7,10,11};
-        };
-        class Node2
-        {
-            offset[] = {0,-0.9,-0.04};
-			seats[] = {5,6};
-        };
-        class Node3
-        {
-            offset[] = {0,-1.7,-0.04};
-			seats[] = {3,4};
-        };
-        class Node4
-        {
-            offset[] = {0,-2.5,-0.04};
-			seats[] = {8,9};
-        };
-    };
-};
-
-
-class WW2_Assets_m_Vehicles_Trucks_m_IF_Us6_p3d : TRIPLES(ADDON,Nodes,Base)
+class LIB_US6_Open : TRIPLES(ADDON,Nodes,Base)
 {
 	    canLoadWeapon = 0;
         class Nodes
@@ -111,9 +114,11 @@ class WW2_Assets_m_Vehicles_Trucks_m_IF_Us6_p3d : TRIPLES(ADDON,Nodes,Base)
         };
     };
 };
+class LIB_US6_Open_Cargo : LIB_US6_Open {};
+class LIB_US6_Tent : LIB_US6_Open {};
+class LIB_US6_Tent_Cargo : LIB_US6_Open {};
 
-
-class WW2_Assets_m_Vehicles_Trucks_m_IF_Zis5v_p3d : TRIPLES(ADDON,Nodes,Base)
+class LIB_Zis5v : TRIPLES(ADDON,Nodes,Base)
 {
         class Nodes
     {
@@ -134,9 +139,9 @@ class WW2_Assets_m_Vehicles_Trucks_m_IF_Zis5v_p3d : TRIPLES(ADDON,Nodes,Base)
         };
     };
 };
+class LIB_Zis5v_w : LIB_Zis5v {};
 
-
-class WW2_Assets_m_Vehicles_Trucks_m_IF_Gmc353Truck_p3d : TRIPLES(ADDON,Nodes,Base)
+class LIB_US_GMC_Open : TRIPLES(ADDON,Nodes,Base)
 {
 	    canLoadWeapon = 0;
         class Nodes
@@ -163,3 +168,8 @@ class WW2_Assets_m_Vehicles_Trucks_m_IF_Gmc353Truck_p3d : TRIPLES(ADDON,Nodes,Ba
         };
     };
 };
+class LIB_US_GMC_Open_w : LIB_US_GMC_Open {};
+class LIB_US_NAC_GMC_Open : LIB_US_GMC_Open {};
+class LIB_US_GMC_Tent : LIB_US_GMC_Open {};
+class LIB_US_NAC_GMC_Tent : LIB_US_GMC_Open {};
+class LIB_US_GMC_Tent_w : LIB_US_GMC_Open {};


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [x] Enhancement

### What have you changed and why?
Information: I have added various IFA vehicles to each of the SPE-IFA templates, to give better variety for players and improve the experience. Light categories are now primarily cars, with APCs moved to relevant APC categories and a few other changes.
    Civilian template now uses soviet truck and variants which are better suited to the role, freeing up the wehrmacht trucks to remain military vehicles

### Please specify which Issue this PR Resolves.
N/A

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Compile the mod, 
Load the mod with Spearhead CDLC and IFA3 AIO mod
Attempt to play the mission on any available map. 
Play testing ensues if nothing goes wrong
********************************************************
Notes:
