### PR TITLE
Fix ACE setName spam and JIP error

### DIFF
--- a/A3A/addons/core/functions/Utility/fn_setIdentityLocal.sqf
+++ b/A3A/addons/core/functions/Utility/fn_setIdentityLocal.sqf
@@ -29,8 +29,9 @@ private _lastName = _identity getOrDefault ["lastName", ""];
 if (_firstName != "" || _lastName != "") then {
     private _fullName = [_firstName, _lastName] select { _x != "" } joinString " ";
     _unit setName [_fullName, _firstName, _lastName];
-    if (A3A_hasACE) then {
+    if (isServer and {!isNil "ace_common_fnc_setName"}) then {
         // Updates the name displayed in ACE Medical, dogtags, name tags and other ACE features
+        // Runs global setVariable so only needs executing once
         _unit call ace_common_fnc_setName;
     };
 };


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
setIdentityLocal was calling `ace_common_fnc_setName` on every machine, which is a performance problem because that function does two global setVariables. Hence with 30 players you have 60 excess global setVariables per unit created. Fixed by only running on the server, which is simple enough that it can get into 3.4.

Also changed the condition so that it doesn't break in JIP.

### Please specify which Issue this PR Resolves.
closes #2995

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
