### PR TITLE
Move FF damage notifications into evaluateEvent (master)

### DIFF
--- a/A3A/addons/core/functions/Punishment/fn_punishment.sqf
+++ b/A3A/addons/core/functions/Punishment/fn_punishment.sqf
@@ -85,22 +85,15 @@ _varspace setVariable ["overhead",_overhead];
 _varspace setVariable ["name",_name];
 _varspace setVariable ["player",_originalBody];
 
-///////////////Victim Notifier//////////////
-private _injuredComrade = "";
+///////////////Log incident/////////////////
 private _victimStats = "damaged systemPunished [AI]";
 if (_victim isKindOf "Man") then {
-	_injuredComrade = ["Injured comrade: ",name _victim] joinString ""; //TODO: Localize
-	[localize "STR_A3A_fn_punish_ff_noti", [_name," ",localize "STR_A3A_fn_punish_pun_hurt"] joinString ""] remoteExecCall ["A3A_fnc_customHint", _victim, false];
 	private _UIDVictim = ["AI", getPlayerUID _victim] select (isPlayer _victim);
 	_victimStats = ["damaged ",name _victim," [",_UIDVictim,"]"] joinString "";
 };
-
-/////////////Instigator Notifier////////////
 private _playerStats = ["Total-time: ",str _timeTotal," (incl. +",str _timeAdded,"), Offence+Overhead: ",str _offenceTotal," [",str (_offenceTotal-_overhead),"+",str _overhead,"] (incl. +",str _offenceAdded,")"] joinString "";
 private _instigatorLog = [["WARNING","GUILTY"] select (_offenceTotal >= 1)," | ",_name," [",_UID,"] ",_victimStats,", ",_playerStats] joinString "";
 Info(_instigatorLog);
-
-[localize "STR_A3A_fn_punish_punEval_warning", [localize "STR_A3A_fn_punish_pun_fire",_injuredComrade,_customMessage] joinString "<br/>"] remoteExecCall ["A3A_fnc_customHint", _originalBody, false];
 
 if (_offenceTotal < 1) exitWith {"WARNING";};
 

--- a/A3A/addons/core/functions/Punishment/fn_punishment_evaluateEvent.sqf
+++ b/A3A/addons/core/functions/Punishment/fn_punishment_evaluateEvent.sqf
@@ -72,15 +72,15 @@ if (_instigator getVariable ["A3A_FFPun_CD", 0] > servertime) exitWith {"PUNISHM
 _instigator setVariable ["A3A_FFPun_CD", servertime + 1, false]; // Local Exec faster
 
 /////////////////Definitions////////////////
+private _injuredComrade = ["", format ["%1 %2",localize "STR_A3A_fn_punish_punEval_injured",name _victim]] select (_victim isKindOf "Man");
 private _victimStats = ["damaged ",["systemPunished",name _victim] select (_victim isKindOf "Man")," "] joinString "";
 _victimStats = [_victimStats,"[",["AI",getPlayerUID _victim] select (isPlayer _victim),"]"] joinString "";
 private _notifyVictim = {
-    if (isPlayer _victim) then {[localize "STR_A3A_fn_punish_ff_noti", format[localize "STR_A3A_fn_punish_punEval_hurt",name _instigator]] remoteExec ["A3A_fnc_customHint", _victim, false];};
+    if (isPlayer _victim) then {[localize "STR_A3A_fn_punish_ff_noti", format [localize "STR_A3A_fn_punish_punEval_hurt", name _instigator]] remoteExec ["A3A_fnc_customHint", _victim, false];};
 };
 private _notifyInstigator = {
     params ["_exempMessage"];
-    private _comradeStats = ["",[localize "STR_A3A_fn_punish_punEval_injured"," ",name _victim,""] joinString ""] select (_victim isKindOf "Man");
-    [localize "STR_A3A_fn_punish_punEval_warning", [_exempMessage,_comradeStats,_customMessage] joinString "<br/>"] remoteExec ["A3A_fnc_customHint", _instigator, false];
+    [localize "STR_A3A_fn_punish_punEval_warning", [_exempMessage, _injuredComrade, _customMessage] joinString "<br/>"] remoteExec ["A3A_fnc_customHint", _instigator, false];
 };
 private _logPvPHurt = {
     if (!(_victim isKindOf "Man")) exitWith {};
@@ -151,6 +151,11 @@ if (!(_exemption isEqualTo "")) exitWith {
     Info_2("%1 | %2", _exemption, _playerStats);
     _exemption;
 };
+
+///////Non-exempt victim & instigator notifiers//////
+call _notifyVictim;
+[localize "STR_A3A_fn_punish_punEval_warning", [localize "STR_A3A_fn_punish_pun_fire", _injuredComrade, _customMessage] joinString "<br/>"] remoteExecCall ["A3A_fnc_customHint", _instigator, false];
+
 
 if (tkPunish == 2) exitWith {"NOTIFYONLY"};
 


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Refactored FF notifications from the punishment system so that they're all called from evaluateEvent. Custom hints like "Watch your fire" and "XXX shot you!" should now show up in notify-only mode. Makes it a bit more readable too.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Should probably get a non-loopback DS test.
