### PR TITLE
Make artillery rotate to target before firing

### DIFF
--- a/A3A/addons/core/functions/Supports/fn_SUP_mortarRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_mortarRoutine.sqf
@@ -34,7 +34,7 @@ if((30 + random 40) >_sideAggression) then
 private _shotsPerVolley = _numberOfRounds / 3;
 
 //A function to repeatedly fire onto a target without loops by using an EH
-_fn_executeMortarFire =
+private _fn_executeMortarFire =
 {
     params ["_mortar"];
 
@@ -55,7 +55,7 @@ _fn_executeMortarFire =
             [_shellTarget, _mortar] spawn
             {
                 params ["_shellTarget", "_mortar"];
-                sleep 0.5;
+                sleep 1;
                 _mortar doArtilleryFire [_shellTarget, _mortar getVariable "shellType", 1];
             }
         }
@@ -66,6 +66,27 @@ _fn_executeMortarFire =
     private _target = _subTargets deleteAt 0;
     _mortar doArtilleryFire [_target, _mortar getVariable "shellType", 1];
 };
+
+
+private _fn_rotateToTarget =
+{
+    params ["_mortar", "_targPos"];
+
+    private _change = (_mortar getDir _targPos) - getDir _mortar;
+    _change = (_change + 540) % 360 - 180;
+
+    addMissionEventHandler ["EachFrame", {
+        _thisArgs params ["_mortar", "_startDir", "_change", "_startTime"];
+
+        private _interval = 10 * (time - _startTime) / abs _change;        // 10 degree/sec turn
+        private _newDir = _startDir + _change * (_interval min 1);
+        _mortar setDir  _newDir;
+        if (!alive _mortar or !alive gunner _mortar or _interval >= 1) exitWith {
+            removeMissionEventHandler ["EachFrame", _thisEventHandler];
+        };
+    }, [_mortar, getDir _mortar, _change, time]];
+};
+
 
 private _timeout = time + _timeAlive;
 while {time < _timeout} do
@@ -97,6 +118,7 @@ while {time < _timeout} do
 
     // Start shooting
     _mortar setVariable ["FireOrder", _subTargets];
+    [_mortar, _targetPos] spawn _fn_rotateToTarget;
     [_mortar] spawn _fn_executeMortarFire;
     _numberOfRounds = _numberOfRounds - _shotsPerVolley;
     _timeout = _timeout max (time + 60);                // don't cleanup until the volley is done

--- a/A3A/addons/core/functions/Supports/fn_SUP_mortarRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_mortarRoutine.sqf
@@ -74,6 +74,7 @@ private _fn_rotateToTarget =
 
     private _change = (_mortar getDir _targPos) - getDir _mortar;
     _change = (_change + 540) % 360 - 180;
+    if (abs _change < 1) exitWith {};
 
     addMissionEventHandler ["EachFrame", {
         _thisArgs params ["_mortar", "_startDir", "_change", "_startTime"];


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Some artillery vehicles have a limited firing arc and the artillery support code didn't take account of that. This PR fixes the issue by making artillery vehicles rotate towards the target before firing. Method should be solid. Adjusted the firing rate to 1/sec max as previously it varied based on rotation distance.

Not tested with anything except vanilla mortars, but should work fine.

### Please specify which Issue this PR Resolves.
closes #2775

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Adjust as required:
`["MORTAR", Occupants, "defence", 500, objNull, markerPos "Therisa", 0.8, 20] call A3A_fnc_createSupport;`