### PR TITLE
Changed: BIS_fnc_compatibleItems to script command

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_randomRifle.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_randomRifle.sqf
@@ -70,7 +70,7 @@ _unit addMagazines [_magazine, round (random 0.5 + _totalMagWeight / _magWeight)
 
 private _compatOptics = A3A_rebelOpticsCache get _weapon;
 if (isNil "_compatOptics") then {
-    private _compatItems = [_weapon] call BIS_fnc_compatibleItems;		// cached, should be fast
+    private _compatItems = compatibleItems _weapon;		// cached, should be fast
     _compatOptics = _compatItems arrayIntersect call {
         if (_weaponType in ["Rifles", "MachineGuns"]) exitWith { A3A_rebelGear get "OpticsMid" };
         if (_weaponType == "SniperRifles") exitWith { A3A_rebelGear get "OpticsLong" };

--- a/A3A/addons/core/functions/CREATE/fn_NATOinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_NATOinit.sqf
@@ -166,7 +166,7 @@ if !(A3A_hasIFA) then
             private _lamps = _weaponItems arrayIntersect allLightAttachments;
             if (_lamps isEqualTo []) then
             {
-                private _compatibleLamps = ((primaryWeapon _unit) call BIS_fnc_compatibleItems) arrayIntersect allLightAttachments;
+                private _compatibleLamps = (compatibleItems (primaryWeapon _unit)) arrayIntersect allLightAttachments;
                 if !(_compatibleLamps isEqualTo []) then
                 {
                     _lamp = selectRandom _compatibleLamps;

--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -32,7 +32,7 @@ private _fnc_addSecondaryAndMags = {
 
     private _compatOptics = A3A_rebelOpticsCache get _weapon;
     if (isNil "_compatOptics") then {
-        private _compatItems = [_weapon] call BIS_fnc_compatibleItems;		// cached, should be fast
+        private _compatItems = compatibleItems _weapon;		// cached, should be fast
         _compatOptics = _compatItems arrayIntersect (A3A_rebelGear get "OpticsAll");
         A3A_rebelOpticsCache set [_weapon, _compatOptics];
     };
@@ -170,7 +170,7 @@ else {
     private _weapon = primaryWeapon _unit;
     private _compatLights = A3A_rebelFlashlightsCache get _weapon;
     if (isNil "_compatLights") then {
-        private _compatItems = [_weapon] call BIS_fnc_compatibleItems;		// cached, should be fast
+        private _compatItems = compatibleItems _weapon;		// cached, should be fast
         _compatLights = _compatItems arrayIntersect (A3A_rebelGear get "LightAttachments");
         A3A_rebelFlashlightsCache set [_weapon, _compatLights];
     };

--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal.sqf
@@ -1343,7 +1343,7 @@ switch _mode do {
 					case (ctrlenabled (_display displayctrl (IDC_RSCDISPLAYARSENAL_LIST + IDC_RSCDISPLAYARSENAL_TAB_HANDGUN))): {handgunweapon player};
 					default {""};
 				};
-				_compatibleItems = _weapon call bis_fnc_compatibleItems;
+				_compatibleItems = compatibleItems _weapon;
 				if not (({_x == _item} count _compatibleItems > 0) || _item isequalto "")exitwith{
 					_ctrlList lbSetColor [_lbAdd, [1,1,1,0.25]];
 				};
@@ -1966,7 +1966,7 @@ switch _mode do {
 				};
 
 				//prevent selecting grey items, needs to be this complicated because bis_fnc_compatibleItems returns some crap resolts like optic_aco instead of Optic_Aco
-				_compatibleItems = _weapon call bis_fnc_compatibleItems;
+				_compatibleItems = compatibleItems _weapon;
 				if not (({_x == _item} count _compatibleItems > 0) || _item isequalto "")exitwith{
 					['TabSelectRight',[_display,_index]] call jn_fnc_arsenal;
 				};


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    Replaces calls to BIS_fnc_compatibleItems to the script command. No need to call the function, and it prevents cba errors when they override the function.

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)