### PR TITLE
Add ACE_suture to initial rebel equipment

### DIFF
--- a/A3A/addons/core/functions/Templates/fn_aceModCompat.sqf
+++ b/A3A/addons/core/functions/Templates/fn_aceModCompat.sqf
@@ -58,7 +58,8 @@ aceMedItems = [
 	"ACE_adenosine",
 	"ACE_splint",
 	"ACE_bodyBag",
-	"ACE_personalAidKit"
+	"ACE_personalAidKit",
+	"ACE_suture"
 ];
 
 aceMedItemsBlood = [


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Added ACE_suture to initial rebel equipment, because apparently it's required for some medical settings.     

### Please specify which Issue this PR Resolves.
closes #2980

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
