### PR TITLE
3CB Weapons & New Stuff Patch

### DIFF
--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_AAF.sqf
@@ -84,6 +84,7 @@
 
 ["faces", ["GreekHead_A3_02", "GreekHead_A3_03", "GreekHead_A3_04", "GreekHead_A3_05", "GreekHead_A3_06", "GreekHead_A3_07", "GreekHead_A3_08", "GreekHead_A3_09", "Ioannou", "Mavros"]] call _fnc_saveToTemplate;
 ["voices", ["Male01GRE", "Male02GRE", "Male03GRE", "Male04GRE", "Male05GRE", "Male06GRE"]] call _fnc_saveToTemplate;
+"GreekMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_ADA.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_ADA.sqf
@@ -82,7 +82,7 @@
 
 ["faces", ["AfricanHead_01", "AfricanHead_02", "AfricanHead_03", "Barklem"]] call _fnc_saveToTemplate;
 ["voices", ["Male01FRE", "Male02FRE", "Male03FRE"]] call _fnc_saveToTemplate;
-"TanoanMen" call _fnc_saveNames;
+"AfricanDesertMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_ADA.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_ADA.sqf
@@ -375,7 +375,7 @@ _policeLoadoutData set ["shotGuns", [
 ["rhs_weap_M590_5RD", "", "", "", ["rhsusf_5Rnd_00Buck", "rhsusf_5Rnd_Slug"], [], ""]
 ]];
 _policeLoadoutData set ["SMGs", [
-["UK3CB_MP5A2", "", "uk3cb_acc_surefiregrip", "", [], [], ""],
+"uk3cb_port_said_m45",
 ["UK3CB_HK33KA2_RIS", "", "rhsusf_acc_M952V", "", [], [], ""],
 ["rhs_weap_ak74n", "", "rhs_acc_2dpZenit", "", ["rhs_30Rnd_545x39_7N10_AK"], [], ""]
 ]];
@@ -404,7 +404,7 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 ["rhs_weap_akmn_gp25", "", "", "", [], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
 ["rhs_weap_ak74n_gp25", "", "", "", [], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""]
 ]];
-_militiaLoadoutData set ["SMGs", ["UK3CB_MP5A2"]];
+_militiaLoadoutData set ["SMGs", ["uk3cb_port_said_m45"]];
 _militiaLoadoutData set ["machineGuns", [
 ["rhs_weap_fnmag", "", "", "", ["rhsusf_50Rnd_762x51", "rhsusf_50Rnd_762x51", "rhsusf_50Rnd_762x51_m62_tracer"], [], ""],
 "rhs_weap_pkm",

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_ADA.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_ADA.sqf
@@ -82,6 +82,7 @@
 
 ["faces", ["AfricanHead_01", "AfricanHead_02", "AfricanHead_03", "Barklem"]] call _fnc_saveToTemplate;
 ["voices", ["Male01FRE", "Male02FRE", "Male03FRE"]] call _fnc_saveToTemplate;
+"TanoanMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //
@@ -342,7 +343,9 @@ _militaryLoadoutData set ["machineGuns", [
 ["rhs_weap_fnmag", "rhsusf_acc_ARDEC_M240", "", "rhsusf_acc_ACOG_MDO", ["rhsusf_100Rnd_762x51_m80a1epr", "rhsusf_100Rnd_762x51_m80a1epr", "rhsusf_100Rnd_762x51_m62_tracer"], [], ""],
 ["rhs_weap_pkp", "", "", "rhs_acc_1p29", ["rhs_100Rnd_762x54mmR_7N26", "rhs_100Rnd_762x54mmR_green"], [], ""],
 ["rhs_weap_pkp", "", "", "rhs_acc_1p78", ["rhs_100Rnd_762x54mmR_7N26", "rhs_100Rnd_762x54mmR_green"], [], ""],
-["rhs_weap_pkp", "", "", "rhs_acc_pkas", ["rhs_100Rnd_762x54mmR_7N26", "rhs_100Rnd_762x54mmR_green"], [], ""]
+["rhs_weap_pkp", "", "", "rhs_acc_pkas", ["rhs_100Rnd_762x54mmR_7N26", "rhs_100Rnd_762x54mmR_green"], [], ""],
+["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39"], [], ""],
+["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39", "UK3CB_RPD_100rnd_762x39_GM"], [], ""]
 ]];
 _militaryLoadoutData set ["marksmanRifles", [
 ["UK3CB_M14DMR_Railed", "", "", "rhsusf_acc_ACOG_RMR", ["UK3CB_M14_20rnd_762x51"], [], ""],
@@ -404,7 +407,9 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 _militiaLoadoutData set ["SMGs", ["UK3CB_MP5A2"]];
 _militiaLoadoutData set ["machineGuns", [
 ["rhs_weap_fnmag", "", "", "", ["rhsusf_50Rnd_762x51", "rhsusf_50Rnd_762x51", "rhsusf_50Rnd_762x51_m62_tracer"], [], ""],
-"rhs_weap_pkm"
+"rhs_weap_pkm",
+["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39"], [], ""],
+["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39", "UK3CB_RPD_100rnd_762x39_GM"], [], ""]
 ]];
 _militiaLoadoutData set ["marksmanRifles", [
 ["UK3CB_FNFAL_FULL", "", "", "uk3cb_optic_SUIT_FNFAL", ["UK3CB_FNFAL_20rnd_762x51"], [], ""]

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_ANA.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_ANA.sqf
@@ -81,6 +81,7 @@
 
 ["faces", ["PersianHead_A3_01","PersianHead_A3_02","PersianHead_A3_03"]] call _fnc_saveToTemplate;
 ["voices", ["Male01PER","Male02PER","Male03PER"]] call _fnc_saveToTemplate;
+"TakistaniMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_BAF_Arctic.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_BAF_Arctic.sqf
@@ -86,6 +86,7 @@
 "WhiteHead_14","WhiteHead_15","WhiteHead_16","WhiteHead_17","WhiteHead_18",
 "WhiteHead_19","WhiteHead_20","WhiteHead_21"]] call _fnc_saveToTemplate;
 ["voices", ["Male01ENGB", "Male02ENGB", "Male03ENGB", "Male04ENGB", "Male05ENGB"]] call _fnc_saveToTemplate;
