### PR TITLE
Add GM Assets

### DIFF
--- a/A3A/addons/core/functions/init/fn_initZones.sqf
+++ b/A3A/addons/core/functions/init/fn_initZones.sqf
@@ -141,7 +141,7 @@ mrkAntennas = [];
 antennas = [];
 private _banktypes = ["Land_Offices_01_V1_F"];
 private _antennatypes = ["Land_TTowerBig_1_F", "Land_TTowerBig_2_F", "Land_Communication_F",
-"Land_Vysilac_FM","Land_A_TVTower_base","Land_Telek1", "Land_vn_tower_signal_01"];
+"Land_Vysilac_FM","Land_A_TVTower_base","Land_Telek1", "Land_vn_tower_signal_01","land_gm_radio_antenna_01"];
 private ["_antenna", "_mrkFinal", "_antennaProv"];
 if (debug) then {
     Debug("Setting up Radio Towers.");


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Adds GM assets for compatibility.

- [x] Radiotower

Fuel stations are defined in mapInfo.hpps, no need for anything
There are no useful buildings to use with static placements, nothing to add here either.