### PR TITLE
Fix some real and theoretical revive issues

### DIFF
--- a/A3A/addons/core/functions/Revive/fn_handleDamage.sqf
+++ b/A3A/addons/core/functions/Revive/fn_handleDamage.sqf
@@ -51,8 +51,9 @@ private _makeUnconscious =
     _unit setVariable ["incapacitated",true,true];
     _unit setVariable ["helpFailed", 0];
     _unit setUnconscious true;
-    _unit setVariable ["incapFrame", diag_frameno+1];
-    if (isPlayer _unit) then {_unit allowDamage false};
+    _unit setVariable ["incapImmuneTime", time + 0.2];
+    _unit setVariable ["overallDamage", 0];
+    if (isPlayer _unit) then { _unit allowDamage false };
 
     if (vehicle _unit != _unit) then { moveOut _unit };
 
@@ -80,7 +81,7 @@ if (_part == "") then
         };
 
         // Don't double-tap with one projectile
-        if (diag_frameno <= _unit getVariable "incapFrame") exitWith {_damage = 0.9};
+        if (time < _unit getVariable "incapImmuneTime") exitWith {_damage = 0.9};
 
         // already unconscious, check whether we're pushed into death
         _overall = (_unit getVariable ["overallDamage",0]) + (_damage - 0.9);
@@ -90,7 +91,8 @@ if (_part == "") then
         if (_overall > 1) exitWith
         {
             _unit setDamage 1;
-            _unit removeAllEventHandlers "HandleDamage";
+            // Don't remove for players because it's transferred on respawn
+            if (!isPlayer _unit) then { _unit removeAllEventHandlers "HandleDamage" };
         };
 
         _unit setVariable ["overallDamage",_overall];

--- a/A3A/addons/core/functions/Revive/fn_handleDamageAAF.sqf
+++ b/A3A/addons/core/functions/Revive/fn_handleDamageAAF.sqf
@@ -42,7 +42,8 @@ private _makeUnconscious =
     _unit setVariable ["incapacitated",true,true];
     _unit setVariable ["helpFailed", 0];
     _unit setUnconscious true;
-    _unit setVariable ["incapFrame", diag_frameno+1];
+    _unit setVariable ["incapImmuneTime", time + 0.2];
+    _unit setVariable ["overallDamage", 0];
 
     // Assume killed handler will be local as well
     // TODO: Check killed/instigator stuff?
@@ -78,7 +79,7 @@ if (_part == "") then
         };
 
         // Don't double-tap with one projectile
-        if (diag_frameno <= _unit getVariable "incapFrame") exitWith {_damage = 0.9};
+        if (time < _unit getVariable "incapImmuneTime") exitWith {_damage = 0.9};
 
         // already unconscious, check whether we're pushed into death
         _overall = (_unit getVariable ["overallDamage",0]) + (_damage - 0.9);

--- a/A3A/addons/core/functions/Revive/fn_unconscious.sqf
+++ b/A3A/addons/core/functions/Revive/fn_unconscious.sqf
@@ -131,7 +131,6 @@ else
 		};
 	};
 
-_unit setVariable ["overallDamage",damage _unit];
 if (_isPlayer and (_unit getVariable ["respawn",false])) exitWith {};
 
 if (time > _bleedOut) exitWith

--- a/A3A/addons/core/functions/Revive/fn_unconsciousAAF.sqf
+++ b/A3A/addons/core/functions/Revive/fn_unconsciousAAF.sqf
@@ -58,7 +58,6 @@ if (alive _unit) then
 {
 	_unit setUnconscious false;
 	_unit playMoveNow "unconsciousoutprone";
-	_unit setVariable ["overallDamage",damage _unit];
 	_unit setVariable ["A3A_downedBy", nil];
 
 	if (_unit getVariable ["surrendering", false]) exitWith {


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
- Fixed a bug where players could have revive permanently disabled if they were killed by damage while downed.
- Changed downed damage lockout to 0.2 seconds rather than one frame. This is to handle a theoretical case where the server might split HandleDamage calls across multiple packets. Not if it happens, but it won't hurt anyway.
- Remove persistence of the downed damage accumulator. The "starting point" for downed damage used to vary by the revive method, but it incorrectly persisted over respawns, and didn't make a whole lot of sense anyway.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
