### PR TITLE
Fix case where loadout_addItems loses magazines

### DIFF
--- a/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_addItems.sqf
+++ b/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_addItems.sqf
@@ -142,7 +142,7 @@ private _backpackItems = if (_backpack isEqualTo []) then {[]} else {_backpack s
 					_uniformItems pushBack _itemInfo;
 					_uniformCurrentLoad = _uniformCurrentLoad +	_totalLoad;
 				};
-				case (_totalLoad < (_vestMaxLoad - _vestCurrentLoad)): {
+				case (_totalLoad < (_vestMaxLoad - _vestCurrentLoad) or _backpackMaxLoad == 0): {
 					_vestItems pushBack _itemInfo;
 					_vestCurrentLoad = _vestCurrentLoad + _totalLoad;
 				};


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
loadout_addItems assumed that units have a backpack, and could dump large item batches into the void under certain conditions, for example if a batch fitted within uniform+vest but not in either individually. Could happen with marksman rifles, as 5x20rnd 7.62 mags is often too much for a vest, and marksmen don't use backpacks.

This PR fixes the problem by using the vest as the fallback container in the case where backpack max load is zero. This may mean that the vest is sometimes overfilled, but that's working as intended. It does the same with backpacks.

### Please specify which Issue this PR Resolves.
closes #3153

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Probably needs a run with various templates to see if anything weirder than expected turns up.