### PR TITLE
Orbital strike already destroys the city naturally, don't do it twice

### DIFF
--- a/A3A/addons/core/functions/Supports/fn_SUP_orbitalStrikeRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_orbitalStrikeRoutine.sqf
@@ -124,7 +124,6 @@ private _citiesInRange = (citiesX - destroyedSites) select {((getMarkerPos _x) d
     ["TaskFailed", ["", format [localize "STR_A3A_fn_supports_cityDestroyed", [_x] call A3A_fnc_localizar]]] remoteExec ["BIS_fnc_showNotification",teamPlayer];
     destroyedSites = destroyedSites + [_x];
 	publicVariable "destroyedSites";
-    [_x] call A3A_fnc_destroyCity;
     sidesX setVariable [_x, Invaders, true];
     garrison setVariable [_x, [], true];
     [_x] call A3A_fnc_mrkUpdate;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
A destroyCity call was added to the orbital strike routine. This is incorrect: The orbital strike routine already causes massive destruction on its own and doesn't need any extra. The punishment attack uses destroyCity because it doesn't cause enough destruction naturally.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
