### PR TITLE
Buff IFA mortars closer to mk6

### DIFF
--- a/A3A/addons/config_fixes/IFA/CfgAmmo.hpp
+++ b/A3A/addons/config_fixes/IFA/CfgAmmo.hpp
@@ -1,0 +1,15 @@
+// IFA - CfgAmmo.hpp
+
+class CfgAmmo {
+    // Buffs to bring mortar effectiveness against unarmoured somewhere near vanilla against armoured
+    class Sh_82mm_AMOS;
+    class LIB_Sh_82_HE : Sh_82mm_AMOS {
+        indirectHitRange = 13;
+    };
+    class LIB_Sh_81_HE : LIB_Sh_82_HE {
+        indirectHitRange = 12.6;
+    };
+    class LIB_Sh_60_HE : LIB_Sh_82_HE {
+        indirectHitRange = 11;
+    };
+};

--- a/A3A/addons/config_fixes/IFA/CfgVehicles.hpp
+++ b/A3A/addons/config_fixes/IFA/CfgVehicles.hpp
@@ -1,5 +1,6 @@
 //IFA - CfgVehicles.hpp
 
+class DefaultEventHandlers;
 class CfgVehicles 
 {
 	class LIB_US_Willys_MB_M1919;
@@ -54,5 +55,11 @@ class CfgVehicles
 			};
 		};
 		animationList[] ={};
+	};
+
+	// CBA event handlers fix
+	class Tank;
+	class LIB_Armored_Target_Dummy : Tank {
+		delete EventHandlers;
 	};
 };

--- a/A3A/addons/config_fixes/IFA/CfgWeapons.hpp
+++ b/A3A/addons/config_fixes/IFA/CfgWeapons.hpp
@@ -1,6 +1,7 @@
 //IFA - CfgWeapons.hpp
 
 //Fun weapons for finding in lootcrates or on SF
+class Mode_SemiAuto;
 class CfgWeapons 
 {
 	class ItemCore;
@@ -81,5 +82,41 @@ class CfgWeapons
             showToPlayer = 1;
         };
         modes[] = {"Single","Full","Far","Medium","Short"};
+    };
+
+    // Adjust so that the mortars aren't wildly inaccurate at longer ranges
+    class LIB_MortarCannon_base;
+    class LIB_GRWR34 : LIB_MortarCannon_base {
+        class Single1 : Mode_SemiAuto {
+            artilleryDispersion = 4;
+        };
+        class Single2 : Single1 {
+            artilleryDispersion = 4;
+        };
+        class Single3 : Single1 {
+            artilleryDispersion = 4;
+        };
+    };
+    class LIB_BM37 : LIB_MortarCannon_base {
+        class Single1 : Mode_SemiAuto {
+            artilleryDispersion = 4;
+        };
+        class Single2 : Single1 {
+            artilleryDispersion = 4;
+        };
+        class Single3 : Single1 {
+            artilleryDispersion = 4;
+        };
+    };
+    class LIB_M2_60 : LIB_MortarCannon_base {
+        class Single1 : Mode_SemiAuto {
+            artilleryDispersion = 4;
+        };
+        class Single2 : Single1 {
+            artilleryDispersion = 4;
+        };
+        class Single3 : Single1 {
+            artilleryDispersion = 4;
+        };
     };
 };

