### PR TITLE
Fix build placer permissions

### DIFF
--- a/A3A/addons/core/functions/Builder/fn_buildingPlacerStart.sqf
+++ b/A3A/addons/core/functions/Builder/fn_buildingPlacerStart.sqf
@@ -27,8 +27,8 @@ if ([getPosATL _centerObject] call A3A_fnc_enemyNearCheck) exitWith {
 
 // Check player eligibility
 // options: teamLeader (1), engineer (2), either (3). Boss always eligible
-private _eligibleTL = (A3A_builderPermissions % 1 != 0) and (typeOf player == "I_G_Soldier_TL_F");
-private _eligibleEng = (A3A_builderPermissions % 2 != 0) and (player call A3A_fnc_isEngineer);
+private _eligibleTL = (A3A_builderPermissions % 2 >= 0) and (typeOf player == "I_G_Soldier_TL_F");
+private _eligibleEng = (A3A_builderPermissions % 4 >= 2) and (player call A3A_fnc_isEngineer);
 if (!_eligibleTL and !_eligibleEng and player != theBoss) exitWith {
 	// TODO: stringtable
 	[_hintTitle, localize "STR_A3A_builder_not_eligible"] call A3A_fnc_customHint;

--- a/A3A/addons/core/functions/Builder/fn_buildingPlacerStart.sqf
+++ b/A3A/addons/core/functions/Builder/fn_buildingPlacerStart.sqf
@@ -38,9 +38,10 @@ if (!_eligibleTL and !_eligibleEng and player != theBoss) exitWith {
 [_builderBox, player, true] remoteExecCall ["A3A_fnc_lockBuilderBox", 2];
 
 private _timeout = time + 5;
-waitUntil { 
+private _owner = objNull;
+waitUntil {
     sleep 0.1;
-    private _owner = _builderBox getVariable ["A3A_build_owner", objNull];
+    _owner = _builderBox getVariable ["A3A_build_owner", objNull];
     time > _timeout or alive _owner
 };
 


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
- Fixed team leader not being able to use the building placer.
- Fixed error in client-side locking logic that allowed multiple players to use the same builder box. Probably.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Locking logic is gonna need further MP testing.
