### PR TITLE
Retextured RHS Mi8's to chdkz camo

### DIFF
--- a/A3A/addons/config_fixes/RHS/chdkz_rhs.hpp
+++ b/A3A/addons/config_fixes/RHS/chdkz_rhs.hpp
@@ -1,4 +1,4 @@
-
+//Armour
 class rhsgref_ins_t72ba;
 class rhsgref_ins_t72bb;
 class rhsgref_ins_t72bc;
@@ -52,4 +52,40 @@ class a3a_rhs_chdkz_72c : rhsgref_ins_t72bc{
 	};
 };
 
+//Air
+class RHS_Mi8T_vvsc;
+class RHS_Mi8mt_vvsc;
+class RHS_Mi8MTV3_vvsc;
+class RHS_Mi8MTV3_heavy_vvsc;
+class RHS_Mi8AMTSh_vvsc;
 
+class a3a_rhs_Mi8T_chdkz : RHS_Mi8T_vvsc{
+	crew = "rhsgref_ins_pilot";
+	dlc = "RHS_GREF";
+	faction = "rhsgref_faction_chdkz";
+	hiddenSelectionsTextures[] ={"rhsafrf\addons\rhs_a2port_air\mi17\data\mi8_body_g_chdkz_co.paa","rhsafrf\addons\rhs_a2port_air\mi17\data\mi8_det_g_cdf_co.paa","rhsafrf\addons\rhs_a2port_air\mi17\data\mi8t\camo\mi8t_tv2_g_chdkz_co.paa","rhsafrf\addons\rhs_a2port_air\mi17\data\mi8_decals_ca.paa","rhsafrf\addons\rhs_decals\data\numbers\aviared\5_ca.paa","rhsafrf\addons\rhs_decals\data\numbers\aviared\8_ca.paa","rhsafrf\addons\rhs_decals\data\labels\aviation\vvs_ca.paa"};
+};
+class a3a_rhs_Mi8mt_chdkz : RHS_Mi8mt_vvsc{
+	crew = "rhsgref_ins_pilot";
+	dlc = "RHS_GREF";
+	faction = "rhsgref_faction_chdkz";
+	hiddenSelectionsTextures[] ={"rhsafrf\addons\rhs_a2port_air\mi17\data\mi8_body_g_chdkz_co.paa","rhsafrf\addons\rhs_a2port_air\mi17\data\mi8_det_g_cdf_co.paa","a3\data_f\clear_empty.paa","rhsafrf\addons\rhs_a2port_air\mi17\data\mi8_decals_ca.paa","rhsafrf\addons\rhs_decals\data\numbers\aviared\4_ca.paa","rhsafrf\addons\rhs_decals\data\numbers\aviared\9_ca.paa","rhsafrf\addons\rhs_decals\data\labels\aviation\vvs_ca.paa"};
+};
+class a3a_rhs_Mi8MTV3_chdkz : RHS_Mi8MTV3_vvsc{
+	crew = "rhsgref_ins_pilot";
+	dlc = "RHS_GREF";
+	faction = "rhsgref_faction_chdkz";
+	hiddenSelectionsTextures[] ={"rhsafrf\addons\rhs_a2port_air\mi17\data\mi8_body_g_chdkz_co.paa","rhsafrf\addons\rhs_a2port_air\mi17\data\mi8_det_g_cdf_co.paa","a3\data_f\clear_empty.paa","rhsafrf\addons\rhs_a2port_air\mi17\data\mi8_decals_ca.paa","rhsafrf\addons\rhs_decals\data\numbers\aviared\3_ca.paa","rhsafrf\addons\rhs_decals\data\numbers\aviared\1_ca.paa","rhsafrf\addons\rhs_decals\data\labels\aviation\vvs_ca.paa"};
+};
+class a3a_rhs_Mi8MTV3_heavy_chdkz : RHS_Mi8MTV3_heavy_vvsc{
+	crew = "rhsgref_ins_pilot";
+	dlc = "RHS_GREF";
+	faction = "rhsgref_faction_chdkz";
+	hiddenSelectionsTextures[] ={"rhsafrf\addons\rhs_a2port_air\mi17\data\mi8_body_g_chdkz_co.paa","rhsafrf\addons\rhs_a2port_air\mi17\data\mi8_det_g_cdf_co.paa","a3\data_f\clear_empty.paa","rhsafrf\addons\rhs_a2port_air\mi17\data\mi8_decals_ca.paa","rhsafrf\addons\rhs_decals\data\numbers\aviared\7_ca.paa","rhsafrf\addons\rhs_decals\data\numbers\aviared\2_ca.paa","rhsafrf\addons\rhs_decals\data\labels\aviation\vvs_ca.paa"};
+};
+class a3a_rhs_Mi8AMTSh_chdkz : RHS_Mi8AMTSh_vvsc{
+	crew = "rhsgref_ins_pilot";
+	dlc = "RHS_GREF";
+	faction = "rhsgref_faction_chdkz";
+	hiddenSelectionsTextures[] ={"rhsafrf\addons\rhs_a2port_air\mi17\data\camo\mi_171_chdkz_co.paa","rhsafrf\addons\rhs_a2port_air\mi17\data\mi8_det_g_cdf_co.paa","a3\data_f\clear_empty.paa","rhsafrf\addons\rhs_a2port_air\mi17\data\mi8_decals_ca.paa","rhsafrf\addons\rhs_decals\data\numbers\aviared\9_ca.paa","rhsafrf\addons\rhs_decals\data\numbers\aviared\7_ca.paa","rhsafrf\addons\rhs_decals\data\labels\aviation\vvs_ca.paa"};
+};

