### PR TITLE
Fix non-basic backpack in SPE FFF rebel template

### DIFF
--- a/A3A/addons/core/Templates/Templates/SPE/SPE_REB_FFF.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE/SPE_REB_FFF.sqf
@@ -76,7 +76,7 @@ private _initialRebelEquipment = [
     ["SPE_Ladung_Small_MINE_mag", 10], ["SPE_US_TNT_half_pound_mag", 10], ["SPE_US_TNT_4pound_mag", 3], ["SPE_Ladung_Big_MINE_mag", 3],
     "SPE_Shg24_Frag", "SPE_NB39", "SPE_US_Mk_1",
     "V_SPE_US_Vest_M1919", "V_SPE_DAK_VestKar98",
-    "B_SPE_FFI_M36_Saboteur", "B_SPE_GER_MedicBackpack_Empty",
+    "B_SPE_FFI_Gasbag", "B_SPE_GER_MedicBackpack_Empty",
     "SPE_Binocular_US"
 ];
 


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
SPE FFF rebel template has a non-basic backpack in initial rebel items, which causes the contents to be switched for explosives when you load it from a loadout. Changed it for the basic variant.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
