### PR TITLE
Refugee mission timer fix

### DIFF
--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -5318,7 +5318,7 @@
         <Czech>Skupina pašeráků byla zatčena v %1 a mají být posláni do vězení. Jděte tam a osvoboďte je, aby se připojili k naší věci. Udělejte to před %2.</Czech>
       </Key>
       <Key ID="STR_A3A_fn_mission_res_refu_text2">
-        <Original>A group of %3 supporters are hidden in %1 awaiting for evacuation. We have to find them before %2 does. If not, there will be a certain death for them. Bring them back to HQ.</Original>
+        <Original>A group of %3 supporters are hidden in %1 awaiting for evacuation. We have to find them before %2 does. If not, there will be a certain death for them. Bring them back to HQ before %4.</Original>
         <Italian>Un gruppo di sostenitori %3 sono nascosti a %1 in attesa di essere evacuati. Dobbiamo trovarli prima che lo faccia %2. Se non ci riusciremo verranno sicuramente giustiziati. Portali al QG.</Italian>
         <Spanish>Un grupo de seguidores de %3 están escondidos en %1 esperando una evacuación. Tenemos que encontrares antes de que %2 lo haga. De lo contrario, su muerte está asegurada. Traedlos  de vuelta al CG.</Spanish>
         <French>Un groupe de %3 partisans sont cachés à %1 et attendent une evacuation. Nous devons les trouver avant que %2 ne le fasse. Sinon leur mort est certaine. Ramenez les au QG.</French>

--- a/A3A/addons/core/functions/Missions/fn_RES_Refugees.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RES_Refugees.sqf
@@ -41,7 +41,7 @@ _displayTime = [_dateLimit] call A3A_fnc_dateToTimeString;//Converts the time po
 _sideX = if (sidesX getVariable [_markerX,sideUnknown] == Occupants) then {Occupants} else {Invaders};
 private _faction = Faction(_sideX);
 _textX = if (_sideX == Occupants) then {format [localize "STR_A3A_fn_mission_res_refu_text1",_nameDest,_displayTime]} 
-else {format [localize "STR_A3A_fn_mission_res_refu_text2",_nameDest,FactionGet(inv,"name"),FactionGet(reb,"name")]};
+else {format [localize "STR_A3A_fn_mission_res_refu_text2",_nameDest,FactionGet(inv,"name"),FactionGet(reb,"name"),_displayTime]};
 _posTsk = if (_sideX == Occupants) then {(position _houseX) getPos [random 100, random 360]} else {position _houseX};
 
 private _taskId = "RES" + str A3A_taskCount;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Added a missing timer element to the description of the Refugees Evac description.

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
`[["Molos"],"A3A_fnc_RES_Refugees"] remoteExec ["A3A_fnc_scheduler",2]` on Altis
