### PR TITLE
Ifa aircraft price update & loadout tweak

### DIFF
--- a/A3A/addons/core/Templates/AircraftLoadouts/IFA/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/IFA/config.cpp
@@ -24,12 +24,14 @@ class A3A {
             class LIB_Ju87 : baseCAS {
                 loadout[] = {"LIB_1Rnd_SC50","LIB_1Rnd_SC50","LIB_1Rnd_SC500","LIB_1Rnd_SC50","LIB_1Rnd_SC50"};
                 mainGun[] = {"LIB_2xMG151_JU87"};
+				rocketLauncher[] = {"LIB_2xMG151_JU87"};
                 bombRacks[] = {"LIB_SC500_Bomb_Mount","LIB_SC50_Bomb_Mount"};
                 diveParams[] = {1200, 300, 110, 55, 15, {15, -2}};
             };
             class LIB_Pe2 : baseCAS {
                 loadout[] = {"LIB_1Rnd_FAB250","LIB_1Rnd_FAB250","LIB_1Rnd_FAB250","LIB_1Rnd_FAB250"};
-                mainGun[] = {"LIB_UBK_PE2"};
+                mainGun[] = {"LIB_UBK_PE2", "LIB_ShKAS_PE2"};
+				rocketLauncher[] = {"LIB_UBK_PE2"};
                 bombRacks[] = {"LIB_FAB250_Bomb_Mount"};
                 diveParams[] = {1200, 300, 110, 55, 15, {12, 0}};
             };
@@ -49,8 +51,8 @@ class A3A {
             };
             class LIB_P39 : baseCAS {
                 loadout[] = {"LIB_1Rnd_US_500lb","LIB_30Rnd_M4_P39","LIB_1000Rnd_M2_P39"};
-                mainGun[] = {"LIB_M4_P39"};
-                rocketLauncher[] = {"LIB_4xM2_P39"};
+                mainGun[] = {"LIB_4xM2_P39"};
+                rocketLauncher[] = {"LIB_M4_P39"};
                 bombRacks[] = {"LIB_US_500lb_Bomb_Mount"};
                 diveParams[] = {1200, 350, 110, 55, 15, {20, 0}};
             };

--- a/A3A/addons/core/Templates/AircraftLoadouts/IFA/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/IFA/config.cpp
@@ -24,14 +24,14 @@ class A3A {
             class LIB_Ju87 : baseCAS {
                 loadout[] = {"LIB_1Rnd_SC50","LIB_1Rnd_SC50","LIB_1Rnd_SC500","LIB_1Rnd_SC50","LIB_1Rnd_SC50"};
                 mainGun[] = {"LIB_2xMG151_JU87"};
-				rocketLauncher[] = {"LIB_2xMG151_JU87"};
+                rocketLauncher[] = {"LIB_2xMG151_JU87"};
                 bombRacks[] = {"LIB_SC500_Bomb_Mount","LIB_SC50_Bomb_Mount"};
                 diveParams[] = {1200, 300, 110, 55, 15, {15, -2}};
             };
             class LIB_Pe2 : baseCAS {
                 loadout[] = {"LIB_1Rnd_FAB250","LIB_1Rnd_FAB250","LIB_1Rnd_FAB250","LIB_1Rnd_FAB250"};
                 mainGun[] = {"LIB_UBK_PE2", "LIB_ShKAS_PE2"};
-				rocketLauncher[] = {"LIB_UBK_PE2"};
+                rocketLauncher[] = {"LIB_UBK_PE2"};
                 bombRacks[] = {"LIB_FAB250_Bomb_Mount"};
                 diveParams[] = {1200, 300, 110, 55, 15, {12, 0}};
             };

--- a/A3A/addons/core/Templates/Templates/IFA/IFA_AI_WEH.sqf
+++ b/A3A/addons/core/Templates/Templates/IFA/IFA_AI_WEH.sqf
@@ -47,7 +47,7 @@ private _vehiclesLightTanks = ["a3a_lib_PzKpfwIV_noShield"];
 ["vehiclesAmphibious", []] call _fnc_saveToTemplate;
 
 ["vehiclesPlanesCAS", ["LIB_Ju87","LIB_FW190F8_2"]] call _fnc_saveToTemplate;             // Will be used with CAS script, must be defined in setPlaneLoadout. Needs fixed gun and either rockets or missiles
-["vehiclesPlanesAA", ["LIB_FW190F8","LIB_FW190F8_4","LIB_FW190F8_2","LIB_FW190F8_5","LIB_FW190F8_3"]] call _fnc_saveToTemplate;              // 
+["vehiclesPlanesAA", ["LIB_FW190F8","LIB_FW190F8_2"]] call _fnc_saveToTemplate;              // 
 ["vehiclesPlanesTransport", ["LIB_C47_RAF"]] call _fnc_saveToTemplate;
 
 ["vehiclesHelisLight", []] call _fnc_saveToTemplate;            // ideally fragile & unarmed helis seating 4+

--- a/A3A/addons/core/Templates/Templates/IFA/IFA_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/IFA/IFA_Vehicle_Attributes.sqf
@@ -14,7 +14,18 @@
     ["LIB_US_M3_Halftrack", ["cost", 60]],
     ["LIB_SOV_M3_Halftrack", ["cost", 60]],
     ["LIB_UK_M3_Halftrack", ["cost", 60]],
-    ["LIB_M8_Greyhound", ["cost", 80]]
+    ["LIB_M8_Greyhound", ["cost", 80]],
+    ["LIB_Ju87", ["cost", 75]],
+    ["LIB_Pe2", ["cost", 75]],
+    ["LIB_FW190F8", ["cost", 75]],
+    ["LIB_FW190F8_2", ["cost", 75]],
+    ["LIB_P47", ["cost", 75]],
+    ["LIB_P39", ["cost", 75]],
+    ["LIB_RA_P39_2", ["cost", 75]],
+    ["LIB_RA_P39_3", ["cost", 75]],
+    ["LIB_RAF_P39", ["cost", 75]],
+    ["LIB_US_P39", ["cost", 75]],
+    ["LIB_US_P39_2", ["cost", 75]]
 ]] call _fnc_saveToTemplate;
 
 if (isClass (configFile >> "CfgPatches" >> "FA_WW2_Armored_Cars")) then {


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:

1. Sets the cost of all IFA aircraft down to a reasonable for their capabilities, 75
2. tweaked the P39, Pe2, and Ju87 loadout configuration to put them better in line with the other airplanes.
3. Removed excessive number of variants of the fw190 from the weh template

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
