### PR TITLE
Prevent concurrent major attacks, and add a planning cost

### DIFF
--- a/A3A/addons/core/functions/Base/fn_aggressionUpdateLoop.sqf
+++ b/A3A/addons/core/functions/Base/fn_aggressionUpdateLoop.sqf
@@ -60,7 +60,7 @@ while {true} do
     {
         private _aggroMul = [1.0 + aggressionOccupants/200, 0.5 + aggressionOccupants/200] select (gameMode != 1);
         private _resRateDef = _aggroMul * A3A_balanceResourceRate / 10;
-        private _resRateAtk = _aggroMul * A3A_balanceResourceRate * (A3A_enemyAttackMul / 10) / 15;       // Attack rate is 2/3 of defence
+        private _resRateAtk = _aggroMul * A3A_balanceResourceRate * (A3A_enemyAttackMul / 10) / 12;       // Attack rate is a bit lower than defence
 
         private _noAirport = -1 == airportsX findIf { sidesX getVariable _x == Occupants };
         if (_noAirport) then { _resRateDef = _resRateDef * 0.6; _resRateAtk = _resRateAtk * 0.6 };

--- a/A3A/addons/core/functions/Base/fn_chooseAttack.sqf
+++ b/A3A/addons/core/functions/Base/fn_chooseAttack.sqf
@@ -92,11 +92,14 @@ if (_targetMrk in citiesX) exitWith {
     if (_side == Invaders) then {
         // Punishment, unsimulated
         Info_2("Starting punishment mission from %1 to %2", _originMrk, _targetMrk);
+        [-400, _side, "attack"] call A3A_fnc_addEnemyResources;
+        bigAttackInProgress = true; publicVariable "bigAttackInProgress";
         [_targetMrk, _originMrk] spawn A3A_fnc_invaderPunish;
     } else {
         // Supply convoy, unsimulated
         // Do we allow these even if there's already a convoy? Probably not harmful.
         Info_2("Sending supply convoy from %1 to %2", _originMrk, _targetMrk);
+        [-200, _side, "attack"] call A3A_fnc_addEnemyResources;
         [[_targetMrk, _originMrk, "Supplies", "attack"],"A3A_fnc_convoy"] call A3A_fnc_scheduler;
     };
     true;
@@ -104,6 +107,8 @@ if (_targetMrk in citiesX) exitWith {
 
 if (_targetMrk == "Synd_HQ") exitWith {
     Info_2("Starting HQ attack from %1", _originMrk);
+    [-400, _side, "attack"] call A3A_fnc_addEnemyResources;
+    bigAttackInProgress = true; publicVariable "bigAttackInProgress";
     [_side, _originMrk] spawn A3A_fnc_attackHQ;
     true;
 };
@@ -114,6 +119,8 @@ if((spawner getVariable _targetMrk) != 2 || (sidesX getVariable _targetMrk) == t
     // Sending real attack, execute the fight
     private _waves = round (1 + random 1 + _localThreat / 1000);         // TODO: magic number
     Info_3("Starting waved attack with %1 waves from %2 to %3", _waves, _originMrk, _targetMrk);
+    [-400, _side, "attack"] call A3A_fnc_addEnemyResources;
+    bigAttackInProgress = true; publicVariable "bigAttackInProgress";
     [_targetMrk, _originMrk, _waves] spawn A3A_fnc_wavedAttack;
     true;
 }
@@ -128,7 +135,7 @@ else
 
     // land units are a bit cheaper, attack is generally more expensive than defence
     private _atkResources = _defResources + _localThreat + _flyoverThreat;
-    _atkResources = _atkResources * (0.75 + 2^(-_countLandAttackBases));
+    _atkResources = 400 + _atkResources * (0.75 + 2^(-_countLandAttackBases));
     [-_atkResources, _side, "attack"] call A3A_fnc_addEnemyResources;
 
     // Flip marker and add garrison once flipped

--- a/A3A/addons/core/functions/CREATE/fn_attackHQ.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_attackHQ.sqf
@@ -20,7 +20,6 @@ params ["_side", "_airbase", "_delay"];			// Side is now specified
 private _targPos = markerPos "Synd_HQ";
 private _faction = Faction(_side);
 
-bigAttackInProgress = true; publicVariable "bigAttackInProgress";
 forcedSpawn pushBack "Synd_HQ"; publicVariable "forcedSpawn";
 
 private _taskId = "DEF_HQ" + str A3A_taskCount;

--- a/A3A/addons/core/functions/CREATE/fn_invaderPunish.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_invaderPunish.sqf
@@ -19,8 +19,6 @@ params ["_mrkDest", "_mrkOrigin", "_delay"];
 
 ServerInfo_2("Launching CSAT Punishment Against %1 from %2", _mrkDest, _mrkOrigin);
 
-// Mostly to prevent fast travel
-bigAttackInProgress = true; publicVariable "bigAttackInProgress";
 forcedSpawn pushBack _mrkDest; publicVariable "forcedSpawn";
 
 private _posDest = getMarkerPos _mrkDest;

--- a/A3A/addons/core/functions/CREATE/fn_wavedAttack.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_wavedAttack.sqf
@@ -18,8 +18,6 @@ params ["_mrkDest", "_mrkOrigin", "_maxWaves"];
 
 Info_3("Creating waved attack against %1 from %2 with %3 waves", _mrkDest, _mrkOrigin, _maxWaves);
 
-// TODO: move this to chooseAttack?
-bigAttackInProgress = true; publicVariable "bigAttackInProgress";
 forcedSpawn pushBack _mrkDest; publicVariable "forcedSpawn";
 
 private _targpos = markerPos _mrkDest;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement
4. [X] Balance

### What have you changed and why?
Because the bigAttackInProgress flag was set in the individual major attack functions (which are spawned), it wasn't necessarily set before the invader flag check happened in aggressionUpdateLoop, so concurrent major attacks were possible, and the flag could then be cleared while a major attack was still running. This PR fixes it by moving the flag set to chooseAttack.

Also added a "planning cost" to attacks to reduce the spamming of cheap attacks, especially punishments (because the helis tend to escape intact, so the failure cost is basically a few squads of infantry) and early-game supply convoys. Attack resource income has been adjusted to compensate.

Not all code paths have been tested yet, because it's difficult to arrange many of the conditions. Verification mostly done by code-staring.

### Please specify which Issue this PR Resolves.
closes #3272

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Definitely needs an actual campaign run.
