### PR TITLE
Fix move asset not working on Petros

### DIFF
--- a/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
@@ -20,7 +20,8 @@ Example:
 params ["_item", "_player"];         // standard addAction
 
 // Redo the checks, because this function might be delayed by script load
-if ((count crew _item != 0) or (!isNull attachedTo _item) or (call A3A_fnc_isCarrying) or (!isNull objectParent _player)) exitWith {};
+if ((!isNull attachedTo _item) or (call A3A_fnc_isCarrying) or (!isNull objectParent _player)) exitWith {};
+if (_item isKindOf "StaticWeapon" and count crew _item != 0) exitWith {};
 
 // Go unscheduled to keep the state consistent
 isNil {


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Turns out `count crew petros` is 1, not 0. Arma never fails to surprise me.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