--- a/A3A/addons/core/Templates/Templates/RHS/RHS_AI_ChDKZ.sqf
+++ b/A3A/addons/core/Templates/Templates/RHS/RHS_AI_ChDKZ.sqf
@@ -59,9 +59,9 @@
 ["vehiclesPlanesAA", ["rhs_mig29s_vvs","rhs_mig29sm_vvs"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesTransport", []] call _fnc_saveToTemplate;
 
-["vehiclesHelisLight", ["RHS_Mi8T_vvsc"]] call _fnc_saveToTemplate;
-["vehiclesHelisTransport", ["RHS_Mi8mt_vvsc","RHS_Mi8mt_vvsc", "RHS_Mi24Vt_vvsc"]] call _fnc_saveToTemplate; //Mi8mt has pk's, Mi24Vt has 12.7 turret only
-["vehiclesHelisLightAttack", ["RHS_Mi8MTV3_vvsc","RHS_Mi8MTV3_heavy_vvsc","RHS_Mi8AMTSh_vvsc"]] call _fnc_saveToTemplate;
+["vehiclesHelisLight", ["a3a_rhs_Mi8T_chdkz"]] call _fnc_saveToTemplate;
+["vehiclesHelisTransport", ["a3a_rhs_Mi8mt_chdkz","a3a_rhs_Mi8mt_chdkz", "RHS_Mi24Vt_vvsc"]] call _fnc_saveToTemplate; //Mi8mt has pk's, Mi24Vt has 12.7 turret only
+["vehiclesHelisLightAttack", ["a3a_rhs_Mi8MTV3_chdkz","a3a_rhs_Mi8MTV3_heavy_chdkz","a3a_rhs_Mi8AMTSh_chdkz"]] call _fnc_saveToTemplate;
 ["vehiclesHelisAttack", ["RHS_Mi24P_vvsc", "RHS_Mi24V_vvsc"]] call _fnc_saveToTemplate;
 
 ["vehiclesArtillery", ["rhsgref_ins_2s1","rhsgref_ins_d30","rhsgref_ins_BM21"]] call _fnc_saveToTemplate;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Added retextured classes of the RHS armed Mi8's to provide correct camouflage for the faction template.

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Loading into the editor and placing these down should be sufficient.

********************************************************
Notes:
