### PR TITLE
Minimum distance check for AAF Road Patrol

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_AAFroadPatrol.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AAFroadPatrol.sqf
@@ -23,10 +23,21 @@ private _bases = (seaports + airportsX + outposts) select {
 	};
 };
 if (_bases isEqualTo []) exitWith {};
-
 Debug_1("Possible patrol bases %1", _bases);
 
-_base = selectRandom _bases;
+//Filters out bases with players too close
+private _startBases = _bases;
+_base = selectRandom _startBases;
+private _limit = 3; //unsure how needed a hard limit on tries is, checking all of _startBases might or might not be acceptable. 
+private _tries = 0;
+while { _tries < _limit && !(_players inAreaArray [markerPos _base, 250, 250] isEqualTo [])} 
+do {
+    _tries = _tries + 1;
+    _startBases deleteAt (_startBases find _base);
+    if (_startBases isEqualTo []) exitWith {};
+    _base = selectRandom _startBases;
+};
+
 _sideX = sidesX getVariable [_base,sideUnknown];
 private _faction = Faction(_sideX);
 


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Filters out patrol starting locations that which have players within 250m

### Please specify which Issue this PR Resolves.
Should close #2589

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Run "[] spawn A3A_fnc_AAFroadPatrol" when close and further away from a valid location.
Changes:
the check for players distance at line 33 may need to be increased as 250 might be a little short.
********************************************************
Notes:
The hard limit on tries is something i admit i feel dubious about, it is _probably_ fine as is.
Because of the exitWith if _startBases is empty it cannot go into a infinite loop, _limit only exists as a performance save.