### PR TITLE
Fix HC icons being visible after leaving HC mode

### DIFF
--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -294,7 +294,8 @@ player addEventHandler ["HandleRating", {0}];
 
 // Prevent squad icons showing in 3d display in high command
 addMissionEventHandler ["CommandModeChanged", {
-    setGroupIconsVisible [true, false];
+    params ["_isHighCommand", "_isForced"];
+    if (_isHighCommand) then { setGroupIconsVisible [true, false] };
 }];
 
 call A3A_fnc_initUndercover;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed high command icons being visible after leaving HC mode. Checked this but apparently I got distracted by the white borders, which are added elsewhere.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
