### PR TITLE
fixed base weapon Vektor R5 GL

### DIFF
--- a/A3A/addons/config_fixes/WS/CfgWeapons.hpp
+++ b/A3A/addons/config_fixes/WS/CfgWeapons.hpp
@@ -1,0 +1,10 @@
+//WS - CfgWeapons.hpp
+
+class CfgWeapons
+{
+    class arifle_VelkoR5_lxWS;
+    class arifle_VelkoR5_GL_lxWS : arifle_VelkoR5_lxWS
+    {
+        baseWeapon = "arifle_VelkoR5_GL_lxWS";
+    };
+};

--- a/A3A/addons/config_fixes/WS/config.cpp
+++ b/A3A/addons/config_fixes/WS/config.cpp
@@ -23,5 +23,6 @@ class CfgPatches
 // Uncomment when needed
 #include "CfgVehicles.hpp"
 #include "CfgMarkers.hpp"
+#include "CfgWeapons.hpp"
 
 #endif      // __has_include("\lxws\data_f_lxws\config.bin")


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    arifle_VelkoR5_lxWS had the wrong baseWeapon entry, making it, this corrects that making the gun compatible with the antistasi loot and arsenal system.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
