### PR TITLE
Make SLAT IFVs CBA-compatible

### DIFF
--- a/A3A/addons/config_fixes/Vanilla/ifv.hpp
+++ b/A3A/addons/config_fixes/Vanilla/ifv.hpp
@@ -1,66 +1,58 @@
 //Vanilla - ifv.hpp
 
 //Marshall
-class B_APC_Wheeled_01_cannon_F;
-class B_T_APC_Wheeled_01_cannon_F;
+class B_APC_Wheeled_01_base_F;
+class B_APC_Wheeled_01_cannon_F : B_APC_Wheeled_01_base_F { class EventHandlers; };
 class a3a_B_APC_Wheeled_01_cannon_F : B_APC_Wheeled_01_cannon_F
 {
     animationList[] = {"showBags",0.5,"showCamonetHull",0,"showCamonetTurret",0,"showSLATHull",1,"showSLATTurret",1};
-	class EventHandlers
-	{
-        fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
+    class EventHandlers : EventHandlers
+    {
         init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-        killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
-	};
+    };
 };
+class B_T_APC_Wheeled_01_cannon_F : B_APC_Wheeled_01_cannon_F {};
 class a3a_B_T_APC_Wheeled_01_cannon_F : B_T_APC_Wheeled_01_cannon_F
 {
     animationList[] = {"showBags",0.5,"showCamonetHull",0,"showCamonetTurret",0,"showSLATHull",1,"showSLATTurret",1};
-	class EventHandlers
-	{
-        fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
+    class EventHandlers : EventHandlers
+    {
         init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-        killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
-	};
+    };
 };
 
 //Rhino
-class B_AFV_Wheeled_01_cannon_F;
-class B_T_AFV_Wheeled_01_cannon_F;
+class AFV_Wheeled_01_base_F;
+class B_AFV_Wheeled_01_cannon_F : AFV_Wheeled_01_base_F { class EventHandlers; };
 class a3a_AFV_Wheeled_01_cannon_F : B_AFV_Wheeled_01_cannon_F
 {
     animationList[] = {"showCamonetHull",0,"showCamonetCannon",0,"showCamonetTurret",0,"showSLATHull",1};
-	class EventHandlers
-	{
-        fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
+    class EventHandlers : EventHandlers
+    {
         init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-        killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
-	};
+    };
 };
+class B_T_AFV_Wheeled_01_cannon_F : AFV_Wheeled_01_base_F { class EventHandlers; };
 class a3a_T_AFV_Wheeled_01_cannon_F :  B_T_AFV_Wheeled_01_cannon_F
 {
     animationList[] = {"showCamonetHull",0,"showCamonetCannon",0,"showCamonetTurret",0,"showSLATHull",1};
-	class EventHandlers
-	{
-        fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
-        init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-        killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
-	};
+    class EventHandlers : EventHandlers
+    {
+       init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
+    };
 };
 
 //Gorgon
-class I_APC_Wheeled_03_cannon_F;
+class I_APC_Wheeled_03_base_F;
+class I_APC_Wheeled_03_cannon_F : I_APC_Wheeled_03_base_F { class EventHandlers; }
 class a3a_APC_Wheeled_03_cannon_F : I_APC_Wheeled_03_cannon_F
 {
     animationList[] = {"showCamonetHull",0,"showBags",0.3,"showBags2",0.3,"showTools",0.3,"showSLATHull",1};
-	class EventHandlers
-	{
-        fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
+    class EventHandlers : EventHandlers
+    {
         init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-        killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
-	};
+    };
 };
-
 class a3a_APC_Wheeled_03_cannon_blufor_F : a3a_APC_Wheeled_03_cannon_F
 {
     textureList[] = {};
@@ -68,73 +60,64 @@ class a3a_APC_Wheeled_03_cannon_blufor_F : a3a_APC_Wheeled_03_cannon_F
 };
 
 //Mora
-class I_APC_tracked_03_cannon_F;
-class I_E_APC_tracked_03_cannon_F;
+class I_APC_tracked_03_base_F;
+class I_APC_tracked_03_cannon_F : I_APC_tracked_03_base_F { class EventHandlers; };
 class a3a_APC_tracked_03_cannon_F : I_APC_tracked_03_cannon_F
 {
     animationList[] = {"showBags",0.3,"showBags2",0.3,"showCamonetHull",0,"showCamonetTurret",0,"showTools",0.3,"showSLATHull",1,"showSLATTurret",1};
-	class EventHandlers
-	{
-        fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
+    class EventHandlers : EventHandlers
+    {
         init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-        killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
-	};
+    };
 };
