### PR TITLE
Fix incorrect config array specifier for diveParams

### DIFF
--- a/A3A/addons/core/Templates/AircraftLoadouts/IFA/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/IFA/config.cpp
@@ -25,13 +25,13 @@ class A3A {
                 loadout[] = {"LIB_1Rnd_SC50","LIB_1Rnd_SC50","LIB_1Rnd_SC500","LIB_1Rnd_SC50","LIB_1Rnd_SC50"};
                 mainGun[] = {"LIB_2xMG151_JU87"};
                 bombRacks[] = {"LIB_SC500_Bomb_Mount","LIB_SC50_Bomb_Mount"};
-                diveParams[] = {1200, 300, 110, 55, 15, [15, -2]};
+                diveParams[] = {1200, 300, 110, 55, 15, {15, -2}};
             };
             class LIB_Pe2 : baseCAS {
                 loadout[] = {"LIB_1Rnd_FAB250","LIB_1Rnd_FAB250","LIB_1Rnd_FAB250","LIB_1Rnd_FAB250"};
                 mainGun[] = {"LIB_UBK_PE2"};
                 bombRacks[] = {"LIB_FAB250_Bomb_Mount"};
-                diveParams[] = {1200, 300, 110, 55, 15, [12, 0]};
+                diveParams[] = {1200, 300, 110, 55, 15, {12, 0}};
             };
         };
         class CAPPlane

--- a/A3A/addons/core/Templates/AircraftLoadouts/SPE/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/SPE/config.cpp
@@ -25,14 +25,14 @@ class A3A {
                 loadout[] = {"SPE_250Rnd_MG151","SPE_250Rnd_MG151","SPE_400Rnd_MG131","SPE_400Rnd_MG131","SPE_1Rnd_SC50","SPE_1Rnd_SC50","SPE_1Rnd_SC500","SPE_1Rnd_SC50","SPE_1Rnd_SC50"};
                 mainGun[] = {"SPE_2xMG151"};
                 bombRacks[] = {"SPE_SC500_Bomb_Mount","SPE_SC50_Bomb_Mount"};
-                diveParams[] = {1200, 300, 110, 55, 15, [0, 0]};
+                diveParams[] = {1200, 300, 110, 55, 15, {0, 0}};
             };
             class SPE_P47 : baseCAS {
                 loadout[] = {"SPE_425rnd_M2_P47","SPE_425rnd_M2_P47","SPE_425rnd_M2_P47","SPE_425rnd_M2_P47","SPE_425rnd_M2_P47","SPE_425rnd_M2_P47","SPE_425rnd_M2_P47","SPE_425rnd_M2_P47","SPE_3Rnd_M8_P47","SPE_3Rnd_M8_P47","SPE_1Rnd_US_500lb","SPE_1Rnd_US_500lb","SPE_1Rnd_US_500lb"};
                 mainGun[] = {"SPE_8xM2_P47"};
                 rocketLauncher[] = {"SPE_M8_Launcher_P47"};
                 bombRacks[] = {"SPE_US_500lb_Bomb_Mount"};
-                diveParams[] = {1200, 350, 110, 55, 15, [3, 0]};
+                diveParams[] = {1200, 350, 110, 55, 15, {3, 0}};
             };
         };
         class CAPPlane


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The loadouts -> config PR used an incorrect array specifier for diveParams entries, causing dive bombing runs to fail. This PR fixes it.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
