### PR TITLE
Move headless clients with HQ to theoretically improve AI responses

### DIFF
--- a/A3A/addons/core/functions/Base/fn_relocateHQObjects.sqf
+++ b/A3A/addons/core/functions/Base/fn_relocateHQObjects.sqf
@@ -26,9 +26,12 @@ posHQ = _newPosition; publicVariable "posHQ";
 "Synd_HQ" setMarkerPos _newPosition;
 chopForest = false; publicVariable "chopForest";
 
-
 [respawnTeamPlayer, 1, teamPlayer] call A3A_fnc_setMarkerAlphaForSide;
 [respawnTeamPlayer, 1, civilian] call A3A_fnc_setMarkerAlphaForSide;
+
+// Move headless client logic objects near HQ so that firedNear EH etc. work more reliably
+private _hcpos = _newPosition vectorAdd [-100, -100, 0];
+{ _x setPosATL _hcpos } forEach (entities "HeadlessClient_F");
 
 private _alignNormals = {
 	private _thing = _this;

--- a/A3A/addons/core/functions/Save/fn_loadServer.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadServer.sqf
@@ -100,6 +100,9 @@ if (isServer) then {
 	{_x setPos getMarkerPos respawnTeamPlayer} forEach ((call A3A_fnc_playableUnits) select {side _x == teamPlayer});
 	_sites = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
 
+	// Move headless client logic objects near HQ so that firedNear EH etc. work more reliably
+	private _hcpos = markerPos respawnTeamPlayer vectorAdd [-100, -100, 0];
+	{ _x setPosATL _hcpos } forEach (entities "HeadlessClient_F");
 
 	tierPreference = 1;
 	publicVariable "tierPreference";

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -86,6 +86,7 @@ if (!isServer) then {
 
 // Headless clients register with server and bail out at this point
 if (!isServer and !hasInterface) exitWith {
+    player setPosATL (markerPos respawnTeamPlayer vectorAdd [-100, -100, 0]);
     [clientOwner] remoteExecCall ["A3A_fnc_addHC",2];
 };
 


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Moved HC logic objects along with HQ. This needed three hooks for different HC join times, because the logic objects don't exist until an HC connects:
1. relocateHQObjects: The obvious one, triggered on new games and when the HQ is moved.
2. loadServer: Loading a game doesn't call any HQ relocation functions.
3. initClient: Required for headless clients joining in progress.

In theory this should improve AI responses, because firedNear event handlers are based on the headless client logic position. Difficult to test but it's easy enough to move the logic objects so may as well.
 
### Please specify which Issue this PR Resolves.
closes #2875

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
