### PR TITLE
Assassinate mission misc fixes

### DIFF
--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -3527,7 +3527,7 @@
     </Container>
     <Container name="A3A_fn_mission">
       <Key ID="STR_A3A_fn_mission_as_off_text">
-        <Original>A %4 officer is inspecting %1. Go there and kill him before %2:%3.</Original>
+        <Original>A %3 officer is inspecting %1. Go there and kill him before %2:%3.</Original>
         <Italian>Un ufficiale %4 sta ispezionando %1. Recati lì ed uccidilo entro %2:%3</Italian>
         <French>Un officier de %4 est en train d'inspecter %1. Allez-y et tuez le avant %2:%3.</French>
         <Czech>Důstojník %4 kontroluje %1. Jděte tam a zabijte ho před %2:%3.</Czech>
@@ -3541,7 +3541,7 @@
         <Czech>Zabít důstojníka.</Czech>
       </Key>
       <Key ID="STR_A3A_fn_mission_as_specop_text">
-        <Original>We have spotted a %3 SpecOp team patrolling around a %1. Ambush them and we will have one less problem. Do this before %2. Be careful, they are tough boys.</Original>
+        <Original>We have spotted a %3 Special Forces team patrolling around a %1. Ambush them and we will have one less problem. Do this before %2. Be careful, they are tough boys.</Original>
         <Italian>Abbiamo avvistato una squadra di FS %3 in pattugliamento intorno a %1. Tendi un'imboscata e avremo un problema in meno. Fallo entro %2. Sii cauto, sono uomini duri.</Italian>
         <French>Nous avons repéré une équipe des Forces Spéciales de %3 en train de patrouiller autours d'un %1. Prenez les en embuscade et ça nous fera un problème de moins. Faites-le avant %2. Soyez prudents, c'est des durs.</French>
         <Korean>%1 인근을 순찰하는 %3 소속 특수작전조를 발견했습니다. 그들을 기습하면 골치아픈 문제가 하나 줄어들 것입니다. %2 이전까지 이 작업을 수행하십시오. 조심하세요. 그들은 고도로 훈련된 녀석들입니다.</Korean>
@@ -3549,7 +3549,7 @@
         <Czech>Zpozorovali jsme tým speciálních jednotek %3, který hlídá okolí %1. Přepadněte je a budeme mít o jeden problém méně. Udělejte to před %2. Buďte opatrní, jsou to tvrdí borci.</Czech>
       </Key>
       <Key ID="STR_A3A_fn_mission_as_specop_titel">
-        <Original>SpecOps</Original>
+        <Original>Special Forces</Original>
         <German>Spezialkräfte</German>
         <Italian>FS</Italian>
         <French>Forces Spéciales</French>
@@ -3566,7 +3566,7 @@
         <Czech>Někdo našel informace o rodině zrádce. Další problémy už působit nebude.</Czech>
       </Key>
       <Key ID="STR_A3A_fn_mission_as_traitor_text">
-        <Original>A traitor has scheduled a meeting with %4 in %1. Kill him before he provides enough intel to give us trouble. Do this before %2. We don't where exactly this meeting will happen. You will recognise the building by the nearby Offroad and %3 presence.</Original>
+        <Original>A traitor has scheduled a meeting with %3 forces in %1. Kill him before he provides enough intel to give us trouble. Do this before %2. We don't know where exactly this meeting will happen. You will recognize the building by the nearby camo-painted Offroad and %3 presence.</Original>
         <Italian>Un traditore si incontrerà con %4 a %1. Uccidilo prima che possa fornirgli intelligence e crearci problemi. Fallo entro %2. Non sappiamo dove avverrà l'incontro. Riconoscerai l'edificio dal Fuoristrada parcheggiato e dalla presenza di %3.</Italian>
         <French>Un traitre va rencontrer %4 dans %1. Tuez-le avant qu'il ne divulge assez de renseignements pour nous causer des problèmes. Faites-le avant %2. Nous ne savons pas exactement où cette rencontre aura lieu. Vous reconnaitrez le batiment grâce au Tout-Terrain proche et la présence de %3.</French>
         <Korean>한 배신자가 %1에서 %4와(과) 만남을 가지기로 일정을 잡았습니다. 그가 우리에게 문제를 일으킬 수 있는 정보를 제공하기 전에 그를 사살하십시오. %2 전에 수행하십시오. 이 만남이 어디서 일어나는지는 정확히 알 수 없습니다. 근처에 있는 오프로드와 %3의 존재로 알 수 있습니다.</Korean>

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -3566,7 +3566,7 @@
         <Czech>Někdo našel informace o rodině zrádce. Další problémy už působit nebude.</Czech>
       </Key>
       <Key ID="STR_A3A_fn_mission_as_traitor_text">
