### PR TITLE
Fixed: itemprice of packed object not extended to package.

### DIFF
--- a/A3A/addons/logistics/Private/fn_packObject.sqf
+++ b/A3A/addons/logistics/Private/fn_packObject.sqf
@@ -26,11 +26,11 @@ if(!(isNull attachedTo _object)) exitWith {};
 private _packageClassName = getText (configFile >> "A3A" >> "A3A_Logistics_Packable" >> typeOf _object >> "packObject"); 
 if (_packageClassName isEqualTo "") then {_packageClassName = "CargoNet_01_box_F"};
 
+private _objectPrice = _object getVariable ['A3A_itemPrice', 0]
 //create package
 private _package = objNull;
 isNil {
     _package = createVehicle [_packageClassName, getPosATL _object, [], 0, "CAN_COLLIDE"];
-    _package setVariable ["A3A_itemPrice", _object getVariable ['A3A_itemPrice', 0]]; 
     _package setVariable ["A3A_packedObject", typeOf _object, true]; 
     _package allowDamage false;
     if(A3A_hasAce) then { [_package, 4] call ACE_cargo_fnc_setSize };
@@ -38,3 +38,4 @@ isNil {
 };
 
 [_package] call A3A_fnc_initObject;
+_package setVariable ["A3A_itemPrice", _objectPrice]; 

--- a/A3A/addons/logistics/Private/fn_packObject.sqf
+++ b/A3A/addons/logistics/Private/fn_packObject.sqf
@@ -30,8 +30,10 @@ if (_packageClassName isEqualTo "") then {_packageClassName = "CargoNet_01_box_F
 private _package = objNull;
 isNil {
     _package = createVehicle [_packageClassName, getPosATL _object, [], 0, "CAN_COLLIDE"];
+    _package setVariable ["A3A_itemPrice", _object getVariable ['A3A_itemPrice', 0]]; 
     _package setVariable ["A3A_packedObject", typeOf _object, true]; 
     _package allowDamage false;
+    if(A3A_hasAce) then { [_package, 4] call ACE_cargo_fnc_setSize };
     deleteVehicle _object;
 };
 

--- a/A3A/addons/logistics/Private/fn_packObject.sqf
+++ b/A3A/addons/logistics/Private/fn_packObject.sqf
@@ -38,4 +38,4 @@ isNil {
 };
 
 [_package] call A3A_fnc_initObject;
-_package setVariable ["A3A_itemPrice", _objectPrice]; 
+_package setVariable ["A3A_itemPrice", _objectPrice, true]; 


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    Item prices were placed on the package, causing refunds to be zero. Extended the price to reflect the packed object.
    Ace cargo wasn't defaulted to a size of 4. That was fixed. All packed objects are size 4 for ace cargo.
    

### Please specify which Issue this PR Resolves.
closes #3084 
closes #3085 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
N/A

********************************************************
Notes:
N/A