### PR TITLE
Various vehicle/static save fixes

### DIFF
--- a/A3A/addons/core/functions/REINF/fn_addFIAveh.sqf
+++ b/A3A/addons/core/functions/REINF/fn_addFIAveh.sqf
@@ -40,6 +40,9 @@ private _fnc_placed = {
 	};
 	_vehicle setFuel random [0.10, 0.175, 0.25];
 	[_vehicle, teamPlayer] call A3A_fnc_AIVehInit;
+	if (_vehicle isKindOf "StaticWeapon") then {
+		staticsToSave pushBack _vehicle; publicVariable "staticsToSave";
+	};
 };
 
 [_typeVehX, _fnc_placed, {false}, [_cost], nil, nil, nil, _extraMessage] call HR_GRG_fnc_confirmPlacement;

--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -323,7 +323,7 @@ if (_varName in _specialVarLoads) then {
             };
             [_veh, teamPlayer] call A3A_fnc_AIVEHinit;                  // Calls initObject instead if it's a buyable item
             // TODO: Check whether various buyable items turn up as "Building"
-            if ((_veh isKindOf "StaticWeapon") or (_veh isKindOf "Building") and !isNil {_veh getVariable "A3A_canGarage"}) then {
+            if ((_veh isKindOf "StaticWeapon") or (_veh isKindOf "Building") and isNil {_veh getVariable "A3A_canGarage"}) then {
                 staticsToSave pushBack _veh;
             };
             if (!isNil "_state") then {

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -143,9 +143,9 @@ _arrayEst = [];
 		continue;
 	};
 
-	if (fullCrew [_veh, "", true] isEqualTo []) then { continue };			// no crew seats, not in utilityItems, not saved
+	if (fullCrew [_x, "", true] isEqualTo []) then { continue };			// no crew seats, not in utilityItems, not saved
 	if (_x isKindOf "StaticWeapon") then { continue };						// static weapons are accounted for in staticsToSave
-	if ({(alive _x) and (!isPlayer _x)} count crew _veh > 0) then { continue };		// no AI-crewed vehicles, those are refunded
+	if ({(alive _x) and (!isPlayer _x)} count crew _x > 0) then { continue };		// no AI-crewed vehicles, those are refunded
 
 	_arrayEst pushBack [typeof _x, getPosWorld _x, vectorUp _x, vectorDir _x, [_x] call HR_GRG_fnc_getState];
 
@@ -155,7 +155,7 @@ _arrayEst = [];
 _sites = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
 {
 	_positionX = position _x;
-	if ((alive _x) and !(surfaceIsWater _positionX) and !(isNull _x)) then {
+	if ((alive _x) and !(surfaceIsWater position _x) and !(isNull attachedTo _x)) then {
 		_arrayEst pushBack [typeOf _x,getPosWorld _x,vectorUp _x, vectorDir _x];
 	};
 } forEach staticsToSave;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Forgot to do full save/load testing for the buyable items refactor. Lots of bugs:
- Fixed bought statics not being added to staticsToSave.
- Fixed incorrect logic for adding statics/bunkers to staticsToSave on load.
- Fixed copypaste errors in 50m HQ vehicle save checks.
- Fixed attached statics being inappropriately saved (partially old).

### Please specify which Issue this PR Resolves.
closes #2867

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
