### PR TITLE
Improve getArtilleryRanges, fix IFA mortar case

### DIFF
--- a/A3A/addons/core/functions/Supports/fn_getArtilleryRanges.sqf
+++ b/A3A/addons/core/functions/Supports/fn_getArtilleryRanges.sqf
@@ -20,6 +20,10 @@ FIX_LINE_NUMBERS()
 
 params ["_vehType", "_shellType"];
 
+private _hmkey = _vehType + "_" + _shellType;
+if (isNil "A3A_artyRangeHM") then { A3A_artyRangeHM = createHashMap };
+if (_hmkey in A3A_artyRangeHM) exitWith { A3A_artyRangeHM get _hmkey };
+
 private _turretCfg = call {
     private _allTurrets = configProperties [configFile >> "CfgVehicles" >> _vehType >> "Turrets"];
     private _idx = _allTurrets findIf { getNumber (_x >> "elevationMode") != 0 };       // no idea if this is a valid check
@@ -35,6 +39,9 @@ private _weapon = getText (configfile >> "CfgMagazines" >> _shellType >> "pylonW
 if (_weapon == "") then { _weapon = getArray (_turretCfg >> "Weapons") # 0 };
 private _weaponCfg = configFile >> "CfgWeapons" >> _weapon;
 
+// Assume that there's no speed override on weapon, probably true for arty
+private _initSpeed = getNumber (configFile >> "CfgMagazines" >> _shellType >> "initSpeed");
+
 // Find min and max charges
 private _minCharge = 1;
 private _maxCharge = 0;
@@ -48,17 +55,30 @@ private _maxCharge = 0;
 
 if (_maxCharge == 0) then { Error_1("Artillery charge lookup failed for %1", _vehType); _minCharge = 1; _maxCharge = 1; };
 
-// Assume that there's no speed override on weapon, probably true for arty
-private _initSpeed = getNumber (configFile >> "CfgMagazines" >> _shellType >> "initSpeed");
+// Now for the horror. There should be a saner way to do this but I couldn't find one.
+private _baseElev = 45;
+isNil {
+    private _veh = createVehicleLocal [_vehType, [0,0,-1000], [], 0, "NONE"];
+    _veh enableSimulation false;
+    private _gunBeg = _veh selectionPosition getText (_turretCfg >> "gunBeg");
+    private _gunEnd = _veh selectionPosition getText (_turretCfg >> "gunEnd");
+    // Arma bug? should be translated to world space (slightly different for LIB_M2_60) but isn't.
+    private _gunDir = _gunEnd vectorFromTo _gunBeg;
+    _baseElev = asin (_gunDir#2) - getNumber (_turretCfg >> "initElev");
+    deleteVehicle _veh;
+};
+
+// Artillery engine doesn't seem to consider minElev as a short-range option
+private _maxElev = _baseElev + getNumber (_turretCfg >> "maxElev");
+private _minElev = _baseElev + getNumber (_turretCfg >> "minElev");
+private _longElev = [45, _minElev] select (_minElev > 45);
+
 // Simple formula works because Arma doesn't calculate air resistance for artillery
-private _maxRange = (_initSpeed * _maxCharge)^2 * sin (2*45) / 9.807;
+private _maxRange = (_initSpeed * _maxCharge)^2 * sin (2*_longElev) / 9.807;
+private _minRange = (_initSpeed * _minCharge)^2 * sin (2*_maxElev) / 9.807;
 
-// TODO: Figure out max elevation. Seems to be relative to model default. Might be impossible.
-//private _maxElev = getNumber (_turretCfg >> "maxElev");
-//private _minRange = (_minCharge * _initSpeed)^2 * sin (2*_maxElev) / 9.807;
-
-// Whatever, life's too short for this shit
-private _minRange = [900, 100] select (_vehType isKindOf "StaticMortar");
 //private _reloadTime = getNumber (_weaponCfg >> "reloadTime");
 
-[_minRange+100, _maxRange-100];     // make sure we can spread shots
+private _result = [200 max (_minRange + 100), _maxRange - 100];          // make sure we can spread shots
+A3A_artyRangeHM set [_hmkey, _result];
+_result;


### PR DESCRIPTION

## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?

- Improve artillery turret detection. I think they worked anyway with the fallback method, but this should throw fewer errors.
- Search fire modes properly in case the maximum charge size isn't 1. Apparently this was an issue with the IFA mortars.
- Remove incorrect attempt at determining minimum range. maxElev and minElev aren't easily usable because they seem to be relative to the default position in the model, which can't be obtained easily through code. Not worth the trouble so I set fixed minimums instead. Arty one might need a bump.

### Please specify which Issue this PR Resolves.
closes #3263

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Should probably recheck some CUP/RHS/3CB artillery. I only did vanilla and IFA, although the methods should work everywhere.

### How can the changes be tested?
Spawn artillery unit as zeus. Enter as gunner and check the ranges in the artillery computer. Run this and compare the max range. Should be pretty close (note intentional 100m margin):
`[typeof vehicle player, magazines vehicle player # 0] call A3A_fnc_getArtilleryRanges`
