### PR TITLE
Fix cases where airspaceControl wouldn't execute

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
@@ -203,19 +203,6 @@ if (_side != teamPlayer) then
 	}];
 };
 
-if(_veh isKindOf "Air") then
-{
-    //Start airspace control script if rebel player enters
-    _veh addEventHandler ["GetIn", {
-		params ["_veh", "_role", "_unit"];
-		if((side (group _unit) == teamPlayer) && {isPlayer _unit}) then
-		{
-			// TODO: check this isn't spammed
-			[_veh] spawn A3A_fnc_airspaceControl;
-		};
-    }];
-};
-
 
 // Handler for refunding vehicles after cleanup
 if (A3A_vehicleResourceCosts getOrDefault [typeof _veh, 0] > 0) then {

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -267,9 +267,7 @@ player addEventHandler ["WeaponDisassembled", {
 }];
 
 player addEventHandler ["GetInMan", {
-    private ["_unit","_veh"];
-    _unit = _this select 0;
-    _veh = _this select 2;
+    params ["_unit", "_role", "_veh", "_turret"];
     _exit = false;
     if !([player] call A3A_fnc_isMember) then {
         if (!isNil {_veh getVariable "A3A_locked"}) then {
@@ -287,7 +285,19 @@ player addEventHandler ["GetInMan", {
                 [] spawn A3A_fnc_goUndercover;
             };
         };
+        if (_veh isKindOf "Air") then {
+            Debug_2("Installing airspace control for player %1, vehicle %2", _unit, typeof _veh);
+            private _handle = [_unit, _veh] spawn A3A_fnc_airspaceControl;
+            _unit setVariable ["airspaceControlHandle", _handle];
+        };
     };
+}];
+
+player addEventHandler ["GetOutMan", {
+    params ["_unit", "_role", "_veh", "_turret"];
+    Debug_2("Terminating airspace control for player %1, vehicle %2", _unit, typeof _veh);
+    private _handle = _unit getVariable ["airspaceControlHandle", scriptNull];
+    if (!isNull _handle) then { terminate _handle };
 }];
 
 // Prevent players getting shot by their own AIs. EH is respawn-persistent


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The airspaceControl routine was launched by a GetIn EH on the vehicle installed locally by AIVEHInit. Because the vehicle is created locally to the client that bought or ungaraged a vehicle, this means the event handler would be lost if the player who placed the vehicle disconnected. Players who boarded that vehicle subsequently would not be checked for airspace control, and could for example steal outpost crates with an undercover civilian heli.

There was additionally a timing condition where if players boarded or left a vehicle close together, airspaceControl might be incorrectly left running or incorrectly removed.

In this PR I've changed the code to launch with a GetInMan EH on the player(s). Multiple airspaceControl routines could run simultaneously on a single vehicle, but the checks are only executed on the effective commander of the vehicle. Seat-switching, bailing etc should all work correctly with no loopholes.

A simpler solution would have been to install the GetIn EH on the server, but the function has substantial performance cost due to the marker searching method. Better to offload it to flying players.

### Please specify which Issue this PR Resolves.
closes #3125

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Needs dedicated server testing with multiple players.
