### PR TITLE
Carry, rotate and loot to crate stringtable fixes

### DIFF
--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -4902,10 +4902,10 @@
       <Key ID="STR_A3A_fn_UtilItem_dropOb_addact_drop">
         <Original>Drop object</Original>
       </Key>
-      <Key ID="STR_A3A_fn_UtilItem_initMovOb_addact_carry">
+      <Key ID="STR_A3A_fn_UtilItem_initObjRem_addact_carry">
         <Original>Carry object</Original>
       </Key>
-      <Key ID="STR_A3A_fn_UtilItem_initMovOb_addact_rotate">
+      <Key ID="STR_A3A_fn_UtilItem_initObjRem_addact_rotate">
         <Original>Rotate object</Original>
       </Key>
       <Key ID="STR_A3A_fn_UtilItem_initObjRem_addact_build">

--- a/A3A/addons/core/functions/LTC/fn_initLootToCrate.sqf
+++ b/A3A/addons/core/functions/LTC/fn_initLootToCrate.sqf
@@ -31,7 +31,7 @@ if ((actionIDs _object) findIf {
 
 //add load actions
 _object addAction [
-    localize "STR_A3A_fn_ltc_init_addact_lt",
+    localize "STR_A3A_fn_ltc_init_addact_ltc",
     {
         [_this#3, clientOwner] remoteExecCall ["A3A_fnc_canLoot", 2];
     },


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Found some stringtable key mismatches:
1. Carry and rotate had wrong key. That's mine from #2384, broke it late in the merge.
2. Loot-to-crate action was missing the c off the end. From Bob's big PR.

Wasn't even trying to test this, so maybe a bit worrying that I found #2.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