+class I_E_APC_tracked_03_base_F;
+class I_E_APC_tracked_03_cannon_F : I_E_APC_tracked_03_base_F { class EventHandlers; };
 class a3a_E_APC_tracked_03_cannon_F : I_E_APC_tracked_03_cannon_F
 {
     animationList[] = {"showBags",0.3,"showBags2",0.3,"showCamonetHull",0,"showCamonetTurret",0,"showTools",0.3,"showSLATHull",1,"showSLATTurret",1};
-	class EventHandlers
-	{
-        fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
+    class EventHandlers : EventHandlers
+    {
         init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-        killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
-	};
+    };
 };
-
 //Marid
-class O_APC_Wheeled_02_rcws_v2_F;
-class O_T_APC_Wheeled_02_rcws_v2_ghex_F;
+class APC_Wheeled_02_base_v2_F;
+class O_APC_Wheeled_02_rcws_v2_F : APC_Wheeled_02_base_v2_F { class EventHandlers; };
 class a3a_APC_Wheeled_02_rcws_v2_F : O_APC_Wheeled_02_rcws_v2_F
 {
     animationList[] = {"showBags",0.2,"showCanisters",0.2,"showTools",0.2,"showCamonetHull",0,"showSLATHull",1};
-	class EventHandlers
-	{
-        fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
+    class EventHandlers : EventHandlers
+    {
         init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-        killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
-	};
+    };
 };
+class O_T_APC_Wheeled_02_rcws_v2_ghex_F : APC_Wheeled_02_base_v2_F { class EventHandlers; };
 class a3a_T_APC_Wheeled_02_rcws_v2_F : O_T_APC_Wheeled_02_rcws_v2_ghex_F
 {
     animationList[] = {"showBags",0.2,"showCanisters",0.2,"showTools",0.2,"showCamonetHull",0,"showSLATHull",1};
-	class EventHandlers
-	{
-        fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
+    class EventHandlers : EventHandlers
+    {
         init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-        killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
-	};
+    };
 };
 
 //Kamysh
-class O_APC_Tracked_02_cannon_F;
-class O_T_APC_Tracked_02_cannon_ghex_F;
+class O_APC_Tracked_02_base_F;
+class O_APC_Tracked_02_cannon_F : O_APC_Tracked_02_base_F { class EventHandlers; };
 class a3a_APC_Tracked_02_cannon_F : O_APC_Tracked_02_cannon_F
 {
     animationList[] = {"showTracks",0.5,"showCamonetHull",0,"showBags",0.5,"showSLATHull",1};
-	class EventHandlers
-	{
-        fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
+    class EventHandlers : EventHandlers
+    {
         init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-        killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
-	};
+    };
 };
+class O_T_APC_Tracked_02_cannon_ghex_F : O_APC_Tracked_02_cannon_F {};
 class a3a_T_APC_Tracked_02_cannon_F : O_T_APC_Tracked_02_cannon_ghex_F
 {
     animationList[] = {"showTracks",0.5,"showCamonetHull",0,"showBags",0.5,"showSLATHull",1};
-	class EventHandlers
-	{
-        fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
+    class EventHandlers : EventHandlers
+    {
         init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-        killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
-	};
+    };
 };

--- a/A3A/addons/config_fixes/Vanilla/ifv.hpp
+++ b/A3A/addons/config_fixes/Vanilla/ifv.hpp
@@ -27,19 +27,13 @@ class B_AFV_Wheeled_01_cannon_F : AFV_Wheeled_01_base_F { class EventHandlers; }
 class a3a_AFV_Wheeled_01_cannon_F : B_AFV_Wheeled_01_cannon_F
 {
     animationList[] = {"showCamonetHull",0,"showCamonetCannon",0,"showCamonetTurret",0,"showSLATHull",1};
-    class EventHandlers : EventHandlers
-    {
-        init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-    };
+    // Already has initVehicle EH
 };
 class B_T_AFV_Wheeled_01_cannon_F : AFV_Wheeled_01_base_F { class EventHandlers; };
 class a3a_T_AFV_Wheeled_01_cannon_F :  B_T_AFV_Wheeled_01_cannon_F
 {
     animationList[] = {"showCamonetHull",0,"showCamonetCannon",0,"showCamonetTurret",0,"showSLATHull",1};
-    class EventHandlers : EventHandlers
-    {
-       init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-    };
+    // Already has initVehicle EH
 };
 
 //Gorgon
