### PR TITLE
Avoid spamming unlockedXXX publicVariables

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_unlockEquipment.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_unlockEquipment.sqf
@@ -6,15 +6,15 @@
 
 	Params:
 		_className - Class of the equipment to unlock.
-
+		_noPublish - If true, don't broadcast the unlockedXXX arrays. For internal use.
 		_dontAddToArsenal - Avoid adding the item to the arsenal, and simply updates the appropriate variables. DO NOT USE UNLESS YOU HAVE A *VERY* GOOD REASON. Primarily used in save/loads.
 
 	Returns:
-		None
+		Array of categories for item
 **/
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
-params ["_className", ["_dontAddToArsenal", false]];
+params ["_className", ["_noPublish", false], ["_dontAddToArsenal", false]];
 
 private _categories = _className call A3A_fnc_equipmentClassToCategories;
 
@@ -26,8 +26,8 @@ if (!_dontAddToArsenal) then {
 };
 
 {
-	private _categoryName = _x;
-	//Consider making this pushBackUnique.
-	(missionNamespace getVariable ("unlocked" + _categoryName)) pushBack _className;
-	publicVariable ("unlocked" + _categoryName);
+	(missionNamespace getVariable ("unlocked" + _x)) pushBackUnique _className;
+	if (!_noPublish) then { publicVariable ("unlocked" + _x) };
 } forEach _categories;
+
+_categories;

--- a/A3A/addons/core/functions/Save/fn_loadServer.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadServer.sqf
@@ -42,13 +42,20 @@ if (isServer) then {
 	//===========================================================================
 
 	//RESTORE THE STATE OF THE 'UNLOCKED' VARIABLES USING JNA_DATALIST
+	private _categoriesToPublish = createHashMap;
 	{
 		private _arsenalTabDataArray = _x;
 		private _unlockedItemsInTab = _arsenalTabDataArray select { _x select 1 == -1 } apply { _x select 0 };
 		{
-			[_x, true] call A3A_fnc_unlockEquipment;
+			private _categories = [_x, true, true] call A3A_fnc_unlockEquipment;
+			_categoriesToPublish insert [true, _categories, []];
 		} forEach _unlockedItemsInTab;
 	} forEach jna_dataList;
+
+	Info_1("Categories to publish: %1", keys _categoriesToPublish);
+
+	// Publish the unlocked categories (once each)
+	{ publicVariable ("unlocked" + _x) } forEach keys _categoriesToPublish;
 
 	if !(unlockedNVGs isEqualTo []) then {
 		haveNV = true; publicVariable "haveNV"
@@ -56,10 +63,6 @@ if (isServer) then {
 
 	//Check if we have radios unlocked and update haveRadio.
 	call A3A_fnc_checkRadiosUnlocked;
-
-	//Sort optics list so that snipers pick the right sight
-	// obsolete since rebelGear
-	//unlockedOptics = [unlockedOptics,[],{getNumber (configfile >> "CfgWeapons" >> _x >> "ItemInfo" >> "mass")},"DESCEND"] call BIS_fnc_sortBy;
 
 	// Set enemy roadblock allegiance to match nearest main marker
 	private _mainMarkers = markersX - controlsX - outpostsFIA;

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -124,12 +124,20 @@ else
     call A3A_fnc_initGarrisons;
 
     // Do initial arsenal filling
+    private _categoriesToPublish = createHashMap;
     {
-		if (_x isEqualType "") then { _x call A3A_fnc_unlockEquipment; continue };
-		_x params ["_class", "_count"];
-		private _arsenalTab = _class call jn_fnc_arsenal_itemType;
-		[_arsenalTab, _class, _count] call jn_fnc_arsenal_addItem;
+        if (_x isEqualType "") then {
+            private _categories = [_x, true] call A3A_fnc_unlockEquipment;
+            _categoriesToPublish insert [true, _categories, []];
+            continue;
+        };
+        _x params ["_class", "_count"];
+        private _arsenalTab = _class call jn_fnc_arsenal_itemType;
+        [_arsenalTab, _class, _count] call jn_fnc_arsenal_addItem;
     } foreach FactionGet(reb,"initialRebelEquipment");
+
+    // Publish the unlocked categories (once each)
+    { publicVariable ("unlocked" + _x) } forEach keys _categoriesToPublish;
 
     Info("Initial arsenal unlocks completed");
     call A3A_fnc_checkRadiosUnlocked;


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
In cases where multiple items were unlocked at once (new campaign, loading, arsenal update), the unlockedXXX arrays were re-published with publicVariable per item, causing massive network load and "message pending" spam in some cases. This PR collates the variable names to publish in these cases, so that each array is not published more than once.

All five code paths tested on both localhost and DS+client.   

### Please specify which Issue this PR Resolves.
closes #3080

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
