### PR TITLE
Allow commanders to make custom HC squads

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -532,6 +532,7 @@ class CfgFunctions
             class buildMinefield {};
             class controlHCsquad {};
             class controlunit {};
+            class convertToSquad {};
             class dismissPlayerGroup {};
             class dismissSquad {};
             class enemyNearCheck {};

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -6953,6 +6953,15 @@
         <Russian>Контроль ИИ</Russian>
         <Chinesesimp>控制单位</Chinesesimp>
       </Key>
+      <Key ID="STR_A3A_fn_reinf_convSqd_title">
+        <Original>Convert To Squad</Original>
+      </Key>
+      <Key ID="STR_A3A_fn_reinf_convSqd_no_selected">
+        <Original>You need to select some valid units.</Original>
+      </Key>
+      <Key ID="STR_A3A_fn_reinf_convSqd_created">
+        <Original>Converted %1 squad members into high command group %2.</Original>
+      </Key>
       <Key ID="STR_A3A_fn_reinf_dismissPlayerGroup_GTFO">
         <Original>Get out of my sight you useless scum!</Original>
         <French>Hors de ma vue vermine!</French>
@@ -10909,6 +10918,12 @@
         <Czech>Vyčistí mrtvá těla, zahozenou výzbroj, zničené vozidla a podobné entity. Výrazně pomáhá s chodem klienta a servru, doporučuje se spustit alespoň jednou za hodinu.</Czech>
         <Turkish>Oyunda birçok şeyi temizler. Görevi dondurduğu için dikkatli kullanın</Turkish>
         <Chinesesimp>清理游戏中的一些东西。谨慎使用, 因为它可能导致任务卡死</Chinesesimp>
+      </Key>
+      <Key ID="STR_antistasi_dialogs_commander_comm_convSquad">
+        <Original>Convert to Squad</Original>
+      </Key>
+      <Key ID="STR_antistasi_dialogs_commander_comm_convSquad_tooltip">
+        <Original>Convert currently selected AI units to a high command squad.</Original>
       </Key>
       <Key ID="STR_antistasi_dialogs_commander_comm_faction_garage">
         <Original>Faction Garage</Original>

--- a/A3A/addons/core/dialogs.hpp
+++ b/A3A/addons/core/dialogs.hpp
@@ -1704,123 +1704,145 @@ class AI_management 		{
 		};
 	};
 };
