### PR TITLE
Fix inconsistent parameter bug with createAttackForceLand

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_createAttackForceLand.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAttackForceLand.sqf
@@ -13,8 +13,8 @@ Arguments:
     <INTEGER> Total number of vehicles to create
     <INTEGER> Number of attack/support vehicles to create
     <INTEGER> Optional, tier modifier to apply to vehicle selection (Default: 0)
+    <STRING> Optional, troop type to use (Default: "Normal")
     <BOOL> Optional, true to only use tanks (Default: false)
-//    <STRING> Optional, troop type to use (Default: "Normal")
 
 Return array:
     <SCALAR> Resources spent
@@ -25,7 +25,7 @@ Return array:
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
 
-params ["_side", "_base", "_target", "_resPool", "_vehCount", "_vehAttackCount", ["_tierMod", 0], ["_tanksOnly", false]];
+params ["_side", "_base", "_target", "_resPool", "_vehCount", "_vehAttackCount", ["_tierMod", 0], ["_troopType", "Normal"], ["_tanksOnly", false]];
 private _targpos = if (_target isEqualType []) then { _target } else { markerPos _target };
 private _transportRatio = 1 - _vehAttackCount / _vehCount;
 
@@ -44,7 +44,7 @@ private _landPosBlacklist = [];
 for "_i" from 1 to _vehCount do {
     private _vehType = selectRandomWeighted ([_supportPool, _transportPool] select _isTransport);
 
-    private _vehData = [_vehType, "Normal", _resPool, _landPosBlacklist, _side, _base, _targPos] call A3A_fnc_createAttackVehicle;
+    private _vehData = [_vehType, _troopType, _resPool, _landPosBlacklist, _side, _base, _targPos] call A3A_fnc_createAttackVehicle;
     if !(_vehData isEqualType []) exitWith {
         Error_1("Failed to spawn land vehicle at marker %1", _base);
     };          // couldn't create for some reason, assume we're out of spawn places?

--- a/A3A/addons/core/functions/Supports/fn_SUP_tankRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_tankRoutine.sqf
@@ -22,7 +22,7 @@ _suppData params ["_supportName", "_side", "_suppType", "_suppCenter", "_suppRad
 sleep _sleepTime;
 
 // Only spawn tanks
-private _data = [_side, _base, _suppCenter, _resPool, _vehCount, _vehCount, 2, true] call A3A_fnc_createAttackForceLand;
+private _data = [_side, _base, _suppCenter, _resPool, _vehCount, _vehCount, 2, "Normal", true] call A3A_fnc_createAttackForceLand;
 _data params ["_resources", "_vehicles", "_crewGroups", "_cargoGroups"];
 Info_1("Spawn performed: Vehicles %1", _vehicles apply { typeOf _x });
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
createAttackForceLand was supposed to have a troopType parameter back in 3.0 but it wasn't implemented. Used the same slot for tanksOnly, which broke some other uses. This PR fixes both the old bug (never using specops in ground vehicles) and the new one.

Tested all three calls of createAttackForceLand (QRF, attack, tanks) and they now work correctly.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?
