### PR TITLE
Artillery round-power compensation

### DIFF
--- a/A3A/addons/core/functions/Supports/fn_SUP_mortarRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_mortarRoutine.sqf
@@ -31,6 +31,55 @@ if((30 + random 40) >_sideAggression) then
     _numberOfRounds = 12;
     _timeAlive = 1800;
 };
+
+if(_suppType == "ARTILLERY") then
+{
+    //Values derrived from vanilla 155mm artillery
+    private _expectedArea = 30 * 30 * 3.14;
+    private _expectedIndirect = 125;
+    private _expectedHit = 340;
+    private _expectedValue = _expectedHit + _expectedIndirect + _expectedArea;
+    
+    private _ammo = getText(configfile >> "CfgMagazines" >> _mortar getVariable ["shellType", []] >> "ammo");
+    private _subMunitionMult = 1;
+    if (getText (configfile >> "CfgAmmo" >> _ammo >> "submunitionAmmo") != "") then 
+    {
+        private _submunitionAmmo = (configfile >> "CfgAmmo" >> _ammo >> "submunitionAmmo");
+        if (getArray (configfile >> "CfgAmmo" >> _ammo >> "submunitionConeType") select 0 == "custom") then 
+        {
+            _subMunitionMult = count ((getArray (configfile >> "CfgAmmo" >> _ammo >> "submunitionConeType")) select 1); //If custom, the number of pairs should be the number of munitions
+        } else 
+        {
+            _subMunitionMult = (getArray (configfile >> "CfgAmmo" >> _ammo >> "submunitionConeType")) select 1;
+        };
+        systemChat format["number of submunition: %1", _subMunitionMult];
+        if (isArray (_submunitionAmmo)) then 
+        {
+            _ammo = getText ((_submunitionAmmo) select 0); //Take the first ammo used, not ideal but don't have many assumptions to go on here
+        } else 
+        {
+            _ammo = getText (_submunitionAmmo); //The ammo only transforms midflight, not cluster
+        };
+    };
+    
+    private _radius = getNumber (configfile >> "CfgAmmo" >> _ammo >> "indirectHitRange");
+    private _area = _radius * _radius * 3.14;
+    private _indirect = getNumber  (configfile >> "CfgAmmo" >> _ammo >> "indirectHit");
+    private _hit = getNumber (configfile >> "CfgAmmo" >> _ammo >> "hit");
+    private _value = (_hit + _indirect + _area) * _subMunitionMult;
+    
+    systemChat format["%4 : _radius is %5, _area is %1, _hit is %2, _indirect is %3", _area, _hit, _indirect, _ammo, _radius];
+    systemChat format["Evaluatd value is: %1, shot multiplier: %2", _value, _expectedValue / _value];
+    
+} else
+{
+    //Values derrived from vanilla 81mm mortar
+    private _expectedArea = 30 * 30 * 3.14;
+    private _expectedIndirect = 125;
+    private _expectedHit = 340;
+    private _expectedValue = _expectedHit + _expectedIndirect + _expectedArea;
+};
+
 private _shotsPerVolley = _numberOfRounds / 3;
 
 //A function to repeatedly fire onto a target without loops by using an EH

--- a/A3A/addons/core/functions/Supports/fn_SUP_mortarRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_mortarRoutine.sqf
@@ -33,6 +33,7 @@ if((30 + random 40) >_sideAggression) then
 };
 
 private _ammo = getText(configfile >> "CfgMagazines" >> _mortar getVariable ["shellType", []] >> "ammo");
