### PR TITLE
Improve double-revive case

### DIFF
--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -5526,6 +5526,9 @@
         <Korean>%1을(를) 잃었다.</Korean>
         <Czech>Ztratili jsme %1.</Czech>
       </Key>
+      <Key ID="STR_A3A_fn_revive_actRev_other">
+        <Original>%1 has been revived by someone else.</Original>
+      </Key>
       <Key ID="STR_A3A_fn_revive_actRev_no_able">
         <Original>You are not able to revive anyone.</Original>
         <Italian>Non sei in grado di rianimare nessuno.</Italian>

--- a/A3A/addons/core/functions/Revive/fn_actionRevive.sqf
+++ b/A3A/addons/core/functions/Revive/fn_actionRevive.sqf
@@ -75,6 +75,7 @@ waitUntil {
     or (time > _timer)
     or (_medic getVariable ["cancelRevive", false])		// medic might get deleted
     or !(alive _cured)
+    or !(_cured getVariable ["incapacitated", false])   // other unit (or self) might revive the target
 };
 
 if (isNull _medic) exitWith { false };
@@ -113,6 +114,10 @@ if (!([_medic] call A3A_fnc_canFight)) exitWith
 {
     if (_player) then {[_titleStr, localize "STR_A3A_fn_revive_actRev_rev_cancel"] call A3A_fnc_customHint;};
     false;
+};
+if !(_cured getVariable ["incapacitated", false]) exitWith {
+    if (_player) then {[_titleStr, format [localize "STR_A3A_fn_revive_actRev_other",name _cured]] call A3A_fnc_customHint;};
+    true;
 };
 
 // Successful revive


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
If a unit was revived (either by another unit or self-revive) while a second unit is attempting to revive them, that unit will continue the revive animation, and will reset the target unit's health state on completion. 

This PR cancels the second revive attempt once a unit is no longer incapacitated. Throws a message for players.

Tested interrupting both players and AIs, works fine.

### Please specify which Issue this PR Resolves.
closes #3038

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
