### PR TITLE
Fix breaking error in citySupportChange type-safety checks

### DIFF
--- a/A3A/addons/core/functions/Base/fn_citySupportChange.sqf
+++ b/A3A/addons/core/functions/Base/fn_citySupportChange.sqf
@@ -8,7 +8,7 @@ cityIsSupportChanging = true;
 params [["_changeGov",""], ["_changeReb",""], ["_pos","",["",[]]], ["_scaled", true], ["_isRadio", false]]; // nil protection
 if !(_changeGov isEqualType 0) exitWith {Error("The first parameter, the government support, must be a number");};
 if !(_changeReb isEqualType 0) exitWith {Error("The second parameter, the rebel support, must be a number");};
-if (_pos == "") exitWith {Error("The third parameter, the position, must be a string (city name) or array (coordinates)");};
+if (_pos isEqualTo "") exitWith {Error("The third parameter, the position, must be a string (city name) or array (coordinates)");};
 
 private _city = if (_pos isEqualType "") then {_pos} else {[citiesX, _pos] call BIS_fnc_nearestPosition};
 private _cityData = server getVariable _city;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The safety checks added to citySupportChange for command line usage currently break when a position is used as input to citySupportChange. This PR fixes it.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Go into a town and steal a car.