### PR TITLE
Fix reordering and unlockedXXX arrays in initial unlocks

### DIFF
--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -127,19 +127,20 @@ else
 
     // Do initial arsenal filling
     private _categoriesToPublish = createHashMap;
-    private _equipHM = FactionGet(reb,"initialRebelEquipment") createHashMapFromArray [];       // dupe proofing
+    private _addedClasses = createHashMap;       // dupe proofing
     {
-        if (_x isEqualType "") then {
-            private _arsenalTab = _x call jn_fnc_arsenal_itemType;
-            jna_dataList#_arsenalTab pushBack [_x, -1];         // direct add to avoid O(N^2) issue
-            private _categories = _x call A3A_fnc_equipmentClassToCategories;
-            _categoriesToPublish insert [true, _categories, []];
-            continue;
-        };
-        _x params ["_class", "_count"];
+        _x params ["_class", ["_count", -1]];
+        if (_class in _addedClasses) then { continue };
+        _addedClasses set [_class, nil];
+
         private _arsenalTab = _class call jn_fnc_arsenal_itemType;
-        jna_dataList#_arsenalTab pushBack [_class, _count];
-    } foreach keys _equipHM;
+        jna_dataList#_arsenalTab pushBack [_class, _count];         // direct add to avoid O(N^2) issue
+
+        private _categories = _class call A3A_fnc_equipmentClassToCategories;
+        { (missionNamespace getVariable ("unlocked" + _x)) pushBack _class } forEach _categories;
+        _categoriesToPublish insert [true, _categories, []];
+
+    } foreach FactionGet(reb,"initialRebelEquipment");
 
     // Publish the unlocked categories (once each)
     { publicVariable ("unlocked" + _x) } forEach keys _categoriesToPublish;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed two issues in the initial unlocks code introduced in 3.5.3:
1. Items now retain their original order in the arsenal, so you can find ACE items again.
2. unlockedXXX arrays are filled out correctly on new campaign start, so outpost crates and looting crates filter items correctly without needing a load/save cycle.

### Please specify which Issue this PR Resolves.
closes #3225

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Start a new campaign with ACE:
1. Check that the ACE items are in the usual order in the arsenal.
2. Check that vars like unlockedMagazines have everything in them.
