### PR TITLE
Fix building repair not working on MP clients

### DIFF
--- a/A3A/addons/core/functions/Builder/fn_buildingPlacer.sqf
+++ b/A3A/addons/core/functions/Builder/fn_buildingPlacer.sqf
@@ -201,8 +201,8 @@ private _eventHanderEachFrame = addMissionEventHandler ["EachFrame", {
         // Show T key and rebuild cost
         private _ruin = _intersectObj;
         private _building = _ruin getVariable "building";
-        if (isNil "_building") then { _building = _ruin getVariable "BIS_fnc_createRuin_object" };
         if (isNil "_building") exitWith {};																	// non-rebuildable ruin
+        if (_building in antennasDead) exitWith {};                                                         // don't use this for radio towers
         if (-1 != (A3A_building_EHDB # BUILD_OBJECTS_ARRAY) findIf { _x#1 == _building }) exitWith {};		// already rebuilt
 
         // Calculate repair cost from bounding box

--- a/A3A/addons/core/functions/Builder/fn_lockBuilderBox.sqf
+++ b/A3A/addons/core/functions/Builder/fn_lockBuilderBox.sqf
@@ -20,6 +20,15 @@ if (_take) then {
         Debug("Builder box already has a valid owner");
     };
 
+    // Publish ruin->building link for nearby buildings
+    private _nearBuildings = destroyedBuildings inAreaArray [getPosATL _box, 100, 100];
+    {
+        private _ruin = _x getVariable ["ruins", objNull];
+        if (isNull _ruin) then { _ruin = _x getVariable ["BIS_fnc_createRuin_ruin", objNull] };
+        if (isNull _ruin) then { continue };
+        _ruin setVariable ["building", _x, owner player];
+    } forEach _nearBuildings;
+
     private _money = _box getVariable ["A3A_itemPrice", 0];
     _box setVariable ["A3A_itemPrice", 0, true];
     _box setVariable ["A3A_build_money", _money, true];


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed building repair not working on MP clients. The ruin/building link vars were never published, so here we publish the required one to the builder client for nearby destroyed buildings.

Also fixed the code theoretically allowing radio towers to be rebuilt. They were probably too large but whatever.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
