### PR TITLE
Fix arsenal backpack weapon attachments code adding the wrong element

### DIFF
--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_handleAction.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_handleAction.sqf
@@ -47,7 +47,7 @@ _attachmentsContainers = [[],[],[]];
 	if!(isNil "_weaponAtt")then{
 
 		{
-			_atts = [_x select 1,_x select 2,_x select 3,_x select 5];
+			_atts = [_x select 1,_x select 2,_x select 3,_x select 6];
 			_atts = _atts - [""];
 			_attachments = _attachments + _atts;
 		} forEach _weaponAtt;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The arsenal code that preserves attachments on weapons inside containers (uniform, vest, backpack) uses the index for the secondary magazine instead of the bipod, causing it to lose bipods and throw an SQF error. This PR fixes it.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
