### PR TITLE
Update fn_vehiclePrice to not fail on absent vehicles.

### DIFF
--- a/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
+++ b/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
@@ -3,11 +3,21 @@ FIX_LINE_NUMBERS()
 
 params ["_typeX"];
 
-private _costs = server getVariable _typeX;
+_costs = 0;
+
+if (isNil "_typeX") then 
+{
+	Error_1("Vehicle does not exist.");
+	_costs = 0;
+}
+else
+{
+	_costs = server getVariable _typeX;
+};
 
 if (isNil "_costs") then
 	{
-        Error_1("Invalid vehicle price :%1.", _typeX);
+	Error_1("Invalid vehicle price :%1.", _typeX);
 	_costs = 0;
 	}
 else

--- a/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
+++ b/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
@@ -29,7 +29,7 @@ else
 	}
 	else
 	{
-		_discount = 0 max ((tierWar - 4) * 0.5);
+		_discount = 0 max ((tierWar - 4) * 0.5);	//4 is the last war tier before discounts, the 0.5 makes the discount go from 0-3 instead of 0-6.
 		_costs = round (_costs - (_costs * 0.1 * _discount));
 	};
 };

--- a/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
+++ b/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
@@ -30,7 +30,7 @@ else
 	else
 	{
 		_discount = 0 max ((tierWar - 4) * 0.5);	//4 is the last war tier before discounts, the 0.5 makes the discount go from 0-3 instead of 0-6.
-		_costs = round (_costs - (_costs * 0.1 * _discount));
+		_costs = 5 * round ((_costs - (_costs * 0.1 * _discount))/5); //Applies the discount, rounds to the nearest 5€
 	};
 };
 

--- a/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
+++ b/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
@@ -3,9 +3,9 @@ FIX_LINE_NUMBERS()
 
 params ["_typeX"];
 
-_costs = 0;
+private _costs = 0;
 
-if (isNil "_typeX") then 
+if (isNil "_typeX") then
 {
 	Error_1("Vehicle does not exist.");
 	_costs = 0;
@@ -16,26 +16,22 @@ else
 };
 
 if (isNil "_costs") then
-	{
+{
 	Error_1("Invalid vehicle price :%1.", _typeX);
 	_costs = 0;
-	}
+}
 else
+{
+	if (count seaports > 3) then
 	{
-		if (count seaports > 3) then {
-			private _numFriendlySeaports = ({sidesX getVariable [_x,sideUnknown] == teamPlayer} count seaports) min 6;
-			_costs = round (_costs - (_costs * 0.05 * _numFriendlySeaports));
-		} else {
-			_discount = switch (true) do {
-                case (tierWar in [1,2]): { 0 };
-                case (tierWar in [3,4]): { 0 };
-				case (tierWar in [5,6]): { 1 };
-				case (tierWar in [7,8]): { 2 };
-				case (tierWar in [9,10]): { 3 };
-				default { 0 };
-			};
-			_costs = round (_costs - (_costs * 0.1 * _discount));
-		};	
+		private _numFriendlySeaports = ({sidesX getVariable [_x,sideUnknown] == teamPlayer} count seaports) min 6;
+		_costs = round (_costs - (_costs * 0.05 * _numFriendlySeaports));
+	}
+	else
+	{
+		_discount = 0 max ((tierWar - 4) * 0.5);
+		_costs = round (_costs - (_costs * 0.1 * _discount));
 	};
+};
 
 _costs


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Adds a check to fn_vehiclePrice that ensure the function doesn't error when _typeX is nil.
This would be the first step in the direction of letting some rebel templates have less stuff.

Reformatted file.
Cleaned up the non-seaport based discount 

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