+"EnglishMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_BAF_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_BAF_Arid.sqf
@@ -86,6 +86,7 @@
 "WhiteHead_14","WhiteHead_15","WhiteHead_16","WhiteHead_17","WhiteHead_18",
 "WhiteHead_19","WhiteHead_20","WhiteHead_21"]] call _fnc_saveToTemplate;
 ["voices", ["Male01ENGB", "Male02ENGB", "Male03ENGB", "Male04ENGB", "Male05ENGB"]] call _fnc_saveToTemplate;
+"EnglishMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_BAF_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_BAF_Temperate.sqf
@@ -86,6 +86,7 @@
 "WhiteHead_14","WhiteHead_15","WhiteHead_16","WhiteHead_17","WhiteHead_18",
 "WhiteHead_19","WhiteHead_20","WhiteHead_21"]] call _fnc_saveToTemplate;
 ["voices", ["Male01ENGB", "Male02ENGB", "Male03ENGB", "Male04ENGB", "Male05ENGB"]] call _fnc_saveToTemplate;
+"EnglishMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_BAF_Tropical.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_BAF_Tropical.sqf
@@ -86,6 +86,7 @@
 "WhiteHead_14","WhiteHead_15","WhiteHead_16","WhiteHead_17","WhiteHead_18",
 "WhiteHead_19","WhiteHead_20","WhiteHead_21"]] call _fnc_saveToTemplate;
 ["voices", ["Male01ENGB", "Male02ENGB", "Male03ENGB", "Male04ENGB", "Male05ENGB"]] call _fnc_saveToTemplate;
+"EnglishMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_CW_SOV.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_CW_SOV.sqf
@@ -88,6 +88,7 @@
 "WhiteHead_14", "WhiteHead_15", "WhiteHead_16", "WhiteHead_18", "WhiteHead_19",
 "WhiteHead_20"]] call _fnc_saveToTemplate;
 ["voices", ["RHS_Male01RUS", "RHS_Male02RUS", "RHS_Male03RUS", "RHS_Male04RUS", "RHS_Male05RUS"]] call _fnc_saveToTemplate;
+"RussianMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_CW_SOV.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_CW_SOV.sqf
@@ -88,6 +88,7 @@
 "WhiteHead_14", "WhiteHead_15", "WhiteHead_16", "WhiteHead_18", "WhiteHead_19",
 "WhiteHead_20"]] call _fnc_saveToTemplate;
 ["voices", ["RHS_Male01RUS", "RHS_Male02RUS", "RHS_Male03RUS", "RHS_Male04RUS", "RHS_Male05RUS"]] call _fnc_saveToTemplate;
+"RussianMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //
@@ -259,7 +260,9 @@ _militaryLoadoutData set ["machineGuns", [
 ["rhs_weap_pkm", "", "", "", ["rhs_100Rnd_762x54mmR", "rhs_100Rnd_762x54mmR_green"], [], ""],
 ["rhs_weap_pkp", "", "", "", ["rhs_100Rnd_762x54mmR", "rhs_100Rnd_762x54mmR_green"], [], ""],
 ["UK3CB_RPK_74N", "", "", "", ["UK3CB_RPK74_60rnd_545x39_G", "UK3CB_RPK74_60rnd_545x39_G", "UK3CB_RPK74_60rnd_545x39_GT"], [], ""],
-["UK3CB_RPK", "", "", "", ["UK3CB_RPK_75rnd_762x39_G", "UK3CB_RPK_75rnd_762x39_G", "UK3CB_RPK_75rnd_762x39_GT"], [], ""]
+["UK3CB_RPK", "", "", "", ["UK3CB_RPK_75rnd_762x39_G", "UK3CB_RPK_75rnd_762x39_G", "UK3CB_RPK_75rnd_762x39_GT"], [], ""],
+["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39"], [], ""],
+["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39", "UK3CB_RPD_100rnd_762x39_GM"], [], ""]
 ]];
 _militaryLoadoutData set ["marksmanRifles", [
 ["rhs_weap_svdp_wd", "", "", "rhs_acc_pso1m2", [], [], ""],
@@ -317,7 +320,9 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 _militiaLoadoutData set ["machineGuns", [
 ["rhs_weap_pkm", "", "", "", ["rhs_100Rnd_762x54mmR", "rhs_100Rnd_762x54mmR_green"], [], ""],
 ["UK3CB_RPK_74N", "", "", "", ["UK3CB_RPK74_60rnd_545x39_G", "UK3CB_RPK74_60rnd_545x39_G", "UK3CB_RPK74_60rnd_545x39_GT"], [], ""],
-["UK3CB_RPK", "", "", "", ["UK3CB_RPK_75rnd_762x39_G", "UK3CB_RPK_75rnd_762x39_G", "UK3CB_RPK_75rnd_762x39_GT"], [], ""]
+["UK3CB_RPK", "", "", "", ["UK3CB_RPK_75rnd_762x39_G", "UK3CB_RPK_75rnd_762x39_G", "UK3CB_RPK_75rnd_762x39_GT"], [], ""],
+["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39"], [], ""],
+["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39", "UK3CB_RPD_100rnd_762x39_GM"], [], ""]
 ]];
 _militiaLoadoutData set ["marksmanRifles", [
 ["UK3CB_SVD_OLD", "", "", "rhs_acc_pso1m2", ["rhs_10Rnd_762x54mmR_7N1"], [], ""]

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_CW_SOV.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_CW_SOV.sqf
@@ -47,7 +47,7 @@
 
 ["vehiclesArtillery", ["UK3CB_CW_SOV_O_LATE_2S1", "UK3CB_CW_SOV_O_LATE_2S3", "UK3CB_CW_SOV_O_LATE_BM21"]] call _fnc_saveToTemplate;         //this line determines artillery vehicles -- Example: ["vehiclesArtillery", ["B_MBT_01_arty_F"]] -- Array, can contain multiple assets
 ["magazines", createHashMapFromArray [
-["UK3CB_CW_SOV_O_LATE_2S1", ["rhs_mag_3of56_10"]],
+["UK3CB_CW_SOV_O_LATE_2S1", ["rhs_mag_3of56_35"]],
 ["UK3CB_CW_SOV_O_LATE_2S3",["rhs_mag_HE_2a33", "rhs_mag_WP_2a33"]],
 ["UK3CB_CW_SOV_O_LATE_BM21", ["rhs_mag_m21of_1"]]
 ]] call _fnc_saveToTemplate;
@@ -88,7 +88,6 @@
 "WhiteHead_14", "WhiteHead_15", "WhiteHead_16", "WhiteHead_18", "WhiteHead_19",
 "WhiteHead_20"]] call _fnc_saveToTemplate;
 ["voices", ["RHS_Male01RUS", "RHS_Male02RUS", "RHS_Male03RUS", "RHS_Male04RUS", "RHS_Male05RUS"]] call _fnc_saveToTemplate;
