### PR TITLE
Fix remote-controlling players despawning rebel garrisons & civs

### DIFF
--- a/A3A/addons/core/functions/Base/fn_distance.sqf
+++ b/A3A/addons/core/functions/Base/fn_distance.sqf
@@ -429,12 +429,14 @@ do
         // Add in rebel-controlled UAVs
         _teamplayer append (allUnitsUAV select { side group _x == teamPlayer });
 
-        // Players array is used to spawn civilians in cities and rebel garrisons, so ignore remote controlled and airborne units
-        _players = (allPlayers - entities "HeadlessClient_F") select {
-            private _veh = vehicle _x;
-            _x getVariable ["owner",objNull] == _x and _x == effectiveCommander _veh
-            and (_veh == _x or {!(_veh isKindOf "Air" and speed _veh > 50)})
-        };
+        // Players array is used to spawn civilians in cities and rebel garrisons, so ignore airborne units and translate remote-control
+        _players = [];
+        {
+            private _rp = _x getVariable ["owner", _x];         // real player unit in remote-control case
+            private _veh = vehicle _rp;
+            if (_rp != effectiveCommander _veh) then { continue };
+            if (_veh == _rp or {!(_veh isKindOf "Air" and speed _veh > 50)}) then { _players pushBack _rp };
+        } forEach (allPlayers - entities "HeadlessClient_F");
     };
 
     {


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Players remote-controlling AIs didn't count for the spawning routine, which could cause nearby markers to despawn unintentionally. This PR fixes it by adding the original player to the array.

### Please specify which Issue this PR Resolves.
closes #3113

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Fast-travel to a rebel garrison or city with no other players nearby. Check that it spawns in (civ cars in the city case, flag and garrison units for the rebel garrison case). Then remote-control a distant high-command squad, wait several seconds and then return control. Check that the state of the nearby marker is unchanged.