@@ -86,19 +80,13 @@ class O_APC_Wheeled_02_rcws_v2_F : APC_Wheeled_02_base_v2_F { class EventHandler
 class a3a_APC_Wheeled_02_rcws_v2_F : O_APC_Wheeled_02_rcws_v2_F
 {
     animationList[] = {"showBags",0.2,"showCanisters",0.2,"showTools",0.2,"showCamonetHull",0,"showSLATHull",1};
-    class EventHandlers : EventHandlers
-    {
-        init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-    };
+    // Already has initVehicle EH
 };
 class O_T_APC_Wheeled_02_rcws_v2_ghex_F : APC_Wheeled_02_base_v2_F { class EventHandlers; };
 class a3a_T_APC_Wheeled_02_rcws_v2_F : O_T_APC_Wheeled_02_rcws_v2_ghex_F
 {
     animationList[] = {"showBags",0.2,"showCanisters",0.2,"showTools",0.2,"showCamonetHull",0,"showSLATHull",1};
-    class EventHandlers : EventHandlers
-    {
-        init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-    };
+    // Already has initVehicle EH
 };
 
 //Kamysh
@@ -107,17 +95,11 @@ class O_APC_Tracked_02_cannon_F : O_APC_Tracked_02_base_F { class EventHandlers;
 class a3a_APC_Tracked_02_cannon_F : O_APC_Tracked_02_cannon_F
 {
     animationList[] = {"showTracks",0.5,"showCamonetHull",0,"showBags",0.5,"showSLATHull",1};
-    class EventHandlers : EventHandlers
-    {
-        init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-    };
+    // Already has initVehicle EH
 };
 class O_T_APC_Tracked_02_cannon_ghex_F : O_APC_Tracked_02_cannon_F {};
 class a3a_T_APC_Tracked_02_cannon_F : O_T_APC_Tracked_02_cannon_ghex_F
 {
     animationList[] = {"showTracks",0.5,"showCamonetHull",0,"showBags",0.5,"showSLATHull",1};
-    class EventHandlers : EventHandlers
-    {
-        init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-    };
+    // Already has initVehicle EH
 };

--- a/A3A/addons/config_fixes/WS/ws_ifv.hpp
+++ b/A3A/addons/config_fixes/WS/ws_ifv.hpp
@@ -2,58 +2,54 @@
 
 //Marshall
 //Ion
-class B_ION_APC_Wheeled_01_command_lxWS;
-class B_ION_APC_Wheeled_01_cannon_lxWS;
-class B_D_APC_Wheeled_01_atgm_lxWS;
+
+class APC_Wheeled_01_base_F;
+class APC_Wheeled_01_command_base_lxWS : APC_Wheeled_01_base_F { class EventHandlers; };    // also used for NATO
+class B_ION_APC_Wheeled_01_command_lxWS: APC_Wheeled_01_command_base_lxWS {};
 class a3a_ION_APC_Wheeled_01_command_lxWS : B_ION_APC_Wheeled_01_command_lxWS
 {
     animationList[] = {"showBags",0.5,"showCamonetHull",0,"showCamonetTurret",0,"showSLATHull",1,"showSLATTurret",1};
-	class EventHandlers
+	class EventHandlers : EventHandlers
 	{
-        fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
         init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-        killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
 	};
 };
+class B_APC_Wheeled_01_cannon_lxWS;
+class B_ION_APC_Wheeled_01_cannon_lxWS: B_APC_Wheeled_01_cannon_lxWS { class EventHandlers; };
 class a3a_ION_APC_Wheeled_01_cannon_lxWS : B_ION_APC_Wheeled_01_cannon_lxWS
 {
     scope = 2;
     animationList[] = {"showBags",0.5,"showCamonetHull",0,"showCamonetTurret",0,"showSLATHull",1,"showSLATTurret",1};
-	class EventHandlers
+	class EventHandlers : EventHandlers
 	{
-        fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
         init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-        killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
 	};
 };
-class a3a_ION_APC_Wheeled_01_atgm : B_D_APC_Wheeled_01_atgm_lxWS{
+class B_D_APC_Wheeled_01_atgm_lxWS;
+class a3a_ION_APC_Wheeled_01_atgm : B_D_APC_Wheeled_01_atgm_lxWS {
     side = 1;
     crew = "B_ION_Soldier_lxWS";
     faction = "BLU_ION_lxWS";
     textureList[] = {"ION_BLACK", 1};
     hiddenSelectionsTextures[] = {"lxws\vehicles_f_lxws\data\APC_Wheeled_01\APC_Wheeled_ion_base_CO.paa","lxws\vehicles_f_lxws\data\APC_Wheeled_01\apc_wheeled_ion_adds_co.paa","lxws\vehicles_f_lxws\data\APC_Wheeled_01\apc_wheeled_ion_tows_co.paa","a3\armor_f\Data\camonet_AAF_stripe_desert_CO.paa","lxws\vehicles_f_lxws\data\APC_Wheeled_01\cage_black_CO.paa","lxws\vehicles_f_lxws\data\APC_Wheeled_01\APC_Wheeled_ion_lxws_CO.paa"};
 };
+
 //NATO
-class APC_Wheeled_01_command_base_lxWS;
-class B_T_APC_Wheeled_01_command_lxWS;
 class a3a_APC_Wheeled_01_command_lxWS : APC_Wheeled_01_command_base_lxWS
 {
     animationList[] = {"showBags",0.5,"showCamonetHull",0,"showCamonetTurret",0,"showSLATHull",1,"showSLATTurret",1};
-	class EventHandlers
+	class EventHandlers : EventHandlers
 	{
-        fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
         init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-        killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
 	};
 };
+class B_T_APC_Wheeled_01_command_lxWS : APC_Wheeled_01_command_base_lxWS {};
 class a3a_T_APC_Wheeled_01_command_lxWS : B_T_APC_Wheeled_01_command_lxWS
 {
     animationList[] = {"showBags",0.5,"showCamonetHull",0,"showCamonetTurret",0,"showSLATHull",1,"showSLATTurret",1};
-	class EventHandlers
+	class EventHandlers : EventHandlers
 	{
-        fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
         init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-        killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
 	};
 };
 
@@ -63,47 +59,27 @@ class O_APC_Tracked_02_30mm_lxWS;
 class a3a_APC_Tracked_02_30mm_lxWS : O_APC_Tracked_02_30mm_lxWS
 {
     animationList[] = {"showTracks",0.5,"showCamonetHull",0,"showBags",0.5,"showSLATHull",1};
-	class EventHandlers
-	{
-        fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
-        init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-        killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
-	};
+    // Has initVehicle EH already
 };
 //Tropical
 class O_T_APC_Tracked_02_30mm_lxWS;
 class a3a_T_APC_Tracked_02_30mm_lxWS : O_T_APC_Tracked_02_30mm_lxWS
 {
     animationList[] = {"showTracks",0.5,"showCamonetHull",0,"showBags",0.5,"showSLATHull",1};
-	class EventHandlers
-	{
-        fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
-        init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-        killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
-	};
+    // Has initVehicle EH already
 };
 //SFIA
 class O_SFIA_APC_Tracked_02_30mm_lxWS;
-class O_SFIA_APC_Tracked_02_cannon_lxWS;
 class a3a_SFIA_APC_Tracked_02_30mm_lxWS : O_SFIA_APC_Tracked_02_30mm_lxWS
 {
     animationList[] = {"showTracks",0.5,"showCamonetHull",0,"showBags",0.5,"showSLATHull",1};
-	class EventHandlers
-	{
-        fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
-        init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-        killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
-	};
+    // Has initVehicle EH already
 };
+class O_SFIA_APC_Tracked_02_cannon_lxWS;
 class a3a_SFIA_APC_Tracked_02_cannon_lxWS : O_SFIA_APC_Tracked_02_cannon_lxWS
 {
     animationList[] = {"showTracks",0.5,"showCamonetHull",0,"showBags",0.5,"showSLATHull",1};
-	class EventHandlers
-	{
-        fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
-        init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-        killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
-	};
+    // Has initVehicle EH already
 };
 //ION
 class a3a_ION_APC_Tracked_02_30mm : O_APC_Tracked_02_30mm_lxWS
@@ -114,10 +90,5 @@ class a3a_ION_APC_Tracked_02_30mm : O_APC_Tracked_02_30mm_lxWS
     animationList[] = {"showTracks",1,"showCamonetHull",0,"showBags",0.2,"showSLATHull",1};
     textureList[] = {"Grey", 1};
     hiddenSelectionsTextures[] = {"lxWS\vehicles_1_f_lxws\APC_Tracked_02\data\APC_Tracked_02_ext_01_black_CO.paa","lxWS\vehicles_1_f_lxws\APC_Tracked_02\data\APC_Tracked_02_ext_02_black_CO.paa","lxWS\vehicles_1_f_lxws\APC_Tracked_02\data\APC_Tracked_02_ext_03_black_CO.paa","lxWS\vehicles_1_f_lxws\APC_Tracked_02\data\APC_Tracked_02_30mm_black_co.paa","A3\Armor_F\Data\camonet_CSAT_Stripe_Desert_CO.paa","lxWS\vehicles_1_f_lxws\APC_Tracked_02\data\cage_black_CO.paa"};
-	class EventHandlers
-	{
-        fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
-        init = "if (local (_this select 0)) then {[(_this select 0), """", [], false] call bis_fnc_initVehicle;};";
-        killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
-	};
+    // Has initVehicle EH already
 };


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
As described in #3127. This PR rewrites the SLAT IFV config entries to inherit their EventHandler classes rather than overwriting.

Some of these vehicles also had non-standard Fired event handlers, so the SLAT versions would have had something missing.

**Todo:** Some of the classes (IIRC the invader ones at least) already have a postInit function that does the texture/animation init, so we should delete one of them. Not sure whether this is better to run as init or postInit. Hopefully doesn't matter.

### Please specify which Issue this PR Resolves.
closes #3127

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

See above, need to cull one of init or postInit for some classes.