### PR TITLE
Pistols for rebel AI - case

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
@@ -2,6 +2,12 @@
 //asval, Mk17 and SCAR-H arguable
 
 private _categoryOverrideTable = [
+//Vanilla
+["launch_NLAW_F", ["MissileLaunchers","Weapons","AT"]],
+["hgun_PDW2000_F", ["SMGs","Weapons"]],
+["hgun_Pistol_Signal_F", ["Unknown","Weapons"]],
+
+//RHS
 ["rhs_weap_vss", ["SniperRifles","Weapons"]],
 ["rhs_weap_vss_grip", ["SniperRifles","Weapons"]],
 ["rhs_weap_vss_npz", ["SniperRifles","Weapons"]],
@@ -39,6 +45,11 @@ private _categoryOverrideTable = [
 ["rhs_weap_m32", ["GrenadeLaunchers","Weapons"]],
 ["rhs_weap_m79", ["GrenadeLaunchers","Weapons"]],
 
+//Disposable flare launchers
+["rhs_weap_rsp30_white", ["Unknown","Weapons"]],
+["rhs_weap_rsp30_green", ["Unknown","Weapons"]],
+["rhs_weap_rsp30_red", ["Unknown","Weapons"]],
+
 // These have a rifle grenade muzzle but with no magazines or wells defined
 ["rhs_weap_m70b1", ["Rifles","Weapons"]],
 ["rhs_weap_m70b1n", ["Rifles","Weapons"]],
@@ -60,9 +71,6 @@ private _categoryOverrideTable = [
 ["UK3CB_M79", ["GrenadeLaunchers","Weapons"]],
 ["UK3CB_BAF_AT4_CS_AT_Launcher", ["RocketLaunchers","Weapons","AT"]],
 ["UK3CB_BAF_AT4_CS_AP_Launcher", ["RocketLaunchers","Weapons","AT"]],
-
-["launch_NLAW_F", ["MissileLaunchers","Weapons","AT"]],
-["hgun_PDW2000_F", ["SMGs","Weapons"]],
 
 ["UK3CB_BAF_L86A2", ["MachineGuns","Weapons"]],
 ["UK3CB_BAF_L86A3", ["MachineGuns","Weapons"]],
@@ -182,11 +190,6 @@ private _categoryOverrideTable = [
 ["CUP_smg_vityaz_vfg", ["SMGs","Weapons"]],
 ["CUP_smg_vityaz_vfg_front_rail", ["SMGs","Weapons"]],
 
-["CUP_arifle_SAIGA_MK03", ["Shotguns","Weapons"]],
-["CUP_arifle_SAIGA_MK03_top_rail", ["Shotguns","Weapons"]],
-["CUP_arifle_SAIGA_MK03_Wood", ["Shotguns","Weapons"]],
-["CUP_arifle_SIAGE_MK03_Wood_top_rail", ["Shotguns","Weapons"]],
-
 ["CUP_srifle_M2010_blk", ["SniperRifles","Weapons"]],
 ["CUP_srifle_M2010_ctrgt", ["SniperRifles","Weapons"]],
 ["CUP_srifle_M2010_dsrt", ["SniperRifles","Weapons"]],
@@ -207,6 +210,8 @@ private _categoryOverrideTable = [
 
 ["CUP_arifle_MG36_hex", ["MachineGuns","Weapons"]],
 ["CUP_arifle_MG36", ["MachineGuns","Weapons"]],
+
+["CUP_hgun_FlareGun", ["Unknown","Weapons"]],
 
 ["CUP_hgun_BallisticShield_Armed_M9", ["Unknown","Weapons"]],
 ["CUP_hgun_BallisticShield_PMM", ["Unknown","Weapons"]],
@@ -247,17 +252,14 @@ private _categoryOverrideTable = [
 ["ACE_microDAGR", ["Gadgets","Items"]],
 ["ACE_DAGR", ["Gadgets","Items"]],
 
-["LIB_PTRD", ["Unknown", "Weapons"]],
-["LIB_M2_Flamethrower", ["Unknown", "Weapons"]],			// don't want these two being chosen randomly by AIs
-["LIB_Bagpipes", ["Unknown","Weapons"]],					// wat
 ["ACE_SatchelCharge_Remote_Mag_Throwable", ["Unknown", "Explosives", "Items"]],
 ["ACE_DemoCharge_Remote_Mag_Throwable", ["Unknown", "Explosives", "Items"]],
 //Flashlights
+["ACE_Flashlight_Maglite_ML300L", ["Unknown","Weapons"]],
 ["vn_mx991", ["Unknown","Weapons"]],
 ["vn_mx991_red", ["Unknown","Weapons"]],
 ["vn_fkb1_red", ["Unknown","Weapons"]],
 ["vn_fkb1", ["Unknown","Weapons"]],
-["ACE_Flashlight_Maglite_ML300L", ["Unknown","Weapons"]],
 
 ["vn_default_helmetbase_09", ["Unknown","Headgear"]],	//Goat Hat
 ["vn_m1897", ["Shotguns","Weapons"]],
@@ -383,6 +385,9 @@ private _categoryOverrideTable = [
 ["ACRE_VHF30108MAST", ["Gadgets","items"]],
 ["ACRE_PRC117F", ["Gadgets","items"]],
 
+["LIB_PTRD", ["Unknown", "Weapons"]],
+["LIB_M2_Flamethrower", ["Unknown", "Weapons"]],			// don't want these two being chosen randomly by AIs
+["LIB_Bagpipes", ["Unknown","Weapons"]],					// wat
 ["LIB_M2_Tripod", ["StaticWeaponParts","Items"]],
 ["LIB_Laffete_Tripod", ["StaticWeaponParts","Items"]],
 ["LIB_BM37_Tripod", ["StaticWeaponParts","Items"]],

--- a/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
@@ -44,6 +44,7 @@ private _shotgun = [];
 private _sniper = [];
 private _mg = [];
 private _gl = [];
+private _handgun = [];
 {
     _x params ["_class", "_amount"];
     private _categories = _class call A3A_fnc_equipmentClassToCategories;
@@ -57,6 +58,15 @@ private _gl = [];
         if ("Shotguns" in _categories) exitWith { [_shotgun, _class, _amount] call _fnc_addItem };
     };
 } forEach (jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON);
+
+{
+    _x params ["_class", "_amount"];
+    private _categories = _class call A3A_fnc_equipmentClassToCategories;
+
+    call {
+        if ("Handguns" in _categories) exitWith { [_handgun, _class, _amount] call _fnc_addItem };
+    };
+} forEach (jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_HANDGUN);
 
 if (count A3A_specialGrenadeLaunchers > 0) then {
     // muzzle + base grenade launchers, broken down in the arsenal
@@ -75,6 +85,7 @@ _rebelGear set ["Shotguns", _shotgun];
 _rebelGear set ["MachineGuns", _mg];
 _rebelGear set ["SniperRifles", _sniper];
 _rebelGear set ["GrenadeLaunchers", _gl];
+_rebelGear set ["Handguns", _handgun];
 
 // Secondary weapon filtering
 private _rlaunchers = [];

--- a/A3A/addons/core/functions/Ammunition/fn_randomRifle.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_randomRifle.sqf
@@ -28,6 +28,9 @@ if (_pool isEqualTo []) then {
         _pool = A3A_rebelGear get "SMGs";
         if (_pool isEqualTo []) then {
             _pool = (A3A_rebelGear get "Shotguns") + (A3A_rebelGear get "SniperRifles");
+            if ((A3A_rebelGear get "SniperRifles") isEqualTo []) then {
+                _pool = _pool + (A3A_rebelGear get "Handguns");
+            };
         };
     };
 };


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Adds the possibility for rebel AI to spawn with pistols if there aren't weapons with range available. (ie there's either only shotguns or no long guns at all)
Added vanilla, cup, and RHS flare launchers to the category overrides, reorganized it a little bit to better group up the entries.

This change is made so that rebel factions that don't have any long guns, or only shotguns, have a bit more diversity and capabilities in their arsenal. 
For example the FFF for SPE can have a more appropriate starting weapon lineup with pistols, and potential new factions that might only have a shotgun as an appropriate long gun (see #3082 for example).

### Please specify which Issue this PR Resolves.
closes #2903

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Remove the starting weapons of a rebel faction of your choice, leaving only the pistols, or pistols + shotguns. then load the faction.

********************************************************
Notes:
There is a couple of ways you could arrange the stuff inside of fn_randomRifle.sqf.
Right now in this PR it is set up to add the pistols if and only if there's no sniper rifles, ie they get used alongside any potential shotguns.
**Alternatively** they could be always added, so the pool consists of bolt action rifles, shotguns, and pistols.
**OR** the case can be made more restricted and only have pistols be used if there's no other choice.
