### PR TITLE
Prevent O(N^2) startup hang with excessive hats/glasses

### DIFF
--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -123,18 +123,23 @@ else
     // Fill out garrisons, set sides/names as appropriate
     call A3A_fnc_initGarrisons;
 
+    Info("Starting item unlocks");
+
     // Do initial arsenal filling
     private _categoriesToPublish = createHashMap;
+    private _equipHM = FactionGet(reb,"initialRebelEquipment") createHashMapFromArray [];       // dupe proofing
     {
         if (_x isEqualType "") then {
-            private _categories = [_x, true] call A3A_fnc_unlockEquipment;
+            private _arsenalTab = _x call jn_fnc_arsenal_itemType;
+            jna_dataList#_arsenalTab pushBack [_x, -1];         // direct add to avoid O(N^2) issue
+            private _categories = _x call A3A_fnc_equipmentClassToCategories;
             _categoriesToPublish insert [true, _categories, []];
             continue;
         };
         _x params ["_class", "_count"];
         private _arsenalTab = _class call jn_fnc_arsenal_itemType;
-        [_arsenalTab, _class, _count] call jn_fnc_arsenal_addItem;
-    } foreach FactionGet(reb,"initialRebelEquipment");
+        jna_dataList#_arsenalTab pushBack [_class, _count];
+    } foreach keys _equipHM;
 
     // Publish the unlocked categories (once each)
     { publicVariable ("unlocked" + _x) } forEach keys _categoriesToPublish;


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement
4. [X] Performance

### What have you changed and why?
The initial arsenal unlocks code used jn_fnc_arsenal_addItem to add each item individually to the arsenal. This blows up when the list is large, because addItem checks each current entry to see if there's a classname match, causing 20min+ startups when mods add a large number of cosmetic headgear or glasses (eg. USP).

This PR fixes the problem by ensuring that the initial gear has no dupes and then adding it directly to jna_datalist. This is a bit of a hack, but then the whole arsenal is a hack at this point. 

This even improves 3CB Factions startup time by several seconds.

### Please specify which Issue this PR Resolves.
closes #3194

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
