### PR TITLE
Move bool param conversion to initServer to fix autoload

### DIFF
--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -77,7 +77,11 @@ private _savedParamsHM = createHashMapFromArray (A3A_saveData get "params");
 {
     if (getArray (_x/"texts") isEqualTo [""]) then { continue };                // spacer/title
     private _val = _savedParamsHM getOrDefault [configName _x, getNumber (_x/"default")];
-    if (getArray (_x/"values") isEqualTo [0,1]) then { _val = !(_val in [false, 0]) };         // number -> bool
+    if (getArray (_x/"values") isEqualTo [0,1]) then {
+        if (_val isEqualType 0) then { _val = _val != 0 };                      // number -> bool
+    } else {
+        if (_val isEqualType false) then { _val = [0, 1] select _val };         // bool -> number
+    };
     missionNamespace setVariable [configName _x, _val, true];                   // just publish them all, doesn't really hurt
 } forEach ("true" configClasses (configFile/"A3A"/"Params"));
 

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -77,6 +77,7 @@ private _savedParamsHM = createHashMapFromArray (A3A_saveData get "params");
 {
     if (getArray (_x/"texts") isEqualTo [""]) then { continue };                // spacer/title
     private _val = _savedParamsHM getOrDefault [configName _x, getNumber (_x/"default")];
+    if (getArray (_x/"values") isEqualTo [0,1]) then { _val = !(_val in [false, 0]) };         // number -> bool
     missionNamespace setVariable [configName _x, _val, true];                   // just publish them all, doesn't really hurt
 } forEach ("true" configClasses (configFile/"A3A"/"Params"));
 

--- a/A3A/addons/gui/functions/SetupGUI/fn_setupParamsTab.sqf
+++ b/A3A/addons/gui/functions/SetupGUI/fn_setupParamsTab.sqf
@@ -94,7 +94,6 @@ switch (_mode) do
         private _params = (_paramsTable getVariable "allCtrls") apply {
             private _cfg = _x getVariable "config";
             private _val = _x lbValue lbCurSel _x;
-            if (getArray (_cfg/"values") isEqualTo [0,1]) then { _val = _val != 0 };          // number -> bool
             [configName _cfg, _val];
         };
         _params;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Moved the number param -> boolean variable conversion to initServer to fix cases where autoloading an old save or starting a game with a mismatched client could break.

### Please specify which Issue this PR Resolves.
partial fix for #3041

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