-"RussianMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //
@@ -260,9 +259,7 @@ _militaryLoadoutData set ["machineGuns", [
 ["rhs_weap_pkm", "", "", "", ["rhs_100Rnd_762x54mmR", "rhs_100Rnd_762x54mmR_green"], [], ""],
 ["rhs_weap_pkp", "", "", "", ["rhs_100Rnd_762x54mmR", "rhs_100Rnd_762x54mmR_green"], [], ""],
 ["UK3CB_RPK_74N", "", "", "", ["UK3CB_RPK74_60rnd_545x39_G", "UK3CB_RPK74_60rnd_545x39_G", "UK3CB_RPK74_60rnd_545x39_GT"], [], ""],
-["UK3CB_RPK", "", "", "", ["UK3CB_RPK_75rnd_762x39_G", "UK3CB_RPK_75rnd_762x39_G", "UK3CB_RPK_75rnd_762x39_GT"], [], ""],
-["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39"], [], ""],
-["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39", "UK3CB_RPD_100rnd_762x39_GM"], [], ""]
+["UK3CB_RPK", "", "", "", ["UK3CB_RPK_75rnd_762x39_G", "UK3CB_RPK_75rnd_762x39_G", "UK3CB_RPK_75rnd_762x39_GT"], [], ""]
 ]];
 _militaryLoadoutData set ["marksmanRifles", [
 ["rhs_weap_svdp_wd", "", "", "rhs_acc_pso1m2", [], [], ""],
@@ -320,9 +317,7 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 _militiaLoadoutData set ["machineGuns", [
 ["rhs_weap_pkm", "", "", "", ["rhs_100Rnd_762x54mmR", "rhs_100Rnd_762x54mmR_green"], [], ""],
 ["UK3CB_RPK_74N", "", "", "", ["UK3CB_RPK74_60rnd_545x39_G", "UK3CB_RPK74_60rnd_545x39_G", "UK3CB_RPK74_60rnd_545x39_GT"], [], ""],
-["UK3CB_RPK", "", "", "", ["UK3CB_RPK_75rnd_762x39_G", "UK3CB_RPK_75rnd_762x39_G", "UK3CB_RPK_75rnd_762x39_GT"], [], ""],
-["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39"], [], ""],
-["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39", "UK3CB_RPD_100rnd_762x39_GM"], [], ""]
+["UK3CB_RPK", "", "", "", ["UK3CB_RPK_75rnd_762x39_G", "UK3CB_RPK_75rnd_762x39_G", "UK3CB_RPK_75rnd_762x39_GT"], [], ""]
 ]];
 _militiaLoadoutData set ["marksmanRifles", [
 ["UK3CB_SVD_OLD", "", "", "rhs_acc_pso1m2", ["rhs_10Rnd_762x54mmR_7N1"], [], ""]

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_CW_US.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_CW_US.sqf
@@ -89,6 +89,7 @@
 "WhiteHead_10","WhiteHead_11","WhiteHead_13","WhiteHead_14","WhiteHead_15",
 "WhiteHead_16","WhiteHead_17","WhiteHead_18","WhiteHead_19","WhiteHead_20","WhiteHead_21"]] call _fnc_saveToTemplate;
 ["voices", ["Male01ENG","Male02ENG","Male03ENG","Male04ENG","Male05ENG","Male06ENG","Male07ENG","Male08ENG","Male09ENG","Male10ENG","Male11ENG","Male12ENG"]] call _fnc_saveToTemplate;
