### PR TITLE
Patch 16

### DIFF
--- a/A3A/addons/core/functions/Supports/fn_SUP_SAM.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_SAM.sqf
@@ -44,7 +44,7 @@ if (_airports isEqualTo []) exitWith {
 };
 
 private _airport = _airports selectRandomWeighted _weights;
-private _launcherType = ["B_SAM_System_03_F", "O_SAM_System_04_F"] select (_side == Invaders);
+private _launcherType = ["B_Ship_MRLS_01_F", "B_Ship_MRLS_01_F"] select (_side == Invaders);
 private _launcher = [_launcherType, markerPos _airport, 50, 5, true] call A3A_fnc_safeVehicleSpawn;
 
 private _group = [_side, _launcher] call A3A_fnc_createVehicleCrew;

--- a/A3A/addons/core/functions/Supports/fn_SUP_SAMAvailable.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_SAMAvailable.sqf
@@ -15,7 +15,7 @@ FIX_LINE_NUMBERS()
 
 params ["_target", "_side", "_maxSpend", "_availTypes"];
 
-if !(_target isKindOf "Air") exitWith { 0 };     // can't hit anything except air
+if (_target isKindOf "Air") exitWith { 0 };     // can't hit anything except air
 
 // Should limit to certain templates?
 

--- a/A3A/addons/core/functions/Supports/fn_SUP_SAMRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_SAMRoutine.sqf
@@ -83,6 +83,8 @@ while {true} do
     // Actually fire
     Debug("Firing at target");
     _launcher reveal [_targetObj, 4];           // does this do anything?
+    _targetObj confirmSensorTarget [_side, true];
+    _side reportRemoteTarget [_targetObj, 300];
     _launcher fireAtTarget [_targetObj];
     [_reveal, getPosATL _targetObj, _side, "SAM", _targetObj, 60] spawn A3A_fnc_showInterceptedSupportCall;
     _missiles = _missiles - 1;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement
4. [x] Test

### What have you changed and why?
Information:

Used SAM code to make cruise missile work. Currently follows the target but I think it's really easy to avoid by placing either laser or a sphere on the target position and then fire at laser/sphere

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
["SAM", Occupants, "attack", 125, player, getPosATL player, 1, 0] spawn A3A_fnc_createSupport;
********************************************************
Notes:
used getPosATL player, but I think the same thing will happen if it would be getPosATL vehicle player