### PR TITLE
Add ACE painkillers to initial rebel equipment

### DIFF
--- a/A3A/addons/core/functions/Templates/fn_aceModCompat.sqf
+++ b/A3A/addons/core/functions/Templates/fn_aceModCompat.sqf
@@ -62,10 +62,11 @@ aceMedItems = [
 	"ACE_suture"
 ];
 
-aceMedItemsBlood = [
+aceMedItemsNonKat = [
 	"ACE_bloodIV",
 	"ACE_bloodIV_250",
-	"ACE_bloodIV_500"
+	"ACE_bloodIV_500",
+	"ACE_painkillers"
 ];
 
 advItems = [
@@ -210,6 +211,7 @@ aceFoodItems = [
 	"ACE_MRE_SteakVegetables"
 ];
 
+/*
 publicVariable "aceItems";
 publicVariable "aceMedItems";
 publicVariable "aceMedItemsBlood";
@@ -217,6 +219,7 @@ publicVariable "advItems";
 publicVariable "katMedItems";
 publicVariable "aceCoolingItems";
 publicVariable "aceFoodItems";
+*/
 
 ////////////////////////////////////
 //   ACE ITEMS MODIFICATIONS     ///
@@ -227,7 +230,7 @@ FactionGet(reb,"initialRebelEquipment") append aceItems;
 //ACE medical starting items
 if (A3A_hasACEMedical && !A3A_hasKAT) then {
 	FactionGet(reb,"initialRebelEquipment") append aceMedItems;
-	FactionGet(reb,"initialRebelEquipment") append aceMedItemsBlood;
+	FactionGet(reb,"initialRebelEquipment") append aceMedItemsNonKat;
 };
 
 if (A3A_hasADV) then {


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Added ACE painkillers to initial rebel equipment when KAT isn't loaded. They're slightly weird with the Antistasi arsenal because they count as magazines rather than items, but whatever.

Disabled the publicVariables because the data isn't currently used anywhere else and probably shouldn't be.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
