### PR TITLE
Cull large builder boxes because they don't work yet

### DIFF
--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -14218,17 +14218,8 @@
         <Turkish>Cephane İstasyonu</Turkish>
         <Chinesesimp>弹药站</Chinesesimp>
       </Key>
-      <Key ID="STR_A3A_Utility_Items_Name_buildboxcolossal">
-        <Original>Colossal construction kit</Original>
-        <Korean>거대 건설 도구</Korean>
-      </Key>
-      <Key ID="STR_A3A_Utility_Items_Name_buildboxenormous">
-        <Original>Enormous construction kit</Original>
-        <Korean>특대형 건설 도구</Korean>
-      </Key>
-      <Key ID="STR_A3A_Utility_Items_Name_buildboxextralarge">
-        <Original>Extra Large construction kit</Original>
-        <Korean>초대형 건설 도구</Korean>
+      <Key ID="STR_A3A_Utility_Items_Name_buildboxmedium">
+        <Original>Medium construction kit</Original>
       </Key>
       <Key ID="STR_A3A_Utility_Items_Name_buildboxlarge">
         <Original>Large construction kit</Original>

--- a/A3A/addons/core/functions/init/fn_initUtilityItems.sqf
+++ b/A3A/addons/core/functions/init/fn_initUtilityItems.sqf
@@ -29,10 +29,10 @@ private _items = [
     [_repairStation#0, _repairStation#1, "repairstation", "repair", ["cmmdr", "place", "move", "rotate", "pack", "save"]],
     [FactionGet(reb,"vehicleLightSource"), 25, "light", "", ["move"]],           // note: If we do want this saved, need to switch saveLoop to nearObjects
     ["Land_PlasticCase_01_medium_F", 100, "buildboxsmall", "", ["place", "move", "build"]],
-    ["Land_PlasticCase_01_large_F", 500, "buildboxlarge", "", ["place", "move", "build"]],
-    ["Land_WoodenCrate_01_F", 1000, "buildboxextralarge", "", ["place", "move", "build"]],
-    ["Land_WoodenCrate_01_stack_x5_F", 5000, "buildboxcolossal", "", ["place", "build", "hugebuild"]],
-    ["Land_Cargo10_cyan_F", 10000, "buildboxenormous", "", ["place", "build", "hugebuild"]]
+    ["Land_PlasticCase_01_large_F", 500, "buildboxmedium", "", ["place", "move", "build"]],
+    ["Land_WoodenCrate_01_F", 1500, "buildboxlarge", "", ["place", "move", "build"]]
+//    ["Land_WoodenCrate_01_stack_x5_F", 5000, "buildboxcolossal", "", ["place", "build", "hugebuild"]],
+//    ["Land_Cargo10_cyan_F", 10000, "buildboxenormous", "", ["place", "build", "hugebuild"]]
     
 ];
 


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
The very large builder boxes don't fit in either width or weight for a lot of vehicles that they'll load into. Can be fixed later, but not in 3.5. Also the gameplay need for them is questionable: We probably don't want people building or repairing that much.

Buffed the "large" box to 1500 as a placeholder.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
