### PR TITLE
Cargo nodes for 3CB Hilux (Covered)

### DIFF
--- a/A3A/addons/logistics/Nodes/3CBFactions.hpp
+++ b/A3A/addons/logistics/Nodes/3CBFactions.hpp
@@ -15,6 +15,24 @@ class UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehic
     };
 };
 
+class UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehicles_datsun_uk3cb_datsun_open_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+    class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-0.6,-1.164};
+            seats[] = {3,4};
+        };
+        class Node2
+        {
+            offset[] = {0,-1.3,-1.164};
+            seats[] = {5,6};
+        };
+    };
+};
+
+
 class UK3CB_Hilux_Closed_Base : TRIPLES(ADDON,Nodes,Base)
 {
     canLoadWeapon = 0;

--- a/A3A/addons/logistics/Nodes/3CBFactions.hpp
+++ b/A3A/addons/logistics/Nodes/3CBFactions.hpp
@@ -32,8 +32,7 @@ class UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehic
     };
 };
 
-
-class UK3CB_Hilux_Closed_Base : TRIPLES(ADDON,Nodes,Base)
+class UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehicles_hilux_uk3cb_hilux_civilian_closed_p3d : TRIPLES(ADDON,Nodes,Base)
 {
     canLoadWeapon = 0;
     class Nodes
@@ -50,16 +49,6 @@ class UK3CB_Hilux_Closed_Base : TRIPLES(ADDON,Nodes,Base)
         };
     };
 };
-
-class UK3CB_APD_B_Hilux_Closed : UK3CB_Hilux_Closed_Base {};
-class UK3CB_APD_I_Hilux_Closed : UK3CB_Hilux_Closed_Base {};
-class UK3CB_ADA_I_Hilux_Closed : UK3CB_Hilux_Closed_Base {};
-class UK3CB_ANA_B_Hilux_Closed : UK3CB_Hilux_Closed_Base {};
-class UK3CB_ANP_B_Hilux_Closed : UK3CB_Hilux_Closed_Base {};
-class UK3CB_ADP_B_Hilux_Closed : UK3CB_Hilux_Closed_Base {};
-class UK3CB_LNM_B_Hilux_Closed : UK3CB_Hilux_Closed_Base {};
-class UK3CB_TKA_B_Hilux_Closed : UK3CB_Hilux_Closed_Base {};
-class UK3CB_C_Hilux_Closed : UK3CB_Hilux_Closed_Base {};
 
 class UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehicles_hilux_uk3cb_hilux_p3d : TRIPLES(ADDON,Nodes,Base)
 {

--- a/A3A/addons/logistics/Nodes/3CBFactions.hpp
+++ b/A3A/addons/logistics/Nodes/3CBFactions.hpp
@@ -15,22 +15,33 @@ class UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehic
     };
 };
 
-class UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehicles_datsun_uk3cb_datsun_open_p3d : TRIPLES(ADDON,Nodes,Base)
+class UK3CB_Hilux_Closed_Base : TRIPLES(ADDON,Nodes,Base)
 {
+    canLoadWeapon = 0;
     class Nodes
     {
         class Node1
         {
-            offset[] = {0,-0.6,-1.164};
-            seats[] = {3,4};
+            offset[] = {-0.05,-0.5,-0.634};
+            seats[] = {5};
         };
         class Node2
         {
-            offset[] = {0,-1.3,-1.164};
-            seats[] = {5,6};
+            offset[] = {-0.05,-1.6,-0.634};
+            seats[] = {3,4,6};
         };
     };
 };
+
+class UK3CB_APD_B_Hilux_Closed : UK3CB_Hilux_Closed_Base {};
+class UK3CB_APD_I_Hilux_Closed : UK3CB_Hilux_Closed_Base {};
+class UK3CB_ADA_I_Hilux_Closed : UK3CB_Hilux_Closed_Base {};
+class UK3CB_ANA_B_Hilux_Closed : UK3CB_Hilux_Closed_Base {};
+class UK3CB_ANP_B_Hilux_Closed : UK3CB_Hilux_Closed_Base {};
+class UK3CB_ADP_B_Hilux_Closed : UK3CB_Hilux_Closed_Base {};
+class UK3CB_LNM_B_Hilux_Closed : UK3CB_Hilux_Closed_Base {};
+class UK3CB_TKA_B_Hilux_Closed : UK3CB_Hilux_Closed_Base {};
+class UK3CB_C_Hilux_Closed : UK3CB_Hilux_Closed_Base {};
 
 class UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehicles_hilux_uk3cb_hilux_p3d : TRIPLES(ADDON,Nodes,Base)
 {


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information: Added cargo nodes to the 3CB covered hiluxes.
Since they have no base class, the initial nodes are defined and then applied to all of the different variants we use in our templates. These are using the same cargo nodes as the other 3CB Hiluxes, since the model is identical except for a canopy.
Note that this means two bugs carry over: the first crate clips into the front of the truck a bit, which will be easier to fix if every value is consistent, and that the large ammo crates clip through the top. Unfortunately I believe there is no fix for this until #3103 is merged
    

### Please specify which Issue this PR Resolves.
closes #3045

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
