### PR TITLE
Fix rogue var breaking vanilla LDF template

### DIFF
--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_LDF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_LDF.sqf
@@ -102,8 +102,7 @@ if ("orange" in A3A_enabledDLC) then {
 
 ["vehiclesCargoTrucks", _cargoTrucks] call _fnc_saveToTemplate;
 
-["vehiclesTanks", _Tanks] call _fnc_saveToTemplate; 
-["vehiclesIFVs", _vehiclesIFVs] call _fnc_saveToTemplate;
+["vehiclesTanks", _Tanks] call _fnc_saveToTemplate;
 ["vehiclesHelisTransport", _HelisTransport] call _fnc_saveToTemplate;
 
 ["vehiclesMilitiaCars", _vehiclesMilitiaCars] call _fnc_saveToTemplate;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Vanilla LDF template broke on a ref to a non-existent variable. This PR fixes it.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Load the vanilla LDF template.
