### PR TITLE
Fix petros placement stringtable conversion bug

### DIFF
--- a/A3A/addons/core/functions/Base/fn_placementselection.sqf
+++ b/A3A/addons/core/functions/Base/fn_placementselection.sqf
@@ -5,7 +5,7 @@ private _disabledPlayerDamage = false;
 private _titleStr = localize "STR_A3A_fn_base_placeselec_title";
 
 player allowDamage false;
-[localize "STR_A3A_fn_base_placeselec_petros_dead"] hintC [localize "STR_A3A_fn_base_placeselec_petros_dead_long"];
+localize "STR_A3A_fn_base_placeselec_petros_dead" hintC localize "STR_A3A_fn_base_placeselec_petros_dead_long";
 
 hintC_arr_EH = findDisplay 72 displayAddEventHandler ["unload",{
 	_this spawn {


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
#3089 added a syntax bug in the Petros placement function that crashed it out, preventing anyone from placing Petros after death. This PR fixes it.

Probably no similar cases because hintC is barely used in the current codebase.

### Please specify which Issue this PR Resolves.
closes #3089
closes #3122 

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
