### PR TITLE
Fix potential double-carry or double-drop errors under heavy script load

### DIFF
--- a/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
@@ -8,7 +8,7 @@ Return Value:
     <nil>
 
 Scope: Clients
-Environment: Unscheduled
+Environment: Scheduled unfortunately (addAction)
 Public: yes
 Dependencies: 
 
@@ -19,48 +19,54 @@ Example:
 
 params ["_item", "_player"];         // standard addAction
 
-if (_item isKindOf "StaticWeapon") then { _item lock true };
+// Redo the checks, because this function might be delayed by script load
+if ((count crew _item != 0) or (!isNull attachedTo _item) or (call A3A_fnc_isCarrying) or (!isNull objectParent _player)) exitWith {};
 
-// Prevent killing players with item
-if (isNil {_item getVariable "A3A_originalMass"}) then { _item setVariable ["A3A_originalMass", getMass _item] };
-[_item, 1e-12] remoteExecCall ["setMass", 0]; 
-[_item, false] remoteExecCall ["enableSimulationGlobal", 2];
+// Go unscheduled to keep the state consistent
+isNil {
+    if (_item isKindOf "StaticWeapon") then { _item lock true };
 
-private _bbReal = boundingBoxReal _item;
-private _spacing = 1.3 - _bbReal#0#1;
-private _height = (1 - _bbReal#1#2) max (0.1 - _bbReal#0#2);
-_item attachTo [_player, [0, _spacing, _height]];
+    // Prevent killing players with item
+    if (isNil {_item getVariable "A3A_originalMass"}) then { _item setVariable ["A3A_originalMass", getMass _item] };
+    [_item, 1e-12] remoteExecCall ["setMass", 0]; 
+    [_item, false] remoteExecCall ["enableSimulationGlobal", 2];
 
-// We need to prevent the player from carrying an object into a vehicle to prevent damage to vehicle
-private _eventIDcarry = _player addEventHandler ["GetInMan", {
-    params ["_unit", "_role", "_vehicle", "_turret"];
-    _unit call A3A_fnc_dropItem;
-}];
+    private _bbReal = boundingBoxReal _item;
+    private _spacing = 1.3 - _bbReal#0#1;
+    private _height = (1 - _bbReal#1#2) max (0.1 - _bbReal#0#2);
+    _item attachTo [_player, [0, _spacing, _height]];
 
-_player setVariable ["A3A_eventIDcarry", _eventIDcarry];
-_player setVariable ["A3A_objectCarried", _item];
-_player setVariable ["A3A_carryingObject", true];
+    // We need to prevent the player from carrying an object into a vehicle to prevent damage to vehicle
+    private _eventIDcarry = _player addEventHandler ["GetInMan", {
+        params ["_unit", "_role", "_vehicle", "_turret"];
+        _unit call A3A_fnc_dropItem;
+    }];
 
-private _dropID = _player addAction [
-    localize "STR_A3A_fn_UtilItem_dropOb_addact_drop",
-    { (_this#1) call A3A_fnc_dropItem }, _item, 4, true, true, "", "true"
-];
-_player setVariable ["A3A_actionIDdrop", _dropID];
+    _player setVariable ["A3A_eventIDcarry", _eventIDcarry];
+    _player setVariable ["A3A_objectCarried", _item];
+    _player setVariable ["A3A_carryingObject", true];
 
-[_player, _item] spawn {
-    params ["_player", "_item"];
-    private _isHQ = _item in [petros, fireX, mapX, vehicleBox, flagX, boxX];
-    waitUntil {
-        _player allowSprint false;
-        !alive _item or !alive _player
-        or (lifestate _player isEqualTo "INCAPACITATED")            // drop when ACE-unconscious
-        or !(_player getVariable ["A3A_carryingObject", false])
-//        or !(vehicle _player == _player)
-        or !(_player == attachedTo _item)
-        or (_isHQ and _player distance2d markerPos "Synd_HQ" > 50)
+    private _dropID = _player addAction [
+        localize "STR_A3A_fn_UtilItem_dropOb_addact_drop",
+        { (_this#1) call A3A_fnc_dropItem }, _item, 4, true, true, "", "true"
+    ];
+    _player setVariable ["A3A_actionIDdrop", _dropID];
+
+    [_player, _item] spawn {
+        params ["_player", "_item"];
+        private _isHQ = _item in [petros, fireX, mapX, vehicleBox, flagX, boxX];
+        waitUntil {
+            _player allowSprint false;
+            !alive _item or !alive _player
+            or (lifestate _player isEqualTo "INCAPACITATED")            // drop when ACE-unconscious
+            or !(_player getVariable ["A3A_carryingObject", false])
+    //        or !(vehicle _player == _player)
+            or !(_player == attachedTo _item)
+            or (_isHQ and _player distance2d markerPos "Synd_HQ" > 50)
+        };
+        if (_player getVariable ["A3A_carryingObject", false]) then { _player call A3A_fnc_dropItem };
+        _player allowSprint true;
     };
-    if (_player getVariable ["A3A_carryingObject", false]) then { _player call A3A_fnc_dropItem };
-    _player allowSprint true;
 };
 
 nil;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
It was apparently possible to fire off the drop item action twice under some real circumstances, which causes script errors. There may also have been ways to dodge some of the carry checks under similar load. This PR hardens the carry & drop actions so that they're hopefully proofed against script load issues.

Note that the github diff is a mess because the indentation changed. Actual changes are just adding sanity checks at the front of each function and wrapping the rest in isNil { code } to make sure it's not interrupted.

**Edit:** I suspect the reported issue was actually caused by dropItem taking a scheduler break between the detach and the A3A_carryingItem reset, which then causes the spawn in carryItem to trigger a second dropItem. The changes should fix that too anyway.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
You can generate massive script load with something like this:
```
for "_i" from 1 to 100 do {
    0 spawn {
        while {isNil "test_stopSpam"} do {
             player nearRoads 100;
        };
    };
};
```
This should delay the addActions enough that you can fire them multiple times. Should work correctly now.