+"NATOMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_HIDF.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_HIDF.sqf
@@ -290,7 +290,7 @@ _policeLoadoutData set ["vests", ["V_TacVest_gen_F"]];
 _policeLoadoutData set ["helmets", ["H_MilCap_gen_F", "H_Beret_gen_F"]];
 
 _policeLoadoutData set ["SMGs", [
-["UK3CB_MP5", "", "", "", ["UK3CB_MP5_30Rnd_Magazine"], [], ""]
+["uk3cb_mat49", "", "", "", ["UK3CB_MAT49_32Rnd_9x19_Magazine"], [], ""]
 ]];
 _policeLoadoutData set ["shotGuns", [
 ["rhs_weap_M590_8RD", "", "", "", ["rhsusf_8Rnd_00Buck"], [], ""]
@@ -322,20 +322,22 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 ]];
 _militiaLoadoutData set ["SMGs", [
 ["rhs_weap_m3a1", "", "", "", ["rhsgref_30rnd_1143x23_M1911B_SMG"], [], ""],
-["UK3CB_Sten", "", "", "", ["UK3CB_Sten_34Rnd_Magazine"], [], ""]
+["uk3cb_mat49", "", "", "", ["UK3CB_MAT49_32Rnd_9x19_Magazine"], [], ""]
 ]];
 _militiaLoadoutData set ["machineGuns", [
-["UK3CB_Bren", "", "", "", ["UK3CB_Bren_30Rnd_762x51_Magazine", "UK3CB_Bren_30Rnd_762x51_Magazine", "UK3CB_Bren_30Rnd_762x51_Magazine_GT"], [], ""],
-["UK3CB_Bren", "", "", "", ["UK3CB_Bren_30Rnd_762x51_Magazine", "UK3CB_Bren_30Rnd_762x51_Magazine", "UK3CB_Bren_30Rnd_762x51_Magazine_GT"], [], ""],
+["UK3CB_Bren_L4_LMG", "", "", "", ["UK3CB_Bren_30Rnd_762x51_Magazine", "UK3CB_Bren_30Rnd_762x51_Magazine", "UK3CB_Bren_30Rnd_762x51_Magazine_GT"], [], ""],
+["UK3CB_Bren_L4_LMG", "", "", "", ["UK3CB_Bren_30Rnd_762x51_Magazine", "UK3CB_Bren_30Rnd_762x51_Magazine", "UK3CB_Bren_30Rnd_762x51_Magazine_GT"], [], ""],
 ["rhs_weap_mg42", "", "", "rhsgref_mg42_acc_AAsight", ["rhsgref_50Rnd_792x57_SmK_drum", "rhsgref_50Rnd_792x57_SmK_drum", "rhsgref_50Rnd_792x57_SmK_alltracers_drum"], [], ""],
 ["UK3CB_M60", "", "", "", ["UK3CB_M60_100rnd_762x51", "UK3CB_M60_100rnd_762x51", "UK3CB_M60_100rnd_762x51_GT"], [], ""]
 ]];
 _militiaLoadoutData set ["marksmanRifles", [
-["rhs_weap_m1garand_sa43", "", "", "", ["rhsgref_8Rnd_762x63_M2B_M1rifle"], [], ""]
+["rhs_weap_m1garand_sa43", "", "", "", ["rhsgref_8Rnd_762x63_M2B_M1rifle"], [], ""],
+["uk3cb_enfield_l42", "", "", "uk3cb_optic_no32", ["uk3cb_l42_enfield_762_10Rnd_magazine"], [], ""],
+["uk3cb_enfield_l8t", "", "", "uk3cb_optic_no32", ["uk3cb_l42_enfield_762_10Rnd_magazine"], [], ""]
 ]];
 _militiaLoadoutData set ["sniperRifles", [
-["rhs_weap_kar98k", "", "", "", ["rhsgref_5Rnd_792x57_kar98k"], [], ""],
-["rhs_weap_m38", "", "", "", ["rhsgref_5Rnd_762x54_m38"], [], ""]
+["uk3cb_enfield_l42", "", "", "uk3cb_optic_no32", ["uk3cb_l42_enfield_762_10Rnd_magazine"], [], ""],
+["uk3cb_enfield_l8t", "", "", "uk3cb_optic_no32", ["uk3cb_l42_enfield_762_10Rnd_magazine"], [], ""]
 ]];
 
 _militiaLoadoutData set ["ATLaunchers", [

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_HIDF.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_HIDF.sqf
@@ -83,6 +83,7 @@
 ["faces", ["TanoanHead_A3_01","TanoanHead_A3_02","TanoanHead_A3_03","TanoanHead_A3_04","TanoanHead_A3_05",
 "TanoanHead_A3_06","TanoanHead_A3_07","TanoanHead_A3_08"]] call _fnc_saveToTemplate;
 ["voices", ["Male01ENGFRE","Male02ENGFRE"]] call _fnc_saveToTemplate;
+"TanoanMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_ION_Arctic.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_ION_Arctic.sqf
@@ -86,7 +86,7 @@
 "WhiteHead_03", "WhiteHead_04", "WhiteHead_05", "WhiteHead_07", "WhiteHead_08", "WhiteHead_09", "WhiteHead_10", "WhiteHead_11", "WhiteHead_13",
 "WhiteHead_14", "WhiteHead_15", "WhiteHead_16", "WhiteHead_17", "WhiteHead_18", "WhiteHead_19", "WhiteHead_21"]] call _fnc_saveToTemplate;
 ["voices", ["Male01ENG", "Male02ENG", "Male03ENG", "Male04ENG", "Male05ENG", "Male06ENG", "Male07ENG", "Male08ENG", "Male09ENG", "Male10ENG", "Male11ENG", "Male12ENG", "Male01GRE", "Male02GRE", "Male03GRE", "Male04GRE", "Male05GRE", "Male06GRE", "Male01ENGB", "Male02ENGB", "Male03ENGB", "Male04ENGB", "Male05ENGB", "Male01ENGFRE", "Male02ENGFRE"]] call _fnc_saveToTemplate;
