### PR TITLE
Fix lootToCrate issues with IFA gear

### DIFF
--- a/A3A/addons/core/functions/LTC/fn_lootToCrate.sqf
+++ b/A3A/addons/core/functions/LTC/fn_lootToCrate.sqf
@@ -49,12 +49,11 @@ _lootBodies = {
 
     private _gear = [[],[],[],[]];//weapons, mags, items, backpacks
     //build list of all gear
-    _weapons = [handgunWeapon _unit];
-    _attachments = handgunItems _unit;
 
-    _weapons = _weapons select {!(_x isEqualTo "")};
+    _weapons = weapons _unit;
     {(_gear#0) pushBack (_x call BIS_fnc_baseWeapon)} forEach _weapons;
-    _attachments = _attachments select {!(_x isEqualTo "")};
+
+    _attachments = primaryWeaponItems _unit + secondaryWeaponItems _unit + handgunItems _unit - [""];
     (_gear#2) append _attachments;
 
     (_gear#2) append assignedItems _unit;
@@ -87,7 +86,7 @@ _lootBodies = {
     };
 
     if !(backpack _unit isEqualTo "") then {
-        (_gear#3) pushBack ((backpack _unit) call BIS_fnc_basicBackpack);
+        (_gear#3) pushBack ((backpack _unit) call A3A_fnc_basicBackpack);
         removeBackpackGlobal _unit;
     };
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed a couple of issues with lootToCrate and IFA gear:
1. MP38s would disappear when looted. lootToCrate only considered handguns as possible weapons on corpses.
2. BIS_fnc_basicBackpack breaks on at least one radio backpack. The workaround in A3A_fnc_basicBackpack seems fine.

### Please specify which Issue this PR Resolves.
closes #3262

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Load IFA AIO. Zeus in a radioman and a sapper from the Fallschirmjager faction (can use vanilla factions). Kill them, loot them with a crate.
