### PR TITLE
Params for no fast travel and no box restore

### DIFF
--- a/A3A/addons/core/Params.hpp
+++ b/A3A/addons/core/Params.hpp
@@ -31,8 +31,8 @@ class Params
     class limitedFT
     {
         title = $STR_A3A_Params_limitedFT_title;
-        values[] = {0,1};
-        texts[] = {$STR_A3A_Params_limitedFT_any, $STR_A3A_Params_limitedFT_hq};
+        values[] = {0,1,2};
+        texts[] = {$STR_A3A_Params_limitedFT_any, $STR_A3A_Params_limitedFT_hq, $STR_A3A_Params_generic_none};
         default = 1;
     };
     class civTraffic
@@ -132,6 +132,13 @@ class Params
         values[] = {1, 2, 3};
         texts[] = {$STR_A3A_Params_builderPermissions_tl, $STR_A3A_Params_builderPermissions_engi, $STR_A3A_Params_builderPermissions_both};
         default = 3;
+    };
+    class A3A_removeRestore
+    {
+        title = $STR_A3A_Params_removeRestore_title;
+        values[] = {0,1};
+        texts[] = {$STR_antistasi_dialogs_generic_button_no_tooltip,$STR_antistasi_dialogs_generic_button_yes_text};
+        default = 0;
     };
 
     class SpacerMembership

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -13473,7 +13473,15 @@
         <Chinesesimp>建造</Chinesesimp>
       </Key>
       <Key ID="STR_antistasi_dialogs_radio_comm_construct_tooltip">
-        <Original>To construct buildings in this version, buy a construction kit from the Buy Vehicle menu and use the action on it.</Original>
+        <Original>To construct buildings in this version, buy a construction kit from the Buy Vehicle menu and use the action on it</Original>
+        <Italian>Costruisci nel punto dove hai selezionato una struttura rivolta verso questa direzione</Italian>
+        <Spanish>Construye en el sitio el edificio seleccionado mirando hacia esta dirección</Spanish>
+        <French>Construire à l'endroit où vous vous trouvez un bâtiment sélectionné faisant face à cette direction</French>
+        <Korean>해당 버전의 건물을 건설하려면 차량 구입 메뉴에서 건설 도구를 구입하고 관련된 행동을 수행하십시오.</Korean>
+        <Russian>Постройте в том месте, где вы выбрали здание, обращенное в этом направлении</Russian>
+        <Polish>Zbuduj, w miejscu w którym jesteś, wybrany budynek zwrócony w tym kierunku</Polish>
+        <Czech>Stavějte na místě, kde jste vybraly budovu otočenou tímto směrem</Czech>
+        <Chinesesimp>在你所在的位置, 朝向此方向建造所选建筑</Chinesesimp>
       </Key>
       <Key ID="STR_antistasi_dialogs_radio_comm_fast_travel">
         <Original>Fast Travel</Original>

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -13474,14 +13474,6 @@
       </Key>
       <Key ID="STR_antistasi_dialogs_radio_comm_construct_tooltip">
         <Original>To construct buildings in this version, buy a construction kit from the Buy Vehicle menu and use the action on it</Original>
-        <Italian>Costruisci nel punto dove hai selezionato una struttura rivolta verso questa direzione</Italian>
-        <Spanish>Construye en el sitio el edificio seleccionado mirando hacia esta dirección</Spanish>
-        <French>Construire à l'endroit où vous vous trouvez un bâtiment sélectionné faisant face à cette direction</French>
-        <Korean>해당 버전의 건물을 건설하려면 차량 구입 메뉴에서 건설 도구를 구입하고 관련된 행동을 수행하십시오.</Korean>
-        <Russian>Постройте в том месте, где вы выбрали здание, обращенное в этом направлении</Russian>
-        <Polish>Zbuduj, w miejscu w którym jesteś, wybrany budynek zwrócony w tym kierunku</Polish>
-        <Czech>Stavějte na místě, kde jste vybraly budovu otočenou tímto směrem</Czech>
-        <Chinesesimp>在你所在的位置, 朝向此方向建造所选建筑</Chinesesimp>
       </Key>
       <Key ID="STR_antistasi_dialogs_radio_comm_fast_travel">
         <Original>Fast Travel</Original>

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -2688,6 +2688,9 @@
         <Czech>Nemůžeš rychle cestovat pokud nemáš řidiče ve všech svých vozidlech, vozidla jsou požkozené a nemohou se hýbat nebo tvoje skupina je na lodi.</Czech>
         <Portuguese>Não podes fazer Viagem Rápida se não tens um condutor em todos os veículos ou os veículos estão danificados e não se conseguem mexer ou o grupo está num barco.</Portuguese>
       </Key>
+      <Key ID="STR_A3A_fn_dialogs_ftradio_no_param">
+        <Original>Fast travel is disabled for this server.</Original>
+      </Key>
       <Key ID="STR_A3A_fn_dialogs_ftradio_no_tow">
         <Original>You cannot Fast Travel with your Tow Rope out or a Vehicle attached.</Original>
         <Italian>Non puoi effettuare il Viaggio Rapido con la Corda da Traino dispiegata o un Veicolo in Traino.</Italian>
