### PR TITLE
Fix fast travel parameter inversion and allowDamage exploit

### DIFF
--- a/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -11,7 +11,7 @@ _esHC = false;
 if (count hcSelected player > 1) exitWith {[_titleStr, localize "STR_A3A_fn_dialogs_ftradio_grp_select"] call A3A_fnc_customHint;};
 if (count hcSelected player == 1) then {_groupX = hcSelected player select 0; _esHC = true} else {_groupX = group player};
 _checkForPlayer = false;
-if ((!_esHC) and (limitedFT == 0)) then {_checkForPlayer = true};
+if ((!_esHC) and (limitedFT == 1)) then {_checkForPlayer = true};
 _boss = leader _groupX;
 
 if ((_boss != player) and (!_esHC)) then {_groupX = player};
@@ -90,7 +90,7 @@ if (count _positionTel > 0) then
  				}
  			};
 		_exit = false;
-		if (limitedFT == 0) then
+		if (limitedFT == 1) then
 			{
 			_vehicles = [];
 			{if (vehicle _x != _x) then {_vehicles pushBackUnique (vehicle _x)}} forEach units _groupX;
@@ -98,12 +98,14 @@ if (count _positionTel > 0) then
 			};
 		if (_checkForPlayer and ((_base != "SYND_HQ") and !(_base in airportsX))) 
 		exitWith {[_titleStr, format [localize "STR_A3A_fn_dialogs_ftradio_cancelled",groupID _groupX]] call A3A_fnc_customHint;};
+		private _ftUnits = [];
 		{
 		_unit = _x;
 		if ((!isPlayer _unit) or (_unit == player)) then
 			{
 			//_unit hideObject true;
 			_unit allowDamage false;
+			_ftUnits pushBack _unit;
 			if (_unit != vehicle _unit) then
 				{
 				if (driver vehicle _unit == _unit) then
@@ -151,7 +153,7 @@ if (count _positionTel > 0) then
 		if (_forcedX) then {forcedSpawn = forcedSpawn - [_base]};
 		[] call A3A_fnc_playerLeashRefresh;
 		sleep 5;
-		{_x allowDamage true} forEach units _groupX;
+		{_x allowDamage true} forEach _ftUnits;
 		}
 	else
 		{


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Two bug fixes in fast travel:
1. Parameter inversion introduced in 3.5.2. Any location and HQ/airfield only options were swapped.    
2. Ancient exploit where changing group shortly after fast travelling would make you immortal.

### Please specify which Issue this PR Resolves.
closes #3193
closes #3164

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
