### PR TITLE
Fix autoRearm first aid kits jam bug and reduce waitUntil spam

### DIFF
--- a/A3A/addons/core/functions/AI/fn_autoRearm.sqf
+++ b/A3A/addons/core/functions/AI/fn_autoRearm.sqf
@@ -63,8 +63,7 @@ if ((_primaryWeapon in FactionGet(reb,"initialRebelEquipment")) || (_primaryWeap
 		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking a better weapon"};
 		_timeOut = time + 60;
-		sleep 1;
-		waitUntil {!([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
+		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
 		if ((unitReady _unit) && ([_unit] call A3A_fnc_canFight) && (_unit distance _selectedContainer > 3) && (_selectedContainer isKindOf "ReammoBox_F") && (!isNull _selectedContainer)) then {_unit setPos position _selectedContainer};
 		if (_unit distance _selectedContainer < 3) then {
 			_unit action ["TakeWeapon",_selectedContainer,_selectedWeapon];
@@ -114,8 +113,7 @@ if ((_foundItem) && (_unit getVariable "rearming")) then {
 	_unit doMove (getPosATL _selectedContainer);
 	if (_inPlayerGroup) then {_unit groupChat "Rearming"};
 	_timeOut = time + 60;
-	sleep 1;
-	waitUntil {!([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
+	waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
 	if ((unitReady _unit) && ([_unit] call A3A_fnc_canFight) && (_unit distance _selectedContainer > 3) && (_selectedContainer isKindOf "ReammoBox_F") && (!isNull _selectedContainer)) then {_unit setPos position _selectedContainer};
 	if (_unit distance _selectedContainer < 3) then {
 		_unit action ["rearm",_selectedContainer];
@@ -156,8 +154,7 @@ if ((_secondaryWeapon == "") && (loadAbs _unit < 340)) then {
 		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking a secondary weapon"};
 		_timeOut = time + 60;
-		sleep 1;
-		waitUntil {!([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
+		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
 		if ((unitReady _unit) && ([_unit] call A3A_fnc_canFight) && (_unit distance _selectedContainer > 3) && (_selectedContainer isKindOf "ReammoBox_F") && (!isNull _selectedContainer)) then {_unit setPos position _selectedContainer};
 		if (_unit distance _selectedContainer < 3) then {
 			_unit action ["TakeWeapon",_selectedContainer,_selectedWeapon];
@@ -205,8 +202,7 @@ if (_secondaryWeapon != "") then {
 		_unit doMove (position _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Rearming"};
 		_timeOut = time + 60;
-		sleep 1;
-		waitUntil {!([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
+		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
 		if ((unitReady _unit) && ([_unit] call A3A_fnc_canFight) && (_unit distance _selectedContainer > 3) && (_selectedContainer isKindOf "ReammoBox_F") && (!isNull _selectedContainer)) then {_unit setPos position _selectedContainer};
 		if (_unit distance _selectedContainer < 3) then {
 			if ((backpack _unit == "") && (backPack _selectedContainer != "")) then {
@@ -250,8 +246,7 @@ if (!haveRadio && {!(_unit call A3A_fnc_hasARadio)}) then {
 		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking a Radio"};
 		_timeOut = time + 60;
-		sleep 1;
-		waitUntil {!([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
+		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
 		if (_unit distance _selectedContainer < 3) then {
 			_unit action ["rearm",_selectedContainer];
 			private _radio = _selectedContainer call A3A_fnc_getRadio;
@@ -281,8 +276,7 @@ if (hmd _unit == "") then {
 		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking NV Googles"};
 		_timeOut = time + 60;
-		sleep 1;
-		waitUntil {!([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
+		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
 		if (_unit distance _selectedContainer < 3) then {
 			_unit action ["rearm",_selectedContainer];
 			_unit linkItem _hmd;
@@ -311,8 +305,7 @@ if (!(headgear _unit in allArmoredHeadgear)) then {
 		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking a Helmet"};
 		_timeOut = time + 60;
-		sleep 1;
-		waitUntil {!([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
+		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
 		if (_unit distance _selectedContainer < 3) then {
 			_unit action ["rearm",_selectedContainer];
 			_unit addHeadgear _helmet;
@@ -341,14 +334,14 @@ if ({_x == "FirstAidKit"} count (items _unit) < _targetFAKs) then {
 		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking a First Aid Kit"};
 		_timeOut = time + 60;
-		sleep 1;
-		waitUntil {!([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
+		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
 		if (_unit distance _selectedContainer < 3) then {
 			while {{_x == "FirstAidKit"} count (items _unit) < _targetFAKs} do {
 				_unit action ["rearm",_selectedContainer];
 				_unit addItem "FirstAidKit";
 				_selectedContainer removeItem "FirstAidKit";
-				if ("FirstAidKit" in items _selectedBody) then {sleep 3};
+				if !("FirstAidKit" in items _selectedBody) exitWith {};
+				sleep 3;
 			};
 		};
 		_selectedContainer setVariable ["busy",false];
@@ -371,8 +364,7 @@ if ((_foundItem) && (_unit getVariable "rearming")) then {
 	_unit doMove (getPosATL _selectedContainer);
 	if (_inPlayerGroup) then {_unit groupChat "Picking a a better vest"};
 	_timeOut = time + 60;
-	sleep 1;
-	waitUntil {!([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
+	waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
 	if (_unit distance _selectedContainer < 3) then {
 		_itemsUnit = vestItems _unit;
 		_unit addVest (vest _selectedContainer);
@@ -405,8 +397,7 @@ if (backpack _unit == "") then {
 		_unit doMove (getPosATL _selectedContainer);
 		if (_inPlayerGroup) then {_unit groupChat "Picking a Backpack"};
 		_timeOut = time + 60;
-		sleep 1;
-		waitUntil {!([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
+		waitUntil {sleep 1; !([_unit] call A3A_fnc_canFight) || (isNull _selectedContainer) || (_unit distance _selectedContainer < 3) || (_timeOut < time) || (unitReady _unit)};
 		if (_unit distance _selectedContainer < 3) then {
 			_unit addBackPackGlobal ((backpack _selectedContainer) call A3A_fnc_basicBackpack);
 			_unit action ["rearm",_selectedContainer];


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The autoRearm function had an ancient bug that caused it to jam permanently if it wasn't possible to fit 10 first aid kits into a medic's equipment. Quick-fixed by bailing when the source container runs out of FAKs. Should work. Also fixed the waitUntil spam on the doMove monitors.

Not tested because I know I'm going to find ten other horrific bugs if I test this monstrosity. It hasn't kept up with rest of the codebase. At least there shouldn't be anything else in there that jams, as the waitUntils have timeouts and the only while is bugfixed.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