@@ -8366,6 +8369,9 @@
         <Korean>아군 AI 숙련도 (서버 숙련도에 영향을 받음)</Korean>
         <Chinesesimp>友方AI能力水平 (会被服务器设定所影响)</Chinesesimp>
       </Key>
+      <Key ID="STR_A3A_Params_removeRestore_title">
+        <Original>Disable the "Restore nearby units" option on the vehicle box.</Original>
+      </Key>
       <Key ID="STR_A3A_Params_reviveTime_10s">
         <Original>10 seconds</Original>
         <Italian>10 Secondi</Italian>
@@ -13467,7 +13473,7 @@
         <Chinesesimp>建造</Chinesesimp>
       </Key>
       <Key ID="STR_antistasi_dialogs_radio_comm_construct_tooltip">
-        <Original>To construct buildings in this version, buy a construction kit from the Buy Vehicle menu and use the action on it</Original>
+        <Original>To construct buildings in this version, buy a construction kit from the Buy Vehicle menu and use the action on it.</Original>
       </Key>
       <Key ID="STR_antistasi_dialogs_radio_comm_fast_travel">
         <Original>Fast Travel</Original>

--- a/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -3,13 +3,15 @@
 private ["_roads","_pos","_positionX","_groupX"];
 private _titleStr = localize "STR_A3A_fn_dialogs_ftradio_title";
 
+if (limitedFT == 2) exitWith {[_titleStr, localize "STR_A3A_fn_dialogs_ftradio_no_param"] call A3A_fnc_customHint;};
+
 _markersX = markersX + [respawnTeamPlayer];
 
 _esHC = false;
 if (count hcSelected player > 1) exitWith {[_titleStr, localize "STR_A3A_fn_dialogs_ftradio_grp_select"] call A3A_fnc_customHint;};
 if (count hcSelected player == 1) then {_groupX = hcSelected player select 0; _esHC = true} else {_groupX = group player};
 _checkForPlayer = false;
-if ((!_esHC) and limitedFT) then {_checkForPlayer = true};
+if ((!_esHC) and (limitedFT == 0)) then {_checkForPlayer = true};
 _boss = leader _groupX;
 
 if ((_boss != player) and (!_esHC)) then {_groupX = player};
@@ -88,7 +90,7 @@ if (count _positionTel > 0) then
  				}
  			};
 		_exit = false;
-		if (limitedFT) then
+		if (limitedFT == 0) then
 			{
 			_vehicles = [];
 			{if (vehicle _x != _x) then {_vehicles pushBackUnique (vehicle _x)}} forEach units _groupX;

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -383,7 +383,7 @@ _flagLight lightAttachObject [flagX, [0, 0, 4]];
 _flagLight setLightAttenuation [7, 0, 0.5, 0.5];
 
 vehicleBox allowDamage false;
-vehicleBox addAction [localize "STR_A3A_actions_restore_units", A3A_fnc_vehicleBoxRestore,nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull]) and (side (group _this) == teamPlayer)", 4];
+vehicleBox addAction [localize "STR_A3A_actions_restore_units", A3A_fnc_vehicleBoxRestore,nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull]) and (side (group _this) == teamPlayer) and (A3A_removeRestore != 1)", 4];
 vehicleBox addAction [localize "STR_A3A_fn_init_initclient_addact_arsenal", JN_fnc_arsenal_handleAction, [], 0, true, false, "", "alive _target && vehicle _this != _this", 10];
 [vehicleBox] call HR_GRG_fnc_initGarage;
 

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -383,7 +383,7 @@ _flagLight lightAttachObject [flagX, [0, 0, 4]];
 _flagLight setLightAttenuation [7, 0, 0.5, 0.5];
 
 vehicleBox allowDamage false;
-vehicleBox addAction [localize "STR_A3A_actions_restore_units", A3A_fnc_vehicleBoxRestore,nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull]) and (side (group _this) == teamPlayer) and (A3A_removeRestore != 1)", 4];
+vehicleBox addAction [localize "STR_A3A_actions_restore_units", A3A_fnc_vehicleBoxRestore,nil,0,false,true,"","(isPlayer _this) and (_this == _this getVariable ['owner',objNull]) and (side (group _this) == teamPlayer) and !A3A_removeRestore", 4];
 vehicleBox addAction [localize "STR_A3A_fn_init_initclient_addact_arsenal", JN_fnc_arsenal_handleAction, [], 0, true, false, "", "alive _target && vehicle _this != _this", 10];
 [vehicleBox] call HR_GRG_fnc_initGarage;
 


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Information:
Added a param to disable the "restore nearby units" option on the garage box.
Added an option to the fast travel param to completely block fast traveling.
Fixed a typo in a string I found on accident.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Everything should be visible and work from the setup GUI.
********************************************************
Notes:
This is all Bob's fault.