### PR TITLE
Reduced priority of highly DLC dependent factions

### DIFF
--- a/A3A/addons/core/Templates/Templates.hpp
+++ b/A3A/addons/core/Templates/Templates.hpp
@@ -74,6 +74,7 @@ class Templates
         file = "Vanilla_AI_NATO_UK_Tropical";
         climate[] = {"tropical"};
         forceDLC[] = {"expansion"};
+        priority = 5;
     };
     class Vanilla_NATO_UK_Temperate : Vanilla_NATO_UK_Tropical
     {
@@ -116,6 +117,7 @@ class Templates
         file = "Vanilla_AI_PMC";
         climate[] = {};
         forceDLC[] = {"enoch","expansion"};
+        priority = 5;
     };
 
     class Vanilla_FIA : Vanilla_Base


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
reduces the priority of the vanilla NATO/UK and vanilla ION factions to 5 such that they won't be the default faction for every damn map and campaign.

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
