### PR TITLE
Fix some weird/broken UI config dependencies

### DIFF
--- a/A3A/addons/garage/defines.hpp
+++ b/A3A/addons/garage/defines.hpp
@@ -343,7 +343,7 @@ class HR_GRG_RscControlsGroup
     };
 };
 
-class RscControlsGroupNoScrollbars: HR_GRG_RscControlsGroup
+class HR_GRG_RscControlsGroupNoScrollbars: HR_GRG_RscControlsGroup
 {
     class VScrollbar: VScrollbar
     {

--- a/A3A/addons/gui/config.cpp
+++ b/A3A/addons/gui/config.cpp
@@ -6,7 +6,8 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"A3A_core"};
+        // Needs A3 loadorder for arsenal limits dialog
+        requiredAddons[] = {"A3_Data_F_AoW_Loadorder", "A3A_core"};
         author = AUTHOR;
         authors[] = { AUTHORS };
         authorUrl = "";
@@ -21,6 +22,7 @@ class CfgPatches {
 #else
     #include "CfgFunctions.hpp"
 #endif
+
 
 // Whether order should be maintained is unknown.
 #include "dialogues\defines.hpp"

--- a/A3A/addons/gui/dialogues/arsenalLimitsDialog.hpp
+++ b/A3A/addons/gui/dialogues/arsenalLimitsDialog.hpp
@@ -6,10 +6,10 @@
 
 #include "ids.inc"
 
-import RscText;
-import RscButton;
-import RscListNBox;
-import RscControlsGroup;
+class RscText;
+class RscButton;
+class RscListNBox;
+class RscControlsGroup;
 
 class A3A_ArsenalLimitsDialog {
     idd = A3A_IDD_ARSENALLIMITSDIALOG;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Apparently the arsenal limits dialog only worked by a weird chain of luck. Unlike everything else in the mission, it used the import keyword with vanilla UI classes, which is very wrong syntax outside mission config. Not entirely sure how it did work, but it's written with the correct dependencies now. Can remove the A3 loadorder if I ever convert the arsenal limits dialog to Antistasi UI classes, but it doesn't hurt anyway.

Also found an unused garage UI define that was accidentally overwriting a vanilla class. Fixed.

### Please specify which Issue this PR Resolves.
closes #3014
closes #2958

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
