### PR TITLE
Fix case where HC vehicles are remote-spawned with no roads near HQ

### DIFF
--- a/A3A/addons/core/functions/REINF/fn_spawnHCVeh.sqf
+++ b/A3A/addons/core/functions/REINF/fn_spawnHCVeh.sqf
@@ -35,7 +35,7 @@ private _spawnPos = false;
 private _spawnDir = false;
 
 for "_i" from 1 to 10 do {
-    //systemChat format ["Attempt %1", _i];
+    if (_roads isEqualTo []) exitWith {};
     private _road = selectRandom _roads;
     (getRoadInfo _road) params ["", "_roadWidth", "", "", "", "", "_begPos", "_endPos"];
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
If high command squads containing vehicles are purchased when the commander is away from HQ, and the HQ has no roads within 100m, the placement code breaks. This PR fixes it to place the vehicle randomly as intended.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
