### PR TITLE
Vanilla ION - adds missing vests

### DIFF
--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_PMC.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_PMC.sqf
@@ -216,6 +216,7 @@ private _sfLoadoutData = _loadoutData call _fnc_copyLoadoutData;
 _sfLoadoutData set ["uniforms", ["U_B_CTRG_2","U_I_G_Story_Protagonist_F","U_B_CombatUniform_mcam_tshirt"]];
 _sfLoadoutData set ["vests", ["V_PlateCarrier1_blk","V_PlateCarrier2_blk","V_PlateCarrierGL_blk", "V_PlateCarrierSpec_blk"]];
 _sfLoadoutData set ["Lvests", ["V_TacVestIR_blk"]];
+_sfLoadoutData set ["Hvests", ["V_PlateCarrierGL_blk", "V_PlateCarrierSpec_blk"]];
 _sfLoadoutData set ["backpacks", ["B_AssaultPack_blk", "B_Carryall_blk", "B_FieldPack_blk", "B_Kitbag_tan"]];
 _sfLoadoutData set ["helmets", ["H_HelmetB_sand", "H_HelmetB_black", "H_HelmetSpecB_blk", "H_HelmetSpecB_sand"]];
 _sfLoadoutData set ["binoculars", ["Laserdesignator"]];


### PR DESCRIPTION
I probably intended to do this

## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
A3 ION was apparently missing its line for heavy vests, or perhaps the use of _fnc_fallback was erroneously assumed.
This PR resolves that.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
