### PR TITLE
SPE panzerfaust and mortyAI fixes

### DIFF
--- a/A3A/addons/core/Templates/Templates/SPE/SPE_REB_FFF.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE/SPE_REB_FFF.sqf
@@ -72,7 +72,7 @@ private _initialRebelEquipment = [
     "SPE_Fusil_Mle_208_12", "SPE_Fusil_Mle_208_12_Sawedoff", "SPE_K98",
     "SPE_2Rnd_12x65_Pellets", "SPE_2Rnd_12x65_Slug", "SPE_5Rnd_792x57",
     "SPE_P08", "SPE_8Rnd_9x19_P08",
-    ["SPE_PzFaust_30m", 50],
+    ["SPE_PzFaust_30m", 50], ["SPE_1Rnd_PzFaust_30m", 50],
     ["SPE_Ladung_Small_MINE_mag", 10], ["SPE_US_TNT_half_pound_mag", 10], ["SPE_US_TNT_4pound_mag", 3], ["SPE_Ladung_Big_MINE_mag", 3],
     "SPE_Shg24_Frag", "SPE_NB39", "SPE_US_Mk_1",
     "V_SPE_US_Vest_M1919", "V_SPE_DAK_VestKar98",

--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_REB_FFF.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_REB_FFF.sqf
@@ -72,7 +72,7 @@ private _initialRebelEquipment = [
     "SPE_Fusil_Mle_208_12", "SPE_Fusil_Mle_208_12_Sawedoff", "SPE_K98",
     "SPE_2Rnd_12x65_Pellets", "SPE_2Rnd_12x65_Slug", "SPE_5Rnd_792x57",
     "SPE_P08", "SPE_8Rnd_9x19_P08",
-    ["SPE_PzFaust_30m", 50],
+    ["SPE_PzFaust_30m", 50], ["SPE_1Rnd_PzFaust_30m", 50],
     ["SPE_Ladung_Small_MINE_mag", 10], ["SPE_US_TNT_half_pound_mag", 10], ["SPE_US_TNT_4pound_mag", 3], ["SPE_Ladung_Big_MINE_mag", 3],
     "SPE_Shg24_Frag", "SPE_NB39", "SPE_US_Mk_1",
     "V_SPE_US_Vest_M1919", "V_SPE_DAK_VestKar98",

--- a/A3A/addons/core/functions/AI/fn_mortyAI.sqf
+++ b/A3A/addons/core/functions/AI/fn_mortyAI.sqf
@@ -30,8 +30,10 @@ while {(alive _morty0) and (alive _morty1)} do
 
 	if (({(alive _x)} count units _groupX == count units _groupX) and !(unitReady _morty0)) then
 		{
-		_morty0 addBackpackGlobal _b0;
-		_morty1 addBackpackGlobal _b1;
+		if (!isNil "_b0") then {
+			_morty0 addBackpackGlobal _b0;
+			_morty1 addBackpackGlobal _b1;
+		};
 		unassignVehicle _morty1;
 		moveOut _morty1;
 		deleteVehicle _mortarX;

--- a/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
@@ -420,6 +420,10 @@ private _categoryOverrideTable = [
 
 //SPE
 
+["SPE_PzFaust_30m", ["RocketLaunchers","Weapons","AT","Disposable"]],
+["SPE_PzFaust_60m", ["RocketLaunchers","Weapons","AT","Disposable"]],
+["SPE_Faustpatrone", ["RocketLaunchers","Weapons","AT","Disposable"]],
+
 ["SPE_Lafette_Tripod", ["StaticWeaponParts","Items"]],
 ["SPE_M1_81_Barrel", ["StaticWeaponParts","Items"]],
 ["SPE_MLE_27_31_Barrel", ["StaticWeaponParts","Items"]],
@@ -435,6 +439,7 @@ private _categoryOverrideTable = [
 ["SPE_M1903A3_Springfield_M1_GL", ["Rifles","Weapons","GrenadeLaunchers"]],
 ["SPE_M1_Carbine_M8", ["Rifles","Weapons","GrenadeLaunchers"]],
 ["SPE_M1_Garand_M7", ["Rifles","Weapons","GrenadeLaunchers"]] ];
+
 
 //Create a local namespace.
 A3A_categoryOverrides = false call A3A_fnc_createNamespace;

--- a/A3A/addons/core/functions/Ammunition/fn_equipmentClassToCategories.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_equipmentClassToCategories.sqf
@@ -25,10 +25,10 @@ private _baseCategory = switch (_itemType select 1) do
         case "BombLauncher": {""}; //Only for vehicles //allBombLaunchers pushBack _nameX};
         case "GrenadeLauncher": {""}; //Only for vehicles //allGrenadeLaunchers pushBack _nameX};
         case "Handgun": {"Handguns"};
-        case "Launcher": {""}; //Unused
         case "MachineGun": {"MachineGuns"};
         case "MissileLauncher": {"MissileLaunchers"};
         case "Mortar": {"Mortars"};
+        case "Launcher";                    // SPE panzerfausts
         case "RocketLauncher": {"RocketLaunchers"};
         case "Shotgun": {"Shotguns"};
         case "Throw": {""}; //Unused


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Some SPE-specific fixes:
- Give panzerfausts the correct types so that AIs equip them.
- Add panzerfaust ammo to starting gear.
- Prevent RPT error in mortyAI when mortar doesn't disassemble.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
