### PR TITLE
RHS ChDKZ T-72 Event Handler Inheritance

### DIFF
--- a/A3A/addons/config_fixes/RHS/chdkz_rhs.hpp
+++ b/A3A/addons/config_fixes/RHS/chdkz_rhs.hpp
@@ -12,18 +12,14 @@ class a3a_rhs_chdkz_72a : rhsgref_ins_t72ba
 {
 	class EventHandlers : EventHandlers
 	{
-		fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
-		init = "";
-		killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
+        class rhs_flag_init{};
 	};
 };
 class a3a_rhs_chdkz_72b : rhsgref_ins_t72bb
 {
 	class EventHandlers : EventHandlers
 	{
-		fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
-		init = "";
-		killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
+        class rhs_flag_init{};
 	};
 };
 class a3a_rhs_chdkz_72c : rhsgref_ins_t72bc
@@ -38,9 +34,7 @@ class a3a_rhs_chdkz_72c : rhsgref_ins_t72bc
 	};
 	class EventHandlers : EventHandlers
 	{
-		fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
-		init = "";
-		killed = "_this call (uinamespace getvariable 'BIS_fnc_effectKilled');";
+        class rhs_flag_init{};
 	};
 };
 

--- a/A3A/addons/config_fixes/RHS/chdkz_rhs.hpp
+++ b/A3A/addons/config_fixes/RHS/chdkz_rhs.hpp
@@ -12,14 +12,14 @@ class a3a_rhs_chdkz_72a : rhsgref_ins_t72ba
 {
 	class EventHandlers : EventHandlers
 	{
-        class rhs_flag_init{};
+		class rhs_flag_init{};
 	};
 };
 class a3a_rhs_chdkz_72b : rhsgref_ins_t72bb
 {
 	class EventHandlers : EventHandlers
 	{
-        class rhs_flag_init{};
+		class rhs_flag_init{};
 	};
 };
 class a3a_rhs_chdkz_72c : rhsgref_ins_t72bc
@@ -34,7 +34,7 @@ class a3a_rhs_chdkz_72c : rhsgref_ins_t72bc
 	};
 	class EventHandlers : EventHandlers
 	{
-        class rhs_flag_init{};
+		class rhs_flag_init{};
 	};
 };
 

--- a/A3A/addons/config_fixes/RHS/chdkz_rhs.hpp
+++ b/A3A/addons/config_fixes/RHS/chdkz_rhs.hpp
@@ -1,13 +1,16 @@
 //RHS - chdkz_rhs.hpp
 
 //Armour
-class rhsgref_ins_t72ba;
-class rhsgref_ins_t72bb;
-class rhsgref_ins_t72bc;
+class rhs_t72ba_tv;
+class rhs_t72bb_tv;
+class rhs_t72bc_tv;
+class rhsgref_ins_t72ba : rhs_t72ba_tv {class EventHandlers; };
+class rhsgref_ins_t72bb : rhs_t72bb_tv {class EventHandlers; };
+class rhsgref_ins_t72bc : rhs_t72bc_tv {class EventHandlers; };
 
 class a3a_rhs_chdkz_72a : rhsgref_ins_t72ba
 {
-	class EventHandlers
+	class EventHandlers : EventHandlers
 	{
 		fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
 		init = "";
@@ -16,7 +19,7 @@ class a3a_rhs_chdkz_72a : rhsgref_ins_t72ba
 };
 class a3a_rhs_chdkz_72b : rhsgref_ins_t72bb
 {
-	class EventHandlers
+	class EventHandlers : EventHandlers
 	{
 		fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
 		init = "";
@@ -33,7 +36,7 @@ class a3a_rhs_chdkz_72c : rhsgref_ins_t72bc
 		"rhsafrf\addons\rhs_t72\data\rhs_t72b_04_co.paa",
 		"rhsafrf\addons\rhs_t72\data\rhs_t72b_05_co.paa"
 	};
-	class EventHandlers
+	class EventHandlers : EventHandlers
 	{
 		fired = "_this call (uinamespace getvariable 'BIS_fnc_effectFired');";
 		init = "";


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Corrects how the eventhandlers for the fixed chdkz tanks from RHS, the ones that had to lose their flags.
In principle the same changes as #3128, and the issue is as described by #3127

### Please specify which Issue this PR Resolves.
closes #3173

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
This should be the final nail in the coffin for these flags, i hope