### PR TITLE
Rework builder UI alignment to work with non 1080p resolutions:

### DIFF
--- a/A3A/addons/gui/dialogues/placerHintsRsc.hpp
+++ b/A3A/addons/gui/dialogues/placerHintsRsc.hpp
@@ -1,8 +1,8 @@
 #include "ids.inc"
 
 
-#define CENTER_GRID_X ((getResolution select 2) * 0.5 * pixelW)
-#define CENTER_GRID_Y ((getResolution select 3) * 0.5 * pixelH)
+#define SCREEN_RIGHT (safeZoneX + safeZoneW)
+#define SCREEN_BOTTOM (safeZoneY + safeZoneH)
 
 class A3A_PlacerHints {
     idd = IDD_PLACERHINT;
@@ -15,8 +15,8 @@ class A3A_PlacerHints {
         class TestText: A3A_Text {
             idc = IDC_PLACERHINT_TEST_TEXT;
             text = "";
-            x = CENTER_GRID_X + 80 * GRID_W;
-            y = CENTER_GRID_Y + 25 * GRID_H;
+            x = SCREEN_RIGHT - 32 * GRID_W;
+            y = SCREEN_BOTTOM - 40 * GRID_H;
             w = 52 * GRID_W;
             h = 8 * GRID_H;
             sizeEx = 2.25 * GRID_H;
@@ -26,16 +26,16 @@ class A3A_PlacerHints {
         class IconALT: A3A_Picture {
             idc = IDC_PLACERHINT_ALT;
             text = A3A_Icon_key_alt;
-            x = CENTER_GRID_X + 85 * GRID_W;
-            y = CENTER_GRID_Y + 29 * GRID_H;
+            x = SCREEN_RIGHT - 32 * GRID_W;
+            y = SCREEN_BOTTOM - 32 * GRID_H;
             w = 7 * GRID_W;
             h = 7 * GRID_H;
         };
         class TextALT: A3A_Text {
             idc = IDC_PLACERHINT_ALT_TEXT;
             text = "";
-            x = CENTER_GRID_X + 94 * GRID_W;
-            y = CENTER_GRID_Y + 30 * GRID_H;
+            x = SCREEN_RIGHT - 23 * GRID_W;
+            y = SCREEN_BOTTOM - 31 * GRID_H;
             w = 45 * GRID_W;
             h = 4 * GRID_H;
             sizeEx = 2.25 * GRID_H;
@@ -45,59 +45,59 @@ class A3A_PlacerHints {
         class IconEKEY: IconALT {
             idc = IDC_PLACERHINT_E;
             text = A3A_Icon_key_e;
-            y = CENTER_GRID_Y + 35 * GRID_H;
+            y = SCREEN_BOTTOM - 27 * GRID_H;
         };
         class TextEKEY: TextALT {
             idc = IDC_PLACERHINT_E_TEXT;
-            y = CENTER_GRID_Y + 36 * GRID_H;
+            y = SCREEN_BOTTOM - 26 * GRID_H;
         };
         class IconRKEY: IconALT {
             idc = IDC_PLACERHINT_R;
             text = A3A_Icon_key_r;
-            y = CENTER_GRID_Y + 41 * GRID_H;
+            y = SCREEN_BOTTOM - 22 * GRID_H;
         };
         class TextRKEY: TextALT {
             idc = IDC_PLACERHINT_R_TEXT;
-            y = CENTER_GRID_Y + 42 * GRID_H;
+            y = SCREEN_BOTTOM - 21 * GRID_H;
         };
 
         // UNSAFE_MODEs
         class IconSHIFT: IconALT {
             idc = IDC_PLACERHINT_SHIFT;
             text = A3A_Icon_key_shift;
-            y = CENTER_GRID_Y + 46 * GRID_H;
+            y = SCREEN_BOTTOM - 17 * GRID_H;
         };
         class TextSHIFT: TextALT {
             idc = IDC_PLACERHINT_SHIFT_TEXT;
-            y = CENTER_GRID_Y + 47 * GRID_H;
+            y = SCREEN_BOTTOM - 16 * GRID_H;
         };
         // cancel/rebuild keys
         class IconCKEY: IconALT {
             idc = IDC_PLACERHINT_C;
             text = A3A_Icon_key_c;
-            y = CENTER_GRID_Y + 51 * GRID_H;
+            y = SCREEN_BOTTOM - 12 * GRID_H;
         };
         class IconTKEY: IconALT {
             idc = IDC_PLACERHINT_T;
             text = A3A_Icon_key_t;
-            y = CENTER_GRID_Y + 51 * GRID_H;
+            y = SCREEN_BOTTOM - 12 * GRID_H;
         };
         class TextCKEY: TextALT {
             idc = IDC_PLACERHINT_C_TEXT;
-            y = CENTER_GRID_Y + 52 * GRID_H;
+            y = SCREEN_BOTTOM - 11 * GRID_H;
         };
         // place key
         class IconSpaceKEY: IconALT {
             idc = IDC_PLACERHINT_SPACE;
             text = A3A_Icon_key_space;
-            x = CENTER_GRID_X + 81 * GRID_W;
-            y = CENTER_GRID_Y + 52 * GRID_H;
+            x = SCREEN_RIGHT - 34 * GRID_W;
+            y = SCREEN_BOTTOM - 11 * GRID_H;
             w = 10 * GRID_W;
             h = 15 * GRID_H;
         };
         class TextSpaceKEY: TextALT {
             idc = IDC_PLACERHINT_SPACE_TEXT;
-            y = CENTER_GRID_Y + 57 * GRID_H;
+            y = SCREEN_BOTTOM - 6 * GRID_H;
         };
     };
 };

--- a/A3A/addons/gui/dialogues/teamLeaderBuilder.hpp
+++ b/A3A/addons/gui/dialogues/teamLeaderBuilder.hpp
@@ -1,8 +1,12 @@
 
-#define CENTER_GRID_X ((getResolution select 2) * 0.5 * pixelW)
-#define CENTER_GRID_Y ((getResolution select 3) * 0.5 * pixelH)
-#define BOTTOM safeZoneH + safeZoneY
+#define SCREEN_RIGHT (safeZoneX + safeZoneW)
+#define SCREEN_BOTTOM (safeZoneY + safeZoneH)
 
+
+class A3A_buttonSmallText : A3A_button
+{
+    SizeEx = GUI_TEXT_SIZE_SMALL;
+};
 
 class A3A_teamLeaderBuilder
 {
@@ -16,17 +20,17 @@ class A3A_teamLeaderBuilder
         {
             moving = true;
             colorBackground[] = A3A_COLOR_TITLEBAR_BACKGROUND;
-            x = CENTER_X(160);
-            y = BOTTOM - PX_H(41);
-            w = PX_W(160);
+            x = safeZoneX;
+            y = SCREEN_BOTTOM - PX_H(41);
+            w = safeZoneW - PX_W(40);
             h = PX_H(5);
         };
 
         class Background : A3A_Background
         {
-            x = CENTER_X(160);
-            y = BOTTOM - PX_H(36);
-            w = PX_W(160);
+            x = safeZoneX;
+            y = SCREEN_BOTTOM - PX_H(36);
+            w = safeZoneW - PX_W(40);
             h = PX_H(36);
         };
     };
@@ -37,18 +41,18 @@ class A3A_teamLeaderBuilder
         {
             idc = -1;
             text = $STR_antistasi_teamleader_placer_title;
-            x = CENTER_X(160);
-            y = BOTTOM - PX_H(41);
-            w = PX_W(80);
+            x = safeZoneX;
+            y = SCREEN_BOTTOM - PX_H(41);
+            w = safeZoneW - PX_W(80);
             h = PX_H(5);
         };
         class RemMoneyText: A3A_TitlebarText
         {
             idc = A3A_IDC_TEAMLEADERBUILDERMONEY;
             text = "500 €";
-            x = CENTER_X(160) + PX_W(80);
-            y = BOTTOM - PX_H(41);
-            w = PX_W(80);
+            x = SCREEN_RIGHT - PX_W(80);
+            y = SCREEN_BOTTOM - PX_H(41);
+            w = PX_W(40);
             h = PX_H(5);
             style = ST_RIGHT;
         };
@@ -57,9 +61,9 @@ class A3A_teamLeaderBuilder
         class MainContent : A3A_DefaultControlsGroup
         {
             idc = A3A_IDC_TEAMLEADERBUILDERMAIN;
-            x = CENTER_X(160);
-            y = BOTTOM - PX_H(36);
-            w = PX_W(160);
+            x = safeZoneX;
+            y = SCREEN_BOTTOM - PX_H(36);
+            w = safeZoneW - PX_W(40);
             h = PX_H(36);
 
             class Controls
@@ -69,8 +73,8 @@ class A3A_teamLeaderBuilder
                     idc = A3A_IDC_TEAMLEADERBUILDINGGROUP;
                     x = 0;
                     y = PX_H(4);
-                    w = PX_W(160);
-                    h = PX_H(36);
+                    w = safeZoneW - PX_W(40);
+                    h = PX_H(32);
                 };
             };
         };

--- a/A3A/addons/gui/functions/GUI/fn_teamLeaderRTSPlacerDialog.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_teamLeaderRTSPlacerDialog.sqf
@@ -46,6 +46,11 @@ switch (_mode) do
 
 		private _buildableObjects = A3A_buildableObjects;
 		
+		private _boxWidth = round ((ctrlPosition _buildControlsGroup # 2) / GRID_W);
+		private _itemsPerRow = floor ((_boxWidth - 6) / 36);			// minimum 32 + 4 grids per tile
+		private _itemWidth = floor ((_boxWidth - 6 - 4*_itemsPerRow) / _itemsPerRow);
+
+		//diag_log format ["Builder: boxWidth %1, itemsPerRow %2, itemWidth %3", _boxWidth, _itemsPerRow, _itemWidth];
 
 		{
 			_x params [
@@ -64,21 +69,23 @@ switch (_mode) do
                 _editorPreview = A3A_PlaceHolder_NoVehiclePreview;
             };
 	
-			private _itemXpos = 7 * GRID_W + ((7 * GRID_W + 44 * GRID_W) * (_forEachIndex % 3));
-			private _itemYpos = (floor (_forEachIndex / 3)) * (44 * GRID_H);
+			private _itemXpos = (4 + (4 + _itemWidth) * (_forEachIndex % _itemsPerRow)) * GRID_W;
+			private _itemYpos = (floor (_forEachIndex / _itemsPerRow)) * (34 * GRID_H);
+
+			//diag_log format ["Builder: Item %1, xpos %2, ypos %3", _forEachIndex, _itemXpos, _itemYPos];
 
 			private _itemControlsGroup = _display ctrlCreate ["A3A_ControlsGroupNoScrollbars", A3A_IDC_TEAMLEADERBUILDITEMGROUP, _buildControlsGroup];
-			_itemControlsGroup ctrlSetPosition[_itemXpos, _itemYpos, 44 * GRID_W, 36 * GRID_H];
+			_itemControlsGroup ctrlSetPosition[_itemXpos, _itemYpos, _itemWidth * GRID_W, 30 * GRID_H];
 			_itemControlsGroup ctrlSetFade 1;
 			_itemControlsGroup ctrlCommit 0;
 
 			private _previewPicture = _display ctrlCreate ["A3A_Picture", A3A_IDC_TEAMLEADERBUILDIMAGEPREVIEW, _itemControlsGroup];
-			_previewPicture ctrlSetPosition [0, 0, 44 * GRID_W, 25 * GRID_H];
+			_previewPicture ctrlSetPosition [0, 0, _itemWidth * GRID_W, 24 * GRID_H];
 			_previewPicture ctrlSetText _editorPreview;
 			_previewPicture ctrlCommit 0;
 	
-			private _button = _display ctrlCreate ["A3A_ShortcutButton", A3A_IDC_TEAMLEADERBUILDBUTTON, _itemControlsGroup];
-			_button ctrlSetPosition [0, 25 * GRID_H, 44 * GRID_W, 8 * GRID_H];
+			private _button = _display ctrlCreate ["A3A_ButtonSmallText", A3A_IDC_TEAMLEADERBUILDBUTTON, _itemControlsGroup];
+			_button ctrlSetPosition [0, 24 * GRID_H, _itemWidth * GRID_W, 6 * GRID_H];
 			_button ctrlSetText _displayName;
 			_button setVariable ["className", _className];
 			_button setVariable ["model", _model];
@@ -119,13 +126,13 @@ switch (_mode) do
 
 			if (_price isNotEqualTo 0) then {
 				private _priceText = _display ctrlCreate ["A3A_InfoTextRight", -1, _itemControlsGroup];
-				_priceText ctrlSetPosition[23 * GRID_W, 21 * GRID_H, 20 * GRID_W, 3 * GRID_H];
+				_priceText ctrlSetPosition[(_itemWidth - 21) * GRID_W, 20 * GRID_H, 20 * GRID_W, 3 * GRID_H];
 				_priceText ctrlSetText format ["%1 €",_price];
 				_priceText ctrlCommit 0;
 			};
 
 			private _buildTime = _display ctrlCreate ["A3A_PictureStroke", -1, _itemControlsGroup];
-			_buildTime ctrlSetPosition[1 * GRID_W, 21 * GRID_H, 4 * GRID_W, 4 * GRID_H];
+			_buildTime ctrlSetPosition[1 * GRID_W, 19 * GRID_H, 4 * GRID_W, 4 * GRID_H];
 			_buildTime ctrlSetText A3A_Icon_Construct;
 			_buildTime ctrlCommit 0;
 	


### PR DESCRIPTION

### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The building placer UI didn't work correctly in any resolution except 1080p, as the placer hints were placed at fixed coords relative to the screen center, and 1080p is the odd one out. Even 4K was busted, because Arma. Non-widescreen resolutions didn't have any room for the hints anyway, as the building selection dialog took up too much space.

Reworked the alignment:
- Hints now based on screen bottom-right, no longer drifts off screen.
- Selector now runs from screen bottom-left to hints UI instead of fixed-width centered.
- Icons a bit smaller so that they fit vertically and you get 3 wide on 4:3.

Icon aspect ratio is varied a bit to avoid giant spaces, because because different resolutions have wildly different pixelgrid counts. The icons come out a shade narrow in 1080p but it's probably fine.

### Please specify which Issue this PR Resolves.
closes #3005

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

1440p and 4K need checking. I don't have a monitor for it.
