### PR TITLE
Vehicle discounts with no seaports

### DIFF
--- a/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
+++ b/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
@@ -17,6 +17,8 @@ else
 			_costs = round (_costs - (_costs * 0.05 * _numFriendlySeaports));
 		} else {
 			_discount = switch (true) do {
+                case (tierWar in [1,2]): { 0 };
+                case (tierWar in [3,4]): { 0 };
 				case (tierWar in [5,6]): { 1 };
 				case (tierWar in [7,8]): { 2 };
 				case (tierWar in [9,10]): { 3 };

--- a/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
+++ b/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
@@ -12,8 +12,18 @@ if (isNil "_costs") then
 	}
 else
 	{
-	private _numFriendlySeaports = ({sidesX getVariable [_x,sideUnknown] == teamPlayer} count seaports) min 6;
-	_costs = round (_costs - (_costs * 0.05 * _numFriendlySeaports));
+		if (count seaports > 3) then {
+			private _numFriendlySeaports = ({sidesX getVariable [_x,sideUnknown] == teamPlayer} count seaports) min 6;
+			_costs = round (_costs - (_costs * 0.05 * _numFriendlySeaports));
+		} else {
+			_discount = switch (true) do {
+				case (tierWar in [5,6]): { 1 };
+				case (tierWar in [7,8]): { 2 };
+				case (tierWar in [9,10]): { 3 };
+				default { 0 };
+			};
+			_costs = round (_costs - (_costs * 0.1 * _discount));
+		};	
 	};
 
 _costs


### PR DESCRIPTION
I had been sitting on this change for a bit now, and wanted to make sure it got in before release.

## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?

Information: Previously, maps without seaports would not allow players any discounts for buying vehicles. Now, if a map has less than 4 seaports (it's a reasonable cutoff, most maps have either 5-6 or 0), the vehicle discount will be scaled on war level instead.
 
### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