-        <Original>A traitor has scheduled a meeting with %3 forces in %1. Kill him before he provides enough intel to give us trouble. Do this before %2. We don't know where exactly this meeting will happen. You will recognize the building by the nearby Offroad and %3 presence.</Original>
+        <Original>A traitor has scheduled a meeting with %3 forces in %1. Kill him before he provides enough intel to give us trouble. Do this before %2. We don't know where exactly this meeting will happen. You will recognize the building by the nearby parked vehicle and %3 presence.</Original>
         <Italian>Un traditore si incontrerà con %4 a %1. Uccidilo prima che possa fornirgli intelligence e crearci problemi. Fallo entro %2. Non sappiamo dove avverrà l'incontro. Riconoscerai l'edificio dal Fuoristrada parcheggiato e dalla presenza di %3.</Italian>
         <French>Un traitre va rencontrer %4 dans %1. Tuez-le avant qu'il ne divulge assez de renseignements pour nous causer des problèmes. Faites-le avant %2. Nous ne savons pas exactement où cette rencontre aura lieu. Vous reconnaitrez le batiment grâce au Tout-Terrain proche et la présence de %3.</French>
         <Korean>한 배신자가 %1에서 %4와(과) 만남을 가지기로 일정을 잡았습니다. 그가 우리에게 문제를 일으킬 수 있는 정보를 제공하기 전에 그를 사살하십시오. %2 전에 수행하십시오. 이 만남이 어디서 일어나는지는 정확히 알 수 없습니다. 근처에 있는 오프로드와 %3의 존재로 알 수 있습니다.</Korean>

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -3566,7 +3566,7 @@
         <Czech>Někdo našel informace o rodině zrádce. Další problémy už působit nebude.</Czech>
       </Key>
       <Key ID="STR_A3A_fn_mission_as_traitor_text">
-        <Original>A traitor has scheduled a meeting with %3 forces in %1. Kill him before he provides enough intel to give us trouble. Do this before %2. We don't know where exactly this meeting will happen. You will recognize the building by the nearby camo-painted Offroad and %3 presence.</Original>
+        <Original>A traitor has scheduled a meeting with %3 forces in %1. Kill him before he provides enough intel to give us trouble. Do this before %2. We don't know where exactly this meeting will happen. You will recognize the building by the nearby Offroad and %3 presence.</Original>
         <Italian>Un traditore si incontrerà con %4 a %1. Uccidilo prima che possa fornirgli intelligence e crearci problemi. Fallo entro %2. Non sappiamo dove avverrà l'incontro. Riconoscerai l'edificio dal Fuoristrada parcheggiato e dalla presenza di %3.</Italian>
         <French>Un traitre va rencontrer %4 dans %1. Tuez-le avant qu'il ne divulge assez de renseignements pour nous causer des problèmes. Faites-le avant %2. Nous ne savons pas exactement où cette rencontre aura lieu. Vous reconnaitrez le batiment grâce au Tout-Terrain proche et la présence de %3.</French>
         <Korean>한 배신자가 %1에서 %4와(과) 만남을 가지기로 일정을 잡았습니다. 그가 우리에게 문제를 일으킬 수 있는 정보를 제공하기 전에 그를 사살하십시오. %2 전에 수행하십시오. 이 만남이 어디서 일어나는지는 정확히 알 수 없습니다. 근처에 있는 오프로드와 %3의 존재로 알 수 있습니다.</Korean>

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -3527,7 +3527,7 @@
     </Container>
     <Container name="A3A_fn_mission">
       <Key ID="STR_A3A_fn_mission_as_off_text">