--- a/A3A/addons/config_fixes/IFA/config.cpp
+++ b/A3A/addons/config_fixes/IFA/config.cpp
@@ -5,13 +5,13 @@
 
 class CfgPatches 
 {
-    class PATCHNAME(A3) 
+    class PATCHNAME(IFA)
     {
         name = COMPONENT_NAME;
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"IFA3_Core","WW2_Assets_c_Weapons_InfantryWeapons_c"};
+        requiredAddons[] = {"IFA3_Core","WW2_Core_c_IF_ZZZ_LastLoaded_c"};
         skipWhenMissingDependencies = 1;
         author = AUTHOR;
         authors[] = { AUTHORS };
@@ -23,3 +23,4 @@ class CfgPatches
 // Uncomment when needed
 #include "CfgVehicles.hpp"
 #include "CfgWeapons.hpp"
+#include "CfgAmmo.hpp"

--- a/A3A/addons/core/Templates/Templates/IFA/IFA_AI_ALLIES.sqf
+++ b/A3A/addons/core/Templates/Templates/IFA/IFA_AI_ALLIES.sqf
@@ -89,10 +89,10 @@ if (isClass (configFile >> "CfgPatches" >> "FA_WW2_Tanks")) then {
 ["staticMGs", ["a3a_hmg_02_high"]] call _fnc_saveToTemplate;
 ["staticAT", ["LIB_Pak40_g"]] call _fnc_saveToTemplate;
 ["staticAA", ["LIB_61k"]] call _fnc_saveToTemplate; //Fake Bofors
-["staticMortars", ["LIB_M2_60"]] call _fnc_saveToTemplate;
+["staticMortars", ["LIB_GrWr34_g"]] call _fnc_saveToTemplate;
 
-["mortarMagazineHE", "LIB_8Rnd_60mmHE_M2"] call _fnc_saveToTemplate;
-["mortarMagazineSmoke", ""] call _fnc_saveToTemplate;
+["mortarMagazineHE", "LIB_8Rnd_81mmHE_GRWR34"] call _fnc_saveToTemplate;
+["mortarMagazineSmoke", "LIB_81mm_GRWR34_SmokeShell"] call _fnc_saveToTemplate;
 
 //Minefield definition
 //CFGVehicles variant of Mines are needed "ATMine", "APERSTripMine", "APERSMine"

--- a/A3A/addons/core/Templates/Templates/IFA/IFA_AI_UK.sqf
+++ b/A3A/addons/core/Templates/Templates/IFA/IFA_AI_UK.sqf
@@ -86,10 +86,10 @@ if (isClass (configFile >> "CfgPatches" >> "FA_WW2_Tanks")) then {
 ["staticMGs", ["a3a_hmg_02_high"]] call _fnc_saveToTemplate;
 ["staticAT", ["LIB_Pak40_g"]] call _fnc_saveToTemplate;
 ["staticAA", ["LIB_61k"]] call _fnc_saveToTemplate;
-["staticMortars", ["LIB_M2_60"]] call _fnc_saveToTemplate;
+["staticMortars", ["LIB_GrWr34_g"]] call _fnc_saveToTemplate;
 
-["mortarMagazineHE", "LIB_8Rnd_60mmHE_M2"] call _fnc_saveToTemplate;
-["mortarMagazineSmoke", ""] call _fnc_saveToTemplate;
+["mortarMagazineHE", "LIB_8Rnd_81mmHE_GRWR34"] call _fnc_saveToTemplate;
+["mortarMagazineSmoke", "LIB_81mm_GRWR34_SmokeShell"] call _fnc_saveToTemplate;
 
 //Minefield definition
 //CFGVehicles variant of Mines are needed "ATMine", "APERSTripMine", "APERSMine"

--- a/A3A/addons/core/Templates/Templates/IFA/IFA_AI_US.sqf
+++ b/A3A/addons/core/Templates/Templates/IFA/IFA_AI_US.sqf
@@ -83,10 +83,10 @@ if (isClass (configFile >> "CfgPatches" >> "FA_WW2_Tanks")) then {
 ["staticMGs", ["a3a_hmg_02_high"]] call _fnc_saveToTemplate;
 ["staticAT", ["LIB_Pak40_g"]] call _fnc_saveToTemplate;
 ["staticAA", ["LIB_61k"]] call _fnc_saveToTemplate; //Fake Bofors
-["staticMortars", ["LIB_M2_60"]] call _fnc_saveToTemplate;
+["staticMortars", ["LIB_GrWr34_g"]] call _fnc_saveToTemplate;
 
-["mortarMagazineHE", "LIB_8Rnd_60mmHE_M2"] call _fnc_saveToTemplate;
-["mortarMagazineSmoke", ""] call _fnc_saveToTemplate;
+["mortarMagazineHE", "LIB_8Rnd_81mmHE_GRWR34"] call _fnc_saveToTemplate;
+["mortarMagazineSmoke", "LIB_81mm_GRWR34_SmokeShell"] call _fnc_saveToTemplate;
 
 //Minefield definition
 //CFGVehicles variant of Mines are needed "ATMine", "APERSTripMine", "APERSMine"

--- a/A3A/addons/core/Templates/Templates/IFA/IFA_REB_AK.sqf
+++ b/A3A/addons/core/Templates/Templates/IFA/IFA_REB_AK.sqf
@@ -28,7 +28,7 @@
 ["vehiclesLightArmed", ["a3a_LIB_Willys_MB_M1919"]] call _fnc_saveToTemplate;  //replace with a version in plain green
 ["vehiclesTruck", ["LIB_Zis5v"]] call _fnc_saveToTemplate;
 ["vehiclesAT", []] call _fnc_saveToTemplate;
-["vehiclesAA", ["LIB_Zis5v_61K"]] call _fnc_saveToTemplate;
+["vehiclesAA", []] call _fnc_saveToTemplate;
 
 ["vehiclesBoat", ["I_G_Boat_Transport_01_F"]] call _fnc_saveToTemplate;
 
@@ -43,7 +43,7 @@
 
 ["staticMGs", ["LIB_Maxim_M30_base"]] call _fnc_saveToTemplate;
 ["staticAT", ["LIB_Zis3"]] call _fnc_saveToTemplate;
-["staticAA", ["LIB_61k"]] call _fnc_saveToTemplate;
+["staticAA", ["LIB_FlaK_30"]] call _fnc_saveToTemplate;
 ["staticMortars", ["LIB_M2_60"]] call _fnc_saveToTemplate;
 ["staticMortarMagHE", "LIB_8Rnd_60mmHE_M2"] call _fnc_saveToTemplate;
 ["staticMortarMagSmoke", ""] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/IFA/IFA_Reb_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/IFA/IFA_Reb_Vehicle_Attributes.sqf
@@ -16,8 +16,8 @@
     ["LIB_Maxim_M30_base", ["rebCost", 800]],
     ["LIB_Zis3", ["rebCost", 2000]],
     ["LIB_Zis3_w", ["rebCost", 2000]],
-    ["LIB_M2_60", ["rebCost", 2000]],
+    ["LIB_M2_60", ["rebCost", 1000]],
     ["LIB_FlaK_30", ["rebCost", 1200]],
     ["LIB_FlaK_30_w", ["rebCost", 1200]],
-    ["LIB_61k", ["rebCost", 1700]]
+    ["LIB_61k", ["rebCost", 2500]]
 ]] call _fnc_saveToTemplate;


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
IFA mortars were extremely weak so I've buffed them a bit closer to the vanilla ones. Changes:
- Flattened out the wild inaccuracy at higher charge sizes. Still worse than vanilla but not so far off.
- Made effective radius against unarmoured units somewhere near vanilla effective radius against armoured units.

The 60mm mortar was left a bit weaker. Should probably adjust the templates so that enemies all use the larger mortars, because the range and effectiveness of the 60mm isn't really sufficient for use as a support.

Also fixed a couple of config bugs while I was in there:
- IFA config fixes were using the vanilla patch name.
- IFA had a bugged target dummy that broke CBA XEH.

### Please specify which Issue this PR Resolves.
closes #3313

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

Should switch the US/UK enemy templates to use 81/82mm mortars, and make the 60mm one cheaper for rebels.
**Edit:** Done