### PR TITLE
Minor fixes 20240302

### DIFF
--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_ADF.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_ADF.sqf
@@ -156,6 +156,7 @@ _loadoutData set ["ATLaunchers", [
 ["launch_MRAWS_sand_F", "", "acc_pointer_IR", "", ["MRAWS_HE_F", "MRAWS_HEAT55_F"], [], ""],
 ["launch_MRAWS_sand_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HEAT55_F"], [], ""],
 ["launch_MRAWS_sand_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HE_F"], [], ""]
+]];
 _loadoutData set ["missileATLaunchers", [
 ["launch_B_Titan_short_F", "", "acc_pointer_IR", "", ["Titan_AT", "Titan_AP"], [], ""],
 ["launch_B_Titan_short_F", "", "acc_pointer_IR", "", ["Titan_AT"], [], ""],

--- a/A3A/addons/core/dialogs.hpp
+++ b/A3A/addons/core/dialogs.hpp
@@ -147,7 +147,7 @@ class HQ_menu 			{
 			y = 0.415981 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
-			action = "closeDialog 0;if (player == theBoss) then {nul = [] call A3A_fnc_FIAskillAdd} else {[""Recruit Vehicle"", ""Only Player Commander has access to this function.""] call A3A_fnc_customHint;};";
+			action = "if (player == theBoss) then {nul = [] call A3A_fnc_FIAskillAdd} else {[""Recruit Vehicle"", ""Only Player Commander has access to this function.""] call A3A_fnc_customHint;};";
 		};
 		class HQ_button_skill: A3A_core_BattleMenuRedButton
 		{

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -111,6 +111,8 @@ recruitCooldown = 0;			//Prevents units being recruited too soon after being dis
 incomeRep = false;
 autoHeal = true;				//Should AI in player squad automatically heal teammates
 
+waitUntil {sleep 0.1; isTouchingGround;}; //setPos has issues if you try to move someone climbing on a lader or in an animation. The rest of the script needs to be put on hold until the player is moved so stuff doesnt break (namely spawner status)
+
 player setPos (getMarkerPos respawnTeamPlayer);
 player setVariable ["spawner",true,true];
 
@@ -357,7 +359,7 @@ if (isServer || player isEqualTo theBoss || (call BIS_fnc_admin) > 0) then {  //
     _modsAndLoadText append _loadedTemplateInfoXML;
 
     if (count _modsAndLoadText isEqualTo 0) exitWith {};
-    private _textXML = "<t align='left'>" + ((_modsAndLoadText apply { "<t color='#f0d498'>" + _x#1 + ":</t>" + _x#2 }) joinString "<br/>") + "</t>";
+    private _textXML = "<t align='left'>" + ((_modsAndLoadText apply { "<t color='#f0d498'>" + _x#1 + ": </t>" + _x#2 }) joinString "<br/>") + "</t>";
     [localize "STR_A3A_fn_init_initclient_mods_loaded",_textXML] call A3A_fnc_customHint;
 };
 
@@ -409,7 +411,7 @@ mapX addAction [localize "STR_A3A_fn_init_initclient_addact_gameOpt", {
         localize "STR_A3A_fn_init_initclient_gameOpt_version"+" "+ QUOTE(VERSION_FULL) +"<br/><br/>"+
         localize "STR_A3A_fn_init_initclient_gameOpt_resoBal"+" "+ (A3A_enemyBalanceMul / 10 toFixed 1) + "x" +"<br/>"+
         localize "STR_A3A_fn_init_initclient_gameOpt_unlockNo"+" "+ str minWeaps +"<br/>"+
-        localize "STR_A3A_fn_init_initclient_gameOpt_limFT"+" "+ (["No","Yes"] select limitedFT) +"<br/>"+
+        localize "STR_A3A_fn_init_initclient_gameOpt_limFT"+" "+ ([localize "STR_antistasi_dialogs_generic_button_no_text",localize "STR_antistasi_dialogs_generic_button_yes_text"] select limitedFT) +"<br/>"+
         localize "STR_A3A_fn_init_initclient_gameOpt_spawnDist"+" "+ str distanceSPWN + "m" +"<br/>"+
         localize "STR_A3A_fn_init_initclient_gameOpt_civLim"+" "+ str globalCivilianMax +"<br/>"+
         localize "STR_A3A_fn_init_initclient_gameOpt_timeGC"+" "+ ([[serverTime-A3A_lastGarbageCleanTime] call A3A_fnc_secondsToTimeSpan,1,0,false,2,false,true] call A3A_fnc_timeSpan_format)

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -111,8 +111,7 @@ recruitCooldown = 0;			//Prevents units being recruited too soon after being dis
 incomeRep = false;
 autoHeal = true;				//Should AI in player squad automatically heal teammates
 
-waitUntil {sleep 0.1; isTouchingGround;}; //setPos has issues if you try to move someone climbing on a lader or in an animation. The rest of the script needs to be put on hold until the player is moved so stuff doesnt break (namely spawner status)
-
+player switchMove ""; // kick the player out of any animation before teleporting
 player setPos (getMarkerPos respawnTeamPlayer);
 player setVariable ["spawner",true,true];
 


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Fixed a broken WS template missing a few brackets.
The troop training GUI will no longer close after an upgrade is purchased, making it easier if you want to buy more than 1 level at a time.
Players will be kicked out of any animations before teleport, fixing a bug with the setup stage.
Added a space in the "loaded mods" hint.
Localized a No/Yes in the Map Info hint.

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
