### PR TITLE
Fixed missing include

### DIFF
--- a/A3A/addons/core/functions/AI/fn_mortarDrill.sqf
+++ b/A3A/addons/core/functions/AI/fn_mortarDrill.sqf
@@ -1,4 +1,6 @@
 #include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+
 private ["_morty","_helperX"];
 
 {if (_x getVariable ["typeOfSoldier",""] == "StaticMortar") then {_morty = _x} else {_helperX = _x}} forEach _this;

--- a/A3A/addons/core/functions/AI/fn_mortarDrill.sqf
+++ b/A3A/addons/core/functions/AI/fn_mortarDrill.sqf
@@ -1,3 +1,4 @@
+#include "..\..\script_component.hpp"
 private ["_morty","_helperX"];
 
 {if (_x getVariable ["typeOfSoldier",""] == "StaticMortar") then {_morty = _x} else {_helperX = _x}} forEach _this;


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Because otherwise the call `Faction(side _groupX)` is not meaningful. `faction` in A3A is both a [unary](https://community.bistudio.com/wiki/faction) and a macro defined in `common.inc`. Without the include, it behaves as the unary function, that expects a unit. My understanding is that here we expect the macro call, that requires the include.

Identified by [sqf-analyzer](https://marketplace.visualstudio.com/items?itemName=SQF-analyzer.sqf-analyzer).

### Please specify which Issue this PR Resolves.

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

