### PR TITLE
Switch respawn & self-revive keys to custom keybinds

### DIFF
--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -8605,6 +8605,18 @@
         <Korean>안티스타시의 전투 메뉴를 엽니다.</Korean>
         <Russian>Открывает меню битвы Antistasi.</Russian>
       </Key>
+      <Key ID="STR_A3A_keybinds_CfgUserAct_respawn_DN">
+        <Original>Respawn</Original>
+      </Key>
+      <Key ID="STR_A3A_keybinds_CfgUserAct_respawn_tip">
+        <Original>Respawn when unconscious in the Antistasi medical system.</Original>
+      </Key>
+      <Key ID="STR_A3A_keybinds_CfgUserAct_selfRevive_DN">
+        <Original>Self revive</Original>
+      </Key>
+      <Key ID="STR_A3A_keybinds_CfgUserAct_selfRevive_tip">
+        <Original>Self revive when unconscious in the Antistasi medical system.</Original>
+      </Key>
       <Key ID="STR_A3A_keybinds_CfgUserAct_cusHintDiss_DN">
         <Original>Dismiss Previous Hint</Original>
         <Italian>Chiudi Suggerimento Precedente</Italian>

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -7717,14 +7717,14 @@
         <Chinesesimp>%1正在赶来救助你的路上</Chinesesimp>
       </Key>
       <Key ID="STR_A3A_fn_revive_unconscious_respawn">
-        <Original>Press R to respawn.</Original>
+        <Original>Press %1 to respawn.</Original>
         <French>Appuyez sur R pour réapparaître.</French>
         <Korean>R 키를 눌러 리스폰합니다.</Korean>
         <Russian>Нажмите R, чтобы возродиться.</Russian>
         <Chinesesimp>按R键重生</Chinesesimp>
       </Key>
       <Key ID="STR_A3A_fn_revive_unconscious_selfRevive">
-        <Original>Press H to shake off the injury.</Original>
+        <Original>Press %1 to shake off the injury.</Original>
         <French>Appuyez sur H pour vous débarrasser de la blessure.</French>
         <Korean>H 키를 눌러 부상을 떨쳐냅니다.</Korean>
         <Russian>Нажмите H, чтобы избавиться от повреждения.</Russian>

--- a/A3A/addons/core/functions/Revive/fn_respawn.sqf
+++ b/A3A/addons/core/functions/Revive/fn_respawn.sqf
@@ -5,7 +5,8 @@ if (_unit getVariable "respawning") exitWith {};
 if (_unit != _unit getVariable ["owner",_unit]) exitWith {};
 if (!isPlayer _unit) exitWith {};
 
-if (!isNil "respawnMenu") then {(findDisplay 46) displayRemoveEventHandler ["KeyDown", respawnMenu]};
+removeAllUserActionEventHandlers ["A3A_core_respawn", "Activate"];
+removeAllUserActionEventHandlers ["A3A_core_selfRevive", "Activate"];
 _unit setVariable ["respawning",true];
 private _layer = ["A3A_infoCenter"] call BIS_fnc_rscLayer;
 ["Respawning",0,0,3,0,0,_layer] spawn bis_fnc_dynamicText;

--- a/A3A/addons/core/functions/Revive/fn_selfRevive.sqf
+++ b/A3A/addons/core/functions/Revive/fn_selfRevive.sqf
@@ -22,6 +22,9 @@ if (time < player getVariable ["A3A_selfReviveTimeout", -1]) exitWith {
 };
 
 // ok so now we actually do it...
+removeAllUserActionEventHandlers ["A3A_core_respawn", "Activate"];
+removeAllUserActionEventHandlers ["A3A_core_selfRevive", "Activate"];
+
 player setVariable ["incapacitated", false, true];
 player setDamage 0.5;
 player removeItem selectRandom _hasFAKs;