+private _sim = getText(configfile >> "CfgMagazines" >> _mortar getVariable ["shellType", []] >> "simulation");
 private _subMunitionMult = 1;
 if (getText (configfile >> "CfgAmmo" >> _ammo >> "submunitionAmmo") != "" || isArray(configfile >> "CfgAmmo" >> _ammo >> "submunitionAmmo")) then 
 {
@@ -51,6 +52,10 @@ if (getText (configfile >> "CfgAmmo" >> _ammo >> "submunitionAmmo") != "" || isA
     } else 
     {
         _ammo = getText (_submunitionAmmo); //The ammo only transforms midflight, not cluster, ie 230mm HE rocket
+    };
+    if (_sim == "shotSubmunitions" && _subMunitionMult == 1) then 
+    {
+        _subMunitionMult = _subMunitionMult * 0.6; //Compensation for some fudging Arma does to make MLRS weapons have their desired effect on target
     };
 };
 

--- a/A3A/addons/core/functions/Supports/fn_SUP_mortarRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_mortarRoutine.sqf
@@ -35,10 +35,11 @@ if((30 + random 40) >_sideAggression) then
 if(_suppType == "ARTILLERY") then
 {
     //Values derrived from vanilla 155mm artillery
+    private _expectedRadius = 30;
     private _expectedArea = 30 * 30 * 3.14;
     private _expectedIndirect = 125;
     private _expectedHit = 340;
-    private _expectedValue = _expectedHit + _expectedIndirect + _expectedArea;
+    private _expectedValue = _expectedHit + _expectedIndirect + _expectedRadius;
     
     private _ammo = getText(configfile >> "CfgMagazines" >> _mortar getVariable ["shellType", []] >> "ammo");
     private _subMunitionMult = 1;
@@ -66,7 +67,7 @@ if(_suppType == "ARTILLERY") then
     private _area = _radius * _radius * 3.14;
     private _indirect = getNumber  (configfile >> "CfgAmmo" >> _ammo >> "indirectHit");
     private _hit = getNumber (configfile >> "CfgAmmo" >> _ammo >> "hit");
-    private _value = ((_hit + _indirect + _area) * _subMunitionMult);
+    private _value = ((_hit + _indirect + _radius) * _subMunitionMult);
     
     systemChat format["%4 : _radius is %5, _area is %1, _hit is %2, _indirect is %3", _area, _hit, _indirect, _ammo, _radius];
     systemChat format["Evaluatd value is: %1, shot multiplier: %2", _value, _expectedValue / _value];
@@ -74,10 +75,11 @@ if(_suppType == "ARTILLERY") then
 } else
 {
     //Values derrived from vanilla 81mm mortar
+    private _expectedRadius = 30;
     private _expectedArea = 30 * 30 * 3.14;
     private _expectedIndirect = 125;
     private _expectedHit = 340;
-    private _expectedValue = _expectedHit + _expectedIndirect + _expectedArea;
+    private _expectedValue = _expectedHit + _expectedIndirect + _expectedRadius;
 };
 
 private _shotsPerVolley = _numberOfRounds / 3;

--- a/A3A/addons/core/functions/Supports/fn_SUP_mortarRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_mortarRoutine.sqf
@@ -42,7 +42,7 @@ if(_suppType == "ARTILLERY") then
     
     private _ammo = getText(configfile >> "CfgMagazines" >> _mortar getVariable ["shellType", []] >> "ammo");
     private _subMunitionMult = 1;
-    if (getText (configfile >> "CfgAmmo" >> _ammo >> "submunitionAmmo") != "") then 
+    if (getText (configfile >> "CfgAmmo" >> _ammo >> "submunitionAmmo") != "" || isArray(configfile >> "CfgAmmo" >> _ammo >> "submunitionAmmo")) then 
     {
         private _submunitionAmmo = (configfile >> "CfgAmmo" >> _ammo >> "submunitionAmmo");
         if (getArray (configfile >> "CfgAmmo" >> _ammo >> "submunitionConeType") select 0 == "custom") then 
@@ -55,10 +55,10 @@ if(_suppType == "ARTILLERY") then
         systemChat format["number of submunition: %1", _subMunitionMult];
         if (isArray (_submunitionAmmo)) then 
         {
-            _ammo = getText ((_submunitionAmmo) select 0); //Take the first ammo used, not ideal but don't have many assumptions to go on here
+            _ammo = (getArray(_submunitionAmmo) select 0); //Take the first ammo used, not ideal but don't have many assumptions to go on here, the cluster might be mixed or it's just the UXO entry
         } else 
         {
-            _ammo = getText (_submunitionAmmo); //The ammo only transforms midflight, not cluster
+            _ammo = getText (_submunitionAmmo); //The ammo only transforms midflight, not cluster, ie 230mm HE rocket
         };
     };
     

