### PR TITLE
PATCOM Garrisons minor fixes and adjustments

### DIFF
--- a/A3A/addons/core/functions/init/fn_initVarCommon.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarCommon.sqf
@@ -143,7 +143,6 @@ A3A_buildingBlacklist = [
 	"Land_vn_tent_mash_02_01","Land_vn_tent_mash_01_03","Land_vn_army_hut_storrage","Land_vn_army_hut_int","Land_vn_wf_field_hospital_east","Land_vn_army_hut2_int","Land_vn_army_hut3_long_int", "Land_vn_o_prop_cong_cage_01", "Land_vn_o_prop_cong_cage_02", "Land_vn_o_prop_cong_cage_03",
 	"Land_SPE_bocage_long_mound", "Land_SPE_bocage_short_mound", "Land_SPE_bocage_short_mound_lc", "Land_SPE_bocage_long_mound_lc"
 ];
-A3A_staticBuildingClasses = ["Land_BagBunker_Small_F", "Land_BagBunker_01_small_green_F"];
 //Lights and Lamps array used for 'Blackout'
 A3A_lampTypes = [
 	"Lamps_Base_F", "PowerLines_base_F", "Land_LampDecor_F", "Land_LampHalogen_F", "Land_LampHarbour_F", "Land_LampShabby_F", "Land_NavigLight", "Land_runway_edgelight", "Land_PowerPoleWooden_L_F", "Land_SPE_StreetLamp_Off", "Land_SPE_StreetLamp", "Land_SPE_StreetLamp_pole_off", "Land_SPE_StreetLamp_pole", "Land_SPE_StreetLamp_wall_off", "Land_SPE_StreetLamp_wall", "Land_SPE_Ger_Lamp", "Land_SPE_US_Lamp", "Land_SPE_Onion_Lamp"

--- a/A3A/addons/core/functions/init/fn_initVarCommon.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarCommon.sqf
@@ -143,6 +143,7 @@ A3A_buildingBlacklist = [
 	"Land_vn_tent_mash_02_01","Land_vn_tent_mash_01_03","Land_vn_army_hut_storrage","Land_vn_army_hut_int","Land_vn_wf_field_hospital_east","Land_vn_army_hut2_int","Land_vn_army_hut3_long_int", "Land_vn_o_prop_cong_cage_01", "Land_vn_o_prop_cong_cage_02", "Land_vn_o_prop_cong_cage_03",
 	"Land_SPE_bocage_long_mound", "Land_SPE_bocage_short_mound", "Land_SPE_bocage_short_mound_lc", "Land_SPE_bocage_long_mound_lc"
 ];
+A3A_staticBuildingClasses = ["Land_BagBunker_Small_F", "Land_BagBunker_01_small_green_F"];
 //Lights and Lamps array used for 'Blackout'
 A3A_lampTypes = [
 	"Lamps_Base_F", "PowerLines_base_F", "Land_LampDecor_F", "Land_LampHalogen_F", "Land_LampHarbour_F", "Land_LampShabby_F", "Land_NavigLight", "Land_runway_edgelight", "Land_PowerPoleWooden_L_F", "Land_SPE_StreetLamp_Off", "Land_SPE_StreetLamp", "Land_SPE_StreetLamp_pole_off", "Land_SPE_StreetLamp_pole", "Land_SPE_StreetLamp_wall_off", "Land_SPE_StreetLamp_wall", "Land_SPE_Ger_Lamp", "Land_SPE_US_Lamp", "Land_SPE_Onion_Lamp"

--- a/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
@@ -85,13 +85,13 @@ if (_unitsPerBuilding < _minimumUnits) then {_unitsPerBuilding = _minimumUnits};
 
          // Move to next position if current one is invalid.
         if (_x isEqualTo [0,0,0]) then {
-            Trace_1("PATCOM | Position invalid in (%1), moving to next position", _class);
+            Debug_1("PATCOM | Position invalid in (%1), moving to next position", _class);
             continue;
         };
 
         // Continue to next building position if current position is too close to a static weapon.
         if ((count (_x nearEntities ["StaticWeapon", 3])) > 0) then {
-            Trace_1("PATCOM | Position (%1) too close to StaticWeapon, moving to next position.", _x);
+            Debug_1("PATCOM | Position (%1) too close to StaticWeapon, moving to next position.", _x);
             continue;
         };
 

--- a/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
@@ -31,13 +31,15 @@ private _buildings = [];
 private _newGroups = [];
 private _minimumUnits = 2; // Minimum units per building.
 
-if (count _units == 0) exitwith {};
+if (count _units == 0) exitwith {
+    Debug_1("PATCOM | No units found in group (%1). Exiting", _group);
+};
 
 _group lockWP true;
 _buildings = [_position, _radius] call A3A_fnc_patrolEnterableBuildings;
 
 if (count _buildings == 0) exitWith {
-    Error_1("PATCOM | No Valid Garrison buildings found near group: %1 | Defaulting to Defend.", _group);
+    Debug_1("PATCOM | No Valid Garrison buildings found near group: %1 | Defaulting to Defend.", _group);
     [_group, "Patrol_Defend", 0, 100, -1, true, _position, false] call A3A_fnc_patrolLoop;
     _group
 };
@@ -55,11 +57,7 @@ if (_unitsPerBuilding < _minimumUnits) then {_unitsPerBuilding = _minimumUnits};
     private _building = _x;
     private _class = typeOf _building;
     private _buildingPositions = [];
-    private _staticsNear = (getPosATL _building) nearEntities ["StaticWeapon", round (sizeOf _class)];
-
-    // Continue if statics are close to the building. 
-    // We don't want garrison units clipping into their positions.
-    if (count _staticsNear > 0) then {continue};
+    private _unitsPlaced = 0;
 
     // Check to see if building is in whitelist first for better unit positions.
     if (_class in PATCOM_Garrison_Positions_Whitelist) then {
@@ -68,7 +66,7 @@ if (_unitsPerBuilding < _minimumUnits) then {_unitsPerBuilding = _minimumUnits};
             if !(_buildingPos isEqualTo [0,0,0]) then {
                 _buildingPositions pushBack _buildingPos;
             } else {
-                Error_1("PATCOM | Bad building position found | Class: %1", _class);
+                Debug_1("PATCOM | Bad building position found | Class: %1", _class);
             };
         } forEach (PATCOM_Garrison_Positions_Whitelist get _class);
     } else {
@@ -79,17 +77,40 @@ if (_unitsPerBuilding < _minimumUnits) then {_unitsPerBuilding = _minimumUnits};
     // Mix up the building positions for better randomization.
     _buildingPositions = _buildingPositions call BIS_fnc_arrayShuffle;
 
-    // Evenly distribute units between found amount of buildings.
-    // Note: If more buildings are found than units, loop will exit when the unit pool reaches zero.
-    for "_i" from 1 to _unitsPerBuilding do {
-        if ((count _units == 0) || (count _buildingPositions == 0)) exitWith {};
+    {
+        // Exit if no more units are available to be placed.
+        if (count _units == 0) exitWith {
+            Debug("PATCOM | No more garrison units available to place. Exiting");
+        };
+
+        // Exit if we have already placed max amount of units in building.
+        if (_unitsPlaced >= _unitsPerBuilding) exitWith {
+            Debug("PATCOM | Max garrison units placed in building. Moving to next building");
+        };
+
+         // Move to next position if current one is invalid.
+        if (_x isEqualTo [0,0,0]) then {
+            Debug_1("PATCOM | Position invalid in (%1), moving to next position", _class);
+            continue;
+        };
+
+        // Continue to next building position if current position is too close to a static weapon.
+        if ((count (_x nearEntities ["StaticWeapon", 3])) > 0) then {
+            Debug_1("PATCOM | Position (%1) too close to StaticWeapon, moving to next position.", _x);
+            continue;
+        };
+
+        // Move the unit and set them up in position.
         private _unit = _units deleteAt 0;
-        private _position = _buildingPositions deleteAt 0;
-        _unit setposATL _position;
+        _unit setposATL _x;
         _unit setdir ((_unit getRelDir _building)-180);
         _unit setUnitPos "UP";
         dostop _unit;
-    };
+        
+        // Add 1 to unit placed counter for max units per building limit. (_minimumUnits)
+        _unitsPlaced = _unitsPlaced + 1;
+
+    } forEach _buildingPositions;
 } forEach _buildings;
 
 // Splits Garrison AI into additional defense groups if not enough buildings/positions were found.

--- a/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
@@ -75,23 +75,23 @@ if (_unitsPerBuilding < _minimumUnits) then {_unitsPerBuilding = _minimumUnits};
     {
         // Exit if no more units are available to be placed.
         if (count _units == 0) exitWith {
-            Debug("PATCOM | No more garrison units available to place. Exiting");
+            Trace("PATCOM | No more garrison units available to place. Exiting");
         };
 
         // Exit if we have already placed max amount of units in building.
         if (_unitsPlaced >= _unitsPerBuilding) exitWith {
-            Debug("PATCOM | Max garrison units placed in building. Moving to next building");
+            Trace("PATCOM | Max garrison units placed in building. Moving to next building");
         };
 
          // Move to next position if current one is invalid.
         if (_x isEqualTo [0,0,0]) then {
-            Debug_1("PATCOM | Position invalid in (%1), moving to next position", _class);
+            Trace_1("PATCOM | Position invalid in (%1), moving to next position", _class);
             continue;
         };
 
         // Continue to next building position if current position is too close to a static weapon.
         if ((count (_x nearEntities ["StaticWeapon", 3])) > 0) then {
-            Debug_1("PATCOM | Position (%1) too close to StaticWeapon, moving to next position.", _x);
+            Trace_1("PATCOM | Position (%1) too close to StaticWeapon, moving to next position.", _x);
             continue;
         };
 

--- a/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
@@ -55,11 +55,11 @@ if (_unitsPerBuilding < _minimumUnits) then {_unitsPerBuilding = _minimumUnits};
     private _building = _x;
     private _class = typeOf _building;
     private _buildingPositions = [];
+    private _staticsNear = (getPosATL _building) nearEntities ["StaticWeapon", round (sizeOf _class)];
 
-    if (_class in A3A_staticBuildingClasses) then {
-        private _staticsNear = nearestObjects [getPosATL _building, ["StaticWeapon"], 6];
-        if (count _staticsNear > 0) then {continue};
-    };
+    // Continue if statics are close to the building. 
+    // We don't want garrison units clipping into their positions.
+    if (count _staticsNear > 0) then {continue};
 
     // Check to see if building is in whitelist first for better unit positions.
     if (_class in PATCOM_Garrison_Positions_Whitelist) then {

--- a/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
@@ -62,12 +62,7 @@ if (_unitsPerBuilding < _minimumUnits) then {_unitsPerBuilding = _minimumUnits};
     // Check to see if building is in whitelist first for better unit positions.
     if (_class in PATCOM_Garrison_Positions_Whitelist) then {
         {
-            private _buildingPos = _building buildingPos _x;
-            if !(_buildingPos isEqualTo [0,0,0]) then {
-                _buildingPositions pushBack _buildingPos;
-            } else {
-                Debug_1("PATCOM | Bad building position found | Class: %1", _class);
-            };
+            _buildingPositions pushBack (_building buildingPos _x);
         } forEach (PATCOM_Garrison_Positions_Whitelist get _class);
     } else {
         // If no pre-defined building positions are found. We default to a random one.

--- a/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
@@ -56,6 +56,8 @@ if (_unitsPerBuilding < _minimumUnits) then {_unitsPerBuilding = _minimumUnits};
             private _buildingPos = _building buildingPos _x;
             if !(_buildingPos isEqualTo [0,0,0]) then {
                 _buildingPositions pushBack _buildingPos;
+            } else {
+                Error_1("PATCOM | Bad building position found | Class: %1", _class);
             };
         } forEach (PATCOM_Garrison_Positions_Whitelist get _class);
     } else {
@@ -69,18 +71,13 @@ if (_unitsPerBuilding < _minimumUnits) then {_unitsPerBuilding = _minimumUnits};
     // Evenly distribute units between found amount of buildings.
     // Note: If more buildings are found than units, loop will exit when the unit pool reaches zero.
     for "_i" from 1 to _unitsPerBuilding do {
-        if (count _units == 0) exitWith {};
-        if (count _buildingPositions == 0) exitWith {};
-        private _unit = _units select 0;
-        private _position = _buildingPositions select 0;
+        if ((count _units == 0) || (count _buildingPositions == 0)) exitWith {};
+        private _unit = _units deleteAt 0;
+        private _position = _buildingPositions deleteAt 0;
         _unit setposATL _position;
         _unit setdir ((_unit getRelDir _building)-180);
         _unit setUnitPos "UP";
-
         dostop _unit;
-
-        _units deleteAt 0;
-        _buildingPositions deleteAt 0;
     };
 } forEach _buildings;
 

--- a/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
@@ -97,7 +97,7 @@ if (_unitsPerBuilding < _minimumUnits) then {_unitsPerBuilding = _minimumUnits};
 
         // Move the unit and set them up in position.
         private _unit = _units deleteAt 0;
-        _unit setposATL _x;
+        _unit setPosATL _x;
         _unit setdir ((_unit getRelDir _building)-180);
         _unit setUnitPos "UP";
         dostop _unit;

--- a/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
@@ -36,6 +36,12 @@ if (count _units == 0) exitwith {};
 _group lockWP true;
 _buildings = [_position, _radius] call A3A_fnc_patrolEnterableBuildings;
 
+if (count _buildings == 0) exitWith {
+    Error_1("PATCOM | No Valid Garrison buildings found near group: %1 | Defaulting to Defend.", _group);
+    [_group, "Patrol_Defend", 0, 100, -1, true, _position, false] call A3A_fnc_patrolLoop;
+    _group
+};
+
 // Don't place units in destroyed buildings
 _buildings = _buildings select { damage _x < 1 && !isObjectHidden _x };
 _buildings = _buildings call BIS_fnc_arrayShuffle;

--- a/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
@@ -56,6 +56,11 @@ if (_unitsPerBuilding < _minimumUnits) then {_unitsPerBuilding = _minimumUnits};
     private _class = typeOf _building;
     private _buildingPositions = [];
 
+    if (_class in A3A_staticBuildingClasses) then {
+        private _staticsNear = nearestObjects [getPosATL _building, ["StaticWeapon"], 6];
+        if (count _staticsNear > 0) then {continue};
+    };
+
     // Check to see if building is in whitelist first for better unit positions.
     if (_class in PATCOM_Garrison_Positions_Whitelist) then {
         {

--- a/A3A/addons/patcom/functions/Patcom/fn_patrolInit.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolInit.sqf
@@ -31,7 +31,7 @@ PATCOM_Building_Blacklist = createHashMap;
 } forEach A3A_buildingBlacklist;
 
 // This HashMap contains a list of valid garrison positions.
-PATCOM_Garrison_Positions = createHashMapFromArray [
+PATCOM_Garrison_Positions_Whitelist = createHashMapFromArray [
     ["Land_Cargo_HQ_V1_F", [6,7,8]],
     ["Land_Cargo_HQ_V2_F", [6,7,8]],
     ["Land_Cargo_HQ_V3_F", [6,7,8]],


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [x] Enhancement

### What have you changed and why?
Information:
Changed how garrison units are distributed to buildings. Instead of filling up all building positions and then moving to the next building in the list, the script now takes the amount of garrison-able buildings and units and distributes them evenly with a defined minimum allowed in each building.

Changes how finding garrison-able buildings functions. Instead of it being a one or the other choice,  it now just uses the A3A building blacklist and checks for pre-defined building positions in the whitelist. If pre-defined positions are not found, we use the default ones and randomize.

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:

Should fix, #2810