### PR TITLE
Add routine for better spawning of high command vehicles

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -542,6 +542,7 @@ class CfgFunctions
             class reDress {};
             class reinfPlayer {};
             class spawnHCGroup {};
+            class spawnHCVeh {};
             class vehiclePrice {};
             class vehStats {};
         };
@@ -750,6 +751,7 @@ class CfgFunctions
         class Utility {
             file = QPATHTOFOLDER(functions\Utility);
             class basicBackpack {};
+            class boxCollisionCheck {};
             class classNameToModel {};
             class countAttachedObjects {};
             class createDataObject {};

--- a/A3A/addons/core/functions/REINF/fn_addFIAsquadHC.sqf
+++ b/A3A/addons/core/functions/REINF/fn_addFIAsquadHC.sqf
@@ -101,24 +101,7 @@ private _fnc_placed = {
     [_formatX, _idFormat, _special, _vehicle] spawn A3A_fnc_spawnHCGroup;
 };
 
-private _vehiclePlacementMethod = if (getMarkerPos respawnTeamPlayer distance player > 50) then {
-    {
-        private _searchCenter = getMarkerPos respawnTeamPlayer getPos [20 + random 30, random 360];
-        private _spawnPos = _searchCenter findEmptyPosition [0, 30, _vehType];
-        if (_spawnPos isEqualTo []) then {_spawnPos = _searchCenter};
-        private _vehicle = _vehType createVehicle _spawnPos;
-
-        if (_mounts isNotEqualTo []) then {
-            private _static = (FactionGet(reb,"staticAA")) # 0 createVehicle _spawnPos;
-            private _nodes = [_vehicle, _static] call A3A_Logistics_fnc_canLoad;
-            if (_nodes isEqualType 0) exitWith {};
-            (_nodes + [true]) call A3A_Logistics_fnc_load;
-            _static call HR_GRG_fnc_vehInit;
-        };
-
-        [_formatX, _idFormat, _special, _vehicle] spawn A3A_fnc_spawnHCGroup;
-    }
-} else { HR_GRG_fnc_confirmPlacement };
+private _vehiclePlacementMethod = if (getMarkerPos respawnTeamPlayer distance player > 50) then { { _this spawn A3A_fnc_spawnHCVeh } } else { HR_GRG_fnc_confirmPlacement };
 
 if (!_isInfantry) exitWith { [_vehType, _fnc_placed, _fnc_placeCheck, [_formatX, _idFormat, _special], _mounts] call _vehiclePlacementMethod };
 

--- a/A3A/addons/core/functions/REINF/fn_spawnHCVeh.sqf
+++ b/A3A/addons/core/functions/REINF/fn_spawnHCVeh.sqf
@@ -1,0 +1,90 @@
+/*
+    Spawn vehicle near HQ for a high command squad
+    Attempts to place facing into a road, otherwise fallbacks to random
+
+Environment: Scheduled (because it's slow)
+
+Arguments:
+    1. <string> classname of vehicle to spawn
+    2. unused (post-placement callback for confirmPlacement)
+    3. unused (position check callback for confirmPlacement)
+    4. <array> Parameters for spawning group with spawnHCGroup
+    5. <array> Non-empty to create AA truck
+*/
+
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+
+// Same params as HR_GRG_fnc_confirmPlacement but doesn't use the callbacks
+params ["_vehType", "", "", "_groupParams", "_mounts"];
+
+private _vehicle = createVehicle [_vehType, [0,0,-1000], [], 0, "CAN_COLLIDE"];
+_vehicle enableSimulation false;
+
+private _bb = boundingBoxReal _vehicle;
+private _bbSize = _bb#1 vectorDiff _bb#0;
+_bbSize params ["_vehWidth", "_vehLength", "_vehHeight"];
+private _slotSize = _bbSize vectorAdd [1.5, 0.3, 0.2];
+_slotSize params ["_slotWidth", "_slotLength", "_slotHeight"];
+
+private _roads = nearestTerrainObjects [markerPos respawnTeamPlayer, ["MAIN ROAD", "ROAD", "TRACK"], 100, false, true];
+_roads = _roads select { count roadsConnectedTo [_x, true] <= 2 };
+
+private _spawnPos = false;
+private _spawnDir = false;
+
+for "_i" from 1 to 10 do {
+    private _road = selectRandom _roads;
+    (getRoadInfo _road) params ["", "_roadWidth", "", "", "", "", "_begPos", "_endPos"];
+
+    if !(_roadWidth isEqualType 0 and _begPos isEqualType []) then { continue };
+
+    private _begPos2d = [_begPos#0, _begPos#1, 0];
+    private _roadDir = _begPos2d vectorFromTo [_endPos#0, _endPos#1];
+    private _slotDir = [_roadDir#1, -(_roadDir#0), 0] vectorMultiply selectRandom [1, -1];
+    private _sideOffset = (_slotLength + _roadWidth) / 2;
+
+    private _slotPos = _begPos vectorAdd ((_endPos vectorDiff _begPos) vectorMultiply random 1);
+    _slotPos = _slotPos vectorAdd (_slotDir vectorMultiply _sideOffset);
+    if (count (_slotPos nearEntities (_slotLength max _slotWidth)/2) > 0) then { continue };
+
+    // check Z diff isn't too high
+    private _slotEndZ = ASLtoATL (_slotPos vectorAdd (_slotDir vectorMultiply _slotLength/2)) # 2;
+    if (_slotEndZ > 1.5 or _slotEndZ < -1.2) then { continue };
+
+    // Actual vehicle collision
+    if ([_slotPos, _slotDir, _vehLength, _vehWidth, _vehHeight] call A3A_fnc_boxCollisionCheck) then { continue };
+
+    // Check that path is clear-ish for exit too
+    private _checkPos = _slotPos vectorAdd (_slotDir vectorMultiply -0.35*_roadwidth);
+    private _checkLength = _slotLength + _roadWidth*0.7;
+    if ([_checkPos, _slotDir, _checkLength, _slotWidth, _slotHeight] call A3A_fnc_boxCollisionCheck) then { continue };
+    _spawnPos = ASLtoATL _slotPos;
+    _spawnDir = _slotDir vectorMultiply -1;
+    break;
+};
+
+if (_spawnPos isEqualType false) then {
+    // Random search fallback
+    private _searchCenter = markerPos respawnTeamPlayer getPos [50 + random 50, random 360];
+    _spawnPos = _searchCenter findEmptyPosition [0, 50, _vehType];
+    if (_spawnPos isEqualTo []) then {_spawnPos = _searchCenter};
+    _vehicle setVehiclePosition [_spawnPos, [], 0, "NONE"];
+    _vehicle setDir random 360;
+} else {
+    isNil {
+        _vehicle setVehiclePosition [_spawnPos, [], 0, "CAN_COLLIDE"];
+        _vehicle setVectorDir _spawnDir;
+    };
+};
+_vehicle enableSimulation true;
+
+if (_mounts isNotEqualTo []) then {
+    private _static = (FactionGet(reb,"staticAA")) # 0 createVehicle _spawnPos;
+    private _nodes = [_vehicle, _static] call A3A_Logistics_fnc_canLoad;
+    if (_nodes isEqualType 0) exitWith {};
+    (_nodes + [true]) call A3A_Logistics_fnc_load;
+    _static call HR_GRG_fnc_vehInit;
+};
+
+_groupParams + [_vehicle] spawn A3A_fnc_spawnHCGroup;

--- a/A3A/addons/core/functions/REINF/fn_spawnHCVeh.sqf
+++ b/A3A/addons/core/functions/REINF/fn_spawnHCVeh.sqf
@@ -26,6 +26,7 @@ private _bbSize = _bb#1 vectorDiff _bb#0;
 _bbSize params ["_vehWidth", "_vehLength", "_vehHeight"];
 private _slotSize = _bbSize vectorAdd [1.5, 0.3, 0.2];
 _slotSize params ["_slotWidth", "_slotLength", "_slotHeight"];
+private _slotRad = sqrt (_slotWidth^2 + _slotLength^2);
 
 private _roads = nearestTerrainObjects [markerPos respawnTeamPlayer, ["MAIN ROAD", "ROAD", "TRACK"], 100, false, true];
 _roads = _roads select { count roadsConnectedTo [_x, true] <= 2 };
@@ -34,6 +35,7 @@ private _spawnPos = false;
 private _spawnDir = false;
 
 for "_i" from 1 to 10 do {
+    //systemChat format ["Attempt %1", _i];
     private _road = selectRandom _roads;
     (getRoadInfo _road) params ["", "_roadWidth", "", "", "", "", "_begPos", "_endPos"];
 
@@ -46,11 +48,18 @@ for "_i" from 1 to 10 do {
 
     private _slotPos = _begPos vectorAdd ((_endPos vectorDiff _begPos) vectorMultiply random 1);
     _slotPos = _slotPos vectorAdd (_slotDir vectorMultiply _sideOffset);
-    if (count (_slotPos nearEntities (_slotLength max _slotWidth)/2) > 0) then { continue };
+    //if (count (_slotPos nearEntities (_slotLength max _slotWidth)/2) > 0) then { continue };
 
     // check Z diff isn't too high
     private _slotEndZ = ASLtoATL (_slotPos vectorAdd (_slotDir vectorMultiply _slotLength/2)) # 2;
+    //systemChat format ["Z diff %1", _slotEndZ];
     if (_slotEndZ > 1.5 or _slotEndZ < -1.2) then { continue };
+
+    // Check for (small) objects within slot area
+    private _nearObj = ASLtoATL _slotPos nearEntities _slotRad;
+    _nearObj append nearestObjects [_slotPos, ["Building"], _slotRad, true];          // Pretty much all editor-placeable objects are Building
+    _nearObj append nearestTerrainObjects [_slotPos, ["FENCE","WALL","TREE","HOUSE","HIDE","POWER LINES"], _slotRad, false, true];
+    if (_nearObj inAreaArray [_slotPos, _slotWidth/2, _slotLength/2, _slotDir#0 atan2 _slotDir#1, true] isNotEqualTo []) then { continue };
 
     // Actual vehicle collision
     if ([_slotPos, _slotDir, _vehLength, _vehWidth, _vehHeight] call A3A_fnc_boxCollisionCheck) then { continue };
@@ -58,7 +67,7 @@ for "_i" from 1 to 10 do {
     // Check that path is clear-ish for exit too
     private _checkPos = _slotPos vectorAdd (_slotDir vectorMultiply -0.35*_roadwidth);
     private _checkLength = _slotLength + _roadWidth*0.7;
-    if ([_checkPos, _slotDir, _checkLength, _slotWidth, _slotHeight] call A3A_fnc_boxCollisionCheck) then { continue };
+    if ([_checkPos, _slotDir vectorMultiply -1, _checkLength, _slotWidth, _slotHeight] call A3A_fnc_boxCollisionCheck) then { continue };
     _spawnPos = ASLtoATL _slotPos;
     _spawnDir = _slotDir vectorMultiply -1;
     break;

--- a/A3A/addons/core/functions/Utility/fn_boxCollisionCheck.sqf
+++ b/A3A/addons/core/functions/Utility/fn_boxCollisionCheck.sqf
@@ -1,0 +1,65 @@
+/*
+    A3A_fnc_boxCollisionCheck
+    Returns true if specified box would collide with objects
+
+    Params:
+	_pos - position2d (Z ignored), center position  
+	_dir - direction (either number or vector) of box length
+    _length - length of test area in metres
+    _width - width of test area in metres
+    _height (default 0) - height of test area, 0 is faster
+*/
+
+params ["_pos", "_dir", "_length", "_width", ["_height", 0]];
+
+_pos set [2, 0]; _pos = AGLtoASL _pos;
+if (_dir isEqualType 0) then { _dir = [sin _dir, cos _dir, 0] };
+private _sideDir = [_dir#1, -(_dir#0), 0];
+private _sideDiff = _sideDir vectorMultiply _width;
+
+private _botRearLeft = _pos vectorAdd (_dir vectorMultiply (-_length/2)) vectorAdd (_sideDir vectorMultiply (-_width/2)) vectorAdd [0,0,0.3];
+private _botFrontLeft = _botRearLeft vectorAdd (_dir vectorMultiply _length);
+private _botRearRight = _botRearLeft vectorAdd _sideDiff;
+private _botFrontRight = _botFrontLeft vectorAdd _sideDiff;
+
+private _lines = [
+    [_botRearLeft, _botFrontRight],         // lower diagonal
+    [_botRearLeft, _botFrontLeft],          // lower box
+    [_botRearRight, _botFrontRight],
+    [_botRearLeft, _botRearRight],
+    [_botFrontLeft, _botFrontRight]
+];
+
+if (_height > 0) then {
+    private _topRearLeft = _botRearLeft vectorAdd [0,0,_height-0.3];
+    private _topFrontLeft = _topRearLeft vectorAdd (_dir vectorMultiply _length);
+    private _topRearRight = _topRearLeft vectorAdd _sideDiff;
+    private _topFrontRight = _topFrontLeft vectorAdd _sideDiff;
+
+    _lines append [
+        [_topRearRight, _topFrontLeft],         // upper diagonal
+        [_botRearLeft, _topRearRight],
+        [_botRearRight, _topFrontRight],
+        [_botFrontRight, _topFrontLeft],
+        [_botFrontLeft, _topRearLeft],
+        [_botFrontLeft, _topRearRight]         // inner diagonal
+    ];
+};
+
+private _collision = false;
+{
+//	private _result = lineIntersectsSurfaces [_x#0, _x#1, objNull, objNull, false, 1, "FIRE", "FIRE"];
+	private _result = lineIntersectsObjs [_x#0, _x#1, objNull, objNull, false, 16];
+	if (count _result > 0) exitWith {
+		_collision = true;
+	};
+} forEach _lines;
+
+/*addMissionEventHandler ["Draw3D", {
+    {
+        drawLine3D [ASLtoAGL (_x#0), ASLtoAGL (_x#1), [1,1,1,1]];
+    } forEach _thisArgs;
+}, _lines];
+*/
+
+_collision;


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
With the introduction of the building placer, remotely recruiting vehicles for high command became even less reliable. This is a new routine that attempts to find empty spots facing onto roads, which does a much better job of picking a place where vehicles can actually drive out of HQ in various directions. Deals ok with various obstacle types and terrain gradients.

Fallback uses the old random placement but with a larger radius.

### Please specify which Issue this PR Resolves.
closes #2999

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
