### PR TITLE
Fix for undefined variable in ArmStatics

### DIFF
--- a/A3A/addons/patcom/functions/Patcom/fn_patrolArmStatics.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolArmStatics.sqf
@@ -55,8 +55,10 @@ _unitArray = _unitArray select {isNull objectParent _x};
 if (count _unitArray == 0) exitWith {};
 
 {
-    private _unit = selectRandom _unitArray;
+    // Exit if unitArray is empty.
+    if (count _unitArray == 0) exitWith {};
 
+    private _unit = selectRandom _unitArray;
     if (_unit distance2D _x < 100) then {
         _assignedPairs pushback [_unit, _x, _group];
         _unitArray deleteAt (_unitArray find _unit);	


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    Undefined Variable in PatrolArmStatics on line 59 due to unitArray being exhausted.

### Please specify which Issue this PR Resolves.
closes #2895 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:

`<12799> 2023/07/16, 16:21:49 Error in expression <e _unit = selectRandom _unitArray;
<12800> 
<12801> if (_unit distance2D _x < 100) then {
<12802> _assig>
<12803> 2023/07/16, 16:21:49   Error position: <_unit distance2D _x < 100) then {
<12804> _assig>
...
<12806> 2023/07/16, 16:21:49   Error Undefined variable in expression: _unit
<12807> 2023/07/16, 16:21:49 File x\A3A\addons\patcom\functions\Patcom\fn_patrolArmStatics.sqf..., line 59`