### PR TITLE
Fix case where seats may not be unlocked when dead crew are deleted

### DIFF
--- a/A3A/addons/core/functions/REINF/fn_postmortem.sqf
+++ b/A3A/addons/core/functions/REINF/fn_postmortem.sqf
@@ -1,6 +1,6 @@
-/*  Handles the despawn and cleanup of dead units
+/*  Handles the despawn and cleanup of dead units and vehicles
 *   Params:
-*       _victim : OBJECT : The dead unit
+*       _victim : OBJECT : The dead unit or vehicle
 *
 *   Returns:
 *       Nothing
@@ -33,7 +33,12 @@ if (_victim getVariable ["stopPostmortem", false]) exitWith {};
 if !(isnull _victim) then
 {
     Debug_1("Cleanup complete for %1 victim.", _victim);
-    deleteVehicle _victim;
+    if (_victim isKindOf "CAManBase" and !isNull objectParent _victim) then {
+        // Otherwise vehicle seats may remain blocked
+        [objectParent _victim, _victim] remoteExec ["deleteVehicleCrew", _victim];
+    } else {
+        deleteVehicle _victim;
+    };
 };
 
 if !(isnull _group) then


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed the remaining case where vehicle seats might be permanently blocked with ACE after the crew is cleaned up.

Example test case: Set the `cleantime` global var to 10 seconds. Put some AIs in a vehicle. Kill them.

### Please specify which Issue this PR Resolves.
closes #3145

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
