### PR TITLE
Fixed error in `fn_updateGarrison.sqf`

### DIFF
--- a/A3A/addons/core/functions/Garrison/fn_updateGarrison.sqf
+++ b/A3A/addons/core/functions/Garrison/fn_updateGarrison.sqf
@@ -27,7 +27,7 @@ for "_i" from 0 to (_garCount - 1) do
 {
   _garData = _garrison select _i;
   _preData = _preferred select _i;
-  if(![_garData select 0, _preData select 0] call A3A_fnc_checkVehicleType) then
+  if !([_garData select 0, _preData select 0] call A3A_fnc_checkVehicleType) then
   {
     _garData set [0, [_preData select 0, _side] call A3A_fnc_selectVehicleType];
     if(_preData select 1 != 0) then
@@ -39,7 +39,7 @@ for "_i" from 0 to (_garCount - 1) do
     {
       _garData set [1, ["","",""]];
     };
-    if(![_garData select 2, _garData select 0, _preData select 2] call A3A_checkGroupType) then
+    if !([_garData select 2, _garData select 0, _preData select 2] call A3A_checkGroupType) then
     {
       _garData set [2, [_garData select 0, _preData select 2, _side] call A3A_fnc_selectGroupType];
     };


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?

The function https://github.com/official-antistasi-community/A3-Antistasi/blob/unstable/A3A/addons/core/functions/Garrison/fn_updateGarrison.sqf

Seems incorrect in line 30 and 42, related to the [order of precedence in sqf](https://community.bistudio.com/wiki/Operators#Order_of_Precedence). Specifically, the statement

```sqf
![] call function
```

is evaluated as `((![]) call function)`, resulting in the function being call with likely incorrect parameters.

### Please specify which Issue this PR Resolves.
None

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: no idea, first contribution
