### PR TITLE
Enable rebel AI to use rifle+muzzle combo grenade launchers

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
@@ -442,3 +442,17 @@ A3A_categoryOverrides = false call A3A_fnc_createNamespace;
 {
 	A3A_categoryOverrides setVariable [_x select 0, _x select 1];
 } forEach _categoryOverrideTable;
+
+
+A3A_specialGrenadeLaunchers = createHashMap;
+{
+	_x params ["_class", "_categories"];
+	if !("GrenadeLaunchers" in _categories) then { continue };
+	private _config = configFile >> "CfgWeapons" >> _class;
+	if !(isClass _config) then { continue };
+	private _baseWeapon = getText (_config >> "baseWeapon");
+	if (_baseWeapon == "") then { continue };
+	private _muzzle = getText (_config >> "LinkedItems" >> "LinkedItemsMuzzle" >> "item");
+	if (_muzzle == "") then { continue };
+	A3A_specialGrenadeLaunchers set [_class, [_baseWeapon, _muzzle]];
+} forEach _categoryOverrideTable;

--- a/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
@@ -446,13 +446,16 @@ A3A_categoryOverrides = false call A3A_fnc_createNamespace;
 
 A3A_specialGrenadeLaunchers = createHashMap;
 {
-	_x params ["_class", "_categories"];
-	if !("GrenadeLaunchers" in _categories) then { continue };
+	private _class = _x#0;
 	private _config = configFile >> "CfgWeapons" >> _class;
 	if !(isClass _config) then { continue };
+
 	private _baseWeapon = getText (_config >> "baseWeapon");
 	if (_baseWeapon == "") then { continue };
+
 	private _muzzle = getText (_config >> "LinkedItems" >> "LinkedItemsMuzzle" >> "item");
 	if (_muzzle == "") then { continue };
+
 	A3A_specialGrenadeLaunchers set [_class, [_baseWeapon, _muzzle]];
-} forEach _categoryOverrideTable;
+
+} forEach (_categoryOverrideTable select { "GrenadeLaunchers" in _x#1 });

--- a/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
@@ -58,6 +58,17 @@ private _gl = [];
     };
 } forEach (jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON);
 
+if (count A3A_specialGrenadeLaunchers > 0) then {
+    // muzzle + base grenade launchers, broken down in the arsenal
+    private _rifleHM = createHashMapFromArray (jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON);
+    private _muzzleHM = createHashMapFromArray (jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_ITEMMUZZLE);
+    {
+        private _weapCount = _rifleHM getOrDefault [_y#0, 0];
+        if (_weapCount >= 0 and _weapCount < 2*ITEM_MIN) then { continue };        // slightly hacky but whatever
+        [_gl, _x, _muzzleHM getOrDefault [_y#1, 0]] call _fnc_addItem;
+    } forEach A3A_specialGrenadeLaunchers;
+};
+
 _rebelGear set ["Rifles", _rifle];
 _rebelGear set ["SMGs", _smg];
 _rebelGear set ["Shotguns", _shotgun];


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Rebel AI can't use the SPE grenade launcher rifles because they're broken down into base weapons when adding them to the arsenal. This PR searches categoryOverrides for suitable weapons and adds them in generateRebelGear when you have sufficient rifles and muzzles.

Probably a bit too dangerous for 3.3.3 because it has a small risk of causing issues in other modsets.

### Please specify which Issue this PR Resolves.
closes #2897

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Check if it does anything weird in other modsets.

### How can the changes be tested?
After startup you can check the value of `A3A_specialGrenadeLaunchers` for weird shit. It's a hashmap with GL rifle classes as keys and [baseweapon, muzzle] values.