--- a/A3A/addons/core/functions/Revive/fn_unconscious.sqf
+++ b/A3A/addons/core/functions/Revive/fn_unconscious.sqf
@@ -92,9 +92,9 @@ while {(time < _bleedOut) and (_unit getVariable ["incapacitated",false]) and (a
 			if (_helper distance _unit < 3) exitWith { format [localize "STR_A3A_fn_revive_unconscious_helping", name _helper] };
 			format [localize "STR_A3A_fn_revive_unconscious_onTheWay", name _helper];
 		};
-		private _respawnText = "<t size='0.6'><br/>" + localize "STR_A3A_fn_revive_unconscious_respawn";
+		private _respawnText = format ["<t size='0.6'><br/>" + localize "STR_A3A_fn_revive_unconscious_respawn", actionKeysNames "A3A_core_respawn"];
 		private _reviveText = call {
-			if (A3A_selfReviveMethods) exitWith { "<br/>" + localize "STR_A3A_fn_revive_unconscious_selfRevive" };
+			if (A3A_selfReviveMethods) exitWith { format ["<br/>" + localize "STR_A3A_fn_revive_unconscious_selfRevive", actionKeysNames "A3A_core_selfRevive"] };
 			//if (A3A_selfReviveMethods == 2) exitWith { "<br/>Hit H to take over nearest AI ally" };
 			""
 		};

--- a/A3A/addons/core/functions/Revive/fn_unconscious.sqf
+++ b/A3A/addons/core/functions/Revive/fn_unconscious.sqf
@@ -17,19 +17,7 @@ if (isPlayer _unit) then
 	_unit spawn { sleep 5; _this allowDamage true };
 	closeDialog 0;
 	openMap false;
-	if (!isNil "respawnMenu") then {(findDisplay 46) displayRemoveEventHandler ["KeyDown", respawnMenu]};
-	respawnMenu = (findDisplay 46) displayAddEventHandler ["KeyDown",
-	{
-		if !(player getVariable ["incapacitated",false]) exitWith {false};
-		if (_this select 1 == 19) then {
-			[player] spawn A3A_fnc_respawn;
-		};
-		if (_this select 1 == 35) then {
-			if (A3A_selfReviveMethods) then { [] spawn A3A_fnc_selfRevive };
-			//if (A3A_selfReviveMethods == 2) then { [] spawn A3A_fnc_transferToAI };		// different keys later?
-		};
-		false;
-	}];
+
 	if (_injurer != Invaders) then {_unit setCaptive true};
 	{
 		if ((!isPlayer _x) and (vehicle _x != _x) and (_x distance _unit < 50)) then {unassignVehicle _x; [_x] orderGetIn false}
@@ -60,22 +48,31 @@ else
 _unit setFatigue 1;
 sleep 2;
 if (_isPlayer) then
-	{
+{
+	addUserActionEventHandler ["A3A_core_respawn", "Activate", {
+		if !(player getVariable ["incapacitated",false]) exitWith {};
+		[player] spawn A3A_fnc_respawn;
+	}];
+	addUserActionEventHandler ["A3A_core_selfRevive", "Activate", {
+		if !(player getVariable ["incapacitated",false]) exitWith {};
+		if (A3A_selfReviveMethods) then { [] spawn A3A_fnc_selfRevive };
+	}];
+
 	if (A3A_hasTFAR || A3A_hasTFARBeta) then
-		{
+	{
 		_saveVolumeVoice = player getVariable ["tf_voiceVolume", 1.0];
 		player setVariable ["tf_unable_to_use_radio", true, true];
 		player setVariable ["tf_voiceVolume", 0];
 		_saveVolume = player getVariable ["tf_globalVolume", 1.0];
 		player setVariable ["tf_globalVolume", 0.7, true];
-		};
+	};
 	group _unit setCombatMode "YELLOW";
 	if (isMultiplayer) then
-		{
+	{
 		[_unit,"heal1"] remoteExec ["A3A_fnc_flagaction",0,_unit];
 		//[_unit,"carry"] remoteExec ["A3A_fnc_flagaction",0,_unit];
-		};
 	};
+};
 
 
 private _nextRequest = 0;
@@ -112,24 +109,26 @@ while {(time < _bleedOut) and (_unit getVariable ["incapacitated",false]) and (a
 };
 
 if (_isPlayer) then
-	{
-	(findDisplay 46) displayRemoveEventHandler ["KeyDown", respawnMenu];
+{
+	removeAllUserActionEventHandlers ["A3A_core_respawn", "Activate"];
+	removeAllUserActionEventHandlers ["A3A_core_selfRevive", "Activate"];
+
 	if (A3A_hasTFAR || A3A_hasTFARBeta) then
-		{
+	{
 		player setVariable ["tf_unable_to_use_radio", false, true];
 		player setVariable ["tf_globalVolume", _saveVolume];
 		player setVariable ["tf_voiceVolume", _saveVolumeVoice, true];
-		};
+	};
 	if (isMultiplayer) then {[_unit,"remove"] remoteExec ["A3A_fnc_flagaction",0,_unit]};
-	}
+}
 else
-	{
+{
 	_unit stop false;
 	if (_inPlayerGroup or _playersX) then
-		{
+	{
 		[_unit,"remove"] remoteExec ["A3A_fnc_flagaction",0,_unit];
-		};
 	};
+};
 
 if (_isPlayer and (_unit getVariable ["respawn",false])) exitWith {};
 

--- a/A3A/addons/core/keybinds/CfgDefaultKeysPresets.hpp
+++ b/A3A/addons/core/keybinds/CfgDefaultKeysPresets.hpp
@@ -4,6 +4,8 @@ class CfgDefaultKeysPresets {
         class Mappings {
             GVAR(battleMenu)[] = {DIK_Y};
             GVAR(artyMenu)[] = {0x2A130015}; //combo Left shift + Y (no double tap)
+            GVAR(respawn)[] = {DIK_R};
+            GVAR(selfRevive)[] = {DIK_H};
             GVAR(infoBar)[] = {0x381300C7}; //combo Left alt + Home (no double tap)
             GVAR(earPlugs)[] = {DIK_END};
             GVAR(customHintDismiss)[] = {};

--- a/A3A/addons/core/keybinds/CfgUserActions.hpp
+++ b/A3A/addons/core/keybinds/CfgUserActions.hpp
@@ -13,6 +13,16 @@ class CfgUserActions {
         onActivate = ACTION(artyMenu);
     };
 
+    class GVAR(respawn) {
+        displayName = $STR_A3A_keybinds_CfgUserAct_respawn_DN;
+        tooltip = $STR_A3A_keybinds_CfgUserAct_respawn_tip;
+    };
+
+    class GVAR(selfRevive) {
+        displayName = $STR_A3A_keybinds_CfgUserAct_selfRevive_DN;
+        tooltip = $STR_A3A_keybinds_CfgUserAct_selfRevive_tip;
+    };
+
     class GVAR(infoBar) {
         displayName = $STR_A3A_keybinds_CfgUserAct_infoBar_DN;
         tooltip = $STR_A3A_keybinds_CfgUserAct_infoBar_tip;

--- a/A3A/addons/core/keybinds/UserActionGroups.hpp
+++ b/A3A/addons/core/keybinds/UserActionGroups.hpp
@@ -5,6 +5,8 @@ class UserActionGroups {
         group[] = {
             QGVAR(battleMenu),
             QGVAR(artyMenu),
+            QGVAR(respawn),
+            QGVAR(selfRevive),
             QGVAR(infoBar),
             QGVAR(earPlugs),
             QGVAR(customHintDismiss)

--- a/A3A/addons/core/keybinds/UserActionsConflictGroups.hpp
+++ b/A3A/addons/core/keybinds/UserActionsConflictGroups.hpp
@@ -3,6 +3,8 @@ class UserActionsConflictsGroups {
         PREFIX[] = {
             QGVAR(battleMenu),
             QGVAR(artyMenu),
+            QGVAR(respawn),
+            QGVAR(selfRevive),
             QGVAR(infoBar),
             QGVAR(earPlugs),
             QGVAR(customHintDismiss)


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Antistasi medical respawn (R) and self-revive (H) keys were hard-coded. Now they're not. Also cleaned up some questionable logic that might have caused weird effects if people hit these keys too early.

### Please specify which Issue this PR Resolves.
closes #3232

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Start Antistasi without ACE medical and self-revive enabled in parameters. Get yourself killed, for example by using this:
`player setPosATL (getPosATL player vectorAdd [0,0,50]);`

Try changing the keybinds in the controls menu.