### PR TITLE
Fix Lafette tripod category override typo

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
@@ -420,7 +420,7 @@ private _categoryOverrideTable = [
 
 //SPE
 
-["SPE_Laffete_Tripod", ["StaticWeaponParts","Items"]],
+["SPE_Lafette_Tripod", ["StaticWeaponParts","Items"]],
 ["SPE_M1_81_Barrel", ["StaticWeaponParts","Items"]],
 ["SPE_MLE_27_31_Barrel", ["StaticWeaponParts","Items"]],
 ["SPE_M1_81_Stand", ["StaticWeaponParts","Items"]],
@@ -435,7 +435,6 @@ private _categoryOverrideTable = [
 ["SPE_M1903A3_Springfield_M1_GL", ["Rifles","Weapons","GrenadeLaunchers"]],
 ["SPE_M1_Carbine_M8", ["Rifles","Weapons","GrenadeLaunchers"]],
 ["SPE_M1_Garand_M7", ["Rifles","Weapons","GrenadeLaunchers"]] ];
-
 
 //Create a local namespace.
 A3A_categoryOverrides = false call A3A_fnc_createNamespace;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Misspelt entry in categoryOverrides, caused some RPT errors when AIs attempted to use a tripod as an anti-tank weapon.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
