### PR TITLE
Fix missing semicolon in initACE ropeDeployed handler

### DIFF
--- a/A3A/addons/core/functions/init/fn_initACE.sqf
+++ b/A3A/addons/core/functions/init/fn_initACE.sqf
@@ -40,7 +40,7 @@ if (A3A_hasACEMedical) then {
 }] call CBA_fnc_addEventHandler;
 
 ["ace_towing_ropeDeployed", {
-    params ["_unit", "_target", "_ropeClass"]
+    params ["_unit", "_target", "_ropeClass"];
     if (captive player && _unit == player) then { player setCaptive false };
 }] call CBA_fnc_addEventHandler;
 


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed a missing semicolon in the ACE rope PR.

Also tested it, works fine except ACE bugged out on connecting the tow rope. Not our problem.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
