### PR TITLE
Fix to allow AI use light helis in QRF

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_createAttackForceAir.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAttackForceAir.sqf
@@ -36,13 +36,13 @@ private _cargoGroups = [];
 private _faction = Faction(_side);
 private _transportPlanes = _faction get "vehiclesPlanesTransport";
 private _transportHelis = _faction get "vehiclesHelisTransport";
-private _lightHelis = _faction get "vehiclesHelisTransport";
+private _lightHelis = _faction get "vehiclesHelisLight";
 private _lhFactor = 0 max (1 - (tierWar+_tierMod) / 10);            // phase out light helis at higher war tiers
 
 private _transportPool = [];
 { _transportPool append [_x, 1 / count _transportPlanes] } forEach _transportPlanes;
 { _transportPool append [_x, 2 / count _transportHelis] } forEach _transportHelis;
-{ _transportPool append [_x, 2 * _lhFactor / count _transportHelis] } forEach _lightHelis;
+{ _transportPool append [_x, 2 * _lhFactor / count _lightHelis] } forEach _lightHelis;
 
 private _supportPool = [_side, tierWar+_tierMod] call A3A_fnc_getVehiclesAirSupport;
 


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:

Fix to allow AI use light helis in QRF    

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes (Probably.)

### How can the changes be tested?
Steps: 
Just spam this command in console ["QRFVAIR", Occupants, attack, 10000, player, getPosATL player, 1, 0] spawn A3A_fnc_createSupport; 
********************************************************