-        <Original>A %3 officer is inspecting %1. Go there and kill him before %2:%3.</Original>
+        <Original>A %3 officer is inspecting %1. Go there and kill him before %2.</Original>
         <Italian>Un ufficiale %4 sta ispezionando %1. Recati lì ed uccidilo entro %2:%3</Italian>
         <French>Un officier de %4 est en train d'inspecter %1. Allez-y et tuez le avant %2:%3.</French>
         <Czech>Důstojník %4 kontroluje %1. Jděte tam a zabijte ho před %2:%3.</Czech>

--- a/A3A/addons/core/functions/Missions/fn_AS_Official.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_Official.sqf
@@ -6,10 +6,6 @@ if (!isServer and hasInterface) exitWith{};
 _markerX = _this select 0;
 
 _difficultX = if (random 10 < tierWar) then {true} else {false};
-_leave = false;
-_contactX = objNull;
-_groupContact = grpNull;
-_tsk = "";
 
 _sideX = if (sidesX getVariable [_markerX,sideUnknown] == Occupants) then {Occupants} else {Invaders};
 private _faction = Faction(_sideX);
@@ -19,10 +15,12 @@ _timeLimit = if (_difficultX) then {30} else {60};//120
 if (A3A_hasIFA) then {_timeLimit = _timeLimit * 2};
 _dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + _timeLimit];
 _dateLimitNum = dateToNumber _dateLimit;
+_dateLimit = numberToDate [date select 0, _dateLimitNum];//converts datenumber back to date array so that time formats correctly
+_displayTime = [_dateLimit] call A3A_fnc_dateToTimeString;//Converts the time portion of the date array to a string for clarity in hints
 
 _nameDest = [_markerX] call A3A_fnc_localizar;
-_naming = if (_sideX == Occupants) then {"NATO"} else {"CSAT"};
-private _taskString = format [localize "STR_A3A_fn_mission_as_off_text",_nameDest,numberToDate [2035,_dateLimitNum] select 3,numberToDate [2035,_dateLimitNum] select 4,_naming];
+_naming = if (_sideX == Occupants) then {FactionGet(occ,"name")} else {FactionGet(inv,"name")};
+private _taskString = format [localize "STR_A3A_fn_mission_as_off_text",_nameDest,_displayTime,_naming];
 
 private _taskId = "AS" + str A3A_taskCount;
 [[teamPlayer,civilian],_taskId,[_taskString,localize "STR_A3A_fn_mission_as_off_titel",_markerX],_positionX,false,0,true,"Kill",true] call BIS_fnc_taskCreate;

