### PR TITLE
Fix fallback code for militia lacking cargo trucks

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_createAIOutposts.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIOutposts.sqf
@@ -256,7 +256,7 @@ if (_spawnParameter isEqualType []) then
 		if (FactionGet(civ,"vehiclesCivFuel") isEqualTo [] and random 1 < 0.1) exitWith { selectRandom (_faction get "vehiclesFuelTrucks") };
 		private _types = if (!_isFIA) then {(_faction get "vehiclesTrucks") + (_faction get "vehiclesCargoTrucks")} else {_faction get "vehiclesMilitiaTrucks"};
 		_types = _types select { _x in FactionGet(all,"vehiclesCargoTrucks") };
-		if (count _types == 0) then { (_faction get "vehiclesCargoTrucks") } else { _types };
+		if (count _types == 0) then { _types = (_faction get "vehiclesCargoTrucks") };
 		selectRandom _types;
 	};
 	isNil {

--- a/A3A/addons/core/functions/CREATE/fn_createAIResources.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIResources.sqf
@@ -152,7 +152,7 @@ if (_spawnParameter isEqualType []) then
 		if (FactionGet(civ,"vehiclesCivFuel") isEqualTo [] and random 1 < 0.1) exitWith { selectRandom (_faction get "vehiclesFuelTrucks") };
 		private _types = if (!_isFIA) then {(_faction get "vehiclesTrucks") + (_faction get "vehiclesCargoTrucks")} else {_faction get "vehiclesMilitiaTrucks"};
 		_types = _types select { _x in FactionGet(all,"vehiclesCargoTrucks") };
-		if (count _types == 0) then { (_faction get "vehiclesCargoTrucks") } else { _types };
+		if (count _types == 0) then { _types = (_faction get "vehiclesCargoTrucks") };
 		selectRandom _types;
 	};
 	isNil {


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The code for spawning trucks at outposts/seaports/resources/factories was supposed to fallback to spawning a truck from vehiclesCargoTrucks if the list would otherwise lack cargo trucks, but the code was incorrect and did nothing. This PR fixes it.

The main difference is that factions are no longer requires to have cargo-capable trucks in the militia list.

### Please specify which Issue this PR Resolves.
closes #3097

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Please test with a faction that doesn't have cargo vehicles in the militia list. Early game factory or resource should work.
