### PR TITLE
Fetch current arsenal data before displaying the arsenal limits dialog

### DIFF
--- a/A3A/addons/gui/functions/GUI/fn_arsenalLimitsDialog.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_arsenalLimitsDialog.sqf
@@ -29,6 +29,15 @@ switch (_mode) do
 {
     case ("init"):
     {
+        if (!isServer) then {
+            // Go fetch a fresh copy of the arsenal data
+            jna_datalist = nil;
+            [clientOwner, "jna_datalist"] remoteExecCall ["publicVariableClient", 2];
+            private _timeout = time + 10;
+            waitUntil { sleep 0.1; !isNil "jna_datalist" or time > _timeout };
+        };
+        if (isNil "jna_datalist") exitWith { closeDialog 0 };
+
         if !(player call A3A_fnc_isMember) then {
             [localize "STR_antistasi_arsenal_limits_dialog_hint_title", localize "STR_antistasi_arsenal_limits_dialog_guest_warning"] call A3A_fnc_customHint;
             (_display displayctrl A3A_IDC_ARSLIMRESETBUTTON) ctrlEnable false;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The arsenal limits dialog never fetched the arsenal data (jna_datalist) itself, so on clients it could show out-of-date information, or error out if the arsenal hadn't been accessed locally. This PR fixes it by fetching the arsenal data on dialog init.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