-
+"NATOMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_ION_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_ION_Arid.sqf
@@ -86,7 +86,7 @@
 "WhiteHead_03", "WhiteHead_04", "WhiteHead_05", "WhiteHead_07", "WhiteHead_08", "WhiteHead_09", "WhiteHead_10", "WhiteHead_11", "WhiteHead_13",
 "WhiteHead_14", "WhiteHead_15", "WhiteHead_16", "WhiteHead_17", "WhiteHead_18", "WhiteHead_19", "WhiteHead_21"]] call _fnc_saveToTemplate;
 ["voices", ["Male01ENG", "Male02ENG", "Male03ENG", "Male04ENG", "Male05ENG", "Male06ENG", "Male07ENG", "Male08ENG", "Male09ENG", "Male10ENG", "Male11ENG", "Male12ENG", "Male01GRE", "Male02GRE", "Male03GRE", "Male04GRE", "Male05GRE", "Male06GRE", "Male01ENGB", "Male02ENGB", "Male03ENGB", "Male04ENGB", "Male05ENGB", "Male01ENGFRE", "Male02ENGFRE"]] call _fnc_saveToTemplate;
-
+"NATOMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_ION_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_ION_Temperate.sqf
@@ -86,7 +86,7 @@
 "WhiteHead_03", "WhiteHead_04", "WhiteHead_05", "WhiteHead_07", "WhiteHead_08", "WhiteHead_09", "WhiteHead_10", "WhiteHead_11", "WhiteHead_13",
 "WhiteHead_14", "WhiteHead_15", "WhiteHead_16", "WhiteHead_17", "WhiteHead_18", "WhiteHead_19", "WhiteHead_21"]] call _fnc_saveToTemplate;
 ["voices", ["Male01ENG", "Male02ENG", "Male03ENG", "Male04ENG", "Male05ENG", "Male06ENG", "Male07ENG", "Male08ENG", "Male09ENG", "Male10ENG", "Male11ENG", "Male12ENG", "Male01GRE", "Male02GRE", "Male03GRE", "Male04GRE", "Male05GRE", "Male06GRE", "Male01ENGB", "Male02ENGB", "Male03ENGB", "Male04ENGB", "Male05ENGB", "Male01ENGFRE", "Male02ENGFRE"]] call _fnc_saveToTemplate;
-
+"NATOMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_KRG.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_KRG.sqf
@@ -87,6 +87,7 @@
 
 ["faces", ["PersianHead_A3_01", "PersianHead_A3_02", "PersianHead_A3_03"]] call _fnc_saveToTemplate;
 ["voices", ["Male01PER", "Male02PER", "Male03PER"]] call _fnc_saveToTemplate;
