### PR TITLE
Fix basic/medical gear missing in SPE/IFA FFF rebel faction

### DIFF
--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_REB_FFF.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_REB_FFF.sqf
@@ -157,6 +157,9 @@ private _squadLeaderTemplate = {
     ["uniforms"] call _fnc_setUniform;
     ["facewear"] call _fnc_setFacewear;
 
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+
     ["maps"] call _fnc_addMap;
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
@@ -166,6 +169,9 @@ private _squadLeaderTemplate = {
 private _riflemanTemplate = {
     ["uniforms"] call _fnc_setUniform;
     ["facewear"] call _fnc_setFacewear;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
 
     ["maps"] call _fnc_addMap;
     ["watches"] call _fnc_addWatch;

--- a/A3A/addons/core/functions/Ammunition/fn_equipmentClassToCategories.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_equipmentClassToCategories.sqf
@@ -132,13 +132,6 @@ call {
         };
     };
 
-    if (_basecategory == "Backpacks") exitWith {
-        // 160 = assault pack. Just a way to limit which backpacks friendly AI are using.
-        if (getNumber (configFile >> "CfgVehicles" >> _className >> "maximumLoad") >= 160) then {
-            _categories pushBack "BackpacksCargo";
-        };
-    };
-
     if (_basecategory == "Optics") exitWith {
         if (getNumber (configFile >> "CfgWeapons" >> _className >> "ace_scopeAdjust_verticalIncrement") > 0) exitWith { _categories pushBack "OpticsLong" };
         if !(isClass (configFile >> "CfgWeapons" >> _className >> "ItemInfo" >> "OpticsModes")) exitWith {};

--- a/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
@@ -127,11 +127,21 @@ _rebelGear set ["ArmoredHeadgear", _aheadgear];
 
 // Backpack filtering
 private _backpacks = [];
+private _bpLoads = createHashMap;
 {
     _x params ["_class", "_amount"];
-    private _categories = _class call A3A_fnc_equipmentClassToCategories;
-    if ("BackpacksCargo" in _categories) then { [_backpacks, _class, _amount] call _fnc_addItem };
+    private _load = getNumber (configFile >> "CfgVehicles" >> _class >> "maximumLoad");
+    _bpLoads set [_class, _load];
+    if (_load > 160) then { [_backpacks, _class, _amount] call _fnc_addItem };
 } forEach (jna_datalist select IDC_RSCDISPLAYARSENAL_TAB_BACKPACK);
+
+if (_backpacks isEqualTo []) then {
+    // If we don't have any high-load backpacks (eg FFF), resort to largest one
+    private _maxLoad = -1;
+    private _class = "";
+    { if (_y > _maxLoad) then { _maxLoad = _y; _class = _x } } forEach _bpLoads;
+    if (_class != "") then { [_backpacks, _class, -1] call _fnc_addItem };
+};
 
 _rebelGear set ["BackpacksCargo", _backpacks];
 

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -180,7 +180,7 @@ Info("Initialising item categories");
 
 //We initialise a LOT of arrays based on the categories. Every category gets a 'allX' variables and an 'unlockedX' variable.
 
-private _unlockableCategories = allCategoriesExceptSpecial + ["AA", "AT", "GrenadeLaunchers", "ArmoredVests", "ArmoredHeadgear", "BackpacksCargo"];
+private _unlockableCategories = allCategoriesExceptSpecial + ["AA", "AT", "GrenadeLaunchers", "ArmoredVests", "ArmoredHeadgear"];
 
 //Build list of 'allX' variables, such as 'allWeapons'
 DECLARE_SERVER_VAR(allEquipmentArrayNames, allCategories apply {"all" + _x});


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Misc essentials and basic medical gear weren't being added to FFF rebels. Troops having no FAKs is pretty bad in vanilla at least, as it prevents them from reviving and may cause them to over-loot later.

I suspect this was a workaround for an issue where the rebel AI equipping code ignores small backpacks even if there aren't any larger ones, as FFF doesn't have any large backpacks at the start. Rewrote that code so that it'll now use the largest available if all of them are small.

Ended up a bit large for a late 3.4 patch but I think I've tested all the cases.

### Please specify which Issue this PR Resolves.
closes #2909

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
