### PR TITLE
Fix errors when there are no suitable buildings to garrison

### DIFF
--- a/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
@@ -9,7 +9,7 @@
         <Number> How far you want to look for potential positions
 
     Return Value:
-        <Group> Returns group if not enough buildings or positions are found.
+        <Group> Returns array of new groups created by the function (for leftover units).
 
     Scope: Any
     Environment: Any
@@ -33,6 +33,7 @@ private _minimumUnits = 2; // Minimum units per building.
 
 if (count _units == 0) exitwith {
     Debug_1("PATCOM | No units found in group (%1). Exiting", _group);
+    _newGroups;
 };
 
 _group lockWP true;
@@ -41,7 +42,7 @@ _buildings = [_position, _radius] call A3A_fnc_patrolEnterableBuildings;
 if (count _buildings == 0) exitWith {
     Debug_1("PATCOM | No Valid Garrison buildings found near group: %1 | Defaulting to Defend.", _group);
     [_group, "Patrol_Defend", 0, 100, -1, true, _position, false] call A3A_fnc_patrolLoop;
-    _group
+    _newGroups;
 };
 
 // Don't place units in destroyed buildings


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The early-out cases in patrolGroupGarrison had incorrect return values, which bugged out garrison spawning in cases where there were no buildings to garrison.

Test case: Tanoa outpost_5, just west of the middle airfield.

### Please specify which Issue this PR Resolves.
closes #3039

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
