### PR TITLE
RF Compatibility - WS Templates

### DIFF
--- a/A3A/addons/config_fixes/RF/CfgVehicles.hpp
+++ b/A3A/addons/config_fixes/RF/CfgVehicles.hpp
@@ -26,7 +26,7 @@ class CfgVehicles
     class a3a_LDF_Pickup_mmg_rf : I_G_Pickup_mmg_rf
     {
         textureList[] = {};
-        hiddenSelectionTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_ldf_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_ldf_co.paa"};
+        hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_ldf_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_ldf_co.paa"};
     };
     class a3a_hex_Pickup_mmg_rf : I_G_Pickup_mmg_rf
     {
@@ -46,12 +46,12 @@ class CfgVehicles
     class a3a_police_Pickup_comms_rf : B_Pickup_comms_rf
     {
         textureList[] = {};
-        hiddenselectionstextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_gendarmerie_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_gendarmerie_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_Launcher_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_gendarmerie_co.paa"};
+        hiddenSelectionstextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_gendarmerie_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_gendarmerie_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_Launcher_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_gendarmerie_co.paa"};
     };
     class a3a_police_Pickup_rf : B_Pickup_rf
     {
         textureList[] = {};
-        hiddenselectionstextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_gendarmerie_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_gendarmerie_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_Launcher_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_gendarmerie_co.paa"};
+        hiddenSelectionstextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_gendarmerie_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_gendarmerie_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_Launcher_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_gendarmerie_co.paa"};
     };
     
     class Heli_light_03_dynamicLoadout_base_F: Heli_light_03_base_F {
@@ -139,11 +139,11 @@ class CfgVehicles
     class Heli_EC_02_base_RF: Heli_EC_01_base_RF {
         class Components;
     };
-    class a3a_Heli_EC_02_RF : Heli_EC_02_base_RF {
+    class a3a_Heli_EC_02_RF : Heli_EC_02_base_RF { // Default camo is a lovely tan, perfect for patrolling your local desert
         scope = 2;
         faction = "IND_F";
         side = 2;
-        hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_02_aaf_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_02_aaf_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_02_aaf_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
+        hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
         class Components : Components {
             class TransportPylonsComponent {
                 uiPicture = "\lxRF\air_rf\heli_medium_ec\data\UI\heli_medium_ec_02_3DEN_CA.paa";
@@ -202,6 +202,10 @@ class CfgVehicles
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_03_ldf_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_03_ldf_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_03_ldf_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
     };
+    class a3a_AAF_Heli_EC_02_RF : a3a_Heli_EC_02_RF {
+        textureList[] = {};
+        hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_02_aaf_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_02_aaf_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_02_aaf_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
+    };
     class a3a_black_Heli_EC_02_RF : a3a_Heli_EC_02_RF {
         factions = "CIV_F";
         side = 2;
@@ -210,12 +214,23 @@ class CfgVehicles
     };
     class a3a_tan_Heli_EC_04_military_RF : B_Heli_EC_04_military_RF {
         textureList[] = {};
-        hiddenSelectionTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
+        hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
     };
     class a3a_tan_Heli_EC_03_RF : B_Heli_EC_03_RF {
         textureList[] = {};
-        hiddenSelectionTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
+        hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
+    };
+    class a3a_ION_Heli_EC_04_military_RF : B_Heli_EC_04_military_RF {
+        textureList[] = {};
+        hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
+    };
+    class a3a_ION_Heli_EC_03_RF : B_Heli_EC_03_RF {
+        textureList[] = {};
+        hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
+    };
+    class a3a_ION_Heli_EC_02_RF : a3a_Heli_EC_02_RF {
+        textureList[] = {};
+        hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
     };
 
 };
-

--- a/A3A/addons/config_fixes/RF/CfgVehicles.hpp
+++ b/A3A/addons/config_fixes/RF/CfgVehicles.hpp
@@ -4,79 +4,79 @@ class CfgVehicles
 {
     class C_IDAP_Pickup_fuel_rf; // Parent is Pickup_fuel_base_rf
     class C_Pickup_rf;
-    class I_E_Pickup_covered_RF;
+    class I_E_Pickup_covered_rf;
     class I_G_Pickup_mmg_rf;
     class I_G_Pickup_hmg_rf;
     class B_Pickup_comms_rf;
     class B_Pickup_rf;
     class I_G_Pickup_rf;
     class Heli_light_03_base_F;
-    class B_Heli_light_03_unarmed_RF;
-    class Heli_EC_01_base_RF;
-    class B_Heli_EC_04_military_RF;
-    class B_Heli_EC_03_RF;
-    class B_ION_Pickup_aat_RF;
+    class B_Heli_light_03_unarmed_rf;
+    class Heli_EC_01_base_rf;
+    class B_Heli_EC_04_military_rf;
+    class B_Heli_EC_03_rf;
+    class B_ION_Pickup_aat_rf;
 
-    class a3a_armored_Pickup_RF : I_G_Pickup_RF {
+    class a3a_armored_Pickup_rf : I_G_Pickup_rf {
         animationList[] = {"hide_bullbar",0.2,"hide_fuel_tank",1,"hide_snorkel",1,"hide_antenna",1,"hide_trunk_cover",1,"hide_trunk_door",0,"trunk_door_open",0,"hide_armor_window_armor_top",0,"window_armor_hatch_L_rot",1,"window_armor_hatch_R_rot",0,"door_F_L_open",0,"door_F_R_open",0,"door_R_L_open",0,"door_R_R_open",0,"hide_rack",1,"hide_rack_spotlights",1,"hide_frame",1,"hide_sidesteps",0.5};
     };
-    class a3a_FIA_Pickup_RF : a3a_armored_Pickup_RF {
+    class a3a_FIA_Pickup_rf : a3a_armored_Pickup_rf {
         textureList[] = {"Guerilla_01",1,"Guerilla_02",1,"Guerilla_03",1,"Guerilla_04",1,"Guerilla_05",1,"Guerilla_06",0.1,"Guerilla_07",0.1,"Guerilla_08",0.1,"Guerilla_09",0.1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_fia_02_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_fia_02_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_fia_02_co.paa"};
     };
-    class a3a_ION_Pickup_RF : a3a_armored_Pickup_RF {
+    class a3a_ION_Pickup_rf : a3a_armored_Pickup_rf {
         textureList[] = {"ION",1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_ion_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_black_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_Launcher_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_black_co.paa"};
     };
-    class a3a_armored_Pickup_mmg_RF : I_G_Pickup_mmg_RF {
+    class a3a_armored_Pickup_mmg_rf : I_G_Pickup_mmg_rf {
         scope = 2;
         animationList[] = {"hide_trunk_cover",1,"hide_frame_full",1,"hide_bullbar",0.2,"hide_snorkel",1,"hide_antenna",1,"hide_trunk_door",0,"trunk_door_open",0,"hide_armor_window_armor_top",0,"window_armor_hatch_L_rot",1,"window_armor_hatch_R_rot",0,"door_F_L_open",0,"door_F_R_open",0,"door_R_L_open",0,"door_R_R_open",0,"hide_frame",0,"hide_sidesteps",0.5};
     };
-    class a3a_FIA_Pickup_mmg_RF : a3a_armored_Pickup_mmg_RF {
+    class a3a_FIA_Pickup_mmg_rf : a3a_armored_Pickup_mmg_rf {
         textureList[] = {"Guerilla_01",1,"Guerilla_02",1,"Guerilla_03",1,"Guerilla_04",1,"Guerilla_05",1,"Guerilla_06",0.1,"Guerilla_07",0.1,"Guerilla_08",0.1,"Guerilla_09",0.1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_fia_02_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_fia_02_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_fia_02_co.paa"};
     };
-    class a3a_ION_Pickup_mmg_RF : a3a_armored_Pickup_mmg_RF {
+    class a3a_ION_Pickup_mmg_rf : a3a_armored_Pickup_mmg_rf {
         textureList[] = {"ION",1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_ion_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_black_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_Launcher_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_black_co.paa"};
     };
-    class a3a_armored_Pickup_hmg_RF : I_G_Pickup_hmg_RF {
+    class a3a_armored_Pickup_hmg_rf : I_G_Pickup_hmg_rf {
         animationList[] = {"Hide_Shield",1,"Hide_Rail",1,"hide_bullbar",0.2,"hide_snorkel",1,"hide_antenna",1,"hide_trunk_door",0,"trunk_door_open",0,"hide_armor_window_armor_top",0,"window_armor_hatch_L_rot",1,"window_armor_hatch_R_rot",0,"door_F_L_open",0,"door_F_R_open",0,"door_R_L_open",0,"door_R_R_open",0,"hide_rack",1,"hide_rack_spotlights",1,"hide_frame",0,"hide_sidesteps",0.5};
     };
-    class a3a_FIA_Pickup_hmg_RF : a3a_armored_Pickup_hmg_RF {
+    class a3a_FIA_Pickup_hmg_rf : a3a_armored_Pickup_hmg_rf {
         textureList[] = {"Guerilla_01",1,"Guerilla_02",1,"Guerilla_03",1,"Guerilla_04",1,"Guerilla_05",1,"Guerilla_06",0.1,"Guerilla_07",0.1,"Guerilla_08",0.1,"Guerilla_09",0.1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_fia_02_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_fia_02_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_fia_02_co.paa"};
     };
-    class a3a_ION_Pickup_hmg_RF : a3a_armored_Pickup_hmg_RF {
+    class a3a_ION_Pickup_hmg_rf : a3a_armored_Pickup_hmg_rf {
         textureList[] = {"ION",1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_ion_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_black_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_Launcher_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_black_co.paa"};
     };
-    class a3a_armored_Pickup_covered_RF : I_E_Pickup_covered_RF {
+    class a3a_armored_Pickup_covered_rf : I_E_Pickup_covered_rf {
         animationList[] = {"hide_rack",1,"hide_rack_antenna",1,"hide_frame",1,"hide_frame_full",1,"hide_frame_full_panel",1,"hide_box",0,"hide_box_door",0,"hide_trunk_door",0,"trunk_door_open",0,"box_door_open",0,"hide_police",1,"hide_Services",1,"BeaconsServicesStart",0,"hide_bullbar",0.2,"hide_snorkel",0,"hide_antenna",1,"hide_armor_window_armor_top",0,"window_armor_hatch_L_rot",1,"window_armor_hatch_R_rot",0,"door_F_L_open",0,"door_F_R_open",0,"door_R_L_open",0,"door_R_R_open",0,"hide_rack_spotlights",0,"hide_sidesteps",0.5};
     };
-    class a3a_FIA_Pickup_covered_RF : a3a_armored_Pickup_covered_RF {
+    class a3a_FIA_Pickup_covered_rf : a3a_armored_Pickup_covered_rf {
         textureList[] = {"Guerilla_01",1,"Guerilla_02",1,"Guerilla_03",1,"Guerilla_04",1,"Guerilla_05",1,"Guerilla_06",0.1,"Guerilla_07",0.1,"Guerilla_08",0.1,"Guerilla_09",0.1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_fia_02_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_fia_02_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_fia_02_co.paa"};
     };
-    class a3a_ION_Pickup_AAT_RF : B_ION_Pickup_aat_RF {
+    class a3a_ION_Pickup_AAT_rf : B_ION_Pickup_aat_rf {
         animationList[] = {"hide_frame",0,"hide_frame_full",1,"hide_bullbar",0,"hide_snorkel",0,"hide_antenna",1,"hide_trunk_door",0,"trunk_door_open",0,"hide_armor_window_armor_top",0,"window_armor_hatch_L_rot",1,"window_armor_hatch_R_rot",0,"door_F_L_open",0,"door_F_R_open",0,"door_R_L_open",0,"door_R_R_open",0,"hide_rack",0,"hide_rack_spotlights",0,"hide_sidesteps",0};
     };
-    class a3a_black_Pickup_rf : a3a_FIA_Pickup_RF
+    class a3a_black_Pickup_rf : a3a_FIA_Pickup_rf
     {
         textureList[] = {"Black",1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_white_tank_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_black_co.paa"};
     };
-    class a3a_black_Pickup_mmg_rf : a3a_FIA_Pickup_mmg_RF
+    class a3a_black_Pickup_mmg_rf : a3a_FIA_Pickup_mmg_rf
     {
         textureList[] = {"Black",1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_white_tank_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_black_co.paa"};
     };
-    class a3a_black_Pickup_hmg_rf : a3a_FIA_Pickup_hmg_RF
+    class a3a_black_Pickup_hmg_rf : a3a_FIA_Pickup_hmg_rf
     {
         textureList[] = {"Black",1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_white_tank_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_black_co.paa"};
     };
-    class a3a_black_Pickup_covered_rf : a3a_FIA_Pickup_covered_RF
+    class a3a_black_Pickup_covered_rf : a3a_FIA_Pickup_covered_rf
     {
         textureList[] = {"Black",1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_white_tank_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_black_co.paa"};
@@ -115,12 +115,12 @@ class CfgVehicles
     class Heli_light_03_dynamicLoadout_base_F: Heli_light_03_base_F {
         class Components;
     };
-    class B_Heli_light_03_dynamicLoadout_RF: Heli_light_03_dynamicLoadout_base_F {
+    class B_Heli_light_03_dynamicLoadout_rf: Heli_light_03_dynamicLoadout_base_F {
         class Components : Components {
             class TransportPylonsComponent;
         };
     };
-    class a3a_Heli_light_03_dynamicLoadout_RF : B_Heli_light_03_dynamicLoadout_RF { // !!!! This is the Olive paint by default. It's more of a bluish-gray though
+    class a3a_Heli_light_03_dynamicLoadout_rf : B_Heli_light_03_dynamicLoadout_rf { // !!!! This is the Olive paint by default. It's more of a bluish-gray though
        class Components : Components {
             class TransportPylonsComponent : TransportPylonsComponent {
                 class Presets {
@@ -169,47 +169,47 @@ class CfgVehicles
             };
         };
     };
-    class a3a_AAF_Heli_light_03_dynamicLoadout_RF : a3a_Heli_light_03_dynamicLoadout_RF {
+    class a3a_AAF_Heli_light_03_dynamicLoadout_rf : a3a_Heli_light_03_dynamicLoadout_rf {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\A3\Air_F_EPB\Heli_Light_03\data\Heli_Light_03_base_INDP_CO.paa","\lxRF\air_rf\Heli_Light_03\data\wildcat_addons_INDP_co.paa"};
     };
-    class a3a_LDF_Heli_light_03_dynamicLoadout_RF : a3a_Heli_light_03_dynamicLoadout_RF {
+    class a3a_LDF_Heli_light_03_dynamicLoadout_rf : a3a_Heli_light_03_dynamicLoadout_rf {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\A3\Air_F_Enoch\Heli_Light_03\data\Heli_Light_03_base_EAF_CO.paa","\lxRF\air_rf\Heli_Light_03\data\wildcat_addons_LDF_co.paa"};
     };
-    class a3a_black_Heli_light_03_dynamicLoadout_RF : a3a_Heli_light_03_dynamicLoadout_RF {
+    class a3a_black_Heli_light_03_dynamicLoadout_rf : a3a_Heli_light_03_dynamicLoadout_rf {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\Heli_Light_03\data\Heli_Light_03_base_black_CO.paa","\lxRF\air_rf\Heli_Light_03\data\wildcat_addons_black_co.paa"};
     };
-    class a3a_tan_Heli_light_03_dynamicLoadout_RF : a3a_Heli_light_03_dynamicLoadout_RF {
+    class a3a_tan_Heli_light_03_dynamicLoadout_rf : a3a_Heli_light_03_dynamicLoadout_rf {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\Heli_Light_03\data\Heli_Light_03_base_tan_CO.paa","\lxRF\air_rf\Heli_Light_03\data\wildcat_addons_tan_co.paa"};
     };
-    class a3a_green_Heli_light_03_dynamicLoadout_RF : a3a_Heli_light_03_dynamicLoadout_RF {
+    class a3a_green_Heli_light_03_dynamicLoadout_rf : a3a_Heli_light_03_dynamicLoadout_rf {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\A3\Air_F_EPB\Heli_Light_03\data\Heli_Light_03_base_CO.paa","\lxRF\air_rf\Heli_Light_03\data\wildcat_addons_green_co.paa"};
     };
-    class a3a_AAF_Heli_light_03_unarmed_RF : B_Heli_light_03_unarmed_RF {
+    class a3a_AAF_Heli_light_03_unarmed_rf : B_Heli_light_03_unarmed_rf {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\A3\Air_F_EPB\Heli_Light_03\data\Heli_Light_03_base_INDP_CO.paa","\lxRF\air_rf\Heli_Light_03\data\wildcat_addons_INDP_co.paa"};
     };
-    class a3a_black_Heli_light_03_unarmed_RF : B_Heli_light_03_unarmed_RF {
+    class a3a_black_Heli_light_03_unarmed_rf : B_Heli_light_03_unarmed_rf {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\Heli_Light_03\data\Heli_Light_03_base_black_CO.paa","\lxRF\air_rf\Heli_Light_03\data\wildcat_addons_black_co.paa"};
     };
-    class a3a_green_Heli_light_03_unarmed_RF : B_Heli_light_03_unarmed_RF {
+    class a3a_green_Heli_light_03_unarmed_rf : B_Heli_light_03_unarmed_rf {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\A3\Air_F_EPB\Heli_Light_03\data\Heli_Light_03_base_CO.paa","\lxRF\air_rf\Heli_Light_03\data\wildcat_addons_green_co.paa"};
     };
-    class a3a_tan_Heli_light_03_unarmed_RF : B_Heli_light_03_unarmed_RF {
+    class a3a_tan_Heli_light_03_unarmed_rf : B_Heli_light_03_unarmed_rf {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\Heli_Light_03\data\Heli_Light_03_base_tan_CO.paa","\lxRF\air_rf\Heli_Light_03\data\wildcat_addons_tan_co.paa"};
     };
 
-    class Heli_EC_02_base_RF: Heli_EC_01_base_RF {
+    class Heli_EC_02_base_rf: Heli_EC_01_base_rf {
         class Components;
     };
-    class a3a_Heli_EC_02_RF : Heli_EC_02_base_RF { // Default camo is a lovely tan, perfect for patrolling your local desert
+    class a3a_Heli_EC_02_rf : Heli_EC_02_base_rf { // Default camo is a lovely tan, perfect for patrolling your local desert
         scope = 2;
         faction = "IND_F";
         side = 2;
@@ -223,7 +223,7 @@ class CfgVehicles
                         displayName = "AT";
                     };
                     class Default {
-                        attachment[] = {"PylonRack_19Rnd_missiles_olive_RF","PylonRack_4Rnd_LG_scalpel","PylonRack_4Rnd_LG_scalpel","PylonRack_19Rnd_missiles_olive_RF"};
+                        attachment[] = {"PylonRack_19Rnd_missiles_olive_rf","PylonRack_4Rnd_LG_scalpel","PylonRack_4Rnd_LG_scalpel","PylonRack_19Rnd_missiles_olive_rf"};
                         displayName = "Default";
                     };
                     class Empty {
@@ -266,41 +266,41 @@ class CfgVehicles
             };
         };
     };
-    class a3a_LDF_Heli_EC_02_RF : a3a_Heli_EC_02_RF {
+    class a3a_LDF_Heli_EC_02_rf : a3a_Heli_EC_02_rf {
         factions = "IND_E_F";
         side = 2;
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_03_ldf_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_03_ldf_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_03_ldf_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
     };
-    class a3a_AAF_Heli_EC_02_RF : a3a_Heli_EC_02_RF {
+    class a3a_AAF_Heli_EC_02_rf : a3a_Heli_EC_02_rf {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_02_aaf_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_02_aaf_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_02_aaf_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
     };
-    class a3a_black_Heli_EC_02_RF : a3a_Heli_EC_02_RF {
+    class a3a_black_Heli_EC_02_rf : a3a_Heli_EC_02_rf {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_34_dark_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_light_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_34_dark_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_34_dark_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_light_co.paa"};
     };
-    class a3a_sfia_Heli_EC_02_RF : a3a_Heli_EC_02_RF {
+    class a3a_sfia_Heli_EC_02_rf : a3a_Heli_EC_02_rf {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_01_sfia_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_01_sfia_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_01_sfia_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
     };
-    class a3a_tan_Heli_EC_04_military_RF : B_Heli_EC_04_military_RF {
+    class a3a_tan_Heli_EC_04_military_rf : B_Heli_EC_04_military_rf {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
     };
-    class a3a_tan_Heli_EC_03_RF : B_Heli_EC_03_RF {
+    class a3a_tan_Heli_EC_03_rf : B_Heli_EC_03_rf {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
     };
-    class a3a_ION_Heli_EC_04_military_RF : B_Heli_EC_04_military_RF {
+    class a3a_ION_Heli_EC_04_military_rf : B_Heli_EC_04_military_rf {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
     };
-    class a3a_ION_Heli_EC_03_RF : B_Heli_EC_03_RF {
+    class a3a_ION_Heli_EC_03_rf : B_Heli_EC_03_rf {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
     };
-    class a3a_ION_Heli_EC_02_RF : a3a_Heli_EC_02_RF {
+    class a3a_ION_Heli_EC_02_rf : a3a_Heli_EC_02_rf {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
     };

--- a/A3A/addons/config_fixes/RF/CfgVehicles.hpp
+++ b/A3A/addons/config_fixes/RF/CfgVehicles.hpp
@@ -16,37 +16,51 @@ class CfgVehicles
     class Heli_EC_01_base_RF;
     class B_Heli_EC_04_military_RF;
     class B_Heli_EC_03_RF;
+    class B_ION_Pickup_aat_RF;
 
-
-    class a3a_civ_Pickup_RF : C_Pickup_RF {
-        textureList[] = {"Red",1,"Tan",1,"White",1,"Blue",1,"Gray",1,"Black",1,"Brown",1,"Olive",1,"Orange",1,"Yellow",1};
-        hiddenSelectionsTextures[] = {"lxrf\vehicles_rf\pickup_01\data\pickup_01_ext_white_co.paa","lxrf\vehicles_rf\pickup_01\data\pickup_01_adds_black_tank_co.paa","lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","lxrf\vehicles_rf\pickup_01\data\pickup_01_service_white_co.paa"};
-    };
-    class a3a_civ_Pickup_covered_RF : C_Pickup_covered_RF {
-        textureList[] = {"Red",1,"Tan",1,"White",1,"Blue",1,"Gray",1,"Black",1,"Brown",1,"Olive",1,"Orange",1,"Yellow",1};
-        hiddenSelectionsTextures[] = {"lxrf\vehicles_rf\pickup_01\data\pickup_01_ext_white_co.paa","lxrf\vehicles_rf\pickup_01\data\pickup_01_adds_black_tank_co.paa","lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","lxrf\vehicles_rf\pickup_01\data\pickup_01_service_white_co.paa"};
-    };
-    class a3a_fia_Pickup_RF : I_G_Pickup_RF {
+    class a3a_armored_Pickup_RF : I_G_Pickup_RF {
         animationList[] = {"hide_bullbar",0.2,"hide_fuel_tank",1,"hide_snorkel",1,"hide_antenna",1,"hide_trunk_cover",1,"hide_trunk_door",0,"trunk_door_open",0,"hide_armor_window_armor_top",0,"window_armor_hatch_L_rot",1,"window_armor_hatch_R_rot",0,"door_F_L_open",0,"door_F_R_open",0,"door_R_L_open",0,"door_R_R_open",0,"hide_rack",1,"hide_rack_spotlights",1,"hide_frame",1,"hide_sidesteps",0.5};
+    };
+    class a3a_fia_Pickup_RF : a3a_armored_Pickup_RF {
         textureList[] = {"Guerilla_01",1,"Guerilla_02",1,"Guerilla_03",1,"Guerilla_04",1,"Guerilla_05",1,"Guerilla_06",0.1,"Guerilla_07",0.1,"Guerilla_08",0.1,"Guerilla_09",0.1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_fia_02_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_fia_02_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_fia_02_co.paa"};
     };
-    class a3a_fia_Pickup_mmg_RF : I_G_Pickup_mmg_RF {
+    class a3a_ION_Pickup_RF : a3a_armored_Pickup_RF {
+        textureList[] = {"ION",1};
+        hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_ion_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_black_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_Launcher_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_black_co.paa"};
+    };
+    class a3a_armored_Pickup_mmg_RF : I_G_Pickup_mmg_RF {
         animationList[] = {"hide_trunk_cover",1,"hide_frame_full",1,"hide_bullbar",0.2,"hide_snorkel",1,"hide_antenna",1,"hide_trunk_door",0,"trunk_door_open",0,"hide_armor_window_armor_top",0,"window_armor_hatch_L_rot",1,"window_armor_hatch_R_rot",0,"door_F_L_open",0,"door_F_R_open",0,"door_R_L_open",0,"door_R_R_open",0,"hide_frame",0,"hide_sidesteps",0.5};
+    };
+    class a3a_fia_Pickup_mmg_RF : a3a_armored_Pickup_mmg_RF {
         textureList[] = {"Guerilla_01",1,"Guerilla_02",1,"Guerilla_03",1,"Guerilla_04",1,"Guerilla_05",1,"Guerilla_06",0.1,"Guerilla_07",0.1,"Guerilla_08",0.1,"Guerilla_09",0.1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_fia_02_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_fia_02_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_fia_02_co.paa"};
     };
-    class a3a_fia_Pickup_hmg_RF : I_G_Pickup_hmg_RF {
+    class a3a_ION_Pickup_mmg_RF : a3a_armored_Pickup_mmg_RF {
+        textureList[] = {"ION",1};
+        hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_ion_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_black_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_Launcher_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_black_co.paa"};
+    };
+    class a3a_armored_Pickup_hmg_RF : I_G_Pickup_hmg_RF {
         animationList[] = {"Hide_Shield",1,"Hide_Rail",1,"hide_bullbar",0.2,"hide_snorkel",1,"hide_antenna",1,"hide_trunk_door",0,"trunk_door_open",0,"hide_armor_window_armor_top",0,"window_armor_hatch_L_rot",1,"window_armor_hatch_R_rot",0,"door_F_L_open",0,"door_F_R_open",0,"door_R_L_open",0,"door_R_R_open",0,"hide_rack",1,"hide_rack_spotlights",1,"hide_frame",0,"hide_sidesteps",0.5};
+    };
+    class a3a_fia_Pickup_hmg_RF : a3a_armored_Pickup_hmg_RF {
         textureList[] = {"Guerilla_01",1,"Guerilla_02",1,"Guerilla_03",1,"Guerilla_04",1,"Guerilla_05",1,"Guerilla_06",0.1,"Guerilla_07",0.1,"Guerilla_08",0.1,"Guerilla_09",0.1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_fia_02_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_fia_02_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_fia_02_co.paa"};
     };
-    class a3a_fia_Pickup_covered_RF : I_E_Pickup_covered_RF {
+    class a3a_ION_Pickup_hmg_RF : a3a_armored_Pickup_hmg_RF {
+        textureList[] = {"ION",1};
+        hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_ion_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_black_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_Launcher_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_black_co.paa"};
+    };
+    class a3a_armored_Pickup_covered_RF : I_E_Pickup_covered_RF {
         animationList[] = {"hide_rack",1,"hide_rack_antenna",1,"hide_frame",1,"hide_frame_full",1,"hide_frame_full_panel",1,"hide_box",0,"hide_box_door",0,"hide_trunk_door",0,"trunk_door_open",0,"box_door_open",0,"hide_police",1,"hide_Services",1,"BeaconsServicesStart",0,"hide_bullbar",0.2,"hide_snorkel",0,"hide_antenna",1,"hide_armor_window_armor_top",0,"window_armor_hatch_L_rot",1,"window_armor_hatch_R_rot",0,"door_F_L_open",0,"door_F_R_open",0,"door_R_L_open",0,"door_R_R_open",0,"hide_rack_spotlights",0,"hide_sidesteps",0.5};
+    };
+    class a3a_fia_Pickup_covered_RF : a3a_armored_Pickup_covered_RF {
         textureList[] = {"Guerilla_01",1,"Guerilla_02",1,"Guerilla_03",1,"Guerilla_04",1,"Guerilla_05",1,"Guerilla_06",0.1,"Guerilla_07",0.1,"Guerilla_08",0.1,"Guerilla_09",0.1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_fia_02_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_fia_02_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_fia_02_co.paa"};
     };
-
+    class a3a_ION_Pickup_AAT_RF : B_ION_Pickup_aat_RF {
+        animationList[] = {"hide_frame",0,"hide_frame_full",1,"hide_bullbar",0,"hide_snorkel",0,"hide_antenna",1,"hide_trunk_door",0,"trunk_door_open",0,"hide_armor_window_armor_top",0,"window_armor_hatch_L_rot",1,"window_armor_hatch_R_rot",0,"door_F_L_open",0,"door_F_R_open",0,"door_R_L_open",0,"door_R_R_open",0,"hide_rack",0,"hide_rack_spotlights",0,"hide_sidesteps",0};
+    };
     class a3a_black_Pickup_rf : a3a_fia_Pickup_RF
     {
         textureList[] = {"Black",1};
@@ -187,7 +201,7 @@ class CfgVehicles
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\A3\Air_F_EPB\Heli_Light_03\data\Heli_Light_03_base_CO.paa","\lxRF\air_rf\Heli_Light_03\data\wildcat_addons_green_co.paa"};
     };
-    class a3a_tan_Heli_light_03_unarmed_RF : a3a_Heli_light_03_dynamicLoadout_RF {
+    class a3a_tan_Heli_light_03_unarmed_RF : B_Heli_light_03_unarmed_RF {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\Heli_Light_03\data\Heli_Light_03_base_tan_CO.paa","\lxRF\air_rf\Heli_Light_03\data\wildcat_addons_tan_co.paa"};
     };
@@ -281,20 +295,14 @@ class CfgVehicles
     class a3a_ION_Heli_EC_04_military_RF : B_Heli_EC_04_military_RF {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
-        factions = "CIV_F";
-        side = 2;
     };
     class a3a_ION_Heli_EC_03_RF : B_Heli_EC_03_RF {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
-        factions = "CIV_F";
-        side = 2;
     };
     class a3a_ION_Heli_EC_02_RF : a3a_Heli_EC_02_RF {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
-        factions = "CIV_F";
-        side = 2;
     };
 
 };

--- a/A3A/addons/config_fixes/RF/CfgVehicles.hpp
+++ b/A3A/addons/config_fixes/RF/CfgVehicles.hpp
@@ -15,7 +15,7 @@ class CfgVehicles
     class Heli_EC_01_base_rf;
     class B_Heli_EC_04_military_rf;
     class B_Heli_EC_03_rf;
-    class B_ION_Pickup_aat_rf;
+    class I_Pickup_aat_rf;
 
     class a3a_armored_Pickup_rf : I_G_Pickup_rf {
         animationList[] = {"hide_bullbar",0.2,"hide_fuel_tank",1,"hide_snorkel",1,"hide_antenna",1,"hide_trunk_cover",1,"hide_trunk_door",0,"trunk_door_open",0,"hide_armor_window_armor_top",0,"window_armor_hatch_L_rot",1,"window_armor_hatch_R_rot",0,"door_F_L_open",0,"door_F_R_open",0,"door_R_L_open",0,"door_R_R_open",0,"hide_rack",1,"hide_rack_spotlights",1,"hide_frame",1,"hide_sidesteps",0.5};
@@ -58,7 +58,9 @@ class CfgVehicles
         textureList[] = {"Guerilla_01",1,"Guerilla_02",1,"Guerilla_03",1,"Guerilla_04",1,"Guerilla_05",1,"Guerilla_06",0.1,"Guerilla_07",0.1,"Guerilla_08",0.1,"Guerilla_09",0.1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_fia_02_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_fia_02_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_fia_02_co.paa"};
     };
-    class a3a_ION_Pickup_AAT_rf : B_ION_Pickup_aat_rf {
+    class a3a_ION_Pickup_AAT_rf : I_Pickup_aat_rf {
+        textureList[] = {};
+        hiddenSelectionTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_ion_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_black_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_Launcher_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_black_co.paa"};
         animationList[] = {"hide_frame",0,"hide_frame_full",1,"hide_bullbar",0,"hide_snorkel",0,"hide_antenna",1,"hide_trunk_door",0,"trunk_door_open",0,"hide_armor_window_armor_top",0,"window_armor_hatch_L_rot",1,"window_armor_hatch_R_rot",0,"door_F_L_open",0,"door_F_R_open",0,"door_R_L_open",0,"door_R_R_open",0,"hide_rack",0,"hide_rack_spotlights",0,"hide_sidesteps",0};
     };
     class a3a_black_Pickup_rf : a3a_FIA_Pickup_rf

--- a/A3A/addons/config_fixes/RF/CfgVehicles.hpp
+++ b/A3A/addons/config_fixes/RF/CfgVehicles.hpp
@@ -10,6 +10,8 @@ class CfgVehicles
     class Heli_light_03_base_F;
     class B_Heli_light_03_unarmed_RF;
     class Heli_EC_01_base_RF;
+    class B_Heli_EC_04_military_RF;
+    class B_Heli_EC_03_RF;
 
     class a3a_black_Pickup_rf : C_Pickup_rf
     {
@@ -20,6 +22,21 @@ class CfgVehicles
     {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_white_tank_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_black_co.paa"};
+    };
+    class a3a_LDF_Pickup_mmg_rf : I_G_Pickup_mmg_rf
+    {
+        textureList[] = {};
+        hiddenSelectionTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_ldf_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_ldf_co.paa"};
+    };
+    class a3a_hex_Pickup_mmg_rf : I_G_Pickup_mmg_rf
+    {
+        textureList[] = {};
+        hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_csat_hex_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_csat_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_Launcher_tan_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_csat_hex_co.paa"};
+    };
+    class a3a_ghex_Pickup_mmg_rf : I_G_Pickup_mmg_rf
+    {
+        textureList[] = {};
+        hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_csat_ghex_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_nato_pacific_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_csat_ghex_co.paa"};
     };
     class a3a_civ_Pickup_fuel_rf : C_IDAP_Pickup_fuel_rf
     {
@@ -191,7 +208,14 @@ class CfgVehicles
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_34_dark_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_light_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_34_dark_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_34_dark_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_light_co.paa"};
     };
-
+    class a3a_tan_Heli_EC_04_military_RF : B_Heli_EC_04_military_RF {
+        textureList[] = {};
+        hiddenSelectionTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
+    };
+    class a3a_tan_Heli_EC_03_RF : B_Heli_EC_03_RF {
+        textureList[] = {};
+        hiddenSelectionTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_09_tan_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
+    };
 
 };
 

--- a/A3A/addons/config_fixes/RF/CfgVehicles.hpp
+++ b/A3A/addons/config_fixes/RF/CfgVehicles.hpp
@@ -4,23 +4,67 @@ class CfgVehicles
 {
     class C_IDAP_Pickup_fuel_rf; // Parent is Pickup_fuel_base_rf
     class C_Pickup_rf;
+    class C_Pickup_covered_RF;
+    class I_E_Pickup_covered_RF;
     class I_G_Pickup_mmg_rf;
+    class I_G_Pickup_hmg_rf;
     class B_Pickup_comms_rf;
     class B_Pickup_rf;
+    class I_G_Pickup_rf;
     class Heli_light_03_base_F;
     class B_Heli_light_03_unarmed_RF;
     class Heli_EC_01_base_RF;
     class B_Heli_EC_04_military_RF;
     class B_Heli_EC_03_RF;
 
-    class a3a_black_Pickup_rf : C_Pickup_rf
+
+    class a3a_civ_Pickup_RF : C_Pickup_RF {
+        textureList[] = {"Red",1,"Tan",1,"White",1,"Blue",1,"Gray",1,"Black",1,"Brown",1,"Olive",1,"Orange",1,"Yellow",1};
+        hiddenSelectionsTextures[] = {"lxrf\vehicles_rf\pickup_01\data\pickup_01_ext_white_co.paa","lxrf\vehicles_rf\pickup_01\data\pickup_01_adds_black_tank_co.paa","lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","lxrf\vehicles_rf\pickup_01\data\pickup_01_service_white_co.paa"};
+    };
+    class a3a_civ_Pickup_covered_RF : C_Pickup_covered_RF {
+        textureList[] = {"Red",1,"Tan",1,"White",1,"Blue",1,"Gray",1,"Black",1,"Brown",1,"Olive",1,"Orange",1,"Yellow",1};
+        hiddenSelectionsTextures[] = {"lxrf\vehicles_rf\pickup_01\data\pickup_01_ext_white_co.paa","lxrf\vehicles_rf\pickup_01\data\pickup_01_adds_black_tank_co.paa","lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","lxrf\vehicles_rf\pickup_01\data\pickup_01_service_white_co.paa"};
+    };
+    class a3a_fia_Pickup_RF : I_G_Pickup_RF {
+        animationList[] = {"hide_bullbar",0.2,"hide_fuel_tank",1,"hide_snorkel",1,"hide_antenna",1,"hide_trunk_cover",1,"hide_trunk_door",0,"trunk_door_open",0,"hide_armor_window_armor_top",0,"window_armor_hatch_L_rot",1,"window_armor_hatch_R_rot",0,"door_F_L_open",0,"door_F_R_open",0,"door_R_L_open",0,"door_R_R_open",0,"hide_rack",1,"hide_rack_spotlights",1,"hide_frame",1,"hide_sidesteps",0.5};
+        textureList[] = {"Guerilla_01",1,"Guerilla_02",1,"Guerilla_03",1,"Guerilla_04",1,"Guerilla_05",1,"Guerilla_06",0.1,"Guerilla_07",0.1,"Guerilla_08",0.1,"Guerilla_09",0.1};
+        hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_fia_02_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_fia_02_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_fia_02_co.paa"};
+    };
+    class a3a_fia_Pickup_mmg_RF : I_G_Pickup_mmg_RF {
+        animationList[] = {"hide_trunk_cover",1,"hide_frame_full",1,"hide_bullbar",0.2,"hide_snorkel",1,"hide_antenna",1,"hide_trunk_door",0,"trunk_door_open",0,"hide_armor_window_armor_top",0,"window_armor_hatch_L_rot",1,"window_armor_hatch_R_rot",0,"door_F_L_open",0,"door_F_R_open",0,"door_R_L_open",0,"door_R_R_open",0,"hide_frame",0,"hide_sidesteps",0.5};
+        textureList[] = {"Guerilla_01",1,"Guerilla_02",1,"Guerilla_03",1,"Guerilla_04",1,"Guerilla_05",1,"Guerilla_06",0.1,"Guerilla_07",0.1,"Guerilla_08",0.1,"Guerilla_09",0.1};
+        hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_fia_02_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_fia_02_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_fia_02_co.paa"};
+    };
+    class a3a_fia_Pickup_hmg_RF : I_G_Pickup_hmg_RF {
+        animationList[] = {"Hide_Shield",1,"Hide_Rail",1,"hide_bullbar",0.2,"hide_snorkel",1,"hide_antenna",1,"hide_trunk_door",0,"trunk_door_open",0,"hide_armor_window_armor_top",0,"window_armor_hatch_L_rot",1,"window_armor_hatch_R_rot",0,"door_F_L_open",0,"door_F_R_open",0,"door_R_L_open",0,"door_R_R_open",0,"hide_rack",1,"hide_rack_spotlights",1,"hide_frame",0,"hide_sidesteps",0.5};
+        textureList[] = {"Guerilla_01",1,"Guerilla_02",1,"Guerilla_03",1,"Guerilla_04",1,"Guerilla_05",1,"Guerilla_06",0.1,"Guerilla_07",0.1,"Guerilla_08",0.1,"Guerilla_09",0.1};
+        hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_fia_02_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_fia_02_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_fia_02_co.paa"};
+    };
+    class a3a_fia_Pickup_covered_RF : I_E_Pickup_covered_RF {
+        animationList[] = {"hide_rack",1,"hide_rack_antenna",1,"hide_frame",1,"hide_frame_full",1,"hide_frame_full_panel",1,"hide_box",0,"hide_box_door",0,"hide_trunk_door",0,"trunk_door_open",0,"box_door_open",0,"hide_police",1,"hide_Services",1,"BeaconsServicesStart",0,"hide_bullbar",0.2,"hide_snorkel",0,"hide_antenna",1,"hide_armor_window_armor_top",0,"window_armor_hatch_L_rot",1,"window_armor_hatch_R_rot",0,"door_F_L_open",0,"door_F_R_open",0,"door_R_L_open",0,"door_R_R_open",0,"hide_rack_spotlights",0,"hide_sidesteps",0.5};
+        textureList[] = {"Guerilla_01",1,"Guerilla_02",1,"Guerilla_03",1,"Guerilla_04",1,"Guerilla_05",1,"Guerilla_06",0.1,"Guerilla_07",0.1,"Guerilla_08",0.1,"Guerilla_09",0.1};
+        hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_fia_02_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_fia_02_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_fia_02_co.paa"};
+    };
+
+    class a3a_black_Pickup_rf : a3a_fia_Pickup_RF
     {
-        textureList[] = {};
+        textureList[] = {"Black",1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_white_tank_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_black_co.paa"};
     };
-    class a3a_black_Pickup_mmg_rf : I_G_Pickup_mmg_rf
+    class a3a_black_Pickup_mmg_rf : a3a_fia_Pickup_mmg_RF
     {
-        textureList[] = {};
+        textureList[] = {"Black",1};
+        hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_white_tank_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_black_co.paa"};
+    };
+    class a3a_black_Pickup_hmg_rf : a3a_fia_Pickup_hmg_RF
+    {
+        textureList[] = {"Black",1};
+        hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_white_tank_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_black_co.paa"};
+    };
+    class a3a_black_Pickup_covered_rf : a3a_fia_Pickup_covered_RF
+    {
+        textureList[] = {"Black",1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_white_tank_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_black_co.paa"};
     };
     class a3a_LDF_Pickup_mmg_rf : I_G_Pickup_mmg_rf
@@ -62,7 +106,7 @@ class CfgVehicles
             class TransportPylonsComponent;
         };
     };
-    class a3a_Heli_light_03_dynamicLoadout_RF : B_Heli_light_03_dynamicLoadout_RF { // !!!! This is the Navy (Camo) paint by default
+    class a3a_Heli_light_03_dynamicLoadout_RF : B_Heli_light_03_dynamicLoadout_RF { // !!!! This is the Olive paint by default. It's more of a bluish-gray though
        class Components : Components {
             class TransportPylonsComponent : TransportPylonsComponent {
                 class Presets {
@@ -123,6 +167,14 @@ class CfgVehicles
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\Heli_Light_03\data\Heli_Light_03_base_black_CO.paa","\lxRF\air_rf\Heli_Light_03\data\wildcat_addons_black_co.paa"};
     };
+    class a3a_tan_Heli_light_03_dynamicLoadout_RF : a3a_Heli_light_03_dynamicLoadout_RF {
+        textureList[] = {};
+        hiddenSelectionsTextures[] = {"\lxRF\air_rf\Heli_Light_03\data\Heli_Light_03_base_tan_CO.paa","\lxRF\air_rf\Heli_Light_03\data\wildcat_addons_tan_co.paa"};
+    };
+    class a3a_green_Heli_light_03_dynamicLoadout_RF : a3a_Heli_light_03_dynamicLoadout_RF {
+        textureList[] = {};
+        hiddenSelectionsTextures[] = {"\A3\Air_F_EPB\Heli_Light_03\data\Heli_Light_03_base_CO.paa","\lxRF\air_rf\Heli_Light_03\data\wildcat_addons_green_co.paa"};
+    };
     class a3a_AAF_Heli_light_03_unarmed_RF : B_Heli_light_03_unarmed_RF {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\A3\Air_F_EPB\Heli_Light_03\data\Heli_Light_03_base_INDP_CO.paa","\lxRF\air_rf\Heli_Light_03\data\wildcat_addons_INDP_co.paa"};
@@ -134,6 +186,10 @@ class CfgVehicles
     class a3a_green_Heli_light_03_unarmed_RF : B_Heli_light_03_unarmed_RF {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\A3\Air_F_EPB\Heli_Light_03\data\Heli_Light_03_base_CO.paa","\lxRF\air_rf\Heli_Light_03\data\wildcat_addons_green_co.paa"};
+    };
+    class a3a_tan_Heli_light_03_unarmed_RF : a3a_Heli_light_03_dynamicLoadout_RF {
+        textureList[] = {};
+        hiddenSelectionsTextures[] = {"\lxRF\air_rf\Heli_Light_03\data\Heli_Light_03_base_tan_CO.paa","\lxRF\air_rf\Heli_Light_03\data\wildcat_addons_tan_co.paa"};
     };
 
     class Heli_EC_02_base_RF: Heli_EC_01_base_RF {
@@ -207,10 +263,12 @@ class CfgVehicles
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_02_aaf_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_02_aaf_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_02_aaf_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
     };
     class a3a_black_Heli_EC_02_RF : a3a_Heli_EC_02_RF {
-        factions = "CIV_F";
-        side = 2;
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_34_dark_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_light_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_34_dark_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_34_dark_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_light_co.paa"};
+    };
+    class a3a_sfia_Heli_EC_02_RF : a3a_Heli_EC_02_RF {
+        textureList[] = {};
+        hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_01_sfia_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_01_sfia_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_01_sfia_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
     };
     class a3a_tan_Heli_EC_04_military_RF : B_Heli_EC_04_military_RF {
         textureList[] = {};
@@ -223,14 +281,20 @@ class CfgVehicles
     class a3a_ION_Heli_EC_04_military_RF : B_Heli_EC_04_military_RF {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
+        factions = "CIV_F";
+        side = 2;
     };
     class a3a_ION_Heli_EC_03_RF : B_Heli_EC_03_RF {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
+        factions = "CIV_F";
+        side = 2;
     };
     class a3a_ION_Heli_EC_02_RF : a3a_Heli_EC_02_RF {
         textureList[] = {};
         hiddenSelectionsTextures[] = {"\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa","#(rgb,1024,1024,1)ui('lxRF_MFDMinimap','lxRF_MFDMinimap')","\lxRF\air_rf\heli_medium_ec\data\as332_adds_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_exterior_06_ion_co.paa","\lxRF\air_rf\heli_medium_ec\data\as332_int_cargo_co.paa"};
+        factions = "CIV_F";
+        side = 2;
     };
 
 };

--- a/A3A/addons/config_fixes/RF/CfgVehicles.hpp
+++ b/A3A/addons/config_fixes/RF/CfgVehicles.hpp
@@ -4,7 +4,6 @@ class CfgVehicles
 {
     class C_IDAP_Pickup_fuel_rf; // Parent is Pickup_fuel_base_rf
     class C_Pickup_rf;
-    class C_Pickup_covered_RF;
     class I_E_Pickup_covered_RF;
     class I_G_Pickup_mmg_rf;
     class I_G_Pickup_hmg_rf;
@@ -21,7 +20,7 @@ class CfgVehicles
     class a3a_armored_Pickup_RF : I_G_Pickup_RF {
         animationList[] = {"hide_bullbar",0.2,"hide_fuel_tank",1,"hide_snorkel",1,"hide_antenna",1,"hide_trunk_cover",1,"hide_trunk_door",0,"trunk_door_open",0,"hide_armor_window_armor_top",0,"window_armor_hatch_L_rot",1,"window_armor_hatch_R_rot",0,"door_F_L_open",0,"door_F_R_open",0,"door_R_L_open",0,"door_R_R_open",0,"hide_rack",1,"hide_rack_spotlights",1,"hide_frame",1,"hide_sidesteps",0.5};
     };
-    class a3a_fia_Pickup_RF : a3a_armored_Pickup_RF {
+    class a3a_FIA_Pickup_RF : a3a_armored_Pickup_RF {
         textureList[] = {"Guerilla_01",1,"Guerilla_02",1,"Guerilla_03",1,"Guerilla_04",1,"Guerilla_05",1,"Guerilla_06",0.1,"Guerilla_07",0.1,"Guerilla_08",0.1,"Guerilla_09",0.1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_fia_02_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_fia_02_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_fia_02_co.paa"};
     };
@@ -30,9 +29,10 @@ class CfgVehicles
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_ion_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_black_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_Launcher_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_black_co.paa"};
     };
     class a3a_armored_Pickup_mmg_RF : I_G_Pickup_mmg_RF {
+        scope = 2;
         animationList[] = {"hide_trunk_cover",1,"hide_frame_full",1,"hide_bullbar",0.2,"hide_snorkel",1,"hide_antenna",1,"hide_trunk_door",0,"trunk_door_open",0,"hide_armor_window_armor_top",0,"window_armor_hatch_L_rot",1,"window_armor_hatch_R_rot",0,"door_F_L_open",0,"door_F_R_open",0,"door_R_L_open",0,"door_R_R_open",0,"hide_frame",0,"hide_sidesteps",0.5};
     };
-    class a3a_fia_Pickup_mmg_RF : a3a_armored_Pickup_mmg_RF {
+    class a3a_FIA_Pickup_mmg_RF : a3a_armored_Pickup_mmg_RF {
         textureList[] = {"Guerilla_01",1,"Guerilla_02",1,"Guerilla_03",1,"Guerilla_04",1,"Guerilla_05",1,"Guerilla_06",0.1,"Guerilla_07",0.1,"Guerilla_08",0.1,"Guerilla_09",0.1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_fia_02_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_fia_02_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_fia_02_co.paa"};
     };
@@ -43,7 +43,7 @@ class CfgVehicles
     class a3a_armored_Pickup_hmg_RF : I_G_Pickup_hmg_RF {
         animationList[] = {"Hide_Shield",1,"Hide_Rail",1,"hide_bullbar",0.2,"hide_snorkel",1,"hide_antenna",1,"hide_trunk_door",0,"trunk_door_open",0,"hide_armor_window_armor_top",0,"window_armor_hatch_L_rot",1,"window_armor_hatch_R_rot",0,"door_F_L_open",0,"door_F_R_open",0,"door_R_L_open",0,"door_R_R_open",0,"hide_rack",1,"hide_rack_spotlights",1,"hide_frame",0,"hide_sidesteps",0.5};
     };
-    class a3a_fia_Pickup_hmg_RF : a3a_armored_Pickup_hmg_RF {
+    class a3a_FIA_Pickup_hmg_RF : a3a_armored_Pickup_hmg_RF {
         textureList[] = {"Guerilla_01",1,"Guerilla_02",1,"Guerilla_03",1,"Guerilla_04",1,"Guerilla_05",1,"Guerilla_06",0.1,"Guerilla_07",0.1,"Guerilla_08",0.1,"Guerilla_09",0.1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_fia_02_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_fia_02_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_fia_02_co.paa"};
     };
@@ -54,29 +54,29 @@ class CfgVehicles
     class a3a_armored_Pickup_covered_RF : I_E_Pickup_covered_RF {
         animationList[] = {"hide_rack",1,"hide_rack_antenna",1,"hide_frame",1,"hide_frame_full",1,"hide_frame_full_panel",1,"hide_box",0,"hide_box_door",0,"hide_trunk_door",0,"trunk_door_open",0,"box_door_open",0,"hide_police",1,"hide_Services",1,"BeaconsServicesStart",0,"hide_bullbar",0.2,"hide_snorkel",0,"hide_antenna",1,"hide_armor_window_armor_top",0,"window_armor_hatch_L_rot",1,"window_armor_hatch_R_rot",0,"door_F_L_open",0,"door_F_R_open",0,"door_R_L_open",0,"door_R_R_open",0,"hide_rack_spotlights",0,"hide_sidesteps",0.5};
     };
-    class a3a_fia_Pickup_covered_RF : a3a_armored_Pickup_covered_RF {
+    class a3a_FIA_Pickup_covered_RF : a3a_armored_Pickup_covered_RF {
         textureList[] = {"Guerilla_01",1,"Guerilla_02",1,"Guerilla_03",1,"Guerilla_04",1,"Guerilla_05",1,"Guerilla_06",0.1,"Guerilla_07",0.1,"Guerilla_08",0.1,"Guerilla_09",0.1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_fia_02_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_fia_02_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_aat_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_fia_02_co.paa"};
     };
     class a3a_ION_Pickup_AAT_RF : B_ION_Pickup_aat_RF {
         animationList[] = {"hide_frame",0,"hide_frame_full",1,"hide_bullbar",0,"hide_snorkel",0,"hide_antenna",1,"hide_trunk_door",0,"trunk_door_open",0,"hide_armor_window_armor_top",0,"window_armor_hatch_L_rot",1,"window_armor_hatch_R_rot",0,"door_F_L_open",0,"door_F_R_open",0,"door_R_L_open",0,"door_R_R_open",0,"hide_rack",0,"hide_rack_spotlights",0,"hide_sidesteps",0};
     };
-    class a3a_black_Pickup_rf : a3a_fia_Pickup_RF
+    class a3a_black_Pickup_rf : a3a_FIA_Pickup_RF
     {
         textureList[] = {"Black",1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_white_tank_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_black_co.paa"};
     };
-    class a3a_black_Pickup_mmg_rf : a3a_fia_Pickup_mmg_RF
+    class a3a_black_Pickup_mmg_rf : a3a_FIA_Pickup_mmg_RF
     {
         textureList[] = {"Black",1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_white_tank_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_black_co.paa"};
     };
-    class a3a_black_Pickup_hmg_rf : a3a_fia_Pickup_hmg_RF
+    class a3a_black_Pickup_hmg_rf : a3a_FIA_Pickup_hmg_RF
     {
         textureList[] = {"Black",1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_white_tank_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_black_co.paa"};
     };
-    class a3a_black_Pickup_covered_rf : a3a_fia_Pickup_covered_RF
+    class a3a_black_Pickup_covered_rf : a3a_FIA_Pickup_covered_RF
     {
         textureList[] = {"Black",1};
         hiddenSelectionsTextures[] = {"\lxRF\vehicles_rf\pickup_01\Data\pickup_01_ext_black_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_adds_white_tank_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_ext2_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_AAT_olive_co.paa","\lxrf\vehicles_rf\pickup_01\data\pickup_01_launcher_co.paa","\lxRF\vehicles_rf\pickup_01\Data\pickup_01_service_black_co.paa"};

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -97,11 +97,11 @@ if ("orange" in A3A_enabledDLC) then {
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
     _vehiclesHelisTransport append ["I_Heli_EC_01A_military_RF"];
-    _vehiclesHelisLight append ["a3a_AAF_Heli_light_03_unarmed_RF"];
-    _vehiclesHelisLightAttack append ["a3a_green_Heli_light_03_unarmed_RF"];
+    _vehiclesHelisLight append ["a3a_green_Heli_light_03_unarmed_RF"];
+    _vehiclesHelisLightAttack append ["a3a_AAF_Heli_light_03_dynamicLoadout_RF"];
     _vehiclesHelisAttack = ["a3a_AAF_Heli_EC_02_RF"];
     _vehiclesMilitiaCars append ["I_Pickup_rf"];
-    _vehiclesMilitiaLightArmed append ["I_Pickup_mmg_rf"];
+    _vehiclesMilitiaLightArmed append ["I_Pickup_mmg_rf","I_Pickup_hmg_rf"];
 };
 ["vehiclesHelisLight", _vehiclesHelisLight] call _fnc_saveToTemplate;
 ["vehiclesHelisTransport", _vehiclesHelisTransport] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -97,9 +97,9 @@ if ("orange" in A3A_enabledDLC) then {
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
     _vehiclesHelisTransport append ["I_Heli_EC_01A_military_RF"];
-    _vehiclesHelisLight append ["a3a_green_Heli_light_03_unarmed_RF"];
-    _vehiclesHelisLightAttack append ["a3a_AAF_Heli_light_03_dynamicLoadout_RF"];
-    _vehiclesHelisAttack = ["a3a_AAF_Heli_EC_02_RF"];
+    _vehiclesHelisLight append ["a3a_green_Heli_light_03_unarmed_rf"];
+    _vehiclesHelisLightAttack append ["a3a_AAF_Heli_light_03_dynamicLoadout_rf"];
+    _vehiclesHelisAttack = ["a3a_AAF_Heli_EC_02_rf"];
     _vehiclesMilitiaCars append ["I_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["I_Pickup_mmg_rf","I_Pickup_hmg_rf"];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -40,7 +40,7 @@ private _AA = ["I_LT_01_AA_F"];
 ["vehiclesPlanesAA", ["I_Plane_Fighter_04_F"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesTransport", []] call _fnc_saveToTemplate;
 
-["vehiclesHelisLight", ["I_Heli_light_03_unarmed_F"]] call _fnc_saveToTemplate;
+private _vehiclesHelisLight = ["I_Heli_light_03_unarmed_F"];
 private _vehiclesHelisTransport = ["I_Heli_Transport_02_F"];
 private _vehiclesHelisLightAttack = ["I_Heli_light_03_dynamicLoadout_F"];
 private _vehiclesHelisAttack = ["B_Heli_Attack_01_dynamicLoadout_F"];
@@ -96,13 +96,14 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
-    _vehiclesHelisTransport append ["a3a_AAF_Heli_light_03_unarmed_RF", "I_Heli_EC_01A_military_RF"];
-    _vehiclesHelisLightAttack append ["a3a_AAF_Heli_light_03_dynamicLoadout_RF"];
+    _vehiclesHelisTransport append ["I_Heli_EC_01A_military_RF"];
+    _vehiclesHelisLight append ["a3a_AAF_Heli_light_03_unarmed_RF"];
+    _vehiclesHelisLightAttack append ["a3a_green_Heli_light_03_unarmed_RF"];
     _vehiclesHelisAttack = ["a3a_AAF_Heli_EC_02_RF"];
     _vehiclesMilitiaCars append ["I_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["I_Pickup_mmg_rf"];
 };
-
+["vehiclesHelisLight", _vehiclesHelisLight] call _fnc_saveToTemplate;
 ["vehiclesHelisTransport", _vehiclesHelisTransport] call _fnc_saveToTemplate;
 ["vehiclesHelisLightAttack", _vehiclesHelisLightAttack] call _fnc_saveToTemplate;
 ["vehiclesHelisAttack", _vehiclesHelisAttack] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -98,7 +98,7 @@ if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
     _vehiclesHelisTransport append ["a3a_AAF_Heli_light_03_unarmed_RF", "I_Heli_EC_01A_military_RF"];
     _vehiclesHelisLightAttack append ["a3a_AAF_Heli_light_03_dynamicLoadout_RF"];
-    _vehiclesHelisAttack = ["a3a_Heli_EC_02_RF"];
+    _vehiclesHelisAttack = ["a3a_AAF_Heli_EC_02_RF"];
     _vehiclesMilitiaCars append ["I_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["I_Pickup_mmg_rf"];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -99,6 +99,8 @@ if ("rf" in A3A_enabledDLC) then {
     _vehiclesHelisTransport append ["a3a_AAF_Heli_light_03_unarmed_RF", "I_Heli_EC_01A_military_RF"];
     _vehiclesHelisLightAttack append ["a3a_AAF_Heli_light_03_dynamicLoadout_RF"];
     _vehiclesHelisAttack = ["a3a_Heli_EC_02_RF"];
+    _vehiclesMilitiaCars append ["I_Pickup_rf"];
+    _vehiclesMilitiaLightArmed append ["I_Pickup_mmg_rf"];
 };
 
 ["vehiclesHelisTransport", _vehiclesHelisTransport] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_CSAT_Apex.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_CSAT_Apex.sqf
@@ -54,9 +54,9 @@ private _Tanks = ["O_T_MBT_02_cannon_ghex_F"];
 ["uavsPortable", ["O_UAV_01_F"]] call _fnc_saveToTemplate;
 
 //Config special vehicles - militia vehicles are mostly used in the early game, police cars are being used by troops around cities -- Example:
-["vehiclesMilitiaLightArmed", ["O_T_LSV_02_armed_F","O_T_LSV_02_AT_F"]] call _fnc_saveToTemplate;
+private _vehiclesMilitiaLightArmed = ["O_T_LSV_02_armed_F","O_T_LSV_02_AT_F"];
 ["vehiclesMilitiaTrucks", ["O_T_Truck_02_F"]] call _fnc_saveToTemplate;
-["vehiclesMilitiaCars", ["O_T_LSV_02_unarmed_F"]] call _fnc_saveToTemplate;
+private _vehiclesMilitiaCars = ["O_T_LSV_02_unarmed_F"];
 
 private _vehiclesPolice = ["B_GEN_Offroad_01_gen_F"];
 
@@ -91,7 +91,11 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
+    _vehiclesMilitiaCars append ["O_T_Pickup_rf"];
+    _vehiclesMilitiaLightArmed append ["a3a_ghex_Pickup_mmg_rf"];
 };
+["vehiclesMilitiaCars", _vehiclesMilitiaCars] call _fnc_saveToTemplate;
+["vehiclesMilitiaLightArmed", _vehiclesMilitiaLightArmed] call _fnc_saveToTemplate;
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;
 
 ["vehiclesTanks", _Tanks] call _fnc_saveToTemplate; 
@@ -434,9 +438,9 @@ if ("rf" in A3A_enabledDLC) then {
     (_sfLoadoutData get "rifles") append [["arifle_ash12_wood_RF","suppressor_127x55_small_wood_RF","acc_pointer_IR","optic_Holosight_lush_F",["20Rnd_127x55_Mag_wood_RF","20Rnd_127x55_Mag_wood_RF","20Rnd_127x55_Mag_wood_RF"], [], ""]];
     (_sfLoadoutData get "grenadeLaunchers") append [["arifle_ash12_GL_wood_RF", "suppressor_127x55_small_wood_RF", "acc_pointer_IR", "optic_Holosight_lush_F", ["20Rnd_127x55_Mag_wood_RF","20Rnd_127x55_Mag_wood_RF","20Rnd_127x55_Mag_wood_RF"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]];
     (_sfLoadoutData get "marksmanRifles") append [
-    ["arifle_ash12_LR_wood_RF","suppressor_127x55_small_wood_RF","acc_pointer_IR","optic_Arco_ghex_F",["10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF"], [], "bipod_02_F_hex"],
-    ["arifle_ash12_LR_wood_RF","suppressor_127x55_small_wood_RF","acc_pointer_IR","optic_DMS",["10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF"], [], "bipod_02_F_hex"],
-    ["arifle_ash12_LR_wood_RF","suppressor_127x55_small_wood_RF","acc_pointer_IR","optic_SOS",["10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF"], [], "bipod_02_F_hex"]  
+    ["arifle_ash12_LR_wood_RF","suppressor_127x55_big_wood_RF","acc_pointer_IR","optic_Arco_ghex_F",["10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF"], [], "bipod_02_F_hex"],
+    ["arifle_ash12_LR_wood_RF","suppressor_127x55_big_wood_RF","acc_pointer_IR","optic_DMS",["10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF"], [], "bipod_02_F_hex"],
+    ["arifle_ash12_LR_wood_RF","suppressor_127x55_big_wood_RF","acc_pointer_IR","optic_SOS",["10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF"], [], "bipod_02_F_hex"]  
     ];
     (_sfLoadoutData get "helmets") append [
         "H_HelmetHeavy_GHex_RF",

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_CSAT_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_CSAT_Arid.sqf
@@ -95,6 +95,8 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
+    _vehiclesMilitiaCars append ["O_Pickup_rf"];
+    _vehiclesMilitiaLightArmed append ["a3a_hex_Pickup_mmg_rf"];
 };
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;
 
@@ -430,9 +432,9 @@ if ("rf" in A3A_enabledDLC) then {
     (_sfLoadoutData get "rifles") append [["arifle_ash12_blk_RF","suppressor_127x55_small_RF","acc_pointer_IR","optic_Holosight_blk_F",["20Rnd_127x55_Mag_RF","20Rnd_127x55_Mag_RF","20Rnd_127x55_Mag_RF"], [], ""]];
     (_sfLoadoutData get "grenadeLaunchers") append [["arifle_ash12_GL_blk_RF", "suppressor_127x55_small_RF", "acc_pointer_IR", "optic_Holosight_blk_F", ["20Rnd_127x55_Mag_RF","20Rnd_127x55_Mag_RF","20Rnd_127x55_Mag_RF"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]];
     (_sfLoadoutData get "marksmanRifles") append [
-    ["arifle_ash12_LR_blk_RF","suppressor_127x55_small_RF","acc_pointer_IR","optic_Arco_blk_F",["10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF"], [], "bipod_02_F_hex"],
-    ["arifle_ash12_LR_blk_RF","suppressor_127x55_small_RF","acc_pointer_IR","optic_DMS",["10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF"], [], "bipod_02_F_hex"],
-    ["arifle_ash12_LR_blk_RF","suppressor_127x55_small_RF","acc_pointer_IR","optic_SOS",["10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF"], [], "bipod_02_F_hex"]  
+    ["arifle_ash12_LR_blk_RF","suppressor_127x55_big_RF","acc_pointer_IR","optic_Arco_blk_F",["10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF"], [], "bipod_02_F_hex"],
+    ["arifle_ash12_LR_blk_RF","suppressor_127x55_big_RF","acc_pointer_IR","optic_DMS",["10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF"], [], "bipod_02_F_hex"],
+    ["arifle_ash12_LR_blk_RF","suppressor_127x55_big_RF","acc_pointer_IR","optic_SOS",["10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF"], [], "bipod_02_F_hex"]  
     ];
     (_sfLoadoutData get "helmets") append [
         "H_HelmetHeavy_Hex_RF",

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_CSAT_Enoch.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_CSAT_Enoch.sqf
@@ -96,6 +96,8 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
+    _vehiclesMilitiaCars append ["O_T_Pickup_rf"];
+    _vehiclesMilitiaLightArmed append ["a3a_ghex_Pickup_mmg_rf"];
 };
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;
 
@@ -444,9 +446,9 @@ if ("rf" in A3A_enabledDLC) then {
     (_sfLoadoutData get "rifles") append [["arifle_ash12_blk_RF","suppressor_127x55_small_RF","acc_pointer_IR","optic_Holosight_blk_F",["20Rnd_127x55_Mag_RF","20Rnd_127x55_Mag_RF","20Rnd_127x55_Mag_RF"], [], ""]];
     (_sfLoadoutData get "grenadeLaunchers") append [["arifle_ash12_GL_blk_RF", "suppressor_127x55_small_RF", "acc_pointer_IR", "optic_Holosight_blk_F", ["20Rnd_127x55_Mag_RF","20Rnd_127x55_Mag_RF","20Rnd_127x55_Mag_RF"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]];
     (_sfLoadoutData get "marksmanRifles") append [
-    ["arifle_ash12_LR_blk_RF","suppressor_127x55_small_RF","acc_pointer_IR","optic_Arco_blk_F",["10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF"], [], "bipod_02_F_hex"],
-    ["arifle_ash12_LR_blk_RF","suppressor_127x55_small_RF","acc_pointer_IR","optic_DMS",["10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF"], [], "bipod_02_F_hex"],
-    ["arifle_ash12_LR_blk_RF","suppressor_127x55_small_RF","acc_pointer_IR","optic_SOS",["10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF"], [], "bipod_02_F_hex"]  
+    ["arifle_ash12_LR_blk_RF","suppressor_127x55_big_RF","acc_pointer_IR","optic_Arco_blk_F",["10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF"], [], "bipod_02_F_hex"],
+    ["arifle_ash12_LR_blk_RF","suppressor_127x55_big_RF","acc_pointer_IR","optic_DMS",["10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF"], [], "bipod_02_F_hex"],
+    ["arifle_ash12_LR_blk_RF","suppressor_127x55_big_RF","acc_pointer_IR","optic_SOS",["10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF","10Rnd_127x55_Mag_RF"], [], "bipod_02_F_hex"]  
     ];
     (_sfLoadoutData get "helmets") append [
         "H_HelmetHeavy_Hex_RF",

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_CSAT_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_CSAT_Temperate.sqf
@@ -97,6 +97,8 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
+    _vehiclesMilitiaCars append ["O_T_Pickup_rf"];
+    _vehiclesMilitiaLightArmed append ["a3a_ghex_Pickup_mmg_rf"];
 };
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;
 
@@ -440,9 +442,9 @@ if ("rf" in A3A_enabledDLC) then {
     (_sfLoadoutData get "rifles") append [["arifle_ash12_wood_RF","suppressor_127x55_small_wood_RF","acc_pointer_IR","optic_Holosight_lush_F",["20Rnd_127x55_Mag_wood_RF","20Rnd_127x55_Mag_wood_RF","20Rnd_127x55_Mag_wood_RF"], [], ""]];
     (_sfLoadoutData get "grenadeLaunchers") append [["arifle_ash12_GL_wood_RF", "suppressor_127x55_small_wood_RF", "acc_pointer_IR", "optic_Holosight_lush_F", ["20Rnd_127x55_Mag_wood_RF","20Rnd_127x55_Mag_wood_RF","20Rnd_127x55_Mag_wood_RF"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]];
     (_sfLoadoutData get "marksmanRifles") append [
-    ["arifle_ash12_LR_wood_RF","suppressor_127x55_small_wood_RF","acc_pointer_IR","optic_Arco_ghex_F",["10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF"], [], "bipod_02_F_hex"],
-    ["arifle_ash12_LR_wood_RF","suppressor_127x55_small_wood_RF","acc_pointer_IR","optic_DMS",["10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF"], [], "bipod_02_F_hex"],
-    ["arifle_ash12_LR_wood_RF","suppressor_127x55_small_wood_RF","acc_pointer_IR","optic_SOS",["10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF"], [], "bipod_02_F_hex"]  
+    ["arifle_ash12_LR_wood_RF","suppressor_127x55_big_wood_RF","acc_pointer_IR","optic_Arco_ghex_F",["10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF"], [], "bipod_02_F_hex"],
+    ["arifle_ash12_LR_wood_RF","suppressor_127x55_big_wood_RF","acc_pointer_IR","optic_DMS",["10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF"], [], "bipod_02_F_hex"],
+    ["arifle_ash12_LR_wood_RF","suppressor_127x55_big_wood_RF","acc_pointer_IR","optic_SOS",["10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF","10Rnd_127x55_Mag_wood_RF"], [], "bipod_02_F_hex"]  
     ];
     (_sfLoadoutData get "helmets") append [
         "H_HelmetHeavy_GHex_RF",

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_LDF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_LDF.sqf
@@ -40,7 +40,7 @@ private _Tanks = ["B_T_MBT_01_TUSK_F", "B_T_MBT_01_cannon_F"];
 ["vehiclesPlanesAA", ["B_Plane_Fighter_01_F"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesTransport", ["B_T_VTOL_01_infantry_F"]] call _fnc_saveToTemplate;
 
-["vehiclesHelisLight", ["I_E_Heli_light_03_unarmed_F", "B_Heli_Light_01_F"]] call _fnc_saveToTemplate;
+private _vehiclesHelisLight = ["I_E_Heli_light_03_unarmed_F", "B_Heli_Light_01_F"];
 private _HelisTransport = ["B_Heli_Transport_01_camo_F"];
 private _vehiclesHelisLightAttack = ["I_E_Heli_light_03_dynamicLoadout_F", "B_Heli_Light_01_armed_F"];
 private _vehiclesHelisAttack = ["B_Heli_Attack_01_F"];
@@ -96,12 +96,14 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
-    _HelisTransport append ["I_E_Heli_light_03_unarmed_RF","I_E_Heli_EC_01A_military_RF"];
+    _HelisTransport append ["I_E_Heli_EC_01A_military_RF"];
+    _vehiclesHelisLight append ["I_E_Heli_light_03_unarmed_RF"];
     _vehiclesHelisLightAttack append ["a3a_LDF_Heli_light_03_dynamicLoadout_RF"];
     _vehiclesHelisAttack append ["a3a_LDF_Heli_EC_02_RF"];
     _vehiclesMilitiaCars append ["I_E_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["a3a_LDF_Pickup_mmg_rf"];
 };
+["vehiclesHelisLight", _vehiclesHelisLight] call _fnc_saveToTemplate;
 ["vehiclesHelisLightAttack", _vehiclesHelisLightAttack] call _fnc_saveToTemplate;
 ["vehiclesHelisAttack", _vehiclesHelisAttack] call _fnc_saveToTemplate;
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_LDF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_LDF.sqf
@@ -99,6 +99,8 @@ if ("rf" in A3A_enabledDLC) then {
     _HelisTransport append ["I_E_Heli_light_03_unarmed_RF","I_E_Heli_EC_01A_military_RF"];
     _vehiclesHelisLightAttack append ["a3a_LDF_Heli_light_03_dynamicLoadout_RF"];
     _vehiclesHelisAttack append ["a3a_LDF_Heli_EC_02_RF"];
+    _vehiclesMilitiaCars append ["I_E_Pickup_rf"];
+    _vehiclesMilitiaLightArmed append ["a3a_LDF_Pickup_mmg_rf"];
 };
 ["vehiclesHelisLightAttack", _vehiclesHelisLightAttack] call _fnc_saveToTemplate;
 ["vehiclesHelisAttack", _vehiclesHelisAttack] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_LDF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_LDF.sqf
@@ -98,8 +98,8 @@ if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
     _HelisTransport append ["I_E_Heli_EC_01A_military_RF"];
     _vehiclesHelisLight append ["I_E_Heli_light_03_unarmed_RF"];
-    _vehiclesHelisLightAttack append ["a3a_LDF_Heli_light_03_dynamicLoadout_RF"];
-    _vehiclesHelisAttack append ["a3a_LDF_Heli_EC_02_RF"];
+    _vehiclesHelisLightAttack append ["a3a_LDF_Heli_light_03_dynamicLoadout_rf"];
+    _vehiclesHelisAttack append ["a3a_LDF_Heli_EC_02_rf"];
     _vehiclesMilitiaCars append ["I_E_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["a3a_LDF_Pickup_mmg_rf"];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Apex.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Apex.sqf
@@ -98,7 +98,7 @@ if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
     _HelisTransport append ["B_Heli_EC_04_military_RF"];
     _vehiclesHelisLight append ["B_Heli_light_03_unarmed_RF"];
-    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","B_Heli_EC_03_RF"];
+    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_rf","B_Heli_EC_03_RF"];
     _vehiclesMilitiaCars append ["B_T_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["B_T_Pickup_mmg_rf"];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Apex.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Apex.sqf
@@ -55,9 +55,10 @@ private _vehiclesHelisLightAttack = ["B_Heli_Light_01_armed_F"];
 ["uavsPortable", ["B_UAV_01_F"]] call _fnc_saveToTemplate;
 
 //Config special vehicles
-["vehiclesMilitiaLightArmed", ["B_T_LSV_01_armed_F"]] call _fnc_saveToTemplate;
+private _vehiclesMilitiaLightArmed = ["B_T_LSV_01_armed_F"];
 ["vehiclesMilitiaTrucks", ["B_T_Truck_01_transport_F"]] call _fnc_saveToTemplate;
-["vehiclesMilitiaCars", ["B_T_LSV_01_unarmed_F"]] call _fnc_saveToTemplate;
+private _vehiclesMilitiaCars = ["B_T_LSV_01_unarmed_F"];
+
 
 private _vehiclesPolice = ["B_GEN_Offroad_01_gen_F"];
 
@@ -95,9 +96,13 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
-    _HelisTransport append ["B_Heli_light_03_unarmed_RF","B_Heli_EC_03_RF"];
+    _HelisTransport append ["a3a_green_Heli_light_03_unarmed_RF","B_Heli_EC_03_RF"];
     _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","B_Heli_EC_04_military_RF"];
+    _vehiclesMilitiaCars append ["B_T_Pickup_rf"];
+    _vehiclesMilitiaLightArmed append ["B_T_Pickup_mmg_rf"];
 };
+["vehiclesMilitiaLightArmed", _vehiclesMilitiaLightArmed] call _fnc_saveToTemplate;
+["vehiclesMilitiaCars", _vehiclesMilitiaCars] call _fnc_saveToTemplate;
 ["vehiclesHelisLightAttack", _vehiclesHelisLightAttack] call _fnc_saveToTemplate;
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;
 

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Apex.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Apex.sqf
@@ -40,7 +40,7 @@ private _Tanks = ["B_T_MBT_01_TUSK_F", "B_T_MBT_01_cannon_F"];
 ["vehiclesPlanesAA", ["B_Plane_Fighter_01_F"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesTransport", ["B_T_VTOL_01_infantry_F"]] call _fnc_saveToTemplate;
 
-["vehiclesHelisLight", ["B_Heli_Light_01_F"]] call _fnc_saveToTemplate;
+private _vehiclesHelisLight = ["B_Heli_Light_01_F"];
 private _HelisTransport = ["B_Heli_Transport_01_camo_F","B_CTRG_Heli_Transport_01_tropic_F"];
 private _vehiclesHelisLightAttack = ["B_Heli_Light_01_armed_F"];
 ["vehiclesHelisAttack", ["B_Heli_Attack_01_F"]] call _fnc_saveToTemplate;
@@ -101,6 +101,7 @@ if ("rf" in A3A_enabledDLC) then {
     _vehiclesMilitiaCars append ["B_T_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["B_T_Pickup_mmg_rf"];
 };
+["vehiclesHelisLight", _vehiclesHelisLight] call _fnc_saveToTemplate;
 ["vehiclesMilitiaLightArmed", _vehiclesMilitiaLightArmed] call _fnc_saveToTemplate;
 ["vehiclesMilitiaCars", _vehiclesMilitiaCars] call _fnc_saveToTemplate;
 ["vehiclesHelisLightAttack", _vehiclesHelisLightAttack] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Apex.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Apex.sqf
@@ -96,7 +96,8 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
-    _HelisTransport append ["B_Heli_light_03_unarmed_RF","B_Heli_EC_04_military_RF"];
+    _HelisTransport append ["B_Heli_EC_04_military_RF"];
+    _vehiclesHelisLight append ["B_Heli_light_03_unarmed_RF"];
     _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","B_Heli_EC_03_RF"];
     _vehiclesMilitiaCars append ["B_T_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["B_T_Pickup_mmg_rf"];

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Arid.sqf
@@ -40,7 +40,7 @@ private _Tanks = ["B_MBT_01_TUSK_F", "B_MBT_01_cannon_F"];
 ["vehiclesPlanesAA", ["B_Plane_Fighter_01_F"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesTransport", ["B_T_VTOL_01_infantry_F","B_T_VTOL_01_infantry_blue_F"]] call _fnc_saveToTemplate;
 
-["vehiclesHelisLight", ["B_Heli_Light_01_F"]] call _fnc_saveToTemplate;
+private _vehiclesHelisLight = ["B_Heli_Light_01_F"];
 private _HelisTransport = ["B_Heli_Transport_01_F"];
 private _vehiclesHelisLightAttack = ["B_Heli_Light_01_dynamicLoadout_F"];
 ["vehiclesHelisAttack", ["B_Heli_Attack_01_dynamicLoadout_F"]] call _fnc_saveToTemplate;
@@ -101,11 +101,13 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
-    _HelisTransport append ["B_Heli_light_03_unarmed_RF","a3a_tan_Heli_EC_04_military_RF"];
-    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_03_RF"];
+    _HelisTransport append ["a3a_tan_Heli_EC_04_military_RF"];
+    _vehiclesHelisLight append ["a3a_tan_Heli_light_03_unarmed_RF"];
+    _vehiclesHelisLightAttack append ["a3a_tan_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_03_RF"];
     _vehiclesMilitiaCars append ["B_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf"];
 };
+["vehiclesHelisLight", _vehiclesHelisLight] call _fnc_saveToTemplate;
 ["vehiclesHelisLightAttack", _vehiclesHelisLightAttack] call _fnc_saveToTemplate;
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;
 

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Arid.sqf
@@ -102,8 +102,8 @@ if ("orange" in A3A_enabledDLC) then {
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
     _HelisTransport append ["a3a_tan_Heli_EC_04_military_RF"];
-    _vehiclesHelisLight append ["a3a_tan_Heli_light_03_unarmed_RF"];
-    _vehiclesHelisLightAttack append ["a3a_tan_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_03_RF"];
+    _vehiclesHelisLight append ["B_Heli_light_03_unarmed_RF"];
+    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_03_RF"];
     _vehiclesMilitiaCars append ["B_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf"];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Arid.sqf
@@ -101,8 +101,10 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
-    _HelisTransport append ["B_Heli_light_03_unarmed_RF","B_Heli_EC_03_RF"];
-    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","B_Heli_EC_04_military_RF"];
+    _HelisTransport append ["B_Heli_light_03_unarmed_RF","a3a_tan_Heli_EC_03_RF"];
+    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_04_military_RF"];
+    _vehiclesMilitiaCars append ["B_Pickup_rf"];
+    _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf"];
 };
 ["vehiclesHelisLightAttack", _vehiclesHelisLightAttack] call _fnc_saveToTemplate;
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Arid.sqf
@@ -103,7 +103,7 @@ if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
     _HelisTransport append ["B_Heli_EC_04_military_RF"];
     _vehiclesHelisLight append ["B_Heli_light_03_unarmed_RF"];
-    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","B_Heli_EC_03_RF"];
+    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_rf","B_Heli_EC_03_RF"];
     _vehiclesMilitiaCars append ["B_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf"];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Arid.sqf
@@ -103,7 +103,7 @@ if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
     _HelisTransport append ["B_Heli_EC_04_military_RF"];
     _vehiclesHelisLight append ["B_Heli_light_03_unarmed_RF"];
-    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_03_RF"];
+    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","B_Heli_EC_03_RF"];
     _vehiclesMilitiaCars append ["B_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf"];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Arid.sqf
@@ -101,7 +101,7 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
-    _HelisTransport append ["a3a_tan_Heli_EC_04_military_RF"];
+    _HelisTransport append ["B_Heli_EC_04_military_RF"];
     _vehiclesHelisLight append ["B_Heli_light_03_unarmed_RF"];
     _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_03_RF"];
     _vehiclesMilitiaCars append ["B_Pickup_rf"];

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Temperate.sqf
@@ -102,7 +102,7 @@ if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
     _HelisTransport append ["B_Heli_EC_04_military_RF"];
     _vehiclesHelisLight append ["B_Heli_light_03_unarmed_RF"];
-    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","B_Heli_EC_03_RF"];
+    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_rf","B_Heli_EC_03_RF"];
     _vehiclesMilitiaCars append ["B_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf"];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Temperate.sqf
@@ -100,9 +100,9 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
-    _HelisTransport append "B_Heli_EC_04_military_RF";
-    _vehiclesHelisLight append ["a3a_tan_Heli_light_03_unarmed_RF"];
-    _vehiclesHelisLightAttack append ["a3a_tan_Heli_light_03_dynamicLoadout_RF","B_Heli_EC_03_RF"];
+    _HelisTransport append ["B_Heli_EC_04_military_RF"];
+    _vehiclesHelisLight append ["B_Heli_light_03_unarmed_RF"];
+    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","B_Heli_EC_03_RF"];
     _vehiclesMilitiaCars append ["B_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf"];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Temperate.sqf
@@ -40,7 +40,7 @@ private _Tanks = ["B_T_MBT_01_TUSK_F", "B_T_MBT_01_cannon_F"];
 ["vehiclesPlanesAA", ["B_Plane_Fighter_01_F"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesTransport", ["B_T_VTOL_01_infantry_blue_F"]] call _fnc_saveToTemplate;
 
-["vehiclesHelisLight", ["B_Heli_Light_01_F"]] call _fnc_saveToTemplate;
+private _vehiclesHelisLight = ["B_Heli_Light_01_F"];
 private _HelisTransport = ["B_Heli_Transport_01_camo_F"];
 private _vehiclesHelisLightAttack = ["B_Heli_Light_01_dynamicLoadout_F"];
 ["vehiclesHelisAttack", ["B_Heli_Attack_01_dynamicLoadout_F"]] call _fnc_saveToTemplate;
@@ -100,11 +100,13 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
-    _HelisTransport append ["B_Heli_light_03_unarmed_RF","B_Heli_EC_04_military_RF"];
-    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","B_Heli_EC_03_RF"];
+    _HelisTransport append "B_Heli_EC_04_military_RF";
+    _vehiclesHelisLight append ["a3a_tan_Heli_light_03_unarmed_RF"];
+    _vehiclesHelisLightAttack append ["a3a_tan_Heli_light_03_dynamicLoadout_RF","B_Heli_EC_03_RF"];
     _vehiclesMilitiaCars append ["B_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf"];
 };
+["vehiclesHelisLight", _vehiclesHelisLight] call _fnc_saveToTemplate;
 ["vehiclesHelisLightAttack", _vehiclesHelisLightAttack] call _fnc_saveToTemplate;
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;
 

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Temperate.sqf
@@ -102,6 +102,8 @@ if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
     _HelisTransport append ["B_Heli_light_03_unarmed_RF","B_Heli_EC_03_RF"];
     _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","B_Heli_EC_04_military_RF"];
+    _vehiclesMilitiaCars append ["B_Pickup_rf"];
+    _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf"];
 };
 ["vehiclesHelisLightAttack", _vehiclesHelisLightAttack] call _fnc_saveToTemplate;
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Tropical.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Tropical.sqf
@@ -101,8 +101,10 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
-    _HelisTransport append ["B_Heli_light_03_unarmed_RF","B_Heli_EC_03_RF"];
+    _HelisTransport append ["a3a_green_Heli_light_03_unarmed_RF","B_Heli_EC_03_RF"];
     _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","B_Heli_EC_04_military_RF"];
+    _vehiclesMilitiaCars append ["B_T_Pickup_rf"];
+    _vehiclesMilitiaLightArmed append ["B_T_Pickup_mmg_rf"];
 };
 ["vehiclesHelisLightAttack", _vehiclesHelisLightAttack] call _fnc_saveToTemplate;
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Tropical.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Tropical.sqf
@@ -103,7 +103,7 @@ if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
     _HelisTransport append ["B_Heli_EC_04_military_RF"];
     _vehiclesHelisLight append ["B_Heli_light_03_unarmed_RF"];
-    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","B_Heli_EC_03_RF"];
+    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_rf","B_Heli_EC_03_RF"];
     _vehiclesMilitiaCars append ["B_T_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["B_T_Pickup_mmg_rf"];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Tropical.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Tropical.sqf
@@ -102,8 +102,8 @@ if ("orange" in A3A_enabledDLC) then {
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
     _HelisTransport append ["B_Heli_EC_04_military_RF"];
-    _vehiclesHelisLight append ["a3a_green_Heli_light_03_unarmed_RF"];
-    _vehiclesHelisLightAttack append ["a3a_green_Heli_light_03_dynamicLoadout_RF","B_Heli_EC_03_RF"];
+    _vehiclesHelisLight append ["B_Heli_light_03_unarmed_RF"];
+    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","B_Heli_EC_03_RF"];
     _vehiclesMilitiaCars append ["B_T_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["B_T_Pickup_mmg_rf"];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Tropical.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Tropical.sqf
@@ -40,7 +40,7 @@ private _Tanks = ["B_T_MBT_01_TUSK_F", "B_T_MBT_01_cannon_F"];
 ["vehiclesPlanesAA", ["B_Plane_Fighter_01_F"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesTransport", ["B_T_VTOL_01_infantry_F"]] call _fnc_saveToTemplate;
 
-["vehiclesHelisLight", ["B_Heli_Light_01_F"]] call _fnc_saveToTemplate;
+private _vehiclesHelisLight = ["B_Heli_Light_01_F"];
 private _HelisTransport = ["B_Heli_Transport_01_camo_F"];
 private _vehiclesHelisLightAttack = ["B_Heli_Light_01_dynamicLoadout_F"];
 ["vehiclesHelisAttack", ["B_Heli_Attack_01_F"]] call _fnc_saveToTemplate;
@@ -101,11 +101,13 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
-    _HelisTransport append ["a3a_green_Heli_light_03_unarmed_RF","B_Heli_EC_04_military_RF"];
-    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","B_Heli_EC_03_RF"];
+    _HelisTransport append ["B_Heli_EC_04_military_RF"];
+    _vehiclesHelisLight append ["a3a_green_Heli_light_03_unarmed_RF"];
+    _vehiclesHelisLightAttack append ["a3a_green_Heli_light_03_dynamicLoadout_RF","B_Heli_EC_03_RF"];
     _vehiclesMilitiaCars append ["B_T_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["B_T_Pickup_mmg_rf"];
 };
+["vehiclesHelisLight", _vehiclesHelisLight] call _fnc_saveToTemplate;
 ["vehiclesHelisLightAttack", _vehiclesHelisLightAttack] call _fnc_saveToTemplate;
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;
 

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
@@ -49,8 +49,8 @@ if ("expansion" in A3A_enabledDLC) then {
 
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesCivCar append ["C_Pickup_rf","C_Pickup_covered_rf"];
-    _vehiclesLightUnarmed append ["a3a_fia_Pickup_RF", "a3a_fia_Pickup_covered_RF"];
-    _vehiclesLightArmed append ["a3a_fia_Pickup_mmg_RF", "a3a_fia_Pickup_hmg_RF"];
+    _vehiclesLightUnarmed append ["a3a_FIA_Pickup_RF", "a3a_FIA_Pickup_covered_RF"];
+    _vehiclesLightArmed append ["a3a_FIA_Pickup_mmg_RF", "a3a_FIA_Pickup_hmg_RF"];
     _staticMortars append ["I_G_CommandoMortar_RF"];
     _vehiclesCivHeli append ["C_Heli_EC_01A_civ_RF","C_Heli_EC_04_rescue_RF"];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
@@ -48,9 +48,9 @@ if ("expansion" in A3A_enabledDLC) then {
 };
 
 if ("rf" in A3A_enabledDLC) then {
-    _vehiclesCivCar append ["C_Pickup_rf","C_Pickup_covered_rf"];
-    _vehiclesLightUnarmed append ["I_G_Pickup_rf"];
-    _vehiclesLightArmed append ["I_G_Pickup_mmg_rf"];
+    _vehiclesCivCar append ["a3a_civ_Pickup_RF","a3a_civ_Pickup_covered_RF"];
+    _vehiclesLightUnarmed append ["a3a_fia_Pickup_RF", "a3a_fia_Pickup_covered_RF"];
+    _vehiclesLightArmed append ["a3a_fia_Pickup_mmg_RF", "a3a_fia_Pickup_hmg_RF"];
     _staticMortars append ["I_G_CommandoMortar_RF"];
     _vehiclesCivHeli append ["C_Heli_EC_01A_civ_RF","C_Heli_EC_04_rescue_RF"];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
@@ -48,7 +48,7 @@ if ("expansion" in A3A_enabledDLC) then {
 };
 
 if ("rf" in A3A_enabledDLC) then {
-    _vehiclesCivCar append ["C_Pickup_RF","C_Pickup_covered_RF"];
+    _vehiclesCivCar append ["C_Pickup_rf","C_Pickup_covered_rf"];
     _vehiclesLightUnarmed append ["a3a_fia_Pickup_RF", "a3a_fia_Pickup_covered_RF"];
     _vehiclesLightArmed append ["a3a_fia_Pickup_mmg_RF", "a3a_fia_Pickup_hmg_RF"];
     _staticMortars append ["I_G_CommandoMortar_RF"];

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
@@ -48,7 +48,7 @@ if ("expansion" in A3A_enabledDLC) then {
 };
 
 if ("rf" in A3A_enabledDLC) then {
-    _vehiclesCivCar append ["a3a_civ_Pickup_RF","a3a_civ_Pickup_covered_RF"];
+    _vehiclesCivCar append ["C_Pickup_RF","C_Pickup_covered_RF"];
     _vehiclesLightUnarmed append ["a3a_fia_Pickup_RF", "a3a_fia_Pickup_covered_RF"];
     _vehiclesLightArmed append ["a3a_fia_Pickup_mmg_RF", "a3a_fia_Pickup_hmg_RF"];
     _staticMortars append ["I_G_CommandoMortar_RF"];

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
@@ -49,9 +49,9 @@ if ("expansion" in A3A_enabledDLC) then {
 
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesCivCar append ["C_Pickup_rf","C_Pickup_covered_rf"];
-    _vehiclesLightUnarmed append ["a3a_FIA_Pickup_RF", "a3a_FIA_Pickup_covered_RF"];
-    _vehiclesLightArmed append ["a3a_FIA_Pickup_mmg_RF", "a3a_FIA_Pickup_hmg_RF"];
-    _staticMortars append ["I_G_CommandoMortar_RF"];
+    _vehiclesLightUnarmed append ["a3a_FIA_Pickup_rf", "a3a_FIA_Pickup_covered_rf"];
+    _vehiclesLightArmed append ["a3a_FIA_Pickup_mmg_rf", "a3a_FIA_Pickup_hmg_rf"];
+    _staticMortars append ["I_G_CommandoMortar_rf"];
     _vehiclesCivHeli append ["C_Heli_EC_01A_civ_RF","C_Heli_EC_04_rescue_RF"];
 };
 

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_LFF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_LFF.sqf
@@ -48,7 +48,7 @@ if ("expansion" in A3A_enabledDLC) then {
 };
 
 if ("rf" in A3A_enabledDLC) then {
-    _vehiclesCivCar append ["C_Pickup_RF","C_Pickup_covered_RF"];
+    _vehiclesCivCar append ["C_Pickup_rf","C_Pickup_covered_rf"];
     _vehiclesLightUnarmed append ["a3a_black_Pickup_rf","a3a_black_Pickup_covered_rf"];
     _vehiclesLightArmed append ["a3a_black_Pickup_mmg_rf","a3a_black_Pickup_hmg_RF"];
     _staticMortars append ["I_G_CommandoMortar_RF"];

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_LFF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_LFF.sqf
@@ -50,8 +50,8 @@ if ("expansion" in A3A_enabledDLC) then {
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesCivCar append ["C_Pickup_rf","C_Pickup_covered_rf"];
     _vehiclesLightUnarmed append ["a3a_black_Pickup_rf","a3a_black_Pickup_covered_rf"];
-    _vehiclesLightArmed append ["a3a_black_Pickup_mmg_rf","a3a_black_Pickup_hmg_RF"];
-    _staticMortars append ["I_G_CommandoMortar_RF"];
+    _vehiclesLightArmed append ["a3a_black_Pickup_mmg_rf","a3a_black_Pickup_hmg_rf"];
+    _staticMortars append ["I_G_CommandoMortar_rf"];
     _vehiclesCivHeli append ["C_Heli_EC_01A_civ_RF","C_Heli_EC_04_rescue_RF"];
 };
 

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_LFF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_LFF.sqf
@@ -48,9 +48,9 @@ if ("expansion" in A3A_enabledDLC) then {
 };
 
 if ("rf" in A3A_enabledDLC) then {
-    _vehiclesCivCar append ["C_Pickup_rf","C_Pickup_covered_rf"];
-    _vehiclesLightUnarmed append ["a3a_black_Pickup_rf"];
-    _vehiclesLightArmed append ["a3a_black_Pickup_mmg_rf"];
+    _vehiclesCivCar append ["a3a_civ_Pickup_RF","a3a_civ_Pickup_covered_RF"];
+    _vehiclesLightUnarmed append ["a3a_black_Pickup_rf","a3a_black_Pickup_covered_rf"];
+    _vehiclesLightArmed append ["a3a_black_Pickup_mmg_rf","a3a_black_Pickup_hmg_RF"];
     _staticMortars append ["I_G_CommandoMortar_RF"];
     _vehiclesCivHeli append ["C_Heli_EC_01A_civ_RF","C_Heli_EC_04_rescue_RF"];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_LFF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_LFF.sqf
@@ -48,7 +48,7 @@ if ("expansion" in A3A_enabledDLC) then {
 };
 
 if ("rf" in A3A_enabledDLC) then {
-    _vehiclesCivCar append ["a3a_civ_Pickup_RF","a3a_civ_Pickup_covered_RF"];
+    _vehiclesCivCar append ["C_Pickup_RF","C_Pickup_covered_RF"];
     _vehiclesLightUnarmed append ["a3a_black_Pickup_rf","a3a_black_Pickup_covered_rf"];
     _vehiclesLightArmed append ["a3a_black_Pickup_mmg_rf","a3a_black_Pickup_hmg_RF"];
     _staticMortars append ["I_G_CommandoMortar_RF"];

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
@@ -48,7 +48,7 @@ if ("ws" in A3A_enabledDLC) then {
 };
 
 if ("rf" in A3A_enabledDLC) then {
-    _vehiclesCivCar append ["a3a_civ_Pickup_RF","a3a_civ_Pickup_covered_RF"];
+    _vehiclesCivCar append ["C_Pickup_RF","C_Pickup_covered_RF"];
     _vehiclesLightUnarmed append ["a3a_fia_Pickup_RF", "a3a_fia_Pickup_covered_RF"];
     _vehiclesLightArmed append ["a3a_fia_Pickup_mmg_RF", "a3a_fia_Pickup_hmg_RF"];
     _staticMortars append ["I_G_CommandoMortar_RF"];

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
@@ -49,8 +49,8 @@ if ("ws" in A3A_enabledDLC) then {
 
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesCivCar append ["C_Pickup_rf","C_Pickup_covered_rf"];
-    _vehiclesLightUnarmed append ["a3a_fia_Pickup_RF", "a3a_fia_Pickup_covered_RF"];
-    _vehiclesLightArmed append ["a3a_fia_Pickup_mmg_RF", "a3a_fia_Pickup_hmg_RF"];
+    _vehiclesLightUnarmed append ["a3a_FIA_Pickup_RF", "a3a_FIA_Pickup_covered_RF"];
+    _vehiclesLightArmed append ["a3a_FIA_Pickup_mmg_RF", "a3a_FIA_Pickup_hmg_RF"];
     _staticMortars append ["I_G_CommandoMortar_RF"];
     _vehiclesCivHeli append ["C_Heli_EC_01A_civ_RF","C_Heli_EC_04_rescue_RF"];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
@@ -48,7 +48,7 @@ if ("ws" in A3A_enabledDLC) then {
 };
 
 if ("rf" in A3A_enabledDLC) then {
-    _vehiclesCivCar append ["C_Pickup_RF","C_Pickup_covered_RF"];
+    _vehiclesCivCar append ["C_Pickup_rf","C_Pickup_covered_rf"];
     _vehiclesLightUnarmed append ["a3a_fia_Pickup_RF", "a3a_fia_Pickup_covered_RF"];
     _vehiclesLightArmed append ["a3a_fia_Pickup_mmg_RF", "a3a_fia_Pickup_hmg_RF"];
     _staticMortars append ["I_G_CommandoMortar_RF"];

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
@@ -49,9 +49,9 @@ if ("ws" in A3A_enabledDLC) then {
 
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesCivCar append ["C_Pickup_rf","C_Pickup_covered_rf"];
-    _vehiclesLightUnarmed append ["a3a_FIA_Pickup_RF", "a3a_FIA_Pickup_covered_RF"];
-    _vehiclesLightArmed append ["a3a_FIA_Pickup_mmg_RF", "a3a_FIA_Pickup_hmg_RF"];
-    _staticMortars append ["I_G_CommandoMortar_RF"];
+    _vehiclesLightUnarmed append ["a3a_FIA_Pickup_rf", "a3a_FIA_Pickup_covered_rf"];
+    _vehiclesLightArmed append ["a3a_FIA_Pickup_mmg_rf", "a3a_FIA_Pickup_hmg_rf"];
+    _staticMortars append ["I_G_CommandoMortar_rf"];
     _vehiclesCivHeli append ["C_Heli_EC_01A_civ_RF","C_Heli_EC_04_rescue_RF"];
 };
 

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
@@ -48,9 +48,9 @@ if ("ws" in A3A_enabledDLC) then {
 };
 
 if ("rf" in A3A_enabledDLC) then {
-    _vehiclesCivCar append ["C_Pickup_rf","C_Pickup_covered_rf"];
-    _vehiclesLightUnarmed append ["I_C_Pickup_rf"];
-    _vehiclesLightArmed append ["I_C_Pickup_mmg_rf"];
+    _vehiclesCivCar append ["a3a_civ_Pickup_RF","a3a_civ_Pickup_covered_RF"];
+    _vehiclesLightUnarmed append ["a3a_fia_Pickup_RF", "a3a_fia_Pickup_covered_RF"];
+    _vehiclesLightArmed append ["a3a_fia_Pickup_mmg_RF", "a3a_fia_Pickup_hmg_RF"];
     _staticMortars append ["I_G_CommandoMortar_RF"];
     _vehiclesCivHeli append ["C_Heli_EC_01A_civ_RF","C_Heli_EC_04_rescue_RF"];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_Vehicle_Attributes.sqf
@@ -24,8 +24,8 @@ if (isClass (configFile >> "CfgPatches" >> "RF_Vehicles")) then {
         ["C_Heli_EC_01A_civ_RF", ["rebCost", 8000]],
         ["C_Heli_EC_01_civ_RF", ["rebCost", 8000]],
         ["C_Heli_EC_04_rescue_RF", ["rebCost", 8000]],
-        ["C_Pickup_RF", ["rebCost", 250]],
-        ["C_Pickup_covered_RF", ["rebCost", 250]],
+        ["C_Pickup_rf", ["rebCost", 250]],
+        ["C_Pickup_covered_rf", ["rebCost", 250]],
         ["a3a_fia_Pickup_hmg_RF", ["rebCost", 900]]
     ];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_Vehicle_Attributes.sqf
@@ -24,8 +24,8 @@ if (isClass (configFile >> "CfgPatches" >> "RF_Vehicles")) then {
         ["C_Heli_EC_01A_civ_RF", ["rebCost", 8000]],
         ["C_Heli_EC_01_civ_RF", ["rebCost", 8000]],
         ["C_Heli_EC_04_rescue_RF", ["rebCost", 8000]],
-        ["C_Pickup_rf", ["rebCost", 250]],
-        ["C_Pickup_covered_rf", ["rebCost", 250]],
+        ["C_Pickup_RF", ["rebCost", 250]],
+        ["C_Pickup_covered_RF", ["rebCost", 250]],
         ["a3a_fia_Pickup_hmg_RF", ["rebCost", 900]]
     ];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_Vehicle_Attributes.sqf
@@ -25,6 +25,7 @@ if (isClass (configFile >> "CfgPatches" >> "RF_Vehicles")) then {
         ["C_Heli_EC_01_civ_RF", ["rebCost", 8000]],
         ["C_Heli_EC_04_rescue_RF", ["rebCost", 8000]],
         ["C_Pickup_rf", ["rebCost", 250]],
-        ["C_Pickup_covered_rf", ["rebCost", 250]]
+        ["C_Pickup_covered_rf", ["rebCost", 250]],
+        ["a3a_fia_Pickup_hmg_RF", ["rebCost", 900]]
     ];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_Vehicle_Attributes.sqf
@@ -26,6 +26,6 @@ if (isClass (configFile >> "CfgPatches" >> "RF_Vehicles")) then {
         ["C_Heli_EC_04_rescue_RF", ["rebCost", 8000]],
         ["C_Pickup_rf", ["rebCost", 250]],
         ["C_Pickup_covered_rf", ["rebCost", 250]],
-        ["a3a_fia_Pickup_hmg_RF", ["rebCost", 900]]
+        ["a3a_FIA_Pickup_hmg_RF", ["rebCost", 900]]
     ];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_Vehicle_Attributes.sqf
@@ -22,10 +22,9 @@ if (isClass (configFile >> "CfgPatches" >> "Vehicles_F_lxWS")) then {
 if (isClass (configFile >> "CfgPatches" >> "RF_Vehicles")) then {
     (["attributesVehicles"] call _fnc_getFromTemplate) append [
         ["C_Heli_EC_01A_civ_RF", ["rebCost", 8000]],
-        ["C_Heli_EC_01_civ_RF", ["rebCost", 8000]],
         ["C_Heli_EC_04_rescue_RF", ["rebCost", 8000]],
         ["C_Pickup_rf", ["rebCost", 250]],
         ["C_Pickup_covered_rf", ["rebCost", 250]],
-        ["a3a_FIA_Pickup_hmg_RF", ["rebCost", 900]]
+        ["a3a_FIA_Pickup_hmg_rf", ["rebCost", 900]]
     ];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Vehicle_Attributes.sqf
@@ -33,3 +33,10 @@ if ("ws" in A3A_enabledDLC) then {
         ["a3a_I_E_Truck_02_zu23_F", ["cost", 60]]
     ];
 };
+
+//Reaction Forces Vehicles
+if (isClass (configFile >> "CfgPatches" >> "RF_Vehicles")) then {
+    (["attributesVehicles"] call _fnc_getFromTemplate) append [
+        ["B_ION_Pickup_aat_rf", ["cost", 40]]
+    ];
+};

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_ADF.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_ADF.sqf
@@ -94,12 +94,12 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
-    _HelisTransport = ["a3a_tan_Heli_EC_04_military_RF"];
-    _vehiclesHelisLight = ["a3a_tan_Heli_light_03_unarmed_RF"];
-    _vehiclesHelisLightAttack = ["a3a_tan_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_03_RF"];
+    _HelisTransport = ["a3a_tan_Heli_EC_04_military_rf"];
+    _vehiclesHelisLight = ["a3a_tan_Heli_light_03_unarmed_rf"];
+    _vehiclesHelisLightAttack = ["a3a_tan_Heli_light_03_dynamicLoadout_rf","a3a_tan_Heli_EC_03_rf"];
     _vehiclesMilitiaCars append ["B_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf","B_Pickup_mmg_rf"];
-    _vehiclesHelisAttack = ["a3a_Heli_EC_02_RF"];
+    _vehiclesHelisAttack = ["a3a_Heli_EC_02_rf"];
 };
 ["vehiclesHelisLight", _vehiclesHelisLight] call _fnc_saveToTemplate;
 ["vehiclesHelisAttack", _vehiclesHelisAttack] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_ADF.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_ADF.sqf
@@ -42,11 +42,11 @@ private _Tanks = ["B_MBT_01_TUSK_F", "B_MBT_01_cannon_F"];
 ["vehiclesPlanesAA", ["a3a_Plane_Fighter_04_grey_F"]] call _fnc_saveToTemplate;              // 
 ["vehiclesPlanesTransport", ["B_T_VTOL_01_infantry_blue_F"]] call _fnc_saveToTemplate;
 
-["vehiclesHelisLight", ["O_Heli_Light_02_unarmed_F", "a3a_Heli_Light_01_ION_F"]] call _fnc_saveToTemplate;            // ideally fragile & unarmed helis seating 4+
+private _vehiclesHelisLight = ["O_Heli_Light_02_unarmed_F", "a3a_Heli_Light_01_ION_F"]; // ideally fragile & unarmed helis seating 4+
 private _HelisTransport = ["B_D_Heli_Transport_01_lxWS", "B_Heli_Transport_01_F", "a3a_ION_Heli_Transport_02_F", "B_CTRG_Heli_Transport_01_sand_F"];
 // Should be capable of dealing damage to ground targets without additional scripting
 private _vehiclesHelisLightAttack = ["B_D_Heli_Light_01_dynamicLoadout_lxWS", "a3a_Heli_Light_02_black_F", "a3a_Heli_Light_01_dynamicLoadout_ION_F"];       // Utility helis with fixed or door guns + rocket pods
-private _vehiclesHelisAttack = ["O_Heli_Attack_02_dynamicLoadout_black_F", "B_D_Heli_Attack_01_dynamicLoadout_lxWS"];
+private _vehiclesHelisAttack = ["B_D_Heli_Attack_01_dynamicLoadout_lxWS"];
 
 ["vehiclesArtillery", ["B_MBT_01_arty_F","B_MBT_01_mlrs_F"]] call _fnc_saveToTemplate; //this line determines artillery vehicles -- Example: ["vehiclesArtillery", ["B_MBT_01_arty_F"]] -- Array, can contain multiple assets
 //new magazines storing methode, all vehicle magazines should be defined here in format [Vehicle class, [magazines]],
@@ -94,13 +94,14 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
-    _HelisTransport append ["B_Heli_light_03_unarmed_RF","a3a_tan_Heli_EC_03_RF"];
-    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_04_military_RF"];
+    _HelisTransport append ["a3a_tan_Heli_EC_03_RF"];
+    _vehiclesHelisLight append ["a3a_tan_Heli_light_03_unarmed_RF"];
+    _vehiclesHelisLightAttack append ["a3a_tan_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_04_military_RF"];
     _vehiclesMilitiaCars append ["B_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf","B_Pickup_mmg_rf"];
-    _vehiclesHelisAttack = _vehiclesHelisAttack - ["O_Heli_Attack_02_dynamicLoadout_black_F"];
     _vehiclesHelisAttack append ["a3a_Heli_EC_02_RF"];
 };
+["vehiclesHelisLight", _vehiclesHelisLight] call _fnc_saveToTemplate;
 ["vehiclesHelisAttack", _vehiclesHelisAttack] call _fnc_saveToTemplate;
 ["vehiclesMilitiaLightArmed", _vehiclesMilitiaLightArmed] call _fnc_saveToTemplate;
 ["vehiclesHelisLightAttack", _vehiclesHelisLightAttack] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_ADF.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_ADF.sqf
@@ -45,7 +45,7 @@ private _Tanks = ["B_MBT_01_TUSK_F", "B_MBT_01_cannon_F"];
 ["vehiclesHelisLight", ["O_Heli_Light_02_unarmed_F", "a3a_Heli_Light_01_ION_F"]] call _fnc_saveToTemplate;            // ideally fragile & unarmed helis seating 4+
 private _HelisTransport = ["B_D_Heli_Transport_01_lxWS", "B_Heli_Transport_01_F", "a3a_ION_Heli_Transport_02_F", "B_CTRG_Heli_Transport_01_sand_F"];
 // Should be capable of dealing damage to ground targets without additional scripting
-["vehiclesHelisLightAttack", ["B_D_Heli_Light_01_dynamicLoadout_lxWS", "a3a_Heli_Light_02_black_F", "a3a_Heli_Light_01_dynamicLoadout_ION_F"]] call _fnc_saveToTemplate;      // Utility helis with fixed or door guns + rocket pods
+private _vehiclesHelisLightAttack = ["B_D_Heli_Light_01_dynamicLoadout_lxWS", "a3a_Heli_Light_02_black_F", "a3a_Heli_Light_01_dynamicLoadout_ION_F"];       // Utility helis with fixed or door guns + rocket pods
 ["vehiclesHelisAttack", ["O_Heli_Attack_02_dynamicLoadout_black_F", "B_D_Heli_Attack_01_dynamicLoadout_lxWS"]] call _fnc_saveToTemplate;           // Proper attack helis: Apache, Hind etc
 
 ["vehiclesArtillery", ["B_MBT_01_arty_F","B_MBT_01_mlrs_F"]] call _fnc_saveToTemplate; //this line determines artillery vehicles -- Example: ["vehiclesArtillery", ["B_MBT_01_arty_F"]] -- Array, can contain multiple assets
@@ -59,7 +59,7 @@ private _HelisTransport = ["B_D_Heli_Transport_01_lxWS", "B_Heli_Transport_01_F"
 ["uavsPortable", ["B_UAV_01_F", "B_UAV_02_lxWS"]] call _fnc_saveToTemplate;
 
 //Config special vehicles - militia vehicles are mostly used in the early game, police cars are being used by troops around cities -- Example:
-["vehiclesMilitiaLightArmed", ["a3a_Offroad_01_tan_armed_F","a3a_tan_Offroad_armor_armed","a3a_Offroad_01_tan_armed_F","a3a_tan_Offroad_armor_armed","a3a_Offroad_01_tan_AT_F","a3a_tan_Offroad_armor_at"]] call _fnc_saveToTemplate;
+private _vehiclesMilitiaLightArmed = ["a3a_Offroad_01_tan_armed_F","a3a_tan_Offroad_armor_armed","a3a_Offroad_01_tan_armed_F","a3a_tan_Offroad_armor_armed","a3a_Offroad_01_tan_AT_F","a3a_tan_Offroad_armor_at"];
 ["vehiclesMilitiaTrucks", ["I_C_Van_02_transport_F", "I_C_Van_01_transport_brown_F"]] call _fnc_saveToTemplate;
 private _vehiclesMilitiaCars = ["a3a_tan_Offroad_armor","a3a_Offroad_01_tan_F"];
 
@@ -92,6 +92,15 @@ if ("heli" in A3A_enabledDLC) then {
 if ("orange" in A3A_enabledDLC) then {
 	_vehiclesPolice append ["B_GEN_Van_02_vehicle_F","B_GEN_Van_02_transport_F"];
 };
+if ("rf" in A3A_enabledDLC) then {
+    _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
+    _HelisTransport append ["B_Heli_light_03_unarmed_RF","a3a_tan_Heli_EC_03_RF"];
+    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_04_military_RF"];
+    _vehiclesMilitiaCars append ["B_Pickup_rf"];
+    _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf"];
+};
+["vehiclesMilitiaLightArmed", _vehiclesMilitiaLightArmed] call _fnc_saveToTemplate;
+["vehiclesHelisLightAttack", _vehiclesHelisLightAttack] call _fnc_saveToTemplate;
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;
 
 ["vehiclesLightUnarmed", _LightUnarmed] call _fnc_saveToTemplate;
@@ -500,6 +509,27 @@ if ("expansion" in A3A_enabledDLC) then {
 	["arifle_SPAR_03_snd_F", "muzzle_snds_B_snd_F", "acc_pointer_IR", "optic_Hamr_sand_lxWS", [], [], "bipod_01_F_snd"],
 	["arifle_SPAR_03_snd_F", "suppressor_h_sand_lxWS", "acc_pointer_IR_sand_lxWS", "optic_ERCO_snd_F", [], [], "bipod_01_F_snd"]
 	];
+};
+if ("rf" in A3A_enabledDLC) then {
+    (_sfLoadoutData get "sidearms") append [
+    ["hgun_Glock19_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", [], [], ""],
+    ["hgun_Glock19_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", [], [], ""],
+    ["hgun_Glock19_auto_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", [], [], ""],
+    ["hgun_Glock19_auto_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", [], [], ""],
+    ["hgun_Glock19_auto_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", [], [], ""]
+    ];
+    (_militaryLoadoutData get "sidearms") append [
+    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_pistol", "", [], [], ""],
+    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_pistol", "", [], [], ""],
+    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_pistol", "", [], [], ""],
+    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_pistol", "optic_MRD_tan_RF", [], [], ""],
+    ["hgun_Glock19_auto_Tan_RF", "", "acc_flashlight_pistol", "", [], [], ""]
+    ];
+    (_policeLoadoutData get "sidearms") append ["hgun_Glock19_RF"];
+    (_sfLoadoutData get "helmets") append [
+    "H_HelmetHeavy_Sand_RF",
+    "H_HelmetHeavy_Simple_Sand_RF",
+    "H_HelmetHeavy_VisorUp_Sand_RF"];
 };
 
 /////////////////////////////////

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_ADF.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_ADF.sqf
@@ -46,7 +46,7 @@ private _Tanks = ["B_MBT_01_TUSK_F", "B_MBT_01_cannon_F"];
 private _HelisTransport = ["B_D_Heli_Transport_01_lxWS", "B_Heli_Transport_01_F", "a3a_ION_Heli_Transport_02_F", "B_CTRG_Heli_Transport_01_sand_F"];
 // Should be capable of dealing damage to ground targets without additional scripting
 private _vehiclesHelisLightAttack = ["B_D_Heli_Light_01_dynamicLoadout_lxWS", "a3a_Heli_Light_02_black_F", "a3a_Heli_Light_01_dynamicLoadout_ION_F"];       // Utility helis with fixed or door guns + rocket pods
-["vehiclesHelisAttack", ["O_Heli_Attack_02_dynamicLoadout_black_F", "B_D_Heli_Attack_01_dynamicLoadout_lxWS"]] call _fnc_saveToTemplate;           // Proper attack helis: Apache, Hind etc
+private _vehiclesHelisAttack = ["O_Heli_Attack_02_dynamicLoadout_black_F", "B_D_Heli_Attack_01_dynamicLoadout_lxWS"];
 
 ["vehiclesArtillery", ["B_MBT_01_arty_F","B_MBT_01_mlrs_F"]] call _fnc_saveToTemplate; //this line determines artillery vehicles -- Example: ["vehiclesArtillery", ["B_MBT_01_arty_F"]] -- Array, can contain multiple assets
 //new magazines storing methode, all vehicle magazines should be defined here in format [Vehicle class, [magazines]],
@@ -97,8 +97,11 @@ if ("rf" in A3A_enabledDLC) then {
     _HelisTransport append ["B_Heli_light_03_unarmed_RF","a3a_tan_Heli_EC_03_RF"];
     _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_04_military_RF"];
     _vehiclesMilitiaCars append ["B_Pickup_rf"];
-    _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf"];
+    _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf","B_Pickup_mmg_rf"];
+    _vehiclesHelisAttack = _vehiclesHelisAttack - ["O_Heli_Attack_02_dynamicLoadout_black_F"];
+    _vehiclesHelisAttack append ["a3a_Heli_EC_02_RF"];
 };
+["vehiclesHelisAttack", _vehiclesHelisAttack] call _fnc_saveToTemplate;
 ["vehiclesMilitiaLightArmed", _vehiclesMilitiaLightArmed] call _fnc_saveToTemplate;
 ["vehiclesHelisLightAttack", _vehiclesHelisLightAttack] call _fnc_saveToTemplate;
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_ADF.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_ADF.sqf
@@ -94,12 +94,12 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
-    _HelisTransport append ["a3a_tan_Heli_EC_03_RF"];
-    _vehiclesHelisLight append ["a3a_tan_Heli_light_03_unarmed_RF"];
-    _vehiclesHelisLightAttack append ["a3a_tan_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_04_military_RF"];
+    _HelisTransport = ["a3a_tan_Heli_EC_04_military_RF"];
+    _vehiclesHelisLight = ["a3a_tan_Heli_light_03_unarmed_RF"];
+    _vehiclesHelisLightAttack = ["a3a_tan_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_03_RF"];
     _vehiclesMilitiaCars append ["B_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf","B_Pickup_mmg_rf"];
-    _vehiclesHelisAttack append ["a3a_Heli_EC_02_RF"];
+    _vehiclesHelisAttack = ["a3a_Heli_EC_02_RF"];
 };
 ["vehiclesHelisLight", _vehiclesHelisLight] call _fnc_saveToTemplate;
 ["vehiclesHelisAttack", _vehiclesHelisAttack] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_CSAT_NAfrica.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_CSAT_NAfrica.sqf
@@ -93,7 +93,7 @@ if ("orange" in A3A_enabledDLC) then
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
     _vehiclesMilitiaCars append ["O_Pickup_rf"];
-    _vehiclesMilitiaLightArmed append ["a3a_hex_Pickup_mmg_rf"];
+    _vehiclesMilitiaLightArmed append ["a3a_hex_Pickup_mmg_rf","a3a_hex_Pickup_mmg_rf"];
 };
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;
 ["vehiclesMilitiaLightArmed", _vehiclesMilitiaLightArmed] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_CSAT_NAfrica.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_CSAT_NAfrica.sqf
@@ -54,7 +54,7 @@ private _Tanks = ["O_MBT_02_cannon_F"];
 ["uavsPortable", ["O_UAV_01_F", "O_UAV_02_lxWS"]] call _fnc_saveToTemplate;
 
 //Config special vehicles - militia vehicles are mostly used in the early game, police cars are being used by troops around cities -- Example:
-["vehiclesMilitiaLightArmed", ["a3a_Offroad_01_tan_armed_F","a3a_tan_Offroad_armor_armed","a3a_Offroad_01_tan_armed_F","a3a_tan_Offroad_armor_armed","a3a_Offroad_01_tan_AT_F","a3a_tan_Offroad_armor_at"]] call _fnc_saveToTemplate;
+private _vehiclesMilitiaLightArmed = ["a3a_Offroad_01_tan_armed_F","a3a_tan_Offroad_armor_armed","a3a_Offroad_01_tan_armed_F","a3a_tan_Offroad_armor_armed","a3a_Offroad_01_tan_AT_F","a3a_tan_Offroad_armor_at"];
 ["vehiclesMilitiaTrucks", ["O_Truck_02_transport_F", "O_Truck_02_covered_F"]] call _fnc_saveToTemplate;
 private _vehiclesMilitiaCars = ["a3a_tan_Offroad_armor","a3a_Offroad_01_tan_F"];
 private _vehiclesPolice = ["B_GEN_Offroad_01_gen_F"];
@@ -90,8 +90,13 @@ if ("orange" in A3A_enabledDLC) then
 {
     _vehiclesPolice append ["B_GEN_Van_02_vehicle_F","B_GEN_Van_02_transport_F"];
 };
+if ("rf" in A3A_enabledDLC) then {
+    _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
+    _vehiclesMilitiaCars append ["O_Pickup_rf"];
+    _vehiclesMilitiaLightArmed append ["a3a_hex_Pickup_mmg_rf"];
+};
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;
-
+["vehiclesMilitiaLightArmed", _vehiclesMilitiaLightArmed] call _fnc_saveToTemplate;
 
 ["vehiclesLightUnarmed", _LightUnarmed] call _fnc_saveToTemplate;
 ["vehiclesLightArmed", _LightArmed] call _fnc_saveToTemplate;
@@ -455,6 +460,27 @@ if ("mark" in A3A_enabledDLC) then {
     _militaryLoadoutData set ["sniperRifles", _mSniper];    
 };
 
+if ("rf" in A3A_enabledDLC) then {
+    (_sfLoadoutData get "slRifles") append [
+    ["arifle_ash12_desert_RF","suppressor_127x55_small_desert_RF","acc_pointer_IR","optic_Arco_blk_F",["20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF"], [], ""],
+    ["arifle_ash12_desert_RF","suppressor_127x55_small_desert_RF","acc_pointer_IR","optic_Arco_blk_F",["20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF"], [], ""]
+    ];
+    (_sfLoadoutData get "rifles") append [["arifle_ash12_desert_RF","suppressor_127x55_small_desert_RF","acc_pointer_IR","optic_Holosight_blk_F",["20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF"], [], ""]];
+    (_sfLoadoutData get "grenadeLaunchers") append [["arifle_ash12_GL_desert_RF", "suppressor_127x55_small_desert_RF", "acc_pointer_IR", "optic_Holosight_blk_F", ["20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]];
+    (_sfLoadoutData get "marksmanRifles") append [
+    ["arifle_ash12_LR_desert_RF","suppressor_127x55_big_desert_RF","acc_pointer_IR","optic_Arco_blk_F",["10Rnd_127x55_Mag_desert_RF","10Rnd_127x55_Mag_desert_RF","10Rnd_127x55_Mag_desert_RF"], [], "bipod_02_F_hex"],
+    ["arifle_ash12_LR_desert_RF","suppressor_127x55_big_desert_RF","acc_pointer_IR","optic_DMS",["10Rnd_127x55_Mag_desert_RF","10Rnd_127x55_Mag_desert_RF","10Rnd_127x55_Mag_desert_RF"], [], "bipod_02_F_hex"],
+    ["arifle_ash12_LR_desert_RF","suppressor_127x55_big_desert_RF","acc_pointer_IR","optic_SOS",["10Rnd_127x55_Mag_desert_RF","10Rnd_127x55_Mag_desert_RF","10Rnd_127x55_Mag_desert_RF"], [], "bipod_02_F_hex"]  
+    ];
+    (_sfLoadoutData get "helmets") append [
+        "H_HelmetHeavy_Hex_RF",
+        "H_HelmetHeavy_Simple_Hex_RF",
+        "H_HelmetHeavy_VisorUp_Hex_RF"
+    ];
+    (_policeLoadoutData get "sidearms") append ["hgun_Glock19_RF"];
+    (_militaryLoadoutData get "helmets") append ["H_HelmetO_ocano_sb_hex_RF"];
+    (_militiaLoadoutData get "helmets") append ["H_HelmetO_ocamo_sb_hex_RF"];
+};
 
 /////////////////////////////////
 //    Unit Type Definitions    //

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_ION.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_ION.sqf
@@ -91,11 +91,11 @@ if ("orange" in A3A_enabledDLC) then {
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
     _HelisTransport append ["a3a_ION_Heli_EC_04_military_rf"];
-    _vehiclesHelisLight append ["a3a_black_Heli_light_03_unarmed_rf"];
+    _vehiclesHelisLight append ["a3a_black_Heli_light_03_unarmed_rf","a3a_black_Heli_light_03_unarmed_rf"];
     _vehiclesHelisLightAttack append ["a3a_black_Heli_light_03_dynamicLoadout_rf","a3a_ION_Heli_EC_03_rf"];
     _vehiclesAA append ["B_ION_Pickup_aat_rf"];
     _vehiclesLightUnarmed append ["a3a_ION_Pickup_rf","a3a_ION_Pickup_rf"];
-    _vehiclesLightArmed append ["B_ION_Pickup_mmg_rf","B_ION_Pickup_mmg_rf","a3a_ION_Pickup_hmg_rfF"];
+    _vehiclesLightArmed append ["B_ION_Pickup_mmg_rf","B_ION_Pickup_mmg_rf","a3a_ION_Pickup_hmg_rf"];
     _vehiclesHelisAttack append ["a3a_ION_Heli_EC_02_rf"];
 };
 ["vehiclesHelisLight", _vehiclesHelisLight] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_ION.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_ION.sqf
@@ -31,8 +31,7 @@ private _vehiclesLightArmed = ["a3a_ION_Offroad_armor_armed","a3a_ION_Offroad_ar
 ["vehiclesAPCs", ["a3a_ION_APC_Wheeled_01_command_lxWS","a3a_ION_APC_Wheeled_01_cannon_lxWS", "a3a_ION_APC_Wheeled_01_atgm"]] call _fnc_saveToTemplate;
 ["vehiclesIFVs", ["a3a_ION_APC_Tracked_02_30mm"]] call _fnc_saveToTemplate;
 private _Tanks = ["a3a_MBT_02_cannon_black_F"];
-["vehiclesAA", ["a3a_ION_Truck_02_zu23_F"]] call _fnc_saveToTemplate;
-
+private _vehiclesAA = ["a3a_ION_Truck_02_zu23_F"];
 
 ["vehiclesTransportBoats", ["B_Boat_Transport_01_F"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["B_Boat_Armed_01_minigun_F", "a3a_Boat_Armed_01_hmg_blufor_F"]] call _fnc_saveToTemplate;
@@ -43,8 +42,8 @@ private _Tanks = ["a3a_MBT_02_cannon_black_F"];
 ["vehiclesPlanesTransport", ["B_T_VTOL_01_infantry_blue_F"]] call _fnc_saveToTemplate;
 
 ["vehiclesHelisLight", ["O_Heli_Light_02_unarmed_F", "B_ION_Heli_Light_02_unarmed_lxWS", "a3a_Heli_Light_01_ION_F"]] call _fnc_saveToTemplate;
-["vehiclesHelisTransport", ["a3a_ION_Heli_Transport_02_F"]] call _fnc_saveToTemplate;
-["vehiclesHelisLightAttack", ["B_ION_Heli_Light_02_dynamicLoadout_lxWS", "a3a_Heli_Light_01_dynamicLoadout_ION_F", "a3a_Heli_Light_02_black_F"]] call _fnc_saveToTemplate;
+private _HelisTransport = ["a3a_ION_Heli_Transport_02_F"];
+private _vehiclesHelisLightAttack = ["B_ION_Heli_Light_02_dynamicLoadout_lxWS", "a3a_Heli_Light_01_dynamicLoadout_ION_F", "a3a_Heli_Light_02_black_F"];
 ["vehiclesHelisAttack", ["O_Heli_Attack_02_dynamicLoadout_black_F"]] call _fnc_saveToTemplate;
 
 ["vehiclesArtillery", ["a3a_ION_Truck_02_MRL_F", "B_MBT_01_arty_F"]] call _fnc_saveToTemplate;
@@ -89,6 +88,17 @@ if ("enoch" in A3A_enabledDLC) then {
 if ("orange" in A3A_enabledDLC) then {
     _vehiclesPolice append ["B_GEN_Van_02_vehicle_F","B_GEN_Van_02_transport_F"];
 };
+if ("rf" in A3A_enabledDLC) then {
+    _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
+    _HelisTransport append ["a3a_black_Heli_light_03_unarmed_RF","a3a_tan_Heli_EC_03_RF"];
+    _vehiclesHelisLightAttack append ["a3a_black_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_04_military_RF"];
+    _vehiclesAA append ["B_ION_Pickup_aat_rf"];
+    _vehiclesMilitiaCars append ["a3a_black_Pickup_rf"];
+    _vehiclesMilitiaLightArmed append ["B_ION_Pickup_mmg_rf"];
+};
+["vehiclesAA", _vehiclesAA] call _fnc_saveToTemplate;
+["vehiclesHelisLightAttack", _vehiclesHelisLightAttack] call _fnc_saveToTemplate;
+["vehiclesHelisTransport", [_HelisTransport]] call _fnc_saveToTemplate;
 ["vehiclesTanks", _Tanks] call _fnc_saveToTemplate;
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;
 ["vehiclesMilitiaCars", _vehiclesMilitiaCars] call _fnc_saveToTemplate;
@@ -482,6 +492,39 @@ if ("expansion" in A3A_enabledDLC) then {
     ["SMG_05_F", "", "saber_light_lxWS", "optic_r1_high_lxWS", [], [], ""],
     ["SMG_05_F", "", "acc_flashlight", "optic_r1_low_lxWS", [], [], ""]
     ];
+};
+if ("rf" in A3A_enabledDLC) then {
+    // Mix of CSAT and NATO equipment; whatever they can get in bulk. The cogs of the market machine keep turning...
+    (_sfLoadoutData get "slRifles") append [
+    ["arifle_ash12_desert_RF","suppressor_127x55_small_desert_RF","acc_pointer_IR","optic_Arco_blk_F",["20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF"], [], ""],
+    ["arifle_ash12_desert_RF","suppressor_127x55_small_desert_RF","acc_pointer_IR","optic_Arco_blk_F",["20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF"], [], ""]
+    ];
+    (_sfLoadoutData get "rifles") append [["arifle_ash12_desert_RF","suppressor_127x55_small_desert_RF","acc_pointer_IR","optic_Holosight_blk_F",["20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF"], [], ""]];
+    (_sfLoadoutData get "grenadeLaunchers") append [["arifle_ash12_GL_desert_RF", "suppressor_127x55_small_desert_RF", "acc_pointer_IR", "optic_Holosight_blk_F", ["20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]];
+    (_sfLoadoutData get "marksmanRifles") append [
+    ["arifle_ash12_LR_desert_RF","suppressor_127x55_big_desert_RF","acc_pointer_IR","optic_Arco_blk_F",["10Rnd_127x55_Mag_desert_RF","10Rnd_127x55_Mag_desert_RF","10Rnd_127x55_Mag_desert_RF"], [], "bipod_02_F_hex"],
+    ["arifle_ash12_LR_desert_RF","suppressor_127x55_big_desert_RF","acc_pointer_IR","optic_DMS",["10Rnd_127x55_Mag_desert_RF","10Rnd_127x55_Mag_desert_RF","10Rnd_127x55_Mag_desert_RF"], [], "bipod_02_F_hex"],
+    ["arifle_ash12_LR_desert_RF","suppressor_127x55_big_desert_RF","acc_pointer_IR","optic_SOS",["10Rnd_127x55_Mag_desert_RF","10Rnd_127x55_Mag_desert_RF","10Rnd_127x55_Mag_desert_RF"], [], "bipod_02_F_hex"]  
+    ];
+    (_sfLoadoutData get "sidearms") append [
+    ["hgun_Glock19_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", [], [], ""],
+    ["hgun_Glock19_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", [], [], ""],
+    ["hgun_Glock19_auto_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", [], [], ""],
+    ["hgun_Glock19_auto_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", [], [], ""],
+    ["hgun_Glock19_auto_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", [], [], ""]
+    ];
+    (_militaryLoadoutData get "sidearms") append [
+    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_pistol", "", [], [], ""],
+    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_pistol", "", [], [], ""],
+    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_pistol", "", [], [], ""],
+    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_pistol", "optic_MRD_tan_RF", [], [], ""],
+    ["hgun_Glock19_auto_Tan_RF", "", "acc_flashlight_pistol", "", [], [], ""]
+    ];
+    (_policeLoadoutData get "sidearms") append ["hgun_Glock19_RF"];
+    (_sfLoadoutData get "helmets") append [
+    "H_HelmetHeavy_Sand_RF",
+    "H_HelmetHeavy_Simple_Sand_RF",
+    "H_HelmetHeavy_VisorUp_Sand_RF"];
 };
 
 

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_ION.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_ION.sqf
@@ -41,7 +41,7 @@ private _vehiclesAA = ["a3a_ION_Truck_02_zu23_F"];
 ["vehiclesPlanesAA", ["a3a_Plane_Fighter_04_grey_F"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesTransport", ["B_T_VTOL_01_infantry_blue_F"]] call _fnc_saveToTemplate;
 
-["vehiclesHelisLight", ["O_Heli_Light_02_unarmed_F", "B_ION_Heli_Light_02_unarmed_lxWS", "a3a_Heli_Light_01_ION_F"]] call _fnc_saveToTemplate;
+private _vehiclesHelisLight = ["O_Heli_Light_02_unarmed_F", "B_ION_Heli_Light_02_unarmed_lxWS", "a3a_Heli_Light_01_ION_F"];
 private _HelisTransport = ["a3a_ION_Heli_Transport_02_F"];
 private _vehiclesHelisLightAttack = ["B_ION_Heli_Light_02_dynamicLoadout_lxWS", "a3a_Heli_Light_01_dynamicLoadout_ION_F", "a3a_Heli_Light_02_black_F"];
 private _vehiclesHelisAttack = ["O_Heli_Attack_02_dynamicLoadout_black_F"];
@@ -90,13 +90,15 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
-    _HelisTransport append ["a3a_black_Heli_light_03_unarmed_RF","a3a_ION_Heli_EC_03_RF"];
+    _HelisTransport append ["a3a_ION_Heli_EC_03_RF"];
+    _vehiclesHelisLight append ["a3a_black_Heli_light_03_unarmed_RF"];
     _vehiclesHelisLightAttack append ["a3a_black_Heli_light_03_dynamicLoadout_RF","a3a_ION_Heli_EC_04_military_RF"];
     _vehiclesAA append ["B_ION_Pickup_aat_rf"];
     _vehiclesLightUnarmed append ["B_ION_Pickup_rf"];
     _vehiclesLightArmed append ["B_ION_Pickup_mmg_rf"];
-    _vehiclesHelisAttack = ["a3a_ION_Heli_EC_02_RF"];
+    _vehiclesHelisAttack append ["a3a_ION_Heli_EC_02_RF"];
 };
+["vehiclesHelisLight", _vehiclesHelisLight] call _fnc_saveToTemplate;
 ["vehiclesHelisAttack", _vehiclesHelisAttack] call _fnc_saveToTemplate;
 ["vehiclesAA", _vehiclesAA] call _fnc_saveToTemplate;
 ["vehiclesHelisLightAttack", _vehiclesHelisLightAttack] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_ION.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_ION.sqf
@@ -44,7 +44,7 @@ private _vehiclesAA = ["a3a_ION_Truck_02_zu23_F"];
 ["vehiclesHelisLight", ["O_Heli_Light_02_unarmed_F", "B_ION_Heli_Light_02_unarmed_lxWS", "a3a_Heli_Light_01_ION_F"]] call _fnc_saveToTemplate;
 private _HelisTransport = ["a3a_ION_Heli_Transport_02_F"];
 private _vehiclesHelisLightAttack = ["B_ION_Heli_Light_02_dynamicLoadout_lxWS", "a3a_Heli_Light_01_dynamicLoadout_ION_F", "a3a_Heli_Light_02_black_F"];
-["vehiclesHelisAttack", ["O_Heli_Attack_02_dynamicLoadout_black_F"]] call _fnc_saveToTemplate;
+private _vehiclesHelisAttack = ["O_Heli_Attack_02_dynamicLoadout_black_F"];
 
 ["vehiclesArtillery", ["a3a_ION_Truck_02_MRL_F", "B_MBT_01_arty_F"]] call _fnc_saveToTemplate;
 ["magazines", createHashMapFromArray [
@@ -90,15 +90,17 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
-    _HelisTransport append ["a3a_black_Heli_light_03_unarmed_RF","a3a_tan_Heli_EC_03_RF"];
-    _vehiclesHelisLightAttack append ["a3a_black_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_04_military_RF"];
+    _HelisTransport append ["a3a_black_Heli_light_03_unarmed_RF","a3a_ION_Heli_EC_03_RF"];
+    _vehiclesHelisLightAttack append ["a3a_black_Heli_light_03_dynamicLoadout_RF","a3a_ION_Heli_EC_04_military_RF"];
     _vehiclesAA append ["B_ION_Pickup_aat_rf"];
-    _vehiclesMilitiaCars append ["a3a_black_Pickup_rf"];
-    _vehiclesMilitiaLightArmed append ["B_ION_Pickup_mmg_rf"];
+    _vehiclesLightUnarmed append ["B_ION_Pickup_rf"];
+    _vehiclesLightArmed append ["B_ION_Pickup_mmg_rf"];
+    _vehiclesHelisAttack = ["a3a_ION_Heli_EC_02_RF"];
 };
+["vehiclesHelisAttack", _vehiclesHelisAttack] call _fnc_saveToTemplate;
 ["vehiclesAA", _vehiclesAA] call _fnc_saveToTemplate;
 ["vehiclesHelisLightAttack", _vehiclesHelisLightAttack] call _fnc_saveToTemplate;
-["vehiclesHelisTransport", [_HelisTransport]] call _fnc_saveToTemplate;
+["vehiclesHelisTransport", _HelisTransport] call _fnc_saveToTemplate;
 ["vehiclesTanks", _Tanks] call _fnc_saveToTemplate;
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;
 ["vehiclesMilitiaCars", _vehiclesMilitiaCars] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_ION.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_ION.sqf
@@ -90,12 +90,12 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
-    _HelisTransport append ["a3a_ION_Heli_EC_03_RF"];
+    _HelisTransport append ["a3a_ION_Heli_EC_04_military_RF"];
     _vehiclesHelisLight append ["a3a_black_Heli_light_03_unarmed_RF"];
-    _vehiclesHelisLightAttack append ["a3a_black_Heli_light_03_dynamicLoadout_RF","a3a_ION_Heli_EC_04_military_RF"];
+    _vehiclesHelisLightAttack append ["a3a_black_Heli_light_03_dynamicLoadout_RF","a3a_ION_Heli_EC_03_RF"];
     _vehiclesAA append ["B_ION_Pickup_aat_rf"];
-    _vehiclesLightUnarmed append ["B_ION_Pickup_rf"];
-    _vehiclesLightArmed append ["B_ION_Pickup_mmg_rf"];
+    _vehiclesLightUnarmed append ["a3a_ION_Pickup_RF","a3a_ION_Pickup_RF"];
+    _vehiclesLightArmed append ["B_ION_Pickup_mmg_rf","B_ION_Pickup_mmg_rf","a3a_ION_Pickup_hmg_RF"];
     _vehiclesHelisAttack append ["a3a_ION_Heli_EC_02_RF"];
 };
 ["vehiclesHelisLight", _vehiclesHelisLight] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_ION.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_ION.sqf
@@ -90,13 +90,13 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
-    _HelisTransport append ["a3a_ION_Heli_EC_04_military_RF"];
-    _vehiclesHelisLight append ["a3a_black_Heli_light_03_unarmed_RF"];
-    _vehiclesHelisLightAttack append ["a3a_black_Heli_light_03_dynamicLoadout_RF","a3a_ION_Heli_EC_03_RF"];
+    _HelisTransport append ["a3a_ION_Heli_EC_04_military_rf"];
+    _vehiclesHelisLight append ["a3a_black_Heli_light_03_unarmed_rf"];
+    _vehiclesHelisLightAttack append ["a3a_black_Heli_light_03_dynamicLoadout_rf","a3a_ION_Heli_EC_03_rf"];
     _vehiclesAA append ["B_ION_Pickup_aat_rf"];
-    _vehiclesLightUnarmed append ["a3a_ION_Pickup_RF","a3a_ION_Pickup_RF"];
-    _vehiclesLightArmed append ["B_ION_Pickup_mmg_rf","B_ION_Pickup_mmg_rf","a3a_ION_Pickup_hmg_RF"];
-    _vehiclesHelisAttack append ["a3a_ION_Heli_EC_02_RF"];
+    _vehiclesLightUnarmed append ["a3a_ION_Pickup_rf","a3a_ION_Pickup_rf"];
+    _vehiclesLightArmed append ["B_ION_Pickup_mmg_rf","B_ION_Pickup_mmg_rf","a3a_ION_Pickup_hmg_rfF"];
+    _vehiclesHelisAttack append ["a3a_ION_Heli_EC_02_rf"];
 };
 ["vehiclesHelisLight", _vehiclesHelisLight] call _fnc_saveToTemplate;
 ["vehiclesHelisAttack", _vehiclesHelisAttack] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_NATO_Desert.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_NATO_Desert.sqf
@@ -91,12 +91,11 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
-    _HelisTransport append ["a3a_tan_Heli_EC_03_RF"];
+    _HelisTransport append ["a3a_tan_Heli_EC_04_military_RF"];
     _vehiclesHelisLight append ["a3a_tan_Heli_light_03_unarmed_RF"];
-    _vehiclesHelisLightAttack append ["a3a_tan_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_04_military_RF"];
-    _vehiclesMilitiaCars append ["B_Pickup_rf"];
-    _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf"];
-    _vehiclesHelisAttack append ["a3a_Heli_EC_02_RF"];
+    _vehiclesHelisLightAttack append ["a3a_tan_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_03_RF"];
+    _vehiclesMilitiaCars append ["B_Pickup_rf","B_Pickup_rf"];
+    _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf","B_Pickup_mmg_rf"];
 };
 ["vehiclesHelisLight", _vehiclesHelisLight] call _fnc_saveToTemplate;
 ["vehiclesHelisAttack", _vehiclesHelisAttack] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_NATO_Desert.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_NATO_Desert.sqf
@@ -42,7 +42,7 @@ private _Tanks = ["B_MBT_01_TUSK_F", "B_MBT_01_cannon_F"];
 private _vehiclesHelisLight = ["B_D_Heli_Light_01_lxWS", "B_Heli_Light_01_F"];
 private _HelisTransport = ["B_D_Heli_Transport_01_lxWS", "B_Heli_Transport_01_F", "B_CTRG_Heli_Transport_01_sand_F"];
 private _vehiclesHelisLightAttack = ["B_D_Heli_Light_01_dynamicLoadout_lxWS", "B_Heli_Light_01_dynamicLoadout_F"];
-private _vehiclesHelisAttack = ["B_D_Heli_Attack_01_dynamicLoadout_lxWS", "B_Heli_Attack_01_dynamicLoadout_F"]
+["vehiclesHelisAttack", ["B_D_Heli_Attack_01_dynamicLoadout_lxWS", "B_Heli_Attack_01_dynamicLoadout_F"]] call _fnc_saveToTemplate;
 
 ["vehiclesArtillery", ["B_MBT_01_arty_F","B_MBT_01_mlrs_F"]] call _fnc_saveToTemplate; //this line determines artillery vehicles -- Example: ["vehiclesArtillery", ["B_MBT_01_arty_F"]] -- Array, can contain multiple assets
 //new magazines storing methode, all vehicle magazines should be defined here in format [Vehicle class, [magazines]],
@@ -98,7 +98,7 @@ if ("rf" in A3A_enabledDLC) then {
     _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf","B_Pickup_mmg_rf"];
 };
 ["vehiclesHelisLight", _vehiclesHelisLight] call _fnc_saveToTemplate;
-["vehiclesHelisAttack", _vehiclesHelisAttack] call _fnc_saveToTemplate;
+
 ["vehiclesMilitiaLightArmed", _vehiclesMilitiaLightArmed] call _fnc_saveToTemplate;
 ["vehiclesHelisLightAttack", _vehiclesHelisLightAttack] call _fnc_saveToTemplate;
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_NATO_Desert.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_NATO_Desert.sqf
@@ -39,7 +39,7 @@ private _Tanks = ["B_MBT_01_TUSK_F", "B_MBT_01_cannon_F"];
 ["vehiclesPlanesAA", ["B_Plane_Fighter_01_F"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesTransport", ["B_T_VTOL_01_infantry_blue_F"]] call _fnc_saveToTemplate;
 
-["vehiclesHelisLight", ["B_D_Heli_Light_01_lxWS", "B_Heli_Light_01_F"]] call _fnc_saveToTemplate;
+private _vehiclesHelisLight = ["B_D_Heli_Light_01_lxWS", "B_Heli_Light_01_F"];
 private _HelisTransport = ["B_D_Heli_Transport_01_lxWS", "B_Heli_Transport_01_F", "B_CTRG_Heli_Transport_01_sand_F"];
 private _vehiclesHelisLightAttack = ["B_D_Heli_Light_01_dynamicLoadout_lxWS", "B_Heli_Light_01_dynamicLoadout_F"];
 private _vehiclesHelisAttack = ["B_D_Heli_Attack_01_dynamicLoadout_lxWS", "B_Heli_Attack_01_dynamicLoadout_F"]
@@ -91,12 +91,14 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
-    _HelisTransport append ["B_Heli_light_03_unarmed_RF","a3a_tan_Heli_EC_03_RF"];
-    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_04_military_RF"];
+    _HelisTransport append ["a3a_tan_Heli_EC_03_RF"];
+    _vehiclesHelisLight append ["a3a_tan_Heli_light_03_unarmed_RF"];
+    _vehiclesHelisLightAttack append ["a3a_tan_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_04_military_RF"];
     _vehiclesMilitiaCars append ["B_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf"];
-    _vehiclesHelisAttack append ["a3a_ION_Heli_EC_02_RF"];
+    _vehiclesHelisAttack append ["a3a_Heli_EC_02_RF"];
 };
+["vehiclesHelisLight", _vehiclesHelisLight] call _fnc_saveToTemplate;
 ["vehiclesHelisAttack", _vehiclesHelisAttack] call _fnc_saveToTemplate;
 ["vehiclesMilitiaLightArmed", _vehiclesMilitiaLightArmed] call _fnc_saveToTemplate;
 ["vehiclesHelisLightAttack", _vehiclesHelisLightAttack] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_NATO_Desert.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_NATO_Desert.sqf
@@ -41,7 +41,7 @@ private _Tanks = ["B_MBT_01_TUSK_F", "B_MBT_01_cannon_F"];
 
 ["vehiclesHelisLight", ["B_D_Heli_Light_01_lxWS", "B_Heli_Light_01_F"]] call _fnc_saveToTemplate;
 private _HelisTransport = ["B_D_Heli_Transport_01_lxWS", "B_Heli_Transport_01_F", "B_CTRG_Heli_Transport_01_sand_F"];
-["vehiclesHelisLightAttack", ["B_D_Heli_Light_01_dynamicLoadout_lxWS", "B_Heli_Light_01_dynamicLoadout_F"]] call _fnc_saveToTemplate;
+private _vehiclesHelisLightAttack = ["B_D_Heli_Light_01_dynamicLoadout_lxWS", "B_Heli_Light_01_dynamicLoadout_F"];
 ["vehiclesHelisAttack", ["B_D_Heli_Attack_01_dynamicLoadout_lxWS", "B_Heli_Attack_01_dynamicLoadout_F"]] call _fnc_saveToTemplate;
 
 ["vehiclesArtillery", ["B_MBT_01_arty_F","B_MBT_01_mlrs_F"]] call _fnc_saveToTemplate; //this line determines artillery vehicles -- Example: ["vehiclesArtillery", ["B_MBT_01_arty_F"]] -- Array, can contain multiple assets
@@ -53,8 +53,7 @@ private _HelisTransport = ["B_D_Heli_Transport_01_lxWS", "B_Heli_Transport_01_F"
 
 ["uavsAttack", ["B_UAV_02_dynamicLoadout_F"]] call _fnc_saveToTemplate;
 ["uavsPortable", ["B_UAV_01_F", "B_UAV_02_lxWS"]] call _fnc_saveToTemplate;
-
-["vehiclesMilitiaLightArmed", ["a3a_Offroad_01_tan_armed_F","a3a_tan_Offroad_armor_armed","a3a_Offroad_01_tan_armed_F","a3a_tan_Offroad_armor_armed","a3a_Offroad_01_tan_AT_F","a3a_tan_Offroad_armor_at"]] call _fnc_saveToTemplate;
+private _vehiclesMilitiaLightArmed = ["a3a_Offroad_01_tan_armed_F","a3a_tan_Offroad_armor_armed","a3a_Offroad_01_tan_armed_F","a3a_tan_Offroad_armor_armed","a3a_Offroad_01_tan_AT_F","a3a_tan_Offroad_armor_at"];
 ["vehiclesMilitiaTrucks", ["I_C_Van_02_transport_F", "I_C_Van_01_transport_brown_F"]] call _fnc_saveToTemplate;
 private _vehiclesMilitiaCars = ["a3a_tan_Offroad_armor","a3a_Offroad_01_tan_F"];
 
@@ -90,6 +89,15 @@ if ("heli" in A3A_enabledDLC) then {
 if ("orange" in A3A_enabledDLC) then {
 	_vehiclesPolice append ["B_GEN_Van_02_vehicle_F","B_GEN_Van_02_transport_F"];
 };
+if ("rf" in A3A_enabledDLC) then {
+    _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
+    _HelisTransport append ["B_Heli_light_03_unarmed_RF","a3a_tan_Heli_EC_03_RF"];
+    _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_04_military_RF"];
+    _vehiclesMilitiaCars append ["B_Pickup_rf"];
+    _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf"];
+};
+["vehiclesMilitiaLightArmed", _vehiclesMilitiaLightArmed] call _fnc_saveToTemplate;
+["vehiclesHelisLightAttack", _vehiclesHelisLightAttack] call _fnc_saveToTemplate;
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;
 
 ["vehiclesLightUnarmed", _LightUnarmed] call _fnc_saveToTemplate;
@@ -520,6 +528,30 @@ if ("mark" in A3A_enabledDLC) then {
 	(_militaryLoadoutData get "sniperRifles") append [
 	["srifle_DMR_02_sniper_F", "", "acc_pointer_IR", "optic_LRPS", [], [], "bipod_01_F_snd"],
 	["srifle_DMR_02_sniper_F", "", "acc_pointer_IR", "optic_LRPS", [], [], "bipod_01_F_snd"]];
+};
+if ("rf" in A3A_enabledDLC) then {
+    (_sfLoadoutData get "sidearms") append [
+    ["hgun_Glock19_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", [], [], ""],
+    ["hgun_Glock19_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", [], [], ""],
+    ["hgun_Glock19_auto_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", [], [], ""],
+    ["hgun_Glock19_auto_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", [], [], ""],
+    ["hgun_Glock19_auto_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", [], [], ""]
+    ];
+    (_militaryLoadoutData get "sidearms") append [
+    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_pistol", "", [], [], ""],
+    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_pistol", "", [], [], ""],
+    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_pistol", "", [], [], ""],
+    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_pistol", "optic_MRD_tan_RF", [], [], ""],
+    ["hgun_Glock19_auto_Tan_RF", "", "acc_flashlight_pistol", "", [], [], ""]
+    ];
+    (_policeLoadoutData get "sidearms") append ["hgun_Glock19_RF"];
+    (_pilotLoadoutData get "uniforms") append ["U_B_HeliPilotCoveralls_MTP_RF"];
+    (_sfLoadoutData get "helmets") append [
+    "H_HelmetB_plain_sb_mtp_RF",
+    "H_HelmetHeavy_Sand_RF",
+    "H_HelmetHeavy_Simple_Sand_RF",
+    "H_HelmetHeavy_VisorUp_Sand_RF"];
+    (_militaryLoadoutData get "helmets") append ["H_HelmetB_plain_sb_mtp_RF"];
 };
 
 

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_NATO_Desert.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_NATO_Desert.sqf
@@ -42,7 +42,7 @@ private _Tanks = ["B_MBT_01_TUSK_F", "B_MBT_01_cannon_F"];
 ["vehiclesHelisLight", ["B_D_Heli_Light_01_lxWS", "B_Heli_Light_01_F"]] call _fnc_saveToTemplate;
 private _HelisTransport = ["B_D_Heli_Transport_01_lxWS", "B_Heli_Transport_01_F", "B_CTRG_Heli_Transport_01_sand_F"];
 private _vehiclesHelisLightAttack = ["B_D_Heli_Light_01_dynamicLoadout_lxWS", "B_Heli_Light_01_dynamicLoadout_F"];
-["vehiclesHelisAttack", ["B_D_Heli_Attack_01_dynamicLoadout_lxWS", "B_Heli_Attack_01_dynamicLoadout_F"]] call _fnc_saveToTemplate;
+private _vehiclesHelisAttack = ["B_D_Heli_Attack_01_dynamicLoadout_lxWS", "B_Heli_Attack_01_dynamicLoadout_F"]
 
 ["vehiclesArtillery", ["B_MBT_01_arty_F","B_MBT_01_mlrs_F"]] call _fnc_saveToTemplate; //this line determines artillery vehicles -- Example: ["vehiclesArtillery", ["B_MBT_01_arty_F"]] -- Array, can contain multiple assets
 //new magazines storing methode, all vehicle magazines should be defined here in format [Vehicle class, [magazines]],
@@ -95,7 +95,9 @@ if ("rf" in A3A_enabledDLC) then {
     _vehiclesHelisLightAttack append ["a3a_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_04_military_RF"];
     _vehiclesMilitiaCars append ["B_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf"];
+    _vehiclesHelisAttack append ["a3a_ION_Heli_EC_02_RF"];
 };
+["vehiclesHelisAttack", _vehiclesHelisAttack] call _fnc_saveToTemplate;
 ["vehiclesMilitiaLightArmed", _vehiclesMilitiaLightArmed] call _fnc_saveToTemplate;
 ["vehiclesHelisLightAttack", _vehiclesHelisLightAttack] call _fnc_saveToTemplate;
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_NATO_Desert.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_NATO_Desert.sqf
@@ -91,9 +91,9 @@ if ("orange" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
-    _HelisTransport append ["a3a_tan_Heli_EC_04_military_RF"];
-    _vehiclesHelisLight append ["a3a_tan_Heli_light_03_unarmed_RF"];
-    _vehiclesHelisLightAttack append ["a3a_tan_Heli_light_03_dynamicLoadout_RF","a3a_tan_Heli_EC_03_RF"];
+    _HelisTransport append ["a3a_tan_Heli_EC_04_military_rf"];
+    _vehiclesHelisLight append ["a3a_tan_Heli_light_03_unarmed_rf"];
+    _vehiclesHelisLightAttack append ["a3a_tan_Heli_light_03_dynamicLoadout_rf","a3a_tan_Heli_EC_03_rf"];
     _vehiclesMilitiaCars append ["B_Pickup_rf","B_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["B_Pickup_mmg_rf","B_Pickup_mmg_rf"];
 };

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_SFIA.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_SFIA.sqf
@@ -43,7 +43,7 @@
 ["vehiclesHelisLight", ["O_Heli_Light_02_unarmed_F"]] call _fnc_saveToTemplate;
 ["vehiclesHelisTransport", ["O_Heli_Transport_04_covered_black_F"]] call _fnc_saveToTemplate;
 ["vehiclesHelisLightAttack", ["O_Heli_Light_02_dynamicLoadout_F"]] call _fnc_saveToTemplate;
-private _vehiclesHelisAttack = ["O_SFIA_Heli_Attack_02_dynamicLoadout_lxWS"]
+private _vehiclesHelisAttack = ["O_SFIA_Heli_Attack_02_dynamicLoadout_lxWS"];
 
 ["vehiclesArtillery", ["O_SFIA_Truck_02_MRL_lxWS", "O_MBT_02_arty_F"]] call _fnc_saveToTemplate;
 ["magazines", createHashMapFromArray [
@@ -84,7 +84,7 @@ if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
     _vehiclesMilitiaCars append ["O_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["a3a_hex_Pickup_mmg_rf","a3a_hex_Pickup_mmg_rf"];
-    _vehiclesHeliAttack append ["a3a_sfia_Heli_EC_02_RF"];
+    _vehiclesHelisAttack append ["a3a_sfia_Heli_EC_02_RF"];
 };
 ["vehiclesHelisAttack", _vehiclesHelisAttack] call _fnc_saveToTemplate;
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_SFIA.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_SFIA.sqf
@@ -80,6 +80,11 @@ if ("enoch" in A3A_enabledDLC) then {
 if ("orange" in A3A_enabledDLC) then {
     _vehiclesPolice append ["B_GEN_Van_02_vehicle_F","B_GEN_Van_02_transport_F"];
 };
+if ("rf" in A3A_enabledDLC) then {
+    _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
+    _vehiclesMilitiaCars append ["O_Pickup_rf"];
+    _vehiclesMilitiaLightArmed append ["a3a_hex_Pickup_mmg_rf"];
+};
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;
 ["vehiclesMilitiaCars", _vehiclesMilitiaCars] call _fnc_saveToTemplate;
 ["vehiclesMilitiaLightArmed", _vehiclesMilitiaLightArmed] call _fnc_saveToTemplate;
@@ -450,7 +455,25 @@ if ("enoch" in A3A_enabledDLC) then {
     ["arifle_AK12U_F", "", "acc_pointer_IR", selectRandom _milSights, ["30Rnd_762x39_AK12_Mag_F", "30Rnd_762x39_AK12_Mag_F", "30Rnd_762x39_AK12_Mag_Tracer_F"], [], ""]
     ];
 };
-
+if ("rf" in A3A_enabledDLC) then {
+    (_sfLoadoutData get "slRifles") append [
+    ["arifle_ash12_desert_RF","suppressor_127x55_small_desert_RF","acc_pointer_IR","optic_Arco_blk_F",["20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF"], [], ""],
+    ["arifle_ash12_desert_RF","suppressor_127x55_small_desert_RF","acc_pointer_IR","optic_Arco_blk_F",["20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF"], [], ""]
+    ];
+    (_sfLoadoutData get "rifles") append [["arifle_ash12_desert_RF","suppressor_127x55_small_desert_RF","acc_pointer_IR","optic_Holosight_blk_F",["20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF"], [], ""]];
+    (_sfLoadoutData get "grenadeLaunchers") append [["arifle_ash12_GL_desert_RF", "suppressor_127x55_small_desert_RF", "acc_pointer_IR", "optic_Holosight_blk_F", ["20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF","20Rnd_127x55_Mag_desert_RF"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]];
+    (_sfLoadoutData get "marksmanRifles") append [
+    ["arifle_ash12_LR_desert_RF","suppressor_127x55_big_desert_RF","acc_pointer_IR","optic_Arco_blk_F",["10Rnd_127x55_Mag_desert_RF","10Rnd_127x55_Mag_desert_RF","10Rnd_127x55_Mag_desert_RF"], [], "bipod_02_F_hex"],
+    ["arifle_ash12_LR_desert_RF","suppressor_127x55_big_desert_RF","acc_pointer_IR","optic_DMS",["10Rnd_127x55_Mag_desert_RF","10Rnd_127x55_Mag_desert_RF","10Rnd_127x55_Mag_desert_RF"], [], "bipod_02_F_hex"],
+    ["arifle_ash12_LR_desert_RF","suppressor_127x55_big_desert_RF","acc_pointer_IR","optic_SOS",["10Rnd_127x55_Mag_desert_RF","10Rnd_127x55_Mag_desert_RF","10Rnd_127x55_Mag_desert_RF"], [], "bipod_02_F_hex"]  
+    ];
+    (_sfLoadoutData get "helmets") append [
+        "H_HelmetHeavy_Sand_RF",
+        "H_HelmetHeavy_Simple_Sand_RF",
+        "H_HelmetHeavy_VisorUp_Sand_RF"
+    ];
+    (_policeLoadoutData get "sidearms") append ["hgun_Glock19_RF"];
+};
 
 /////////////////////////////////
 //    Unit Type Definitions    //

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_SFIA.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_SFIA.sqf
@@ -83,7 +83,7 @@ if ("orange" in A3A_enabledDLC) then {
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
     _vehiclesMilitiaCars append ["O_Pickup_rf"];
-    _vehiclesMilitiaLightArmed append ["a3a_hex_Pickup_mmg_rf"];
+    _vehiclesMilitiaLightArmed append ["a3a_hex_Pickup_mmg_rf","a3a_hex_Pickup_mmg_rf"];
 };
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;
 ["vehiclesMilitiaCars", _vehiclesMilitiaCars] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_SFIA.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_SFIA.sqf
@@ -43,7 +43,7 @@
 ["vehiclesHelisLight", ["O_Heli_Light_02_unarmed_F"]] call _fnc_saveToTemplate;
 ["vehiclesHelisTransport", ["O_Heli_Transport_04_covered_black_F"]] call _fnc_saveToTemplate;
 ["vehiclesHelisLightAttack", ["O_Heli_Light_02_dynamicLoadout_F"]] call _fnc_saveToTemplate;
-["vehiclesHelisAttack", ["O_SFIA_Heli_Attack_02_dynamicLoadout_lxWS"]] call _fnc_saveToTemplate;
+private _vehiclesHelisAttack = ["O_SFIA_Heli_Attack_02_dynamicLoadout_lxWS"]
 
 ["vehiclesArtillery", ["O_SFIA_Truck_02_MRL_lxWS", "O_MBT_02_arty_F"]] call _fnc_saveToTemplate;
 ["magazines", createHashMapFromArray [
@@ -84,7 +84,9 @@ if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
     _vehiclesMilitiaCars append ["O_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["a3a_hex_Pickup_mmg_rf","a3a_hex_Pickup_mmg_rf"];
+    _vehiclesHeliAttack append ["a3a_sfia_Heli_EC_02_RF"];
 };
+["vehiclesHelisAttack", _vehiclesHelisAttack] call _fnc_saveToTemplate;
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;
 ["vehiclesMilitiaCars", _vehiclesMilitiaCars] call _fnc_saveToTemplate;
 ["vehiclesMilitiaLightArmed", _vehiclesMilitiaLightArmed] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/WS/WS_AI_SFIA.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_AI_SFIA.sqf
@@ -84,7 +84,7 @@ if ("rf" in A3A_enabledDLC) then {
     _vehiclesPolice append ["a3a_police_Pickup_rf", "B_GEN_Pickup_covered_rf", "a3a_police_Pickup_comms_rf"];
     _vehiclesMilitiaCars append ["O_Pickup_rf"];
     _vehiclesMilitiaLightArmed append ["a3a_hex_Pickup_mmg_rf","a3a_hex_Pickup_mmg_rf"];
-    _vehiclesHelisAttack append ["a3a_sfia_Heli_EC_02_RF"];
+    _vehiclesHelisAttack append ["a3a_sfia_Heli_EC_02_rf"];
 };
 ["vehiclesHelisAttack", _vehiclesHelisAttack] call _fnc_saveToTemplate;
 ["vehiclesPolice", _vehiclesPolice] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/WS/WS_Reb_TURA.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_Reb_TURA.sqf
@@ -45,9 +45,9 @@ if ("expansion" in A3A_enabledDLC) then {
 	_vehiclesAT append ["I_C_Offroad_02_AT_F"];
 };
 if ("rf" in A3A_enabledDLC) then {
-    _vehiclesCivCar append ["C_Pickup_rf"];
-    _vehiclesLightUnarmed append ["I_Tura_Pickup_01_RF"];
-    _vehiclesLightArmed append ["I_Tura_Pickup_01_mmg_rf"];
+    _vehiclesCivCar append ["a3a_civ_Pickup_RF","a3a_civ_Pickup_covered_RF"];
+    _vehiclesLightUnarmed append ["a3a_fia_Pickup_RF", "a3a_fia_Pickup_covered_RF"];
+    _vehiclesLightArmed append ["a3a_fia_Pickup_mmg_RF", "a3a_fia_Pickup_hmg_RF"];
     _staticMortars append ["I_G_CommandoMortar_RF"];
     _vehiclesCivHeli append ["C_Heli_EC_01A_civ_RF","C_Heli_EC_04_rescue_RF"];
 };

--- a/A3A/addons/core/Templates/Templates/WS/WS_Reb_TURA.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_Reb_TURA.sqf
@@ -46,10 +46,10 @@ if ("expansion" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesCivCar append ["C_Pickup_rf","C_Pickup_covered_rf"];
-    _vehiclesLightUnarmed append ["a3a_FIA_Pickup_RF", "a3a_FIA_Pickup_covered_RF"];
-    _vehiclesLightArmed append ["a3a_FIA_Pickup_mmg_RF", "a3a_FIA_Pickup_hmg_RF"];
-    _staticMortars append ["I_G_CommandoMortar_RF"];
-    _vehiclesCivHeli append ["C_Heli_EC_01A_civ_RF","C_Heli_EC_04_rescue_RF"];
+    _vehiclesLightUnarmed append ["a3a_FIA_Pickup_rf", "a3a_FIA_Pickup_covered_rf"];
+    _vehiclesLightArmed append ["a3a_FIA_Pickup_mmg_rf", "a3a_FIA_Pickup_hmg_rf"];
+    _staticMortars append ["I_G_CommandoMortar_rf"];
+    _vehiclesCivHeli append ["C_Heli_EC_01A_civ_rf","C_Heli_EC_04_rescue_rf"];
 };
 
 ["vehiclesCivHeli", _vehiclesCivHeli] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/WS/WS_Reb_TURA.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_Reb_TURA.sqf
@@ -46,8 +46,8 @@ if ("expansion" in A3A_enabledDLC) then {
 };
 if ("rf" in A3A_enabledDLC) then {
     _vehiclesCivCar append ["C_Pickup_rf","C_Pickup_covered_rf"];
-    _vehiclesLightUnarmed append ["a3a_fia_Pickup_RF", "a3a_fia_Pickup_covered_RF"];
-    _vehiclesLightArmed append ["a3a_fia_Pickup_mmg_RF", "a3a_fia_Pickup_hmg_RF"];
+    _vehiclesLightUnarmed append ["a3a_FIA_Pickup_RF", "a3a_FIA_Pickup_covered_RF"];
+    _vehiclesLightArmed append ["a3a_FIA_Pickup_mmg_RF", "a3a_FIA_Pickup_hmg_RF"];
     _staticMortars append ["I_G_CommandoMortar_RF"];
     _vehiclesCivHeli append ["C_Heli_EC_01A_civ_RF","C_Heli_EC_04_rescue_RF"];
 };

--- a/A3A/addons/core/Templates/Templates/WS/WS_Reb_TURA.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_Reb_TURA.sqf
@@ -45,7 +45,7 @@ if ("expansion" in A3A_enabledDLC) then {
 	_vehiclesAT append ["I_C_Offroad_02_AT_F"];
 };
 if ("rf" in A3A_enabledDLC) then {
-    _vehiclesCivCar append ["a3a_civ_Pickup_RF","a3a_civ_Pickup_covered_RF"];
+    _vehiclesCivCar append ["C_Pickup_RF","C_Pickup_covered_RF"];
     _vehiclesLightUnarmed append ["a3a_fia_Pickup_RF", "a3a_fia_Pickup_covered_RF"];
     _vehiclesLightArmed append ["a3a_fia_Pickup_mmg_RF", "a3a_fia_Pickup_hmg_RF"];
     _staticMortars append ["I_G_CommandoMortar_RF"];

--- a/A3A/addons/core/Templates/Templates/WS/WS_Reb_TURA.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_Reb_TURA.sqf
@@ -45,7 +45,7 @@ if ("expansion" in A3A_enabledDLC) then {
 	_vehiclesAT append ["I_C_Offroad_02_AT_F"];
 };
 if ("rf" in A3A_enabledDLC) then {
-    _vehiclesCivCar append ["C_Pickup_RF","C_Pickup_covered_RF"];
+    _vehiclesCivCar append ["C_Pickup_rf","C_Pickup_covered_rf"];
     _vehiclesLightUnarmed append ["a3a_fia_Pickup_RF", "a3a_fia_Pickup_covered_RF"];
     _vehiclesLightArmed append ["a3a_fia_Pickup_mmg_RF", "a3a_fia_Pickup_hmg_RF"];
     _staticMortars append ["I_G_CommandoMortar_RF"];

--- a/A3A/addons/logistics/Nodes/RF.hpp
+++ b/A3A/addons/logistics/Nodes/RF.hpp
@@ -49,3 +49,8 @@ class lxRF_vehicles_rf_pickup_01_pickup_01_service_rf_p3d : TRIPLES(ADDON,Nodes,
         };
     };
 };
+
+class a3a_civ_Pickup_fuel_rf : TRIPLES(ADDON,Nodes,Base)
+{
+    class Nodes {};
+};


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Information:
Added RF compatibility to the WS templates, as well as adding pickups to the militia vehicle pool for most factions.
Switched the SF marksmen to using the big suppressor for their 12.7mm rifle.
Several known bugs right now, but since the RPT has no errors I'm throwing this up now for a preliminary review.

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

### How can the changes be tested?
Known bugs:
Military vehicles will take on civilian colors sometimes when bought.

********************************************************
Notes:
