### PR TITLE
Speculative init order fix

### DIFF
--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -64,7 +64,8 @@ while {true} do {
     if (dialog) then { sleep 0.1; continue };           // don't spam hints while the setup dialog is open
     private _stateStr = localize ("STR_A3A_feedback_serverinfo_" + A3A_startupState);
     isNil { [localize "STR_A3A_feedback_serverinfo", _stateStr, true] call A3A_fnc_customHint };         // not re-entrant, apparently
-    if (A3A_startupState == "completed") exitWith {};
+    //if (A3A_startupState == "completed") exitWith {};
+    if (!isNil "serverInitDone") exitWith {};           // speculative init order fix
     sleep 0.1;
 };
 

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -303,9 +303,9 @@ if (A3A_hasACE) then {
 };
 
 
+A3A_startupState = "completed"; publicVariable "A3A_startupState";
 serverInitDone = true; publicVariable "serverInitDone";
 Info("Setting serverInitDone as true");
-A3A_startupState = "completed"; publicVariable "A3A_startupState";
 
 
 // ********************* Initialize loops *******************************************


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug?
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Apparently initClientDone can be true before A3A_utilityItemHM exists on the client, causing errors in the initRemoteObject JIP function. This was expected to be impossible due to publicVariable order guarantees. I have a dumb theory that subsequent publicVariable calls on the same variable don't update the order, which means that A3A_startupState is not a valid fence variable.

This PR switches the fence variable to serverInitDone. If the ordering problem doesn't show up again then we learnt something weird about Arma.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

It's probably not possible to generate the issue without a heavily loaded server & client. 
