### PR TITLE
Fix buy vehicle menu function tagging

### DIFF
--- a/A3A/addons/gui/dialogues/buyVehicleDialog.hpp
+++ b/A3A/addons/gui/dialogues/buyVehicleDialog.hpp
@@ -1,7 +1,7 @@
 class A3A_BuyVehicleDialog : A3A_TabbedDialog
 {
-  idd = A3A_IDD_BUYVEHICLEDIALOG;
-  onLoad = "[""onLoad""] spawn A3A_fnc_buyVehicleDialog";
+    idd = A3A_IDD_BUYVEHICLEDIALOG;
+    onLoad = "[""onLoad""] spawn A3A_GUI_fnc_buyVehicleDialog";
 
     class Controls
     {
@@ -29,7 +29,7 @@ class A3A_BuyVehicleDialog : A3A_TabbedDialog
                 {
                     idc = -1;
                     text = $STR_antistasi_dialogs_vehicle_tab_civ;
-                    onButtonClick = "[""switchTab"", [""civilian""]] call A3A_fnc_buyVehicleDialog";
+                    onButtonClick = "[""switchTab"", [""civilian""]] call A3A_GUI_fnc_buyVehicleDialog";
                     x = 0;
                     y = 0;
                     w = 30 * GRID_W;
@@ -40,7 +40,7 @@ class A3A_BuyVehicleDialog : A3A_TabbedDialog
                 {
                     idc = -1;
                     text = $STR_antistasi_dialogs_vehicle_tab_reb;
-                    onButtonClick = "[""switchTab"", [""rebel""]] call A3A_fnc_buyVehicleDialog";
+                    onButtonClick = "[""switchTab"", [""rebel""]] call A3A_GUI_fnc_buyVehicleDialog";
                     x = 30 * GRID_W;
                     y = 0;
                     w = 30 * GRID_W;
@@ -51,7 +51,7 @@ class A3A_BuyVehicleDialog : A3A_TabbedDialog
                 {
                     idc = -1;
                     text = $STR_antistasi_dialogs_vehicle_tab_static;
-                    onButtonClick = "[""switchTab"", [""static""]] call A3A_fnc_buyVehicleDialog";
+                    onButtonClick = "[""switchTab"", [""static""]] call A3A_GUI_fnc_buyVehicleDialog";
                     x = 60 * GRID_W;
                     y = 0;
                     w = 30 * GRID_W;
@@ -62,7 +62,7 @@ class A3A_BuyVehicleDialog : A3A_TabbedDialog
                 {
                     idc = -1;
                     text = $STR_antistasi_dialogs_vehicle_tab_other;
-                    onButtonClick = "[""switchTab"", [""other""]] call A3A_fnc_buyVehicleDialog";
+                    onButtonClick = "[""switchTab"", [""other""]] call A3A_GUI_fnc_buyVehicleDialog";
                     x = 90 * GRID_W;
                     y = 0;
                     w = 30 * GRID_W;

--- a/A3A/addons/gui/functions/GUI/fn_buyVehicleDialog.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_buyVehicleDialog.sqf
@@ -13,7 +13,7 @@ Public: No
 Dependencies:
     None
 Example:
-    ["onLoad"] spawn A3A_fnc_buyVehicleDialog; // initialization
+    ["onLoad"] spawn A3A_GUI_fnc_buyVehicleDialog; // initialization
 */
 
 #include "..\..\dialogues\ids.inc"
@@ -98,10 +98,10 @@ switch (_mode) do
         (A3A_faction_reb get 'staticAT') +
         (A3A_faction_reb get 'staticAA');
 
-        ["vehicles", [A3A_IDC_BUYCIVVEHICLEMAIN, A3A_IDC_CIVVEHICLESGROUP, _civilianVehicles]] call A3A_fnc_buyVehicleTabs;
-        ["vehicles", [A3A_IDC_BUYREBVEHICLEMAIN, A3A_IDC_REBVEHICLESGROUP, _militaryVehicles]] call A3A_fnc_buyVehicleTabs;
-        ["vehicles", [A3A_IDC_BUYSTATICMAIN, A3A_IDC_STATICSGROUP, _statics]] call A3A_fnc_buyVehicleTabs;
-        ["other"] call A3A_fnc_buyVehicleTabs;
+        ["vehicles", [A3A_IDC_BUYCIVVEHICLEMAIN, A3A_IDC_CIVVEHICLESGROUP, _civilianVehicles]] call A3A_GUI_fnc_buyVehicleTabs;
+        ["vehicles", [A3A_IDC_BUYREBVEHICLEMAIN, A3A_IDC_REBVEHICLESGROUP, _militaryVehicles]] call A3A_GUI_fnc_buyVehicleTabs;
+        ["vehicles", [A3A_IDC_BUYSTATICMAIN, A3A_IDC_STATICSGROUP, _statics]] call A3A_GUI_fnc_buyVehicleTabs;
+        ["other"] call A3A_GUI_fnc_buyVehicleTabs;
 
         // show the vehicle tab so that user don't freak out
         private _display = findDisplay A3A_IDD_BUYVEHICLEDIALOG;

--- a/A3A/addons/gui/functions/GUI/fn_buyVehicleTabs.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_buyVehicleTabs.sqf
@@ -17,7 +17,7 @@ Dependencies:
     None
 
 Example:
-    ["logistics"] call A3A_fnc_buyVehicleTab;
+    ["logistics"] call A3A_GUI_fnc_buyVehicleTab;
 */
 
 #include "..\..\dialogues\ids.inc"
@@ -60,7 +60,7 @@ if (_tab isEqualTo "vehicles") then
         private _configClass = configFile >> "CfgVehicles" >> _className;
         if (!isClass _configClass) then { continue };
 
-        private _crewCount = [_className] call A3A_fnc_getVehicleCrewCount;
+        private _crewCount = [_className] call A3A_GUI_fnc_getVehicleCrewCount;
         _crewCount params ["_driver", "_coPilot", "_commander", "_gunners", "_passengers", "_passengersFFV"];
 
         private _displayName = getText (_configClass >> "displayName");


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The buy vehicle menu somehow got skipped in the GUI function tagging update, so it just came up blank. This PR fixes it.

Also checked build placer and arsenal limits, but those are fine.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
