### PR TITLE
Fix ACE fuel state not being correctly set on ungaraging

### DIFF
--- a/A3A/addons/garage/StatePreservation/fn_setFuel.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_setFuel.sqf
@@ -27,6 +27,6 @@ if !(local _vehicle) exitWith {};
 _fuelStats params [["_fuel",1, [0]], ["_fuelCargo",-1,[0]], "_aceFuel"];
 _vehicle setFuel _fuel;
 _vehicle setFuelCargo _fuelCargo;
-if (!isNil "_aceFuel") then {
-    _vehicle setVariable ["ace_refuel_currentFuelCargo", _aceFuel, true];
+if (!isNil "_aceFuel" and !isNil "ace_refuel_fnc_setFuel") then {
+    [_vehicle, _aceFuel] call ace_refuel_fnc_setFuel;
 };


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The ACE fuel cargo state wasn't being correctly set when ungaraging vehicles, because ACE uses the ace_refuel_capacity variable to indicate whether the fuel cargo vars have been initialized, and doesn't set it itself until a player interacts with the vehicle. Hence fuel vehicles were being topped up to capacity when players interacted with them.

Not absolutely sure that this is a good thing to merge, because I don't think there's currently any way to top up fuel cargo other than this bug. Community might not deal well with the fix.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
