### PR TITLE
Add more logging for rebel and enemy airstrikes

### DIFF
--- a/A3A/addons/core/functions/REINF/fn_NATObomb.sqf
+++ b/A3A/addons/core/functions/REINF/fn_NATObomb.sqf
@@ -41,8 +41,9 @@ if (!visibleMap) exitWith {deleteMarker _mrkOrig};
 _pos2 = positionTel;
 positionTel = [];
 
-_ang = [_pos1,_pos2] call BIS_fnc_dirTo;
+ServerInfo_6("Commander %1 [%2] called %3 airstrike from %4 to %5, %6m from HQ", name theBoss, getPlayerUID theBoss, _typeX, _pos1, _pos2, _pos1 distance markerPos "Synd_HQ");
 
+_ang = [_pos1,_pos2] call BIS_fnc_dirTo;
 
 bombRuns = bombRuns - 1;
 publicVariable "bombRuns";

--- a/A3A/addons/core/functions/Supports/fn_SUP_airstrikeRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_airstrikeRoutine.sqf
@@ -57,7 +57,7 @@ if (_bombType == "HE") then {_bombCount = _bombCount * 2};
 private _bombParams = [_plane, _bombType, _bombCount, 200];
 private _flightSpeed = ["LIMITED", "NORMAL", "FULL"] select (round random [1, _aggroValue / 50, 0]);
 if (_isHelicopter) then {_flightSpeed = "FULL"};
-Info_3("Airstrike %1 will be carried out with %2 bombs at %3 speed", _supportName, _bombCount, toLower _flightSpeed);
+Info_5("Airstrike %1 against %2 with %3 %4 bombs at %5 speed", _supportName, _targetPos, _bombCount, _bombType, toLower _flightSpeed);
 
 _plane flyInHeight 150;
 private _minAltASL = (ATLToASL [_targetPos select 0, _targetPos select 1, 0])#2 +150;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Added logging to rebel airstrikes, and expanded it a little for enemy airstrikes.

### Please specify which Issue this PR Resolves.
closes #3111

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