+"TakistaniMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_LDF.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_LDF.sqf
@@ -433,10 +433,12 @@ _militiaLoadoutData set ["machineGuns", [
 ["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39", "UK3CB_RPD_100rnd_762x39_GM"], [], ""]
 ]];
 _militiaLoadoutData set ["marksmanRifles", [
-["UK3CB_SVD_OLD", "", "", "rhs_acc_pso1m2", ["rhs_10Rnd_762x54mmR_7N1"], [], ""]
+["UK3CB_SVD_OLD", "", "", "rhs_acc_pso1m2", ["rhs_10Rnd_762x54mmR_7N1"], [], ""],
+["UK3CB_SVD_OLD", "", "", "rhs_acc_pso1m2", ["rhs_10Rnd_762x54mmR_7N1"], [], ""],
+["UK3CB_CZ550", "", "", "uk3cb_optic_sro", ["UK3CB_CZ550_5rnd_Mag"], [], ""]
 ]];
 _militiaLoadoutData set ["sniperRifles", [
-["UK3CB_SVD_OLD", "", "", "rhs_acc_pso1m2", ["rhs_10Rnd_762x54mmR_7N1"], [], ""]
+["UK3CB_SVD_OLD", "", "", "rhs_acc_pso1m2", ["rhs_10Rnd_762x54mmR_7N1"], [], ""],
 ["UK3CB_CZ550", "", "", "uk3cb_optic_sro", ["UK3CB_CZ550_5rnd_Mag"], [], ""]
 ]];
 _militiaLoadoutData set ["lightATLaunchers", [

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_LDF.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_LDF.sqf
@@ -428,13 +428,16 @@ _militiaLoadoutData set ["machineGuns", [
 ["rhs_weap_pkm", "", "", "", ["rhs_100Rnd_762x54mmR", "rhs_100Rnd_762x54mmR_green"], [], ""],
 ["UK3CB_UKM2000P", "", "", "", ["UK3CB_UKM_100rnd_762x51", "UK3CB_UKM_100rnd_762x51_GT"], [], ""],
 ["UK3CB_RPK_74N", "", "", "", ["UK3CB_RPK74_60rnd_545x39_G", "UK3CB_RPK74_60rnd_545x39_G", "UK3CB_RPK74_60rnd_545x39_GT"], [], ""],
-["UK3CB_RPK", "", "", "", ["UK3CB_RPK_75rnd_762x39_G", "UK3CB_RPK_75rnd_762x39_G", "UK3CB_RPK_75rnd_762x39_GT"], [], ""]
+["UK3CB_RPK", "", "", "", ["UK3CB_RPK_75rnd_762x39_G", "UK3CB_RPK_75rnd_762x39_G", "UK3CB_RPK_75rnd_762x39_GT"], [], ""],
+["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39"], [], ""],
+["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39", "UK3CB_RPD_100rnd_762x39_GM"], [], ""]
 ]];
 _militiaLoadoutData set ["marksmanRifles", [
 ["UK3CB_SVD_OLD", "", "", "rhs_acc_pso1m2", ["rhs_10Rnd_762x54mmR_7N1"], [], ""]
 ]];
 _militiaLoadoutData set ["sniperRifles", [
 ["UK3CB_SVD_OLD", "", "", "rhs_acc_pso1m2", ["rhs_10Rnd_762x54mmR_7N1"], [], ""]
+["UK3CB_CZ550", "", "", "uk3cb_optic_sro", ["UK3CB_CZ550_5rnd_Mag"], [], ""]
 ]];
 _militiaLoadoutData set ["lightATLaunchers", [
 "rhs_weap_rpg18", "rhs_weap_rpg26", "rhs_weap_rpg75", "rhs_weap_m80"

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_MDF.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_MDF.sqf
@@ -405,7 +405,7 @@ _militiaLoadoutData set ["carbines", [
 _militiaLoadoutData set ["grenadeLaunchers", [
 ["UK3CB_FAMAS_F1_GLM203", "", "", "", ["UK3CB_FAMAS_25rnd_556x45", "UK3CB_FAMAS_25rnd_556x45", "UK3CB_FAMAS_25rnd_556x45_RT"], ["rhs_mag_M441_HE", "rhs_mag_M441_HE", "rhs_mag_M433_HEDP", "rhs_mag_m714_White"], ""]
 ]];
-_militiaLoadoutData set ["SMGs", ["UK3CB_MP5A2"]];
+_militiaLoadoutData set ["SMGs", ["uk3cb_mat49"]];
 _militiaLoadoutData set ["machineGuns", [
 ["rhs_weap_fnmag", "", "", "", ["rhsusf_50Rnd_762x51", "rhsusf_50Rnd_762x51", "rhsusf_50Rnd_762x51_m62_tracer"], [], ""]
 ]];

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_MDF.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_MDF.sqf
@@ -88,6 +88,7 @@
 "WhiteHead_16","WhiteHead_17","WhiteHead_18","WhiteHead_19","WhiteHead_20",
 "WhiteHead_21"]] call _fnc_saveToTemplate;
 ["voices", ["Male01ENGFRE","Male02ENGFRE"]] call _fnc_saveToTemplate;
+"GreekMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TKA_East.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TKA_East.sqf
@@ -82,6 +82,7 @@
 
 ["voices", ["Male01PER", "Male02PER", "Male03PER"]] call _fnc_saveToTemplate;
 ["faces", ["PersianHead_A3_01", "PersianHead_A3_02", "PersianHead_A3_03"]] call _fnc_saveToTemplate;
+"TakistaniMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //
@@ -307,10 +308,12 @@ _militaryLoadoutData set ["grenadeLaunchers", [
 ["rhs_weap_ak74n_gp25", "rhs_acc_dtk3", "", "rhs_acc_pkas", ["rhs_30Rnd_545x39_7N10_AK"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
 ["rhs_weap_ak74n_gp25", "rhs_acc_dtk3", "", "rhs_acc_1p63", ["rhs_30Rnd_545x39_7N10_AK"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""]
 ]];
-_militaryLoadoutData set ["SMGs", ["rhs_weap_pp2000"]];
+_militaryLoadoutData set ["SMGs", ["uk3cb_port_said_m45"]];
 _militaryLoadoutData set ["machineGuns", [
 ["rhs_weap_pkm", "", "", "",["rhs_100Rnd_762x54mmR", "rhs_100Rnd_762x54mmR_green"], [], ""],
-["rhs_weap_pkm", "", "", "",["rhs_100Rnd_762x54mmR_7N13", "rhs_100Rnd_762x54mmR_green"], [], ""]
+["rhs_weap_pkm", "", "", "",["rhs_100Rnd_762x54mmR_7N13", "rhs_100Rnd_762x54mmR_green"], [], ""],
+["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39"], [], ""],
+["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39", "UK3CB_RPD_100rnd_762x39_GM"], [], ""]
 ]];
 _militaryLoadoutData set ["marksmanRifles", [
 ["rhs_weap_svdp", "", "", "rhs_acc_pso1m2", [], [], ""],
@@ -333,7 +336,7 @@ _policeLoadoutData set ["antiInfantryGrenades", ["rhs_mag_fakel", "rhs_mag_fakel
 _policeLoadoutData set ["rifles", [
 ["rhs_weap_ak103_1", "rhs_acc_dtk", "", "", ["rhs_10Rnd_762x39mm"], [], ""]
 ]];
-_policeLoadoutData set ["SMGs", ["rhs_weap_pp2000"]];
+_policeLoadoutData set ["SMGs", ["uk3cb_port_said_m45"]];
 _policeLoadoutData set ["sidearms", [
 ["rhs_weap_pya", "", "", "", [], [""], ""]
 ]];
@@ -364,8 +367,11 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 ["rhs_weap_akms_gp25", "rhs_acc_dtkakm", "", "", ["rhs_30Rnd_762x39mm", "rhs_30Rnd_762x39mm_tracer"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
 ["rhs_weap_aks74n_gp25", "rhs_acc_dtk", "", "", ["rhs_30Rnd_545x39_7N10_AK"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""]
 ]];
-_militiaLoadoutData set ["SMGs", ["rhs_weap_pp2000"]];
-_militiaLoadoutData set ["machineGuns", ["rhs_weap_pkm"]];
+_militiaLoadoutData set ["SMGs", ["uk3cb_port_said_m45"]];
+_militiaLoadoutData set ["machineGuns", ["rhs_weap_pkm",
+["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39"], [], ""],
+["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39", "UK3CB_RPD_100rnd_762x39_GM"], [], ""]
+]];
 _militiaLoadoutData set ["marksmanRifles", [
 ["rhs_weap_svdp", "", "", "rhs_acc_pso1m2", ["rhs_10Rnd_762x54mmR_7N1"], [], ""]
 ]];

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TKA_Mix.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TKA_Mix.sqf
@@ -83,6 +83,7 @@
 
 ["voices", ["Male01PER", "Male02PER", "Male03PER"]] call _fnc_saveToTemplate;
 ["faces", ["PersianHead_A3_01", "PersianHead_A3_02", "PersianHead_A3_03"]] call _fnc_saveToTemplate;
+"TakistaniMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //
@@ -408,7 +409,7 @@ _policeLoadoutData set ["shotGuns", [
 ]];
 
 _policeLoadoutData set ["SMGs", [
-["rhs_weap_pp2000", "", "", "", [], [], ""],
+["uk3cb_port_said_m45", "", "", "", [], [], ""],
 ["UK3CB_MP5", "", "", "", ["UK3CB_MP5_30Rnd_Magazine"], [""], ""],
 ["rhsusf_weap_MP7A2", "", "rhsusf_acc_wmx_bk", "rhsusf_acc_eotech_xps3", [], [], ""]
 ]];
@@ -452,8 +453,11 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 ["UK3CB_HK33KA2_RIS_GL", "", "", "", ["UK3CB_HK33_30rnd_556x45_G", "UK3CB_HK33_30rnd_556x45_G", "UK3CB_HK33_30rnd_556x45_YT"], ["rhs_mag_M441_HE", "rhs_mag_M441_HE", "rhs_mag_M433_HEDP", "rhs_mag_m714_White"], ""],
 ["UK3CB_M16A2_UGL", "", "", "", ["rhs_mag_30Rnd_556x45_M855_Stanag", "rhs_mag_30Rnd_556x45_M855_Stanag", "rhs_mag_30Rnd_556x45_M855_Stanag_Tracer_Red"], ["rhs_mag_M441_HE", "rhs_mag_M441_HE", "rhs_mag_M433_HEDP", "rhs_mag_m714_White"], ""]
 ]];
-_militiaLoadoutData set ["SMGs", ["rhs_weap_pp2000"]];
-_militiaLoadoutData set ["machineGuns", ["rhs_weap_pkm"]];
+_militiaLoadoutData set ["SMGs", ["uk3cb_port_said_m45"]];
+_militiaLoadoutData set ["machineGuns", ["rhs_weap_pkm",
+["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39"], [], ""],
+["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39", "UK3CB_RPD_100rnd_762x39_GM"], [], ""]
+]];
 _militiaLoadoutData set ["marksmanRifles", [
 ["rhs_weap_svdp", "", "", "rhs_acc_pso1m2", ["rhs_10Rnd_762x54mmR_7N1"], [], ""],
 ["UK3CB_G3SG1", "", "", "uk3cb_optic_STANAGZF_G3", [], [], ""]

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_CHC.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_CHC.sqf
@@ -29,7 +29,8 @@
     ,"UK3CB_CHC_C_Pickup",0.5]] call _fnc_saveToTemplate;
 
 ["vehiclesCivIndustrial", [
-    "UK3CB_CHC_C_Tractor", 0.2
+    "UK3CB_C_Forklift", 0.05
+    ,"UK3CB_CHC_C_Tractor", 0.2
     ,"UK3CB_CHC_C_Tractor_Old", 0.2
     ,"UK3CB_CHC_C_Kamaz_Covered", 0.3
     ,"UK3CB_CHC_C_Kamaz_Open", 0.3

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_TKC.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_TKC.sqf
@@ -29,7 +29,8 @@
     ,"UK3CB_TKC_C_Pickup",0.5]] call _fnc_saveToTemplate;
 
 ["vehiclesCivIndustrial", [
-    "UK3CB_TKC_C_Tractor", 0.2
+    "UK3CB_C_Forklift", 0.05
+    ,"UK3CB_TKC_C_Tractor", 0.2
     ,"UK3CB_TKC_C_Tractor_Old", 0.2
     ,"UK3CB_TKC_C_Kamaz_Covered", 0.3
     ,"UK3CB_TKC_C_Kamaz_Open", 0.3

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Reb_CNM.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Reb_CNM.sqf
@@ -103,6 +103,7 @@ private _rebUniforms = [
 "WhiteHead_12", "WhiteHead_13", "WhiteHead_14", "WhiteHead_15", "WhiteHead_16",
 "WhiteHead_17", "WhiteHead_19", "WhiteHead_20", "WhiteHead_21"]] call _fnc_saveToTemplate;
 ["voices", ["RHS_Male01CZ", "RHS_Male02CZ", "RHS_Male03CZ", "RHS_Male04CZ", "RHS_Male05CZ"]] call _fnc_saveToTemplate;
+"ChernarusMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Reb_FIA.sqf
@@ -165,6 +165,7 @@ private _rebUniforms = [
 "GreekHead_A3_05", "GreekHead_A3_06", "GreekHead_A3_07", "GreekHead_A3_08",
 "GreekHead_A3_09", "Ioannou", "Mavros"]] call _fnc_saveToTemplate;
 ["voices", ["Male01GRE", "Male02GRE", "Male03GRE", "Male04GRE", "Male05GRE", "Male06GRE"]] call _fnc_saveToTemplate;
+"GreekMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Reb_ION.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Reb_ION.sqf
@@ -131,6 +131,7 @@ default {
 "WhiteHead_03", "WhiteHead_04", "WhiteHead_05", "WhiteHead_07", "WhiteHead_08", "WhiteHead_09", "WhiteHead_10", "WhiteHead_11", "WhiteHead_13",
 "WhiteHead_14", "WhiteHead_15", "WhiteHead_16", "WhiteHead_17", "WhiteHead_18", "WhiteHead_19", "WhiteHead_21"]] call _fnc_saveToTemplate;
 ["voices", ["Male01ENG", "Male02ENG", "Male03ENG", "Male04ENG", "Male05ENG", "Male06ENG", "Male07ENG", "Male08ENG", "Male09ENG", "Male10ENG", "Male11ENG", "Male12ENG", "Male01GRE", "Male02GRE", "Male03GRE", "Male04GRE", "Male05GRE", "Male06GRE", "Male01ENGB", "Male02ENGB", "Male03ENGB", "Male04ENGB", "Male05ENGB", "Male01ENGFRE", "Male02ENGFRE"]] call _fnc_saveToTemplate;
+"NATOMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Reb_TKM.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Reb_TKM.sqf
@@ -96,6 +96,7 @@ private _rebUniforms = [
     "UK3CB_TKC_H_Turban_04_1",
     "UK3CB_TKC_H_Turban_05_1"
 ]] call _fnc_saveToTemplate;
