### PR TITLE
Add hint to help older players find the new construction system

### DIFF
--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -13461,7 +13461,7 @@
         <Chinesesimp>建造</Chinesesimp>
       </Key>
       <Key ID="STR_antistasi_dialogs_radio_comm_construct_tooltip">
-        <Original>Construct in the spot where you are a selected building facing this direction</Original>
+        <Original>To construct buildings in this version, buy a construction kit from the Buy Vehicle menu and use the action on it</Original>
         <Italian>Costruisci nel punto dove hai selezionato una struttura rivolta verso questa direzione</Italian>
         <Spanish>Construye en el sitio el edificio seleccionado mirando hacia esta dirección</Spanish>
         <French>Construire à l'endroit où vous vous trouvez un bâtiment sélectionné faisant face à cette direction</French>

--- a/A3A/addons/core/dialogs.hpp
+++ b/A3A/addons/core/dialogs.hpp
@@ -1317,7 +1317,7 @@ class radio_comm 		{
 			y = 0.415981 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
-			//tooltip = $STR_antistasi_dialogs_radio_comm_construct_tooltip;
+			tooltip = $STR_antistasi_dialogs_radio_comm_construct_tooltip;
 			//action = "closeDialog 0;_nul = createDialog ""construction_menu"";";
 		};
 		class 8slots_L3: A3A_core_BattleMenuRedButton


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Added a tooltip to the blank button in the Y menu so that players from older version can find the new construction system more easily.

### Please specify which Issue this PR Resolves.
closes #3132

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
