### PR TITLE
Fix garrison spawning case where all buildings are destroyed

### DIFF
--- a/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
@@ -39,14 +39,14 @@ if (count _units == 0) exitwith {
 _group lockWP true;
 _buildings = [_position, _radius] call A3A_fnc_patrolEnterableBuildings;
 
+// Don't place units in destroyed buildings
+_buildings = _buildings select { damage _x < 1 && !isObjectHidden _x };
+
 if (count _buildings == 0) exitWith {
     Debug_1("PATCOM | No Valid Garrison buildings found near group: %1 | Defaulting to Defend.", _group);
     [_group, "Patrol_Defend", 0, 100, -1, true, _position, false] call A3A_fnc_patrolLoop;
     _newGroups;
 };
-
-// Don't place units in destroyed buildings
-_buildings = _buildings select { damage _x < 1 && !isObjectHidden _x };
 _buildings = _buildings call BIS_fnc_arrayShuffle;
 
 // Figure out how many units should be put in each building.


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The building count check in patrolGroupGarrison was put in the wrong place, so garrison spawning may error out when all valid garrison buildings have been destroyed.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