+"TakistaniMen" call _fnc_saveNames;
 
 /////////////////////
 ///  Identities   ///
@@ -103,6 +104,7 @@ private _rebUniforms = [
 
 ["voices", ["Male01PER", "Male02PER", "Male03PER"]] call _fnc_saveToTemplate;
 ["faces", ["PersianHead_A3_01", "PersianHead_A3_02", "PersianHead_A3_03"]] call _fnc_saveToTemplate;
+"TakistaniMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Reb_TKM.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Reb_TKM.sqf
@@ -96,7 +96,6 @@ private _rebUniforms = [
     "UK3CB_TKC_H_Turban_04_1",
     "UK3CB_TKC_H_Turban_05_1"
 ]] call _fnc_saveToTemplate;
-"TakistaniMen" call _fnc_saveNames;
 
 /////////////////////
 ///  Identities   ///

--- a/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
@@ -2,6 +2,9 @@
 //asval, Mk17 and SCAR-H arguable
 
 private _categoryOverrideTable = [
+//Bespoke, a3a
+["a3a_UK3CB_CZ550_8mm", ["SniperRifles","Weapons"]], //UK3CB_CZ550 in 8mm
+
 //Vanilla
 ["launch_NLAW_F", ["MissileLaunchers","Weapons","AT"]],
 ["hgun_PDW2000_F", ["SMGs","Weapons"]],

--- a/A3A/addons/logistics/Cargo/3CBFactions.hpp
+++ b/A3A/addons/logistics/Cargo/3CBFactions.hpp
@@ -15,3 +15,10 @@ class UK3CB_Factions_addons_UK3CB_Factions_Static_UK3CB_Factions_Static_M240_UK3
     recoil = 50;
     isWeapon = 1;
 };
