### PR TITLE
Prevent high command squad icons from being visible in 3d display

### DIFF
--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -292,6 +292,11 @@ player addEventHandler ["GetInMan", {
 // Prevent players getting shot by their own AIs. EH is respawn-persistent
 player addEventHandler ["HandleRating", {0}];
 
+// Prevent squad icons showing in 3d display in high command
+addMissionEventHandler ["CommandModeChanged", {
+    setGroupIconsVisible [true, false];
+}];
+
 call A3A_fnc_initUndercover;
 
 ["InitializePlayer", [player]] call BIS_fnc_dynamicGroups;//Exec on client


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Prevent high command squad icons from being visible in 3d display, because it's a massive cheat. The icons make it very easy to spot enemy units when you're commander.

### Please specify which Issue this PR Resolves.
closes #2971

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
