### PR TITLE
Add log/notify only option to punishment system

### DIFF
--- a/A3A/addons/core/Params.hpp
+++ b/A3A/addons/core/Params.hpp
@@ -165,9 +165,9 @@ class Params
     class tkPunish
     {
         title = $STR_A3A_Params_tkPunish_title;
-        values[] = {0,1};
-        texts[] = {$STR_antistasi_dialogs_generic_button_no_tooltip,$STR_antistasi_dialogs_generic_button_yes_text};
-        default = 1;
+        values[] = {0,1,2};
+        texts[] = {$STR_antistasi_dialogs_generic_button_no_tooltip,$STR_antistasi_dialogs_generic_button_yes_text,$STR_A3A_Params_tkPunish_logonly};
+        default = 2;
     };
     class memberSlots
     {

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -7065,6 +7065,9 @@
         <French>Activer la Punition pour le Teamkill</French>
         <Korean>팀킬 처벌 활성화</Korean>
       </Key>
+      <Key ID="STR_A3A_Params_tkPunish_logonly">
+        <Original>Notify only</Original>
+      </Key>
       <Key ID="STR_A3A_Params_unlockedUnlimitedAmmo_title">
         <Original>Do Unlocked Weapons Automatically Unlock Their Standard Magazine?</Original>
         <French>Débloquer Une Arme Débloque Automatiquement Ses Chargeurs Standards ?</French>

--- a/A3A/addons/core/functions/Punishment/fn_punishment_FF_AddEH.sqf
+++ b/A3A/addons/core/functions/Punishment/fn_punishment_FF_AddEH.sqf
@@ -33,7 +33,7 @@ params [ ["_unit",objNull,[objNull]], ["_addToAI",false,[false]] ];
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
 
-if (!tkPunish) exitWith {false};
+if (tkPunish == 0) exitWith {false};
 if (!(_unit isKindOf "Man")) exitWith {
     Error("No unit given");
     false;
@@ -84,8 +84,8 @@ true;
 All other public variables referenced:
 | Name              | Type          | Machine   | Domain            | Description                                                           |
 |-------------------|---------------|-----------|-------------------|-----------------------------------------------------------------------|
-| A3A_hasACE            | BOOLEAN       | Public    | missionNamespace  | If ACE is loaded.                                                     |
-| tkPunish          | BOOLEAN       | Public    | missionNamespace  | Parameter. If the FF system should be enabled.                        |
+| A3A_hasACE        | BOOLEAN       | Public    | missionNamespace  | If ACE is loaded.                                                     |
+| tkPunish          | SCALAR        | Public    | missionNamespace  | Parameter. 0 - disabled, 1 - enabled, 2 - log/notify only             |
 | petros            | OBJECT        | Public    | missionNamespace  | AI that rebels need to protect and access.                            |
 | posHQ             | POS3D<AGL>    | Public    | missionNamespace  | getMarkerPos respawnTeamPlayer. The position of the HQ marker.        |
 

--- a/A3A/addons/core/functions/Punishment/fn_punishment_checkStatus.sqf
+++ b/A3A/addons/core/functions/Punishment/fn_punishment_checkStatus.sqf
@@ -32,7 +32,7 @@ License: MIT License, Copyright (c) 2019 Barbolani & The Official Antistasi Comm
 params [["_UID","",[""]]];
 private _fileName = "fn_punishment_checkStatus";
 
-if ((!tkPunish) || {_UID isEqualTo ""}) exitWith {false;};
+if ((tkPunish != 1) || {_UID isEqualTo ""}) exitWith {false;};
 
 private _offenceTotal = [missionNamespace,"A3A_FFPun",_UID,"offenceTotal",0] call A3A_fnc_getNestedObject;
 

--- a/A3A/addons/core/functions/Punishment/fn_punishment_evaluateEvent.sqf
+++ b/A3A/addons/core/functions/Punishment/fn_punishment_evaluateEvent.sqf
@@ -103,7 +103,7 @@ if (_victim isKindOf "Man") then {
     };
 };
 _exemption = switch (true) do {  // ~0.012 ms for all false cases
-    case (!tkPunish):                                       {"FF PUNISH IS DISABLED"};
+    case (tkPunish == 0):                                   {"FF PUNISH IS DISABLED"};
     case (!isMultiplayer):                                  {"IS NOT MULTIPLAYER"};
     case ("HC" in (getPlayerUID _instigator)):              {"FF BY HC"};  // Quick & reliable check
     case (!(isPlayer _instigator)):                         {"FF BY AI"};
@@ -151,6 +151,8 @@ if (!(_exemption isEqualTo "")) exitWith {
     Info_2("%1 | %2", _exemption, _playerStats);
     _exemption;
 };
+
+if (tkPunish == 2) exitWith {"NOTIFYONLY"};
 
 ///////////////Drop The Hammer//////////////
 [_instigator,_timeAdded,_offenceAdded,_victim,_customMessage] call A3A_fnc_punishment;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Added a log & notify only option to the punishment system. Implemented before the actual punishment function because life is too short to read that again.

Needs #3042 to autoload older saves correctly due to bool -> number conversion.

Probably works but not fully tested due to lack of RAM.

### Please specify which Issue this PR Resolves.
closes #3060

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

