### PR TITLE
Fix copypaste error preventing vehicles saving near HQ

### DIFF
--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -143,9 +143,9 @@ _arrayEst = [];
 		continue;
 	};
 
-	if (fullCrew [_veh, "", true] isEqualTo []) then { continue };			// no crew seats, not in utilityItems, not saved
+	if (fullCrew [_x, "", true] isEqualTo []) then { continue };			// no crew seats, not in utilityItems, not saved
 	if (_x isKindOf "StaticWeapon") then { continue };						// static weapons are accounted for in staticsToSave
-	if ({(alive _x) and (!isPlayer _x)} count crew _veh > 0) then { continue };		// no AI-crewed vehicles, those are refunded
+	if ({(alive _x) and (!isPlayer _x)} count crew _x > 0) then { continue };		// no AI-crewed vehicles, those are refunded
 
 	_arrayEst pushBack [typeof _x, getPosWorld _x, vectorUp _x, vectorDir _x, [_x] call HR_GRG_fnc_getState];
 


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
I broke vehicle saving in the utility items rewrite with a couple of copypaste bugs. This PR fixes it.

### Please specify which Issue this PR Resolves.
closes #2867

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