--- a/A3A/addons/core/functions/Missions/fn_AS_Traitor.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_Traitor.sqf
@@ -132,7 +132,7 @@ waitUntil  {sleep 1; (traitorIntel) || {(dateToNumber date > _dateLimitNum) or {
 
 if (not alive _traitor || traitorIntel) then
 {
-	[_taskId, "AS", "SUCCEEDED", true] call A3A_fnc_taskSetState;
+	[_taskId, "AS", "SUCCEEDED", false] call A3A_fnc_taskSetState;
 	if(traitorIntel && (alive _traitor)) then
 	{
 		{[petros,"hint",localize "STR_A3A_fn_mission_as_traitor_hint"] remoteExec ["A3A_fnc_commsMP",_x]} forEach ([500,0,_traitor,teamPlayer] call A3A_fnc_distanceUnits);
@@ -171,7 +171,7 @@ if (not alive _traitor || traitorIntel) then
 }
 else
 {
-	[_taskId, "AS", "FAILED", true] call A3A_fnc_taskSetState;
+	[_taskId, "AS", "FAILED", false] call A3A_fnc_taskSetState;
 	if (_difficultX) then {[-10,theBoss] call A3A_fnc_playerScoreAdd} else {[-10,theBoss] call A3A_fnc_playerScoreAdd};
 	if (dateToNumber date > _dateLimitNum) then
 	{

--- a/A3A/addons/core/functions/Missions/fn_AS_Traitor.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_Traitor.sqf
@@ -5,11 +5,6 @@ FIX_LINE_NUMBERS()
 _markerX = _this select 0;
 
 _difficultX = if (random 10 < tierWar) then {true} else {false};
-_leave = false;
-_contactX = objNull;
-_groupContact = grpNull;
-_tsk = "";
-_tsk1 = "";
 
 _positionX = getMarkerPos _markerX;
 
@@ -57,8 +52,7 @@ _groupTraitor selectLeader _traitor;
 _posTsk = (position _houseX) getPos [random 100, random 360];
 
 private _taskId = "AS" + str A3A_taskCount;
-[[teamPlayer,civilian],_taskID,[format [localize "STR_A3A_fn_mission_as_traitor_text",_nameDest,_displayTime,FactionGet(occ,"name")],localize "STR_A3A_fn_mission_as_traitor_titel",_markerX],_posTsk,false,0,true,"Kill",true] call BIS_fnc_taskCreate;//old pvp blufor mission - won't localize
-[[Occupants],_taskID+"B",[format ["We arranged a meeting in %1 with a %3 contact who may have vital information about their Headquarters position. Protect him until %2.",_nameDest,_displayTime,FactionGet(reb,"name")],"Protect Contact",_markerX],getPos _houseX,false,0,true,"Defend",true] call BIS_fnc_taskCreate;//old pvp blufor mission - won't localize
+[[teamPlayer,civilian],_taskID,[format [localize "STR_A3A_fn_mission_as_traitor_text",_nameDest,_displayTime,FactionGet(occ,"name")],localize "STR_A3A_fn_mission_as_traitor_titel",_markerX],_posTsk,false,0,true,"Kill",true] call BIS_fnc_taskCreate;
 [_taskId, "AS", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
 traitorIntel = false; publicVariable "traitorIntel";

--- a/A3A/addons/core/functions/Missions/fn_AS_specOP.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_specOP.sqf
@@ -3,11 +3,8 @@ if (!isServer and hasInterface) exitWith{};
 
 _markerX = _this select 0;
 
-_leave = false;
-_contactX = objNull;
-_groupContact = grpNull;
-_tsk = "";
 _positionX = getMarkerPos _markerX;
+
 _sideX = if (sidesX getVariable [_markerX,sideUnknown] == Occupants) then {Occupants} else {Invaders};
 _difficultX = if (random 10 < tierWar) then {true} else {false};
 _timeLimit = if (_difficultX) then {60} else {120};
@@ -18,8 +15,8 @@ _dateLimit = numberToDate [date select 0, _dateLimitNum];//converts datenumber b
 _displayTime = [_dateLimit] call A3A_fnc_dateToTimeString;//Converts the time portion of the date array to a string for clarity in hints
 
 _nameDest = [_markerX] call A3A_fnc_localizar;
-_naming = if (_sideX == Occupants) then {"NATO"} else {"CSAT"};
-private _taskString = format [localize "STR_A3A_fn_mission_as_specop_text",_nameDest,_displayTime];
+_naming = if (_sideX == Invaders) then {FactionGet(inv,"name")} else {FactionGet(occ,"name")};
+private _taskString = format [localize "STR_A3A_fn_mission_as_specop_text",_nameDest,_displayTime,_naming];
 private _taskId = "AS" + str A3A_taskCount;
 
 [[teamPlayer,civilian],_taskId,[_taskString,localize "STR_A3A_fn_mission_as_specop_titel",_markerX],_positionX,false,0,true,"Kill",true] call BIS_fnc_taskCreate;

--- a/A3A/addons/core/functions/Missions/fn_AS_specOP.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_specOP.sqf
@@ -1,4 +1,7 @@
+#include "..\..\script_component.hpp"
 //Mission: Assassinate a SpecOp team
+FIX_LINE_NUMBERS()
+
 if (!isServer and hasInterface) exitWith{};
 
 _markerX = _this select 0;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Stringtable: Changed SpecOps to Special Forces. Personal preference, I've heard this and "SF" a lot more than SpecOps, and it's a bit less confusing
Officer mission should render time and faction correctly, and removed a few useless lines
Traitor mission, removed a few useless lines and the old pvp mission
SpecOps: The faction should be displayed correctly, SEE BELOW    

### Please specify which Issue this PR Resolves.
closes https://discord.com/channels/449481990513754112/647694189236322305/1139340437132419212 

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Officer: Move to the middle of the peninsula south of the southwest airbase, and call an assassinate mission, or move HQ to the middle of the ocean.

********************************************************
Notes:
