### PR TITLE
Updates fn_initZones.sqf to remove the case sensitivity of the town-type check

### DIFF
--- a/A3A/addons/core/functions/init/fn_initZones.sqf
+++ b/A3A/addons/core/functions/init/fn_initZones.sqf
@@ -73,7 +73,7 @@ private _disabledTowns = getArray (_mapInfo/"disabledTowns");
 {server setVariable [_x select 0,_x select 1]} forEach _townPopulations;
 private _hardCodedPopulation = _townPopulations isNotEqualTo [];
 
-"(getText (_x >> ""type"") in [""NameCityCapital"",""Namecitycapital"", ""NameCity"",""Namecity"", ""NameVillage"", ""nameVillage"",""Namevillage"", ""CityCenter"",""Citycenter""]) &&
+"(toLower getText (_x >> ""type"") in [""namecitycapital"",""namecity"",""namevillage"",""citycenter""]) &&
 !(getText (_x >> ""Name"") isEqualTo """") &&
 !((configName _x) in _disabledTowns)"
 configClasses (configfile >> "CfgWorlds" >> worldName >> "Names") apply {

--- a/A3A/addons/core/functions/init/fn_initZones.sqf
+++ b/A3A/addons/core/functions/init/fn_initZones.sqf
@@ -73,7 +73,7 @@ private _disabledTowns = getArray (_mapInfo/"disabledTowns");
 {server setVariable [_x select 0,_x select 1]} forEach _townPopulations;
 private _hardCodedPopulation = _townPopulations isNotEqualTo [];
 
-"(getText (_x >> ""type"") in [""NameCityCapital"",""Namecitycapital"", ""NameCity"",""Namecity"", ""NameVillage"",""Namevillage"", ""CityCenter"",""Citycenter""]) &&
+"(getText (_x >> ""type"") in [""NameCityCapital"",""Namecitycapital"", ""NameCity"",""Namecity"", ""NameVillage"", ""nameVillage"",""Namevillage"", ""CityCenter"",""Citycenter""]) &&
 !(getText (_x >> ""Name"") isEqualTo """") &&
 !((configName _x) in _disabledTowns)"
 configClasses (configfile >> "CfgWorlds" >> worldName >> "Names") apply {


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
~~adds "nameVillage" to fn_initZones.sqf as that is how some terrains are.~~

~~We could really do with a case insensitive or otherwise more clever solution to this.~~

Kills the case sensitivity of the check at line 76.
No need to add special cases for the various miss-casings of the town types anymore.

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
example map https://steamcommunity.com/sharedfiles/filedetails/?id=1757672655
********************************************************
Notes:
