### PR TITLE
Fix missing comma in CUP civ vehicles addon

### DIFF
--- a/A3A/addons/core/Templates/AddonVics/cup_veh_Civ.sqf
+++ b/A3A/addons/core/Templates/AddonVics/cup_veh_Civ.sqf
@@ -38,7 +38,7 @@ _addon set ["vehiclesCivRepair", [
 	,"CUP_I_V3S_Repair_TKG" , 0.1
 ]];
 
-_addon set ["vehiclesCivIndustrial" [
+_addon set ["vehiclesCivIndustrial", [
 	"CUP_C_Ural_Open_Civ_01" , 0.5
 	,"CUP_C_Ural_Open_Civ_02" , 0.5
 	,"CUP_C_Ural_Civ_02" , 0.5


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The CUP civ vehicles addon (#2919) had a missing comma. Tested working now.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
