### PR TITLE
Fix logistics JIP bugs

### DIFF
--- a/A3A/addons/core/functions/Base/fn_flagaction.sqf
+++ b/A3A/addons/core/functions/Base/fn_flagaction.sqf
@@ -80,7 +80,9 @@ switch _typeX do
 
             _actionX = _flag addAction [format ["<t>Carry %1</t> <img image='\A3\ui_f\data\igui\cfg\actions\take_ca.paa' size='1.6' shadow=2 />",name _flag], A3A_fnc_carry,nil,5,true,false,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull]) and (isNull attachedTo _target) and !(_this getVariable [""helping"",false]);",4];// TODO: partial string created - unsure about implementation
             _flag setUserActionText [_actionX,format [localize "STR_A3A_fn_base_flagaction_heal_carry",name _flag],"<t size='2'><img image='\A3\ui_f\data\igui\cfg\actions\take_ca.paa'/></t>"];// TODO: string created, unsure about implementation
-            [_flag] call A3A_Logistics_fnc_addLoadAction;
+
+            // Call the internal logistics function, because this one is already global-JIP
+            [_flag, "load"] call A3A_Logistics_fnc_addAction;
         };
     };
     case "remove":

--- a/A3A/addons/logistics/Public/fn_addLoadAction.sqf
+++ b/A3A/addons/logistics/Public/fn_addLoadAction.sqf
@@ -33,5 +33,6 @@ if (!alive _object) exitWith {
 
 if (([_object] call A3A_Logistics_fnc_getCargoNodeType) isEqualTo -1) exitWith {nil};
 
-[_object , _action] remoteExec ["A3A_Logistics_fnc_addAction", 0, _object];
+private _jipKey = "A3A_Logistics_" + _action + ((str _object splitString ":") joinString "");
+[_object, _action, _jipKey] remoteExec ["A3A_Logistics_fnc_addAction", 0, _jipKey];
 nil


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed the static weapon move asset and AI permissions actions not showing for JIP clients, caused by the logistics load action JIP blatting them. This was a regression added in #2511 shortly before the 3.0 release.

Also fixed an issue where the non-ACE action for loading an unconscious unit into a vehicle was being global-JIP spammed in a function that was already global JIP.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