+class UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehicles_motorbikes_uk3cb_m1030_p3d : TRIPLES(ADDON,Cargo,Base)
+{
+    offset[] = {0.01,-0.3,1.6};
+    rotation[] = {0.06,0.1,0};
+    size = 2;
+    recoil = 0;
+};

--- a/A3A/addons/logistics/Nodes/3CBFactions.hpp
+++ b/A3A/addons/logistics/Nodes/3CBFactions.hpp
@@ -719,3 +719,114 @@ class UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehic
         };
     };
 };
+
+class UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehicles_scud_uk3cb_maz_543_open_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+    class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,0.2,-0.35};
+            seats[] = {0,1};
+        };
+        class Node2
+        {
+            offset[] = {0,-0.6,-0.35};
+            seats[] = {2,3};
+        };
+        class Node3
+        {
+            offset[] = {0,-1.4,-0.35};
+            seats[] = {4,5};
+        };
+        class Node4
+        {
+            offset[] = {0,-2.2,-0.35};
+            seats[] = {6,7};
+        };
+        class Node5
+        {
+            offset[] = {0,-3,-0.35};
+            seats[] = {8,9};
+        };
+        class Node6
+        {
+            offset[] = {0,-3.8,-0.35};
+            seats[] = {10,11};
+        };
+    };
+};
+class UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehicles_scud_uk3cb_maz_543_closed_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+    class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,0.2,-0.35};
+            seats[] = {0,1};
+        };
+        class Node2
+        {
+            offset[] = {0,-0.6,-0.35};
+            seats[] = {2,3};
+        };
+        class Node3
+        {
+            offset[] = {0,-1.4,-0.35};
+            seats[] = {4,5};
+        };
+        class Node4
+        {
+            offset[] = {0,-2.2,-0.35};
+            seats[] = {6,7};
+        };
+        class Node5
+        {
+            offset[] = {0,-3,-0.35};
+            seats[] = {8,9};
+        };
+        class Node6
+        {
+            offset[] = {0,-3.8,-0.35};
+            seats[] = {10,11};
+        };
+    };
+};
+class UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehicles_scud_uk3cb_maz_543_Recovery_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+    class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,2.6,-3.25};
+        };
+        class Node2
+        {
+            offset[] = {0,1.8,-3.25};
+        };
+        class Node3
+        {
+            offset[] = {0,1,-3.25};
+        };
+        class Node4
+        {
+            offset[] = {0,0.2,-3.25};
+        };
+        class Node5
+        {
+            offset[] = {0,-0.6,-3.25};
+        };
+        class Node6
+        {
+            offset[] = {0,-1.4,-3.25};
+        };
+        class Node7
+        {
+            offset[] = {0,-2.2,-3.25};
+        };
+        class Node8
+        {
+            offset[] = {0,-3,-3.25};
+        };
+    };
+};


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Adds name identity to a number of template that were opened in the process.
Adds Forklift as rare civilian vehicle.

Adds the MAT49 submachinegun to template MDF and HIDF were appropriate.
Adds the Port Said (M/45) Submachinegun to ADA, TKA East, and TKA Mix were appropriate.
Adds the RPD lightmachinegun to ADA, CW_SOV, LDF, TKA East, and TKA Mix were appropriate.
Adds the CZ550 sniper rifle to the LDF Militia.
Adds scoped Enfield rifles to the HIDF Militia, replacing some rifles.

Fixes the HIDF Militia having the wrong classname for the Bren gun, due to the latest 3CB update (Update 8.0.0 2024-03-12)

### Please specify which Issue this PR Resolves.
closes /*Next report of the HIDF militia not having machineguns*/
closes #3180 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
