### PR TITLE
Disable forced marker spawn in artySupport

### DIFF
--- a/A3A/addons/core/functions/AI/fn_artySupport.sqf
+++ b/A3A/addons/core/functions/AI/fn_artySupport.sqf
@@ -184,7 +184,7 @@ else
 	_roundsMax = _rounds;
 	};
 
-_markerX = [markersX,_positionTel] call BIS_fnc_nearestPosition;
+/*_markerX = [markersX,_positionTel] call BIS_fnc_nearestPosition;
 _size = [_markerX] call A3A_fnc_sizeMarker;
 _forcedX = false;
 
@@ -194,6 +194,7 @@ if ((not(_markerX in forcedSpawn)) and (_positionTel distance (getMarkerPos _mar
 	forcedSpawn pushBack _markerX;
 	publicVariable "forcedSpawn";
 	};
+*/
 
 _roundPlural = if (round _rounds == 1) then {localize "STR_A3A_fn_ai_artySupport_singleRound"} else {localize "STR_A3A_fn_ai_artySupport_multiRound"};
 _textX = format [localize "STR_A3A_fn_ai_artySupport_fireMission", mapGridPosition _positionTel, round _rounds, _roundPlural];
@@ -290,7 +291,7 @@ sleep 10;
 deleteMarkerLocal _mrkFinal;
 if (_typeArty == "BARRAGE") then {deleteMarkerLocal _mrkFinal2};
 
-if (_forcedX) then
+/*if (_forcedX) then
 	{
 	sleep 20;
 	if (_markerX in forcedSpawn) then
@@ -299,3 +300,4 @@ if (_forcedX) then
 		publicVariable "forcedSpawn";
 		};
 	};
+*/


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
The rebel high command artillery function currently force-spawned markers near the start point. This kinda makes sense, but we don't do it for anything else except major attacks, every other usage assumes it indicates a major attack. It's dangerous because it modifies and pushes the forcedSpawn array from the commander's client, which can lead to desyncs where a marker remains in the array permanently or is incorrectly removed.

This PR disables the forced spawn.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
