### PR TITLE
Adds Air Patrol Vehicle category 

### DIFF
--- a/A3A/addons/core/Templates/Templates/FactionDefaults/EnemyDefaults.sqf
+++ b/A3A/addons/core/Templates/Templates/FactionDefaults/EnemyDefaults.sqf
@@ -13,6 +13,7 @@
 
 ["vehiclesLightTanks", []] call _fnc_saveToTemplate;
 
+["vehiclesAirPatrol", []] call _fnc_saveToTemplate;
 ["attributesVehicles", []] call _fnc_saveToTemplate;
 
 ["faces", ["GreekHead_A3_02","GreekHead_A3_03","GreekHead_A3_04","GreekHead_A3_05","GreekHead_A3_06","GreekHead_A3_07","GreekHead_A3_08","GreekHead_A3_09","Ioannou","Mavros"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/RHS/RHS_AI_ChDKZ.sqf
+++ b/A3A/addons/core/Templates/Templates/RHS/RHS_AI_ChDKZ.sqf
@@ -57,6 +57,7 @@
 ["vehiclesPlanesCAS", ["RHS_Su25SM_vvsc"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesAA", ["rhs_mig29s_vvs","rhs_mig29sm_vvs"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesTransport", []] call _fnc_saveToTemplate;
+["vehiclesAirPatrol", ["a3a_rhs_Mi8mt_chdkz"]] call _fnc_saveToTemplate;
 
 ["vehiclesHelisLight", ["a3a_rhs_Mi8T_chdkz"]] call _fnc_saveToTemplate;
 ["vehiclesHelisTransport", ["a3a_rhs_Mi8mt_chdkz","a3a_rhs_Mi8mt_chdkz", "RHS_Mi24Vt_vvsc"]] call _fnc_saveToTemplate; //Mi8mt has pk's, Mi24Vt has 12.7 turret only

--- a/A3A/addons/core/Templates/Templates/RHS/RHS_AI_USAF_Army_Arctic.sqf
+++ b/A3A/addons/core/Templates/Templates/RHS/RHS_AI_USAF_Army_Arctic.sqf
@@ -39,6 +39,7 @@
 ["vehiclesPlanesCAS", ["RHS_A10"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesAA", ["rhsusf_f22"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesTransport", ["RHS_C130J"]] call _fnc_saveToTemplate;
+["vehiclesAirPatrol", ["RHS_MELB_H6M"]] call _fnc_saveToTemplate;
 
 ["vehiclesHelisLight", ["RHS_MELB_MH6M"]] call _fnc_saveToTemplate;
 ["vehiclesHelisTransport", ["RHS_UH60M", "RHS_UH60M", "RHS_UH60M", "RHS_UH60M", "RHS_UH60M_ESSS2", "RHS_UH60M2", "RHS_CH_47F", "RHS_CH_47F", "RHS_CH_47F", "RHS_CH_47F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/RHS/RHS_AI_USAF_Army_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/RHS/RHS_AI_USAF_Army_Arid.sqf
@@ -39,6 +39,7 @@
 ["vehiclesPlanesCAS", ["RHS_A10"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesAA", ["rhsusf_f22"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesTransport", ["RHS_C130J"]] call _fnc_saveToTemplate;
+["vehiclesAirPatrol", ["RHS_MELB_H6M"]] call _fnc_saveToTemplate;
 
 ["vehiclesHelisLight", ["RHS_MELB_MH6M"]] call _fnc_saveToTemplate;
 ["vehiclesHelisTransport", ["RHS_UH60M_d", "RHS_UH60M_d", "RHS_UH60M_d", "RHS_UH60M_d", "RHS_UH60M_d", "RHS_UH60M_d", "RHS_UH60M_ESSS2_d", "RHS_UH60M2_d", "RHS_CH_47F_light", "RHS_CH_47F_light", "RHS_CH_47F_light", "RHS_CH_47F_light"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/RHS/RHS_AI_USAF_Army_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/RHS/RHS_AI_USAF_Army_Temperate.sqf
@@ -39,6 +39,7 @@
 ["vehiclesPlanesCAS", ["RHS_A10"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesAA", ["rhsusf_f22"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesTransport", ["RHS_C130J"]] call _fnc_saveToTemplate;
+["vehiclesAirPatrol", ["RHS_MELB_H6M"]] call _fnc_saveToTemplate;
 
 ["vehiclesHelisLight", ["RHS_MELB_MH6M"]] call _fnc_saveToTemplate;
 ["vehiclesHelisTransport", ["RHS_UH60M", "RHS_UH60M", "RHS_UH60M", "RHS_UH60M", "RHS_UH60M_ESSS2", "RHS_UH60M2", "RHS_CH_47F", "RHS_CH_47F", "RHS_CH_47F", "RHS_CH_47F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/RHS/RHS_AI_USAF_Marines_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/RHS/RHS_AI_USAF_Marines_Arid.sqf
@@ -39,6 +39,7 @@
 ["vehiclesPlanesCAS", ["RHS_A10"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesAA", ["rhsusf_f22"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesTransport", ["RHS_C130J"]] call _fnc_saveToTemplate;
+["vehiclesAirPatrol", ["RHS_MELB_H6M"]] call _fnc_saveToTemplate;
 
 ["vehiclesHelisLight", ["RHS_UH1Y_UNARMED_d"]] call _fnc_saveToTemplate;
 ["vehiclesHelisTransport", ["RHS_CH_47F_light", "rhsusf_CH53E_USMC_GAU21_D", "rhsusf_CH53E_USMC_D"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/RHS/RHS_AI_USAF_Marines_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/RHS/RHS_AI_USAF_Marines_Temperate.sqf
@@ -39,6 +39,7 @@
 ["vehiclesPlanesCAS", ["RHS_A10"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesAA", ["rhsusf_f22"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesTransport", ["RHS_C130J"]] call _fnc_saveToTemplate;
+["vehiclesAirPatrol", ["RHS_MELB_H6M"]] call _fnc_saveToTemplate;
 
 ["vehiclesHelisLight", ["RHS_UH1Y_UNARMED"]] call _fnc_saveToTemplate;
 ["vehiclesHelisTransport", ["RHS_UH1Y_UNARMED", "RHS_CH_47F", "rhsusf_CH53E_USMC_GAU21", "rhsusf_CH53E_USMC"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/functions/CREATE/fn_AAFroadPatrol.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AAFroadPatrol.sqf
@@ -41,6 +41,9 @@ if (_base in seaports) then {
 		private _lowAir = _faction getOrDefault ["attributeLowAir", false];
 		if (!_lowAir and (_base in airportsX) and (random 1 < 0.5)) exitWith {
 			_typeCar = selectRandom (_faction get "vehiclesHelisLight");
+        	if(count (_faction get "vehiclesAirPatrol") > 0) then {
+        		_typeCar = selectRandom (_faction get "vehiclesAirPatrol");
+        	};
 			_typePatrol = "AIR";
 		};
 		_typeCar = selectRandom ((_faction get "vehiclesLightArmed") + (_faction get "vehiclesLightUnarmed"));

--- a/A3A/addons/core/functions/CREATE/fn_AAFroadPatrol.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AAFroadPatrol.sqf
@@ -33,21 +33,29 @@ private _faction = Faction(_sideX);
 
 _typeCar = "";
 _typePatrol = "LAND";
-if (_base in seaports) then {
+if (_base in seaports) then 
+{
 	_typeCar = selectRandom (_faction get "vehiclesGunBoats");
 	_typePatrol = "SEA";
-} else {
-	if ( _sideX isEqualTo Invaders || random 10 < tierWar + aggressionOccupants/10) then {
+}
+else 
+{
+	if ( _sideX isEqualTo Invaders || random 10 < tierWar + aggressionOccupants/10) then 
+	{
 		private _lowAir = _faction getOrDefault ["attributeLowAir", false];
-		if (!_lowAir and (_base in airportsX) and (random 1 < 0.5)) exitWith {
+		if (!_lowAir and (_base in airportsX) and (random 1 < 0.5)) exitWith 
+		{
 			_typeCar = selectRandom (_faction get "vehiclesHelisLight");
-        	if(count (_faction get "vehiclesAirPatrol") > 0) then {
-        		_typeCar = selectRandom (_faction get "vehiclesAirPatrol");
-        	};
+			if(count (_faction get "vehiclesAirPatrol") > 0) then 
+			{
+				_typeCar = selectRandom (_faction get "vehiclesAirPatrol");
+			};
 			_typePatrol = "AIR";
 		};
 		_typeCar = selectRandom ((_faction get "vehiclesLightArmed") + (_faction get "vehiclesLightUnarmed"));
-	} else {
+	}
+	else 
+	{
 		_typeCar = selectRandom ((_faction get "vehiclesPolice") + (_faction get "vehiclesMilitiaLightArmed"));
 	};
 };
@@ -58,37 +66,37 @@ _posbase = getMarkerPos _base;
 
 
 if (_typePatrol == "AIR") then
-	{
+{
 	_arrayDestinations = markersX select {sidesX getVariable [_x,sideUnknown] == _sideX};
 	_distanceX = 200;
-	}
+}
 else
-	{
+{
 	if (_typePatrol == "SEA") then
-		{
+	{
 		_arrayDestinations = seaMarkers select {(getMarkerPos _x) distance _posbase < 2500};
 		_distanceX = 100;
-		}
+	}
 	else
-		{
+	{
 		_arrayDestinations = markersX select {sidesX getVariable [_x,sideUnknown] == _sideX};
 		_arrayDestinations = [_arrayDestinations,_posBase] call A3A_fnc_patrolDestinations;
 		_distanceX = 50;
-		};
 	};
+};
 
 if (count _arrayDestinations < 4) exitWith {};
 
 AAFpatrols = AAFpatrols + 1;
 
 if (_typePatrol != "AIR") then
-	{
+{
 	if (_typePatrol == "SEA") then
-		{
+	{
 		_posbase = [_posbase,50,150,10,2,0,0] call BIS_Fnc_findSafePos;
-		}
+	}
 	else
-		{
+	{
 		_indexX = airportsX find _base;
 		if (_indexX != -1) then
 		{
@@ -99,8 +107,8 @@ if (_typePatrol != "AIR") then
 		{
 			_posbase = position ([_posbase] call A3A_fnc_findNearestGoodRoad);
 		};
-		};
 	};
+};
 
 _vehicle=[_posBase, 0,_typeCar, _sideX] call A3A_fnc_spawnVehicle;
 _veh = _vehicle select 0;
@@ -116,26 +124,26 @@ _vehiclesX = _vehiclesX + [_veh];
 
 
 if (_typeCar in (_faction get "vehiclesLightUnarmed")) then
-	{
+{
 	sleep 1;
 	_groupX = [_posbase, _sideX, _faction get "groupSentry"] call A3A_fnc_spawnGroup;
 	{_x assignAsCargo _veh;_x moveInCargo _veh; _soldiers pushBack _x; [_x] joinSilent _groupVeh; [_x,"",false] call A3A_fnc_NATOinit} forEach units _groupX;
 	deleteGroup _groupX;
-	};
+};
 
 //if (_typePatrol == "LAND") then {_veh forceFollowRoad true};
 
 while {alive _veh} do
-	{
+{
 	if (count _arrayDestinations < 2) exitWith {};
 	_destinationX = selectRandom _arrayDestinations;
 	if (debug) then {player globalChat format ["Generated AI patrol. Origin %2, destination %1.", _destinationX, _base]; sleep 3};
 	_posDestination = getMarkerPos _destinationX;
 	if (_typePatrol == "LAND") then
-		{
+	{
 		_road = [_posDestination] call A3A_fnc_findNearestGoodRoad;
 		_posDestination = position _road;
-		};
+	};
 	_Vwp0 = _groupVeh addWaypoint [_posDestination, 0];
 	_Vwp0 setWaypointType "MOVE";
 	_Vwp0 setWaypointBehaviour "SAFE";
@@ -146,22 +154,22 @@ while {alive _veh} do
 	waitUntil {sleep 60; (_veh distance _posDestination < _distanceX) or (time > _timeout) or ({[_x] call A3A_fnc_canFight} count _soldiers == 0) or (!canMove _veh)};
 	if !(_veh distance _posDestination < _distanceX) exitWith {};
 	if (_typePatrol == "AIR") then
-		{
+	{
 		_arrayDestinations = markersX select {sidesX getVariable [_x,sideUnknown] == _sideX};
-		}
+	}
 	else
-		{
+	{
 		if (_typePatrol == "SEA") then
-			{
+		{
 			_arrayDestinations = seaMarkers select {(getMarkerPos _x) distance position _veh < 2500};
-			}
+		}
 		else
-			{
+		{
 			_arrayDestinations = markersX select {sidesX getVariable [_x,sideUnknown] == _sideX};
 			_arrayDestinations = [_arrayDestinations,position _veh] call A3A_fnc_patrolDestinations;
-			};
 		};
 	};
+};
 
 { [_x] spawn A3A_fnc_VEHDespawner } forEach _vehiclesX;
 { [_x] spawn A3A_fnc_enemyReturnToBase } forEach _groups;

--- a/A3A/addons/core/functions/Templates/fn_compileMissionAssets.sqf
+++ b/A3A/addons/core/functions/Templates/fn_compileMissionAssets.sqf
@@ -77,6 +77,7 @@ setVar("vehiclesHelisTransport", OccAndInv("vehiclesHelisTransport"));
 setVar("vehiclesPlanesAA", OccAndInv("vehiclesPlanesAA"));
 setVar("vehiclesPlanesCAS", OccAndInv("vehiclesPlanesCAS"));
 setVar("vehiclesPlanesTransport", OccAndInv("vehiclesPlanesTransport"));
+setVar("vehiclesAirPatrol", OccAndInv("vehiclesAirPatrol"));
 setVar("staticMortars", OccAndInv("staticMortars") + Reb("staticMortars"));
 setVar("staticAA", OccAndInv("staticAA") + Reb("staticAA"));
 setVar("staticAT", OccAndInv("staticAT") + Reb("staticAT"));

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -471,7 +471,7 @@ private _vehicleResourceCosts = createHashMap;
 { _vehicleResourceCosts set [_x, 20] } forEach FactionGet(all, "staticAA") + FactionGet(all, "staticAT") + FactionGet(all, "staticMortars");
 { _vehicleResourceCosts set [_x, 20] } forEach FactionGet(all, "vehiclesLightUnarmed") + FactionGet(all, "vehiclesTrucks");
 { _vehicleResourceCosts set [_x, 50] } forEach FactionGet(all, "vehiclesLightArmed");
-{ _vehicleResourceCosts set [_x, 60] } forEach FactionGet(all, "vehiclesLightAPCs");
+{ _vehicleResourceCosts set [_x, 60] } forEach FactionGet(all, "vehiclesLightAPCs") + FactionGet(all, "vehiclesAirPatrol");
 { _vehicleResourceCosts set [_x, 100] } forEach FactionGet(all, "vehiclesAPCs");
 { _vehicleResourceCosts set [_x, 150] } forEach FactionGet(all, "vehiclesAA") + FactionGet(all, "vehiclesArtillery") + FactionGet(all, "vehiclesIFVs") + FactionGet(all, "vehiclesLightTanks");
 { _vehicleResourceCosts set [_x, 230] } forEach FactionGet(all, "vehiclesTanks");

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -471,12 +471,12 @@ private _vehicleResourceCosts = createHashMap;
 { _vehicleResourceCosts set [_x, 20] } forEach FactionGet(all, "staticAA") + FactionGet(all, "staticAT") + FactionGet(all, "staticMortars");
 { _vehicleResourceCosts set [_x, 20] } forEach FactionGet(all, "vehiclesLightUnarmed") + FactionGet(all, "vehiclesTrucks");
 { _vehicleResourceCosts set [_x, 50] } forEach FactionGet(all, "vehiclesLightArmed");
-{ _vehicleResourceCosts set [_x, 60] } forEach FactionGet(all, "vehiclesLightAPCs") + FactionGet(all, "vehiclesAirPatrol");
+{ _vehicleResourceCosts set [_x, 60] } forEach FactionGet(all, "vehiclesLightAPCs");
 { _vehicleResourceCosts set [_x, 100] } forEach FactionGet(all, "vehiclesAPCs");
 { _vehicleResourceCosts set [_x, 150] } forEach FactionGet(all, "vehiclesAA") + FactionGet(all, "vehiclesArtillery") + FactionGet(all, "vehiclesIFVs") + FactionGet(all, "vehiclesLightTanks");
 { _vehicleResourceCosts set [_x, 230] } forEach FactionGet(all, "vehiclesTanks");
 
-{ _vehicleResourceCosts set [_x, 70] } forEach FactionGet(all, "vehiclesHelisLight");
+{ _vehicleResourceCosts set [_x, 70] } forEach FactionGet(all, "vehiclesHelisLight") + FactionGet(all, "vehiclesAirPatrol");
 { _vehicleResourceCosts set [_x, 100] } forEach FactionGet(all, "vehiclesHelisTransport");
 { _vehicleResourceCosts set [_x, 130] } forEach FactionGet(all, "vehiclesHelisLightAttack") + FactionGet(all, "vehiclesPlanesTransport");
 { _vehicleResourceCosts set [_x, 250] } forEach FactionGet(all, "vehiclesPlanesCAS") + FactionGet(all, "vehiclesPlanesAA");


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [x] Enhancement

### What have you changed and why?
Information:
add a vanity/atmosphere vehicle category which dictates what vehicles the enemy send on air patrols.
This category can include: scout planes, scout helicopters, and light helicopters with door gunners.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

run
`tierWar = 10; [] spawn A3A_fnc_AAFroadPatrol;`
in the vicinity (2km) from enemy airbase.

********************************************************
Notes:
