### PR TITLE
Rework anti-air support response balance

### DIFF
--- a/A3A/addons/core/Params.hpp
+++ b/A3A/addons/core/Params.hpp
@@ -228,6 +228,14 @@ class Params
         texts[] =  {"1.0x","1.1x","1.2x","1.3x","1.4x","1.5x"};
         default = 12;
     };
+    class A3A_enemyResponseTime
+    {
+        attr[] = {"server"};
+        title = $STR_A3A_Params_enemyResponseTime_title;
+        values[] = {20,15,10,7,5};
+        texts[] =  {$STR_A3A_Params_generic_veryslow, $STR_A3A_Params_generic_slow, $STR_A3A_Params_generic_normal, $STR_A3A_Params_generic_fast, $STR_A3A_Params_generic_veryfast};
+        default = 10;
+    };
     class A3A_attackHQProximityMul
     {
         attr[] = {"server"};

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -9426,6 +9426,18 @@
         <Russian>Очень низкая</Russian>
         <Chinesesimp>非常低</Chinesesimp>
       </Key>
+      <Key ID="STR_A3A_Params_generic_veryslow">
+        <Original>Very slow</Original>
+      </Key>
+      <Key ID="STR_A3A_Params_generic_slow">
+        <Original>Slow</Original>
+      </Key>
+      <Key ID="STR_A3A_Params_generic_fast">
+        <Original>Fast</Original>
+      </Key>
+      <Key ID="STR_A3A_Params_generic_veryfast">
+        <Original>Very fast</Original>
+      </Key>
       <Key ID="STR_A3A_Params_globalCivilianMax_title">
         <Original>Maximum global civilians</Original>
         <Italian>Numero massimo globale di civili </Italian>
@@ -9507,6 +9519,9 @@
         <Korean>점령군과 관련된 침략군에 대한 자원 승수</Korean>
         <Russian>Множитель ресурсов для захватчиков по отношению к оккупантам</Russian>
         <Chinesesimp>入侵者相对于占领者的资源倍增</Chinesesimp>
+      </Key>
+      <Key ID="STR_A3A_Params_enemyResponseTime_title">
+        <Original>Speed of enemy air responses</Original>
       </Key>
       <Key ID="STR_A3A_Params_limitedFT_any">
         <Original>Any friendly position</Original>

--- a/A3A/addons/core/functions/AI/fn_AIreactOnKill.sqf
+++ b/A3A/addons/core/functions/AI/fn_AIreactOnKill.sqf
@@ -35,7 +35,8 @@ _unit setVariable ["downedTimeout", time + 1200];
 if((isNil "_killer") || {(isNull _killer) || {side (group _killer) == side _group}}) exitWith {};
 
 // Add the unit to recent kills for reaction purposes
-[side _group, getPosATL _unit, 10] remoteExec ["A3A_fnc_addRecentDamage", 2];
+[side _group, getPosATL _unit, 10, _killer] remoteExec ["A3A_fnc_addRecentDamage", 2];
+
 
 private _enemy = objNull;
 private _activeGroupMembers = (units _group) select {_x call A3A_fnc_canFight};

--- a/A3A/addons/core/functions/Base/fn_addRecentDamage.sqf
+++ b/A3A/addons/core/functions/Base/fn_addRecentDamage.sqf
@@ -7,6 +7,7 @@ Arguments:
     <SIDE> Side that took the damage, must be occupants or invaders
     <POS2D> Position that damage was taken
     <SCALAR> Resource value of damage, max 999
+    <OBJECT> Killer vehicle, for adding threat to
 */
 
 #include "..\..\script_component.hpp"
@@ -14,9 +15,16 @@ FIX_LINE_NUMBERS()
 
 if (!isServer) exitWith { Error("Server-only function miscalled") };
 
-params ["_side", "_pos", "_value"];
+params ["_side", "_pos", "_value", "_killer"];
 
 if (_side != Occupants && _side != Invaders) exitWith { Error_1("Called with invalid side: %1", _side) };
 
 private _killPosValue = [_pos#0, _pos#1, 1000*20 + round _value];      // upper part is a time in minutes, lower part is value
 ([A3A_recentDamageOcc, A3A_recentDamageInv] select (_side == Invaders)) pushBack _killPosValue;
+
+if (_killer isKindOf "Air") then {
+    Debug_2("Adding %1 threat to vehicle %2", _value, typeof _killer);
+
+    private _extraThreat = _killer getVariable ["A3A_airKills", 0];
+    _killer setVariable ["A3A_airKills", _extraThreat + _value];
+};

--- a/A3A/addons/core/functions/Base/fn_addRecentDamage.sqf
+++ b/A3A/addons/core/functions/Base/fn_addRecentDamage.sqf
@@ -1,4 +1,5 @@
 /*  Adds an entry to the enemy recent damage records on the server
+    For air vehicles, adds the input threat to the vehicle instead
 
 Scope: Server
 Environment: Preferably unscheduled
@@ -17,14 +18,14 @@ if (!isServer) exitWith { Error("Server-only function miscalled") };
 
 params ["_side", "_pos", "_value", "_killer"];
 
-if (_side != Occupants && _side != Invaders) exitWith { Error_1("Called with invalid side: %1", _side) };
-
-private _killPosValue = [_pos#0, _pos#1, 1000*20 + round _value];      // upper part is a time in minutes, lower part is value
-([A3A_recentDamageOcc, A3A_recentDamageInv] select (_side == Invaders)) pushBack _killPosValue;
-
-if (_killer isKindOf "Air") then {
+if (_killer isKindOf "Air") exitWith {
     Debug_2("Adding %1 threat to vehicle %2", _value, typeof _killer);
 
     private _extraThreat = _killer getVariable ["A3A_airKills", 0];
     _killer setVariable ["A3A_airKills", _extraThreat + _value];
 };
+
+if (_side != Occupants && _side != Invaders) exitWith { Error_1("Called with invalid side: %1", _side) };
+
+private _killPosValue = [_pos#0, _pos#1, 1000*20 + round _value];      // upper part is a time in minutes, lower part is value
+([A3A_recentDamageOcc, A3A_recentDamageInv] select (_side == Invaders)) pushBack _killPosValue;

--- a/A3A/addons/core/functions/Base/fn_aggressionUpdateLoop.sqf
+++ b/A3A/addons/core/functions/Base/fn_aggressionUpdateLoop.sqf
@@ -42,8 +42,8 @@ while {true} do
     private _lastScale = A3A_balancePlayerScale;
     A3A_balancePlayerScale = (A3A_activePlayerCount ^ 0.8 + 1 + tierWar / 4) / 6;           // Normalized to 1 == 5 players @ war tier 6
     A3A_balancePlayerScale = A3A_balancePlayerScale * (A3A_enemyBalanceMul / 10);
-    A3A_balanceVehicleCost = 100 + ([tierWar * 10, 50] select (gameMode == 1));
-    A3A_balanceResourceRate = A3A_balancePlayerScale * A3A_balanceVehicleCost;          // base resources gained per 10 minutes
+    A3A_balanceVehicleCost = 100 + tierWar * 10;
+    A3A_balanceResourceRate = A3A_balancePlayerScale * ([A3A_balanceVehicleCost, 140] select (gameMode == 1));          // base resources gained per 10 minutes
     publicVariable "A3A_balancePlayerScale";            // needed for determining enemy skill on headless clients
 
     // Rescale defence resources when player count or difficulty changes

--- a/A3A/addons/core/functions/Base/fn_aggressionUpdateLoop.sqf
+++ b/A3A/addons/core/functions/Base/fn_aggressionUpdateLoop.sqf
@@ -42,10 +42,8 @@ while {true} do
     private _lastScale = A3A_balancePlayerScale;
     A3A_balancePlayerScale = (A3A_activePlayerCount ^ 0.8 + 1 + tierWar / 4) / 6;           // Normalized to 1 == 5 players @ war tier 6
     A3A_balancePlayerScale = A3A_balancePlayerScale * (A3A_enemyBalanceMul / 10);
-    A3A_balanceVehicleCost = 100 + tierWar * 10;                                            // pretty close to true
+    A3A_balanceVehicleCost = 100 + ([tierWar * 10, 50] select (gameMode == 1));
     A3A_balanceResourceRate = A3A_balancePlayerScale * A3A_balanceVehicleCost;          // base resources gained per 10 minutes
-    // back off the tier scaling a bit for reb vs occ vs inv, because you get some natural tier scaling due to attack choice
-    if (gameMode == 1) then { A3A_balanceResourceRate = A3A_balanceResourceRate * (1 - tierWar / 35) };
     publicVariable "A3A_balancePlayerScale";            // needed for determining enemy skill on headless clients
 
     // Rescale defence resources when player count or difficulty changes

--- a/A3A/addons/core/functions/Base/fn_airspaceControl.sqf
+++ b/A3A/addons/core/functions/Base/fn_airspaceControl.sqf
@@ -67,8 +67,10 @@ private _fn_sendSupport =
     params ["_vehicle", "_marker", "_threat"];
     private _markerSide = sidesX getVariable [_marker, sideUnknown];
 
+    ServerDebug_2("Vehicle %1 violated airspace of marker %2", typeof _vehicle, _marker);
+
     // Add threat to vehicle on server side. Hopefully faster than the requestSupport call
-    [_markerSide, false, _vehicle, _threat] remoteExecCall ["A3A_fnc_addRecentDamage", 2];
+    [_markerSide, false, _threat, _vehicle] remoteExecCall ["A3A_fnc_addRecentDamage", 2];
 
     // Let support system decide whether it's worth reacting to
     private _revealValue = [getMarkerPos _marker, _markerSide] call A3A_fnc_calculateSupportCallReveal;

--- a/A3A/addons/core/functions/Base/fn_distance.sqf
+++ b/A3A/addons/core/functions/Base/fn_distance.sqf
@@ -424,7 +424,7 @@ do
         _teamplayer = units teamPlayer select {
             private _veh = vehicle _x;
             _x getVariable ["spawner", false] and _x == effectiveCommander _veh
-            and (_veh == _x or {!(_veh isKindOf "Plane" and speed _veh > 250)})
+            and (_veh == _x or {!(_veh isKindOf "Plane" and speed _veh > 100)})
         };
         // Add in rebel-controlled UAVs
         _teamplayer append (allUnitsUAV select { side group _x == teamPlayer });

--- a/A3A/addons/core/functions/Base/fn_distance.sqf
+++ b/A3A/addons/core/functions/Base/fn_distance.sqf
@@ -424,7 +424,7 @@ do
         _teamplayer = units teamPlayer select {
             private _veh = vehicle _x;
             _x getVariable ["spawner", false] and _x == effectiveCommander _veh
-            and (_veh == _x or {!(_veh isKindOf "Plane" and speed _veh > 100)})
+            and (_veh == _x or {!(_veh isKindOf "Plane" and (!isTouchingGround _veh or speed _veh > 80))})
         };
         // Add in rebel-controlled UAVs
         _teamplayer append (allUnitsUAV select { side group _x == teamPlayer });

--- a/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
@@ -144,7 +144,7 @@ if (_side == Invaders or _side == Occupants) then
 
 		// Add 1/3 cost to recent casualties list on server
 		private _vehCost = A3A_vehicleResourceCosts getOrDefault [typeof _veh, 0];
-		[_veh getVariable "ownerSide", getPos _veh, _vehCost/3] remoteExec ["A3A_fnc_addRecentDamage", 2];
+		[_veh getVariable "ownerSide", getPos _veh, _vehCost/3, _source] remoteExec ["A3A_fnc_addRecentDamage", 2];
 
 		// Attempt to call for support if there's a crew. Assume local, should be true
 		if !(isNull group _veh) then { [group _veh, _source] spawn A3A_fnc_callForSupport };

--- a/A3A/addons/core/functions/CREATE/fn_availableBasesAir.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_availableBasesAir.sqf
@@ -27,7 +27,8 @@ private _weights = [];
     if (count (garrison getVariable [_x,[]]) < 16) then {continue};
 
     _freeAirports pushBack _x;
-    _weights pushBack (1 / (markerPos _x distance2D _targPos)^2);
+    private _effDist = abs ((markerPos _x distance2D _targPos) - 5000);     // prefer mid-distance spawns
+    _weights pushBack (1 / _effDist^2);
 } forEach airportsX;
 
 // Carrier/air corridor is always available

--- a/A3A/addons/core/functions/CREATE/fn_vehKilledOrCaptured.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_vehKilledOrCaptured.sqf
@@ -5,11 +5,12 @@
 	Params:
 	1. Object: Vehicle object
 	2. Side: Side of unit that captured or destroyed the vehicle
-	2. Bool (default false): True if captured, else destroyed
+	3. Bool (default false): True if captured, else destroyed
+	4. Object (default objNull): Killer vehicle. Used for passthrough to reaction functions
 */
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
-params ["_veh", "_sideEnemy", ["_captured", false]];
+params ["_veh", "_sideEnemy", ["_captured", false], ["_killer", objNull]];
 
 private _type = typeof _veh;
 private _side = _veh getVariable ["ownerSide", teamPlayer];			// default because Zeus
@@ -38,7 +39,7 @@ if ((_side == Occupants or _side == Invaders) and _vehCost > 0) then
 		// Vehicle not pre-resourced, deplete both pools
 		[-_vehCost, _side, "legacy"] remoteExecCall ["A3A_fnc_addEnemyResources", 2];
 	};
-	[_side, getPos _veh, 2*_vehCost/3] remoteExec ["A3A_fnc_addRecentDamage", 2];		// other third applied in HandleDamage
+	[_side, getPos _veh, 2*_vehCost/3, _killer] remoteExec ["A3A_fnc_addRecentDamage", 2];		// other third applied in HandleDamage
 
 	if (_sideEnemy != teamPlayer) exitWith {};
 

--- a/A3A/addons/core/functions/OrgPlayers/fn_playerLeash.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_playerLeash.sqf
@@ -42,7 +42,7 @@ while {!([player] call A3A_fnc_isMember) || _debugMode} do {
     private _withinLeash = switch (true) do {
         case (!isNil "A3A_FFPun_Jailed" && {(getPlayerUID player) in A3A_FFPun_Jailed}): { true };
         case (player == theBoss): { true };             // covered in playerLeashCheckPosition, but shortcut
-        case (vehicle player isKindOf "Plane" and {speed vehicle player > 270}): { true };          // no air spawning check, distance.sqf + margin
+        case (vehicle player isKindOf "Plane" and {speed vehicle player > 120}): { true };          // no air spawning check, distance.sqf + margin
         // Add leash exemptions here.
         default { [getPosATL player,_nearestLeashCentre] call A3A_fnc_playerLeashCheckPosition };
     };

--- a/A3A/addons/core/functions/OrgPlayers/fn_playerLeash.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_playerLeash.sqf
@@ -42,6 +42,7 @@ while {!([player] call A3A_fnc_isMember) || _debugMode} do {
     private _withinLeash = switch (true) do {
         case (!isNil "A3A_FFPun_Jailed" && {(getPlayerUID player) in A3A_FFPun_Jailed}): { true };
         case (player == theBoss): { true };             // covered in playerLeashCheckPosition, but shortcut
+        case (vehicle player isKindOf "Plane" and {speed vehicle player > 270}): { true };          // no air spawning check, distance.sqf + margin
         // Add leash exemptions here.
         default { [getPosATL player,_nearestLeashCentre] call A3A_fnc_playerLeashCheckPosition };
     };

--- a/A3A/addons/core/functions/OrgPlayers/fn_playerLeash.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_playerLeash.sqf
@@ -39,10 +39,11 @@ if (memberDistance <= 0 || !membershipEnabled) exitWith {};
 // Membership is rechecked in the case that a temporary membership is granted.
 while {!([player] call A3A_fnc_isMember) || _debugMode} do {
     private _nearestLeashCentre = getPosATL player;  // Only 2D pos is evaluated. Default to player position when no members or ff punishment is the exemption.
+    private _veh = vehicle player;
     private _withinLeash = switch (true) do {
         case (!isNil "A3A_FFPun_Jailed" && {(getPlayerUID player) in A3A_FFPun_Jailed}): { true };
         case (player == theBoss): { true };             // covered in playerLeashCheckPosition, but shortcut
-        case (vehicle player isKindOf "Plane" and {speed vehicle player > 120}): { true };          // no air spawning check, distance.sqf + margin
+        case (_veh isKindOf "Plane" and {!isTouchingGround _veh or speed _veh > 100}): { true };          // no air spawning check, distance.sqf + margin
         // Add leash exemptions here.
         default { [getPosATL player,_nearestLeashCentre] call A3A_fnc_playerLeashCheckPosition };
     };

--- a/A3A/addons/core/functions/Supports/fn_SUP_ASF.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_ASF.sqf
@@ -28,7 +28,7 @@ private _faction = Faction(_side);
 private _vehType = selectRandom (_faction get "vehiclesPlanesAA");
 
 private _aggro = if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
-if (_delay < 0) then { _delay = (0.5 + random 1) * (300 - 15*tierWar - 1*_aggro) };
+if (_delay < 0) then { _delay = (0.5 + random 1) * (280 - 1*_aggro) };
 
 private _targArray = [];
 if (_target isEqualType objNull and {!isNull _target}) then {

--- a/A3A/addons/core/functions/Supports/fn_SUP_ASF.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_ASF.sqf
@@ -28,7 +28,7 @@ private _faction = Faction(_side);
 private _vehType = selectRandom (_faction get "vehiclesPlanesAA");
 
 private _aggro = if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
-if (_delay < 0) then { _delay = (0.5 + random 1) * (280 - 1*_aggro) };
+if (_delay < 0) then { _delay = (0.5 + random 1) * (100 - _aggro + 18*A3A_enemyResponseTime) };
 
 private _targArray = [];
 if (_target isEqualType objNull and {!isNull _target}) then {

--- a/A3A/addons/core/functions/Supports/fn_SUP_CAS.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_CAS.sqf
@@ -28,7 +28,7 @@ private _faction = Faction(_side);
 private _vehType = selectRandom (_faction get "vehiclesPlanesCAS");
 
 private _aggro = if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
-if (_delay < 0) then { _delay = (0.5 + random 1) * (300 - 15*tierWar - 1*_aggro) };
+if (_delay < 0) then { _delay = (0.5 + random 1) * (280 - 1*_aggro) };
 
 private _targArray = [];
 if (_target isEqualType objNull and {!isNull _target}) then {

--- a/A3A/addons/core/functions/Supports/fn_SUP_CAS.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_CAS.sqf
@@ -28,7 +28,7 @@ private _faction = Faction(_side);
 private _vehType = selectRandom (_faction get "vehiclesPlanesCAS");
 
 private _aggro = if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
-if (_delay < 0) then { _delay = (0.5 + random 1) * (280 - 1*_aggro) };
+if (_delay < 0) then { _delay = (0.5 + random 1) * (100 - _aggro + 18*A3A_enemyResponseTime) };
 
 private _targArray = [];
 if (_target isEqualType objNull and {!isNull _target}) then {

--- a/A3A/addons/core/functions/Supports/fn_SUP_SAM.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_SAM.sqf
@@ -54,7 +54,7 @@ _group deleteGroupWhenEmpty true;
 
 
 private _aggro = if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
-if (_delay < 0) then { _delay = (0.5 + random 1) * (320 - 1*_aggro) };
+if (_delay < 0) then { _delay = (0.5 + random 1) * (100 - _aggro + 22*A3A_enemyResponseTime) };
 
 private _targArray = [];
 if (_target isEqualType objNull and {!isNull _target}) then {

--- a/A3A/addons/core/functions/Supports/fn_SUP_SAM.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_SAM.sqf
@@ -54,7 +54,7 @@ _group deleteGroupWhenEmpty true;
 
 
 private _aggro = if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
-if (_delay < 0) then { _delay = (0.5 + random 1) * (350 - 15*tierWar - 1*_aggro) };
+if (_delay < 0) then { _delay = (0.5 + random 1) * (320 - 1*_aggro) };
 
 private _targArray = [];
 if (_target isEqualType objNull and {!isNull _target}) then {

--- a/A3A/addons/core/functions/Supports/fn_SUP_SAMAvailable.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_SAMAvailable.sqf
@@ -17,6 +17,11 @@ params ["_target", "_side", "_maxSpend", "_availTypes"];
 
 if !(_target isKindOf "Air") exitWith { 0 };     // can't hit anything except air
 
-// Should limit to certain templates?
+private _targThreat = A3A_vehicleResourceCosts getOrDefault [typeOf _target, 0];
+_targThreat = _targThreat + (_target getVariable ["A3A_airKills", 0]);
 
-1;          // maybe set higher, especially if it's fixed-wing aircraft?
+// Avoid using SAMs against low-threat targets unless it's a low air faction
+private _lowAir = Faction(_side) getOrDefault ["attributeLowAir", false];
+if (_lowAir) then { _targThreat = _targThreat - 150 };
+
+_targThreat / 500;

--- a/A3A/addons/core/functions/Supports/fn_SUP_SAMAvailable.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_SAMAvailable.sqf
@@ -22,6 +22,6 @@ _targThreat = _targThreat + (_target getVariable ["A3A_airKills", 0]);
 
 // Avoid using SAMs against low-threat targets unless it's a low air faction
 private _lowAir = Faction(_side) getOrDefault ["attributeLowAir", false];
-if (_lowAir) then { _targThreat = _targThreat - 150 };
+if (!_lowAir) then { _targThreat = _targThreat - 150 };
 
 _targThreat / 500;

--- a/A3A/addons/core/functions/Supports/fn_initSupports.sqf
+++ b/A3A/addons/core/functions/Supports/fn_initSupports.sqf
@@ -41,7 +41,7 @@ private _initData = [
     ["QRFLAND",       "TROOPS", 1.0, 1.4,   0,   0,  "", ""],
     ["QRFAIR",        "TROOPS", 0.5, 0.1,   0,   0,  "", ""],
     ["CARPETBOMBS",     "AREA", 0.5, 0.1, 200,   0, "u", ""],                            // balanced against airstrikes
-    ["SAM",           "TARGET", 1.0, 1.0,   0, 100, "u", ""],                             // balanced against ASF
+    ["SAM",           "TARGET", 1.0, 1.0,   0, 100,  "", ""],                             // balanced against ASF
     ["ORBITALSTRIKE",   "AREA", 0.2, 0.0, 300,   0, "f", ""]
 //    ["GUNSHIP",    ["AREA",   0.2,  50,   0]],                 // uh. Does AREA work for this? Only lasts 5 minutes so maybe...
 ];

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -258,7 +258,7 @@ addMissionEventHandler ["EntityKilled", {
 
     if !(isNil {_victim getVariable "ownerSide"}) then {
         // Antistasi-created vehicle
-        [_victim, _killerSide, false] call A3A_fnc_vehKilledOrCaptured;
+        [_victim, _killerSide, false, _killer] call A3A_fnc_vehKilledOrCaptured;
         [_victim] spawn A3A_fnc_postmortem;
     };
 }];

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -128,7 +128,7 @@ A3A_recentDamageInv = [];
 // Balance params updated by aggressionUpdateLoop
 A3A_balancePlayerScale = 1;					// Important due to load/save scaling to 1 playerScale
 A3A_balanceVehicleCost = 110;
-A3A_balanceResourceRate = A3A_balancePlayerScale * A3A_balanceVehicleCost;
+A3A_balanceResourceRate = A3A_balancePlayerScale * ([A3A_balanceVehicleCost, 140] select (gameMode == 1));
 
 // Current resources, overwritten by saved game
 A3A_resourcesDefenceOcc = A3A_balanceResourceRate * 3;													// 30% of max


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Wrote a semi-proper system for support system responses against air vehicles. Previously, any airspace violation or damage-related support call against an air vehicle would automatically draw responses, until a cap was reached. The new system also takes account of base vehicle threat, vehicle activity (both damage and airspace, cumulative), supports already called against that vehicle and available resources. Starved factions need serious provocation to send a response to air threats, although it should always happen eventually.

Other changes:
- War tier scaling removed for CAS/ASF/SAM response times. Should lead to longer response times overall. Feels maybe too long to me, but we'll see.
- Adjusted airfield choice to prefer airfields ~5km away over very close ones. Should reduce cases of air vehicles (esp CAS & ASF) spawning within firing range.
- Moved SAMs out of unfair supports. Usage is now scaled so that they're much more likely to be used against high-threat air units, eg. those that have already shot down multiple aircraft.
- General change to remove enemy war tier resource income scaling for reb vs occ vs inv. Seems that the occ vs inv penalty is easily enough to weaken the enemy factions in the early game. This should help reduce issues with occ vs inv enemies being overly weak in the early game, although I'm not sure that it's enough.

### Please specify which Issue this PR Resolves.
closes #3246

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

I'm not good enough at using air vehicles to adequately test air responses.
