### PR TITLE
Prevent Arma from deleting player corpses for 15 mins

### DIFF
--- a/A3A/addons/maps/MissionDescription/gameSettings.hpp
+++ b/A3A/addons/maps/MissionDescription/gameSettings.hpp
@@ -1,6 +1,9 @@
 respawn = "BASE";
 respawnDelay = 15;
 
+// Player corpses preserved for 15min minimum
+corpseRemovalMinTime = 900;
+
 aiKills = 0;
 disabledAI = 1;
 Saving = 0;


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Short-term fix for player corpses getting deleted too early under high user count conditions. Didn't realise Arma had a system for this that's enabled by default. Could disable it entirely, but I've compromised on giving players at least 15 mins to get their gear back.

### Please specify which Issue this PR Resolves.
closes #3213

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Respawn 16 times. Check that the first corpse is still present for 15 minutes afterwards.