### PR TITLE
Corrected magazine for RHS 2S1 Artillery 

### DIFF
--- a/A3A/addons/core/Templates/Templates/RHS/RHS_AI_AFRF_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/RHS/RHS_AI_AFRF_Arid.sqf
@@ -47,7 +47,7 @@
 
 ["vehiclesArtillery", ["rhs_2s1_tv", "rhs_2s3_tv", "RHS_BM21_VV_01"]] call _fnc_saveToTemplate;
 ["magazines", createHashMapFromArray [
-["rhs_2s1_tv", ["rhs_mag_3of56_10"]],
+["rhs_2s1_tv", ["rhs_mag_3of56_35"]],
 ["rhs_2s3_tv",["rhs_mag_HE_2a33", "rhs_mag_WP_2a33"]],
 ["RHS_BM21_VV_01", ["rhs_mag_m21of_1"]]
 ]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/RHS/RHS_AI_AFRF_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/RHS/RHS_AI_AFRF_Temperate.sqf
@@ -47,7 +47,7 @@
 
 ["vehiclesArtillery", ["rhs_2s1_tv", "rhs_2s3_tv", "RHS_BM21_VV_01"]] call _fnc_saveToTemplate;
 ["magazines", createHashMapFromArray [
-["rhs_2s1_tv", ["rhs_mag_3of56_10"]],
+["rhs_2s1_tv", ["rhs_mag_3of56_35"]],
 ["rhs_2s3_tv",["rhs_mag_HE_2a33", "rhs_mag_WP_2a33"]],
 ["RHS_BM21_VV_01", ["rhs_mag_m21of_1"]]
 ]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/RHS/RHS_AI_CDF.sqf
+++ b/A3A/addons/core/Templates/Templates/RHS/RHS_AI_CDF.sqf
@@ -47,7 +47,7 @@
 
 ["vehiclesArtillery", ["rhsgref_cdf_b_2s1", "rhsgref_cdf_b_reg_d30", "rhsgref_cdf_b_reg_BM21"]] call _fnc_saveToTemplate;
 ["magazines", createHashMapFromArray [
-["rhsgref_cdf_b_2s1",["rhs_mag_3of56_10"]],
+["rhsgref_cdf_b_2s1",["rhs_mag_3of56_35"]],
 ["rhsgref_cdf_b_reg_d30",["rhs_mag_3of56_10"]],
 ["rhsgref_cdf_b_reg_BM21", ["rhs_mag_m21of_1"]]
 ]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/RHS/RHS_AI_ChDKZ.sqf
+++ b/A3A/addons/core/Templates/Templates/RHS/RHS_AI_ChDKZ.sqf
@@ -65,7 +65,7 @@
 
 ["vehiclesArtillery", ["rhsgref_ins_2s1","rhsgref_ins_d30","rhsgref_ins_BM21"]] call _fnc_saveToTemplate;
 ["magazines", createHashMapFromArray [
-["rhsgref_ins_2s1",["rhs_mag_3of56_10"]],
+["rhsgref_ins_2s1",["rhs_mag_3of56_35"]],
 ["rhsgref_ins_d30",["rhs_mag_3of56_10"]],
 ["rhsgref_ins_BM21", ["rhs_mag_m21of_1"]]
 ]] call _fnc_saveToTemplate; //element format: [Vehicle class, [Magazines]]

--- a/A3A/addons/core/Templates/Templates/RHS/RHS_AI_SAF.sqf
+++ b/A3A/addons/core/Templates/Templates/RHS/RHS_AI_SAF.sqf
@@ -47,7 +47,7 @@
 
 ["vehiclesArtillery", ["rhs_2s1_tv", "rhs_2s3_tv", "RHS_BM21_VV_01"]] call _fnc_saveToTemplate;
 ["magazines", createHashMapFromArray [
-["rhs_2s1_tv", ["rhs_mag_3of56_10"]],
+["rhs_2s1_tv", ["rhs_mag_3of56_35"]],
 ["rhs_2s3_tv",["rhs_mag_HE_2a33", "rhs_mag_WP_2a33"]],
 ["RHS_BM21_VV_01", ["rhs_mag_m21of_1"]]
 ]] call _fnc_saveToTemplate;


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
the magazine hash for the 2s1 was set to the same magazine as the D-30 rhs_mag_3of56_10 instead of rhs_mag_3of56_35, preventing the gun for functioning.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Changes aren't necessarily need in this PR but the RHS 2S1 could potentially be not the only one with this issue.
I have not checked 3CB, CUP, and i cannot check CDLC artillery. 
3CB can potentially have inherited this issue, probably what happened with the RHS templates. 
PR itself has been loaded and the gun now functions.

********************************************************
Notes:
before / after 
![image](https://github.com/official-antistasi-community/A3-Antistasi/assets/49555217/03824567-73f5-499e-9c98-b052558c4d0f)
![image](https://github.com/official-antistasi-community/A3-Antistasi/assets/49555217/6b6a1329-c0d5-475e-b1f9-cbf8aa2095de)
