### PR TITLE
Fix script error for missing variable in placement rays rendering code

### DIFF
--- a/A3A/addons/garage/Core/fn_confirmPlacement.sqf
+++ b/A3A/addons/garage/Core/fn_confirmPlacement.sqf
@@ -406,7 +406,7 @@ HR_GRG_EH_EF = addMissionEventHandler ["EachFrame", {
 
     if (HR_GRG_renderPlacementRays) then { //Debug render
         HR_GRG_dispSquare params ["_adjustment", "_square"];
-        _square params ["_a","_b"];
+        _square params ["_a","_b","_c"];
         drawLine3D [HR_GRG_dispVehicle modelToWorldVisual _adjustment,HR_GRG_dispVehicle modelToWorldVisual (_adjustment vectorAdd [_a,0,0]), [0.9,0,0,1]];
         drawLine3D [HR_GRG_dispVehicle modelToWorldVisual _adjustment,HR_GRG_dispVehicle modelToWorldVisual (_adjustment vectorAdd [0,_b,0]), [0.9,0,0,1]];
         drawLine3D [HR_GRG_dispVehicle modelToWorldVisual _adjustment,HR_GRG_dispVehicle modelToWorldVisual (_adjustment vectorAdd [0,0,_c]), [0.9,0,0,1]];


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
If you enable the placement rays rendering in the garage options, you get a script error for a missing variable. Didn't hurt much, but we fix these things.

Wasn't entirely sure about the intention here but it looks fine, so whatever.

### Please specify which Issue this PR Resolves.
closes #3199

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Load CBA. Enable placement rays rendering. Attempt to place a vehicle from the garage.