+
 class commander_comm 		{
 	idd=-1;
 	movingenable=false;
 	class controls {
 		//Menu Structure
-		class 8slots_box: A3A_core_BattleMenuBOX
+		class 10slots_box: A3A_core_BattleMenuBOX
 		{
 			idc = -1;
 			text = $STR_antistasi_dialogs_generic_box_text;
 			x = 0.244979 * safezoneW + safezoneX;
-			y = 0.223941 * safezoneH + safezoneY;
+			y = 0.173941 * safezoneH + safezoneY;
 			w = 0.445038 * safezoneW;
-			h = 0.492103 * safezoneH;
+			h = 0.592103 * safezoneH;
 		};
-		class 8slots_frame: A3A_core_BattleMenuFrame
+		class 10slots_frame: A3A_core_BattleMenuFrame
 		{
 			idc = -1;
 			text = $STR_antistasi_dialogs_commander_comm;
 			x = 0.254979 * safezoneW + safezoneX;
-			y = 0.233941 * safezoneH + safezoneY;
+			y = 0.183941 * safezoneH + safezoneY;
 			w = 0.425038 * safezoneW;
-			h = 0.462103 * safezoneH;
+			h = 0.562103 * safezoneH;
 		};
-		class 8slots_Back: A3A_core_BattleMenuRedButton
+		class 10slots_Back: A3A_core_BattleMenuRedButton
 		{
 			idc = -1;
 			text = $STR_antistasi_dialogs_generic_button_back_text;
 			x = 0.61 * safezoneW + safezoneX;
-			y = 0.251941 * safezoneH + safezoneY;
-			w = 0.06 * safezoneW;
+			y = 0.201941 * safezoneH + safezoneY;
+			w = 0.06 * safezoneW;//0.175015
 			h = 0.05 * safezoneH;
 			action = "closeDialog 0;nul = createDialog ""radio_comm"";";
 		};
-		//Action Buttons
-		class 8slots_L1: A3A_core_BattleMenuRedButton
+		class 10slots_L1: A3A_core_BattleMenuRedButton
 		{
 			idc = -1;
 			text = $STR_antistasi_dialogs_commander_comm_recruit;
 			x = 0.272481 * safezoneW + safezoneX;
-			y = 0.317959 * safezoneH + safezoneY;
+			y = 0.267959 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			tooltip = $STR_antistasi_dialogs_commander_comm_recruit_tooltip;
 			action = "closeDialog 0;if (player == theBoss) then { [] spawn A3A_fnc_squadRecruit; } else {[""Recruit Squad"", ""Only Player Commander has access to this function.""] call A3A_fnc_customHint;};";
 		};
-		class 8slots_R1: A3A_core_BattleMenuRedButton
+		class 10slots_R1: A3A_core_BattleMenuRedButton
 		{
 			idc = -1;
 			text = $STR_antistasi_dialogs_commander_comm_air_support;
 			x = 0.482498 * safezoneW + safezoneX;
-			y = 0.317959 * safezoneH + safezoneY;
+			y = 0.267959 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			tooltip = $STR_antistasi_dialogs_commander_comm_air_support_tooltip;
 			action = "closeDialog 0;if (player == theBoss) then {_nul = createDialog ""carpet_bombing""} else {[""Air Support"", ""Only Player Commander has access to this function.""] call A3A_fnc_customHint;};";
 		};
-		class 8slots_L2: A3A_core_BattleMenuRedButton
+		class 10slots_L2: A3A_core_BattleMenuRedButton
+		{
+			idc = -1;
+			text = $STR_antistasi_dialogs_commander_comm_convSquad;
+			x = 0.272481 * safezoneW + safezoneX;
+			y = 0.365981 * safezoneH + safezoneY;
+			w = 0.175015 * safezoneW;
+			h = 0.0560125 * safezoneH;
+			tooltip = $STR_antistasi_dialogs_commander_comm_convSquad_tooltip;
+			action = "if (player == theBoss) then { closeDialog 0; [] spawn A3A_fnc_convertToSquad } else {[""Create Squad"", ""You're not the Commander!""] call A3A_fnc_customHint;};";
+		};
+		class 10slots_R2: A3A_core_BattleMenuRedButton
+		{
+			idc = -1;
+			text = "";
+			x = 0.482498 * safezoneW + safezoneX;
+			y = 0.365981 * safezoneH + safezoneY;
+			w = 0.175015 * safezoneW;
+			h = 0.0560125 * safezoneH;
+			tooltip = "";
+			action = "";
+		};
+		class 10slots_L3: A3A_core_BattleMenuRedButton
 		{
 			idc = -1;
 			text = $STR_antistasi_dialogs_commander_comm_roadblock;
 			x = 0.272481 * safezoneW + safezoneX;
-			y = 0.415981 * safezoneH + safezoneY;
+			y = 0.464003 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			tooltip = $STR_antistasi_dialogs_commander_comm_roadblock_tooltip;
 			action = "if (player == theBoss) then {closeDialog 0;[""create""] spawn A3A_fnc_outpostDialog} else {[""Outposts/Roadblocks"", ""You're not the Commander!""] call A3A_fnc_customHint;};";
 		};
-		class 8slots_R2: A3A_core_BattleMenuRedButton
+		class 10slots_R3: A3A_core_BattleMenuRedButton
 		{
 			idc = -1;
 			text = $STR_antistasi_dialogs_commander_comm_clean;
 			x = 0.482498 * safezoneW + safezoneX;
-			y = 0.415981 * safezoneH + safezoneY;
+			y = 0.464003 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			tooltip = $STR_antistasi_dialogs_commander_comm_clean_tooltip;
 			action = "if (player == theBoss) then {closedialog 0;[] remoteExec [""A3A_fnc_garbageCleaner"",2]} else {[""Garbage Cleaner"", ""Only Player Commander has access to this function.""] call A3A_fnc_customHint;};";
 		};
-		class 8slots_L3: A3A_core_BattleMenuRedButton
+		class 10slots_L4: A3A_core_BattleMenuRedButton
 		{
 			idc = -1;
 			text = $STR_antistasi_dialogs_commander_comm_roadblock_delete;
 			x = 0.272481 * safezoneW + safezoneX;
-			y = 0.514003 * safezoneH + safezoneY;
+			y = 0.562025 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			tooltip = $STR_antistasi_dialogs_commander_comm_roadblock_delete_tooltip;
 			action = "if (player == theBoss) then {closeDialog 0; [""delete""] spawn A3A_fnc_outpostDialog} else {[""Outposts/Roadblocks"", ""You're not the Commander!""] call A3A_fnc_customHint;};";
 		};
-		class 8slots_R3: A3A_core_BattleMenuRedButton
+		class 10slots_R4: A3A_core_BattleMenuRedButton
 		{
 			idc = -1;
 			text = "Arsenal Limits";		//$STR_antistasi_dialogs_commander_comm_faction_garage;
 			x = 0.482498 * safezoneW + safezoneX;
-			y = 0.514003 * safezoneH + safezoneY;
+			y = 0.562025 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			tooltip = "Manage arsenal limitations of guests";	//$STR_antistasi_dialogs_commander_comm_faction_garage_tooltip;
 			action = "if (player == theBoss) then {closeDialog 0; createDialog ""A3A_ArsenalLimitsDialog""} else {[""Arsenal limits"", ""Only commanders have access to this function""] call A3A_fnc_customHint}";
 		};
-		class 8slots_L4: A3A_core_BattleMenuRedButton
+		class 10slots_L5: A3A_core_BattleMenuRedButton
 		{
 			idc = -1;
 			text = $STR_antistasi_dialogs_commander_comm_resign;
 			x = 0.272481 * safezoneW + safezoneX;
-			y = 0.612025 * safezoneH + safezoneY;
+			y = 0.660047 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			tooltip = $STR_antistasi_dialogs_commander_comm_resign_tooltip;
 			action = "if (isMultiplayer) then {closedialog 0;[player, cursorTarget] remoteExec [""A3A_fnc_theBossToggleEligibility"", 2]} else {[""Resign Commander"", ""This feature is MP Only.""] call A3A_fnc_customHint;};";
 		};
-		class 8slots_R4: A3A_core_BattleMenuRedButton
+		class 10slots_R5: A3A_core_BattleMenuRedButton
 		{
 			idc = -1;
 			text = $STR_antistasi_dialogs_commander_comm_sell;
 			x = 0.482498 * safezoneW + safezoneX;
-			y = 0.612025 * safezoneH + safezoneY;
+			y = 0.660047 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
 			tooltip = $STR_antistasi_dialogs_commander_comm_sell_tooltip;

--- a/A3A/addons/core/functions/REINF/fn_convertToSquad.sqf
+++ b/A3A/addons/core/functions/REINF/fn_convertToSquad.sqf
@@ -1,0 +1,43 @@
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+
+
+private _titleStr = localize "STR_A3A_fn_reinf_convSqd_title";
+
+// reuse some addFIAsquadHC messages, should be fine
+if (player != theBoss) exitWith {[_titleStr, localize "STR_A3A_fn_reinf_addSqdHC_no_commander"] call A3A_fnc_customHint};
+if (markerAlpha respawnTeamPlayer == 0) exitWith {[_titleStr, localize "STR_A3A_fn_reinf_addSqdHC_no_movehq"] call A3A_fnc_customHint};
+if !([player] call A3A_fnc_hasRadio) exitWith {[_titleStr, localize "STR_A3A_fn_reinf_addSqdHC_no_radio"] call A3A_fnc_customHint};
+
+private _maxGroups = [6,10] select (player call A3A_fnc_isMember);
+if (count hcAllGroups player >= _maxGroups) exitWith {
+    [_titleStr, localize "STR_A3A_fn_reinf_addSqdHC_no_many"] call A3A_fnc_customHint;
+};
+
+private _bannedTypes = [FactionGet(reb,"unitCrew"), FactionGet(reb,"unitUnarmed"), FactionGet(reb,"unitPetros"), "unknown"];
+private _units = groupSelectedUnits player select { !isPlayer _x and !(_x getVariable ["unitType", "unknown"] in _bannedTypes) };
+if (_units isEqualTo []) exitWith {
+    [_titleStr, localize "STR_A3A_fn_reinf_convSqd_no_selected"] call A3A_fnc_customHint;
+};
+// apparently the units are unselected when you change command bar mode, so don't need to worry about that
+
+private _group = createGroup teamPlayer;
+_group setGroupIdGlobal ["Tm-" + str ({side (leader _x) == teamPlayer} count allGroups)];       // uh. whatever
+_units join _group;
+
+// Select a suitable leader for the squad
+private _types = _units apply {_x getVariable "unitType"};
+private _leaderIndex = _types find FactionGet(reb,"unitSL");            // not actually possible atm
+if (_leaderIndex == -1) then {
+    private _badLeaders = [FactionGet(reb,"unitMedic"), FactionGet(reb,"unitAA"), FactionGet(reb,"unitAT")];
+    _leaderIndex = _types findIf {!(_x in _badLeaders)};
+};
+if (_leaderIndex != -1) then { _group selectLeader _units#_leaderIndex };
+
+player hcSetGroup [_group];
+_group spawn A3A_fnc_attackDrillAI;
+
+private _successStr = format [localize "STR_A3A_fn_reinf_convSqd_created", count _units, groupId _group];
+[_titleStr, _successStr] call A3A_fnc_customHint;
+
+// todo: comment, allow commander to purchase AI with faction money

--- a/A3A/addons/core/functions/REINF/fn_reinfPlayer.sqf
+++ b/A3A/addons/core/functions/REINF/fn_reinfPlayer.sqf
@@ -10,17 +10,9 @@ if ([getPosATL player] call A3A_fnc_enemyNearCheck) exitWith {[_titleStr, locali
 
 if (player != leader group player) exitWith {[_titleStr, localize "STR_A3A_fn_reinf_reinfPlayer_no_lead"] call A3A_fnc_customHint;};
 
-private _hr = server getVariable "hr";
-
-if (_hr < 1) exitWith {[_titleStr, localize "STR_A3A_fn_reinf_reinfPlayer_no_hr"] call A3A_fnc_customHint;};
-private _typeUnit = _this select 0;
-private _costs = server getVariable _typeUnit;
-private _resourcesFIA = 0;
-if (!isMultiPlayer) then {_resourcesFIA = server getVariable "resourcesFIA"} else {_resourcesFIA = player getVariable "moneyX";};
-
-if (_costs > _resourcesFIA) exitWith {[_titleStr, format [localize "STR_A3A_fn_reinf_reinfPlayer_no_money",_costs]] call A3A_fnc_customHint;};
-
 if ((count units group player) + (count units stragglers) > 9) exitWith {[_titleStr, localize "STR_A3A_fn_reinf_reinfPlayer_no_full"] call A3A_fnc_customHint;};
+
+call A3A_fnc_fetchRebelGear;		// Fetch rebel gear from the server if we're out of date
 
 private _weaponHM = createHashMapFromArray [
 	[A3A_faction_reb get "unitSniper", "SniperRifles"],
@@ -30,19 +22,27 @@ private _weaponHM = createHashMapFromArray [
 	[A3A_faction_reb get "unitAA", "MissileLaunchersAA"],
 	[A3A_faction_reb get "unitAT", "MissileLaunchersAT"]];
 
+private _typeUnit = _this select 0;
 if (A3A_rebelGear getOrDefault [_weaponHM getOrDefault [_typeUnit, ""], false] isEqualTo []) exitWith {
 	[_titleStr, localize "STR_A3A_fn_reinf_reinfPlayer_no_weapons"] call A3A_fnc_customHint;
 };
 
+private _hr = server getVariable "hr";
+if (_hr < 1) exitWith {[_titleStr, localize "STR_A3A_fn_reinf_reinfPlayer_no_hr"] call A3A_fnc_customHint;};
+private _costs = server getVariable _typeUnit;
+
+private _resources = if (player == theBoss) then { server getVariable "resourcesFIA" } else { player getVariable "moneyX" };
+if (_costs > _resources) exitWith {[_titleStr, format [localize "STR_A3A_fn_reinf_reinfPlayer_no_money",_costs]] call A3A_fnc_customHint;};
+
 private _unit = [group player, _typeUnit, position player, [], 0, "NONE"] call A3A_fnc_createUnit;
 
-if (!isMultiPlayer) then {
-	_nul = [-1, - _costs] remoteExec ["A3A_fnc_resourcesFIA",2];
+if (player == theBoss) then {
+	[-1, -_costs] remoteExec ["A3A_fnc_resourcesFIA",2];
 } else {
-	_nul = [-1, 0] remoteExec ["A3A_fnc_resourcesFIA",2];
+	[-1, 0] remoteExec ["A3A_fnc_resourcesFIA",2];
 	[- _costs] call A3A_fnc_resourcesPlayer;
-	[_titleStr, localize "STR_A3A_fn_reinf_reinfPlayer_recruited"] call A3A_fnc_customHint;
 };
+[_titleStr, localize "STR_A3A_fn_reinf_reinfPlayer_recruited"] call A3A_fnc_customHint;
 
 [_unit] spawn A3A_fnc_FIAinit;
 _unit disableAI "AUTOCOMBAT";


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Added a commander dialog button to convert currently selected personal-squad members to a high command squad. This is mostly to make it easier to use vehicles with AI. Previously for a 2-man vehicle you needed a sniper team, while for a three-man vehicle you have to buy a team and murder one of them.

To make it less annoying to use, I also changed personal-squad recruiting to use faction rather than personal money for commanders, as with vehicle purchasing.  Maybe slightly controversial but it's probably fine.

While I was in there, I also fixed a bug where RPT errors could be thrown the first time a player attempted to purchase a unit. Consequence is that it might be delayed for a second or two. Not really noticeable.

I think I covered all the potential busted cases. It'll ignore players, petros and rescued hostages. All the normal restrictions to HC purchase are applied, including the squad count limit.

### Please specify which Issue this PR Resolves.
closes #2976

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Buy some units, hit the button on the commander UI.
