### PR TITLE
Add explosiveSpecialist and UAVHacker traits to default commander slot

### DIFF
--- a/A3A/addons/core/functions/OrgPlayers/fn_unitTraits.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_unitTraits.sqf
@@ -32,6 +32,8 @@ if(roleDescription player == "Default Commander") then
     player setUnitTrait ["audibleCoef",0.8];
     player setUnitTrait ["loadCoef",1.4];
     player setUnitTrait ["medic", true];
+    player setUnitTrait ["explosiveSpecialist", true];
+    player setUnitTrait ["UAVHacker", true];
     // ACE clears the engineer unitTrait and adds this var at CBA initPost, so we have to do it ourselves
     if (missionNamespace getVariable ["ace_repair_enabled", false]) then { player setVariable ["ace_isEngineer", true, true] } else { player setUnitTrait ["engineer", true] };
     _text = localize "STR_A3A_fn_orgp_unitTraits_commander1" + "<br/>" + localize "STR_A3A_fn_orgp_unitTraits_commander2";


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Just adds the explosiveSpecialist and UAVHacker traits to the default commander slot so that solo players can disarm mines and convert UAVs. Shouldn't be controversial.    

### Please specify which Issue this PR Resolves.
closes #3253

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