--- a/A3A/addons/core/functions/Supports/fn_SUP_mortarRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_mortarRoutine.sqf
@@ -66,7 +66,7 @@ if(_suppType == "ARTILLERY") then
     private _area = _radius * _radius * 3.14;
     private _indirect = getNumber  (configfile >> "CfgAmmo" >> _ammo >> "indirectHit");
     private _hit = getNumber (configfile >> "CfgAmmo" >> _ammo >> "hit");
-    private _value = (_hit + _indirect + _area) * _subMunitionMult;
+    private _value = ((_hit + _indirect + _area) * _subMunitionMult);
     
     systemChat format["%4 : _radius is %5, _area is %1, _hit is %2, _indirect is %3", _area, _hit, _indirect, _ammo, _radius];
     systemChat format["Evaluatd value is: %1, shot multiplier: %2", _value, _expectedValue / _value];

--- a/A3A/addons/core/functions/Supports/fn_SUP_mortarRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_mortarRoutine.sqf
@@ -55,19 +55,19 @@ if (getText (configfile >> "CfgAmmo" >> _ammo >> "submunitionAmmo") != "" || isA
     };
     if (_sim == "shotSubmunitions" && _subMunitionMult == 1) then 
     {
-        _subMunitionMult = _subMunitionMult * 0.6; //Compensation for some fudging Arma does to make MLRS weapons have their desired effect on target
+        _subMunitionMult = _subMunitionMult * 0.75; //Compensation for some fudging Arma does to make MLRS weapons have their desired effect on target
     };
 };
 
 private _radius = getNumber (configfile >> "CfgAmmo" >> _ammo >> "indirectHitRange");
-private _area = _radius * _radius * 3.14;
+private _area = _radius * _radius * 0.314;
 private _indirect = getNumber  (configfile >> "CfgAmmo" >> _ammo >> "indirectHit");
 private _hit = getNumber (configfile >> "CfgAmmo" >> _ammo >> "hit");
 private _value = ((_hit + _indirect + _area) * _subMunitionMult);
 
 //Values derrived from vanilla 81mm mortar "Sh_82mm_AMOS"
 private _expectedRadius = 18;
-private _expectedArea = 18 * 18 * 3.14;
+private _expectedArea = 18 * 18 * 0.314;
 private _expectedIndirect = 52;
 private _expectedHit = 165;
 private _expectedValue = _expectedHit + _expectedIndirect + _expectedArea;
@@ -76,7 +76,7 @@ if(_suppType == "ARTILLERY") then
 {
     //Values derrived from vanilla 155mm artillery "Sh_155mm_AMOS"
     _expectedRadius = 30;
-    _expectedArea = 30 * 30 * 3.14;
+    _expectedArea = 30 * 30 * 0.314;
     _expectedIndirect = 125;
     _expectedHit = 340;
     _expectedValue = _expectedHit + _expectedIndirect + _expectedArea;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Adds automatic adjustment of the number of shells artillery/mortars will use per volley/in total.
The goal being to even out the amount of destruction per artillery piece to be roughly equivalent, allowing for the inclusion of both weaker and stronger artillery pieces than the baseline without being too under/over powered.

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
the evaluation equation needs to be tuned, example data can be seen here https://docs.google.com/spreadsheets/d/14P1HDYs_WirOe7HBpreDg4GNrKvMKqWdCunDo4fMbtQ/edit?usp=sharing
Some coefficients and constants may need to be adjusted or added to bring it more in line with what we want.

********************************************************
Notes:
