### PR TITLE
Parachutes in airbase crates

### DIFF
--- a/A3A/addons/core/Templates/Templates/FactionDefaults/RebelDefaults.sqf
+++ b/A3A/addons/core/Templates/Templates/FactionDefaults/RebelDefaults.sqf
@@ -8,7 +8,7 @@
 ["toolKits", ["ToolKit"]] call _fnc_saveToTemplate;  // Relies on autodetection.
 ["itemMaps", ["ItemMap"]] call _fnc_saveToTemplate;  // Relies on autodetection.
 ["diveGear", ["U_I_Wetsuit", "V_RebreatherIA", "G_Diving"]] call _fnc_saveToTemplate;
-["flyGear", ["U_I_pilotCoveralls"]] call _fnc_saveToTemplate;
+["flyGear", ["U_I_pilotCoveralls","B_Parachute"]] call _fnc_saveToTemplate;
 
 ["surrenderCrate", "Box_IND_Wps_F"] call _fnc_saveToTemplate;
 

--- a/A3A/addons/core/Templates/Templates/GM/GM_Reb.sqf
+++ b/A3A/addons/core/Templates/Templates/GM/GM_Reb.sqf
@@ -17,7 +17,7 @@
 ["mediKits", ["gm_gc_army_medbox","gm_ge_army_medkit_80"]] call _fnc_saveToTemplate;  // Relies on autodetection. However, item is tested for for help and reviving.
 ["toolKits", ["gm_repairkit_01"]] call _fnc_saveToTemplate;  // Relies on autodetection.
 
-["flyGear", ["gm_ge_uniform_pilot_commando_blk", "gm_ge_uniform_pilot_commando_gry", "gm_ge_uniform_pilot_commando_oli", "gm_ge_uniform_pilot_commando_rolled_blk", "gm_ge_uniform_pilot_commando_rolled_gry", "gm_ge_uniform_pilot_commando_rolled_oli"]] call _fnc_saveToTemplate;
+["flyGear", ["gm_ge_uniform_pilot_commando_blk", "gm_ge_uniform_pilot_commando_gry", "gm_ge_uniform_pilot_commando_oli", "gm_ge_uniform_pilot_commando_rolled_blk", "gm_ge_uniform_pilot_commando_rolled_gry", "gm_ge_uniform_pilot_commando_rolled_oli","gm_backpack_t10_parachute"]] call _fnc_saveToTemplate;
 
 //////////////////////////
 //       Vehicles       //

--- a/A3A/addons/core/Templates/Templates/VN/VN_Reb_POF.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_Reb_POF.sqf
@@ -19,7 +19,7 @@
 ["itemMaps", ["vn_b_item_map"]] call _fnc_saveToTemplate;  // Relies on autodetection.
 
 ["diveGear", ["vn_b_uniform_seal_09_01", "vn_b_acc_seal_01", "vn_b_vest_seal_01"]] call _fnc_saveToTemplate;
-["flyGear", ["vn_b_uniform_heli_01_01"]] call _fnc_saveToTemplate;
+["flyGear", ["vn_b_uniform_heli_01_01","vn_i_pack_parachute_01"]] call _fnc_saveToTemplate;
 
 ["surrenderCrate", "vn_o_ammobox_04"] call _fnc_saveToTemplate;
 

--- a/A3A/addons/core/functions/CREATE/fn_createAIAirbase.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIAirbase.sqf
@@ -258,7 +258,11 @@ private _ammoBox = if (garrison getVariable [_markerX + "_lootCD", 0] == 0) then
 	[_ammoBox] spawn {
 		sleep 1;    //make sure fillLootCrate finished clearing the crate
 		{
-			_this#0 addItemCargoGlobal [_x, round random [5,15,15]];
+			if (getText(configFile >> "CfgVehicles" >> _x >> "vehicleClass") isEqualTo "Backpacks") then {
+				_this#0 addBackpackCargoGlobal [_x, round random [5,15,15]];
+			} else {
+				_this#0 addItemCargoGlobal [_x, round random [5,15,15]];
+			};
 		} forEach (A3A_faction_reb get "flyGear");
 	};
 	_ammoBox;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Information:
Faction dependent parachutes will now spawn in airbase crates to make them more reliable to unlock. Added appropriate parachutes to every appropriate template with `flyGear`.

### Please specify which Issue this PR Resolves.
closes [this suggestion on Discord](https://discord.com/channels/449481990513754112/566329285024022567/1240311553685721210)

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: Spawn any airbase crate with an appropriate faction, so not WW2 factions mostly