### PR TITLE
Fix road patrol early despawn and increase spawn rate

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_AAFroadPatrol.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AAFroadPatrol.sqf
@@ -139,7 +139,7 @@ while {alive _veh} do
 	_veh setFuel 1;
 
 	private _timeout = time + (_veh distance2d _posDestination) / 6 + 300;			// stuck detection
-	waitUntil {sleep 60; (_veh distance _posDestination < _distanceX) or (_timeout > time) or ({[_x] call A3A_fnc_canFight} count _soldiers == 0) or (!canMove _veh)};
+	waitUntil {sleep 60; (_veh distance _posDestination < _distanceX) or (time > _timeout) or ({[_x] call A3A_fnc_canFight} count _soldiers == 0) or (!canMove _veh)};
 	if !(_veh distance _posDestination < _distanceX) exitWith {};
 	if (_typePatrol == "AIR") then
 		{

--- a/A3A/addons/core/functions/CREATE/fn_reinforcementsAI.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_reinforcementsAI.sqf
@@ -129,8 +129,8 @@ private _fnc_pickSquadType = {
 } forEach [Occupants, Invaders];
 
 
-// If there aren't too many road patrols around already, generate about 1.5 * playerScale per hour
-if (AAFpatrols < round (3 * A3A_balancePlayerScale) and (random 4 < A3A_balancePlayerScale)) then {
+// If there aren't too many road patrols around already, generate about 3 * playerScale per hour
+if (AAFpatrols < round (3 * A3A_balancePlayerScale) and (random 2 < A3A_balancePlayerScale)) then {
 	[] spawn A3A_fnc_AAFroadPatrol;
 };
 


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
AAFRoadPatrol had a backwards termination condition, which would often cause patrols to RTB and despawn after 60 seconds. Also increased the spawn rate, because it was rather low considering that the spawn function frequently fails to generate anything. Max active patrols is unchanged so there's no danger of getting flooded by patrols.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
