### PR TITLE
Add Arma version checking

### DIFF
--- a/A3A/addons/core/Includes/script_mod.hpp
+++ b/A3A/addons/core/Includes/script_mod.hpp
@@ -16,7 +16,7 @@
 // probably should move to script_version.hpp?
 #define MINIMUM_MISSION_VERSION_AR 2,6,1
 
-#define REQUIRED_VERSION 2.06
+#define REQUIRED_VERSION 2.12
 
 #ifdef COMPONENT_BEAUTIFIED
     #define COMPONENT_NAME QUOTE(PREFIX - COMPONENT_BEAUTIFIED)

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -11,6 +11,7 @@ Info_1("Client version: %1", QUOTE(VERSION_FULL));
 
 // *************************** Client pre-setup init *******************************
 
+if (!requiredVersion QUOTE(REQUIRED_VERSION)) exitWith { Error("Arma version is out of date") };
 if (call A3A_fnc_modBlacklist) exitWith {};
 
 //Disables rabbits and snakes, because they cause the log to be filled with "20:06:39 Ref to nonnetwork object Agent 0xf3b4a0c0"

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -12,6 +12,7 @@ Info_1("Server version: %1", QUOTE(VERSION_FULL));
 // ********************** Pre-setup init ****************************************************
 
 if (isClass (missionConfigFile/"CfgFunctions"/"A3A")) exitWith {};          // Pre-mod mission will break. Messaging handled in initPreJIP
+if (!requiredVersion QUOTE(REQUIRED_VERSION)) exitWith { Error("Arma version is out of date") };
 if (call A3A_fnc_modBlacklist) exitWith {};
 
 // hide all the HQ objects


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Add checking of Arma version, as requiredVersion is apparently ignored.

Can test by setting REQUIRED_VERSION to a value higher than 2.14 or higher. Effect is a pop-up on starting the mission. Not super-clear what it means, but better than having pirates complain about the AIs not moving and having to dig out their RPTs to find out they're running an ancient Arma version.

I don't think we're currently using anything from 2.14 so I set it at 2.12.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
