### PR TITLE
Fix Huron (vanilla Chinook-like) not using gear on combat landing

### DIFF
--- a/A3A/addons/core/functions/AI/fn_combatLanding.sqf
+++ b/A3A/addons/core/functions/AI/fn_combatLanding.sqf
@@ -34,6 +34,7 @@ _helicopter flyInHeight _midHeight;
 waitUntil {sleep 1; (_helicopter distance2D _landPos) < 600};
 
 _helicopter flyInHeight 0;                  // helps to keep it near the ground after landing
+_helicopter land "LAND";                    // also drops the gear on the huron
 
 // Landing path setup
 private _endPos = getPosASL _landPad;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The combat landing routine didn't trigger landing gear use because it never told Arma that it was landing. This PR fixes it. Seems to work and shouldn't have any negative effects on other helis. Might be more reliable in other ways.

Not sure if any helis weren't currently using have landing gear aside from the vanilla Huron.

### Please specify which Issue this PR Resolves.
closes #2929

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
See #2929
