### PR TITLE
Added WS AA/Zu truck vehicle attributes 

### DIFF
--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Vehicle_Attributes.sqf
@@ -27,9 +27,9 @@
 if ("ws" in A3A_enabledDLC) then {
     (["attributesVehicles"] call _fnc_getFromTemplate) append
     [
-        ["a3a_O_Truck_02_zu23_F", ["cost", 60], ["threat", 70]],
-        ["a3a_O_T_Truck_02_zu23_F", ["cost", 60], ["threat", 70]],
-        ["I_A_Truck_02_aa_lxWS", ["cost", 60], ["threat", 70]],
-        ["a3a_I_E_Truck_02_zu23_F", ["cost", 60], ["threat", 70]]
+        ["a3a_O_Truck_02_zu23_F", ["cost", 60]],
+        ["a3a_O_T_Truck_02_zu23_F", ["cost", 60]],
+        ["I_A_Truck_02_aa_lxWS", ["cost", 60]],
+        ["a3a_I_E_Truck_02_zu23_F", ["cost", 60]]
     ];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Vehicle_Attributes.sqf
@@ -22,3 +22,14 @@
     ["O_MBT_04_command_F", ["cost", 250], ["threat", 330]]    // -||-
 
 ]] call _fnc_saveToTemplate;
+
+//If Western Sahara DLC
+if ("ws" in A3A_enabledDLC) then {
+    (["attributesVehicles"] call _fnc_getFromTemplate) append
+    [
+        ["a3a_O_Truck_02_zu23_F", ["cost", 60], ["threat", 70]],
+        ["a3a_O_T_Truck_02_zu23_F", ["cost", 60], ["threat", 70]],
+        ["I_A_Truck_02_aa_lxWS", ["cost", 60], ["threat", 70]],
+        ["a3a_I_E_Truck_02_zu23_F", ["cost", 60], ["threat", 70]]
+    ];
+};

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_CSAT_NAfrica.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_CSAT_NAfrica.sqf
@@ -19,7 +19,7 @@
 
 ["vehiclesBasic", ["O_Quadbike_01_F"]] call _fnc_saveToTemplate;
 private _LightUnarmed = ["O_MRAP_02_F"];
-private _LightArmed = ["O_MRAP_02_hmg_F", "O_MRAP_02_gmg_F"];
+private _LightArmed = ["O_MRAP_02_hmg_F", "O_MRAP_02_gmg_F", "a3a_O_Truck_02_zu23_F"];
 ["vehiclesTrucks", ["O_Truck_03_transport_F", "O_Truck_03_covered_F"]] call _fnc_saveToTemplate;
 private _cargoTrucks = ["O_Truck_02_transport_F", "O_Truck_02_covered_F", "O_Truck_03_transport_F", "O_Truck_03_covered_F", "O_Truck_02_cargo_lxWS","O_Truck_02_flatbed_lxWS"];
 ["vehiclesAmmoTrucks", ["O_Truck_02_Ammo_F", "O_Truck_03_ammo_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_ION.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_ION.sqf
@@ -20,7 +20,7 @@
 // vehicles can be placed in more than one category if they fit between both. Cost will be derived by the higher category
 ["vehiclesBasic", ["B_ION_Quadbike_01_lxWS"]] call _fnc_saveToTemplate;
 private _vehiclesLightUnarmed = ["a3a_ION_Offroad_armor"];
-private _vehiclesLightArmed = ["a3a_ION_Offroad_armor_armed","a3a_ION_Offroad_armor_at"];
+private _vehiclesLightArmed = ["a3a_ION_Offroad_armor_armed","a3a_ION_Offroad_armor_at", "a3a_ION_Truck_02_zu23_F"];
 ["vehiclesTrucks", ["B_ION_Truck_02_covered_lxWS", "a3a_ION_Truck_02_transport_F"]] call _fnc_saveToTemplate;
 ["vehiclesCargoTrucks", ["B_ION_Truck_02_covered_lxWS", "a3a_ION_Truck_02_transport_F","a3a_ION_Truck_02_cargo_F","a3a_ION_Truck_02_flatbed_F"]] call _fnc_saveToTemplate;
 ["vehiclesAmmoTrucks", ["a3a_ION_Truck_02_Ammo_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/WS/WS_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_Vehicle_Attributes.sqf
@@ -3,11 +3,16 @@
 [
     ["B_ION_APC_Wheeled_01_cannon_lxWS", ["cost", 100], ["threat", 120]],
     ["B_ION_APC_Wheeled_01_command_lxWS", ["cost", 70], ["threat", 120]],
+    
+    ["B_ION_Heli_Light_02_dynamicLoadout_lxWS", ["cost", 100]],
+    
     ["B_D_Heli_Light_01_dynamicLoadout_lxWS", ["cost", 100]],
 
+    ["a3a_ION_Truck_02_zu23_F", ["cost", 60], ["threat", 70]],
+    ["O_SFIA_Truck_02_aa_lxWS", ["cost", 60], ["threat", 70]],
+    
     ["a3a_Heli_Light_01_dynamicLoadout_ION_F", ["cost", 100]],
     ["a3a_Heli_Light_02_black_F", ["cost", 90]],
-    ["B_ION_Heli_Light_02_dynamicLoadout_lxWS", ["cost", 100]],
 
     ["a3a_Plane_Fighter_03_grey_F", ["cost", 200]]
 ];

--- a/A3A/addons/core/Templates/Templates/WS/WS_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_Vehicle_Attributes.sqf
@@ -8,8 +8,8 @@
     
     ["B_D_Heli_Light_01_dynamicLoadout_lxWS", ["cost", 100]],
 
-    ["a3a_ION_Truck_02_zu23_F", ["cost", 60], ["threat", 70]],
-    ["O_SFIA_Truck_02_aa_lxWS", ["cost", 60], ["threat", 70]],
+    ["a3a_ION_Truck_02_zu23_F", ["cost", 60]],
+    ["O_SFIA_Truck_02_aa_lxWS", ["cost", 60]],
     
     ["a3a_Heli_Light_01_dynamicLoadout_ION_F", ["cost", 100]],
     ["a3a_Heli_Light_02_black_F", ["cost", 90]],


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
both ION and AAF was way overpaying for their AA vehicle.
Vehicle attributes for the variants of Zu-23 trucks added.
Zu-23 truck added to light armed of ION and CSAT north africa.

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
