### PR TITLE
Adjust air support response for cheap planes

### DIFF
--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_US.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_US.sqf
@@ -75,7 +75,7 @@
 ["minefieldAT", ["SPE_US_M1A1_ATMINE"]] call _fnc_saveToTemplate;
 ["minefieldAPERS", ["SPE_US_M3_Pressure_MINE", "SPE_US_M3_MINE"]] call _fnc_saveToTemplate;
 
-//#include "3CBFactions_Vehicle_Attributes.sqf"
+#include "SPE_Vehicle_Attributes.sqf"
 
 /////////////////////
 ///  Identities   ///

--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_WEH.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_WEH.sqf
@@ -75,7 +75,7 @@
 ["minefieldAT", ["SPE_US_M1A1_ATMINE"]] call _fnc_saveToTemplate;
 ["minefieldAPERS", ["SPE_US_M3_Pressure_MINE", "SPE_US_M3_MINE"]] call _fnc_saveToTemplate;
 
-//#include "3CBFactions_Vehicle_Attributes.sqf"
+#include "SPE_Vehicle_Attributes.sqf"
 
 /////////////////////
 ///  Identities   ///

--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_Vehicle_Attributes.sqf
@@ -1,0 +1,5 @@
+["attributesVehicles", [
+    // WW2 planes are not super effective
+    ["SPE_P47", ["cost", 75]],
+    ["SPE_FW190F8", ["cost", 75]]
+]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/functions/Supports/fn_SUP_ASF.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_ASF.sqf
@@ -32,7 +32,7 @@ if (_delay < 0) then { _delay = (0.5 + random 1) * (100 - _aggro + 18*A3A_enemyR
 
 private _targArray = [];
 if (_target isEqualType objNull and {!isNull _target}) then {
-    A3A_supportStrikes pushBack [_side, "TARGET", _target, time + 1200, 1200, 200];
+    A3A_supportStrikes pushBack [_side, "TARGET", _target, time + 1200, 1200, A3A_vehicleResourceCosts get _vehType];
     _targArray = [_target, _targPos];
 };
 

--- a/A3A/addons/core/functions/Supports/fn_SUP_SAM.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_SAM.sqf
@@ -58,7 +58,7 @@ if (_delay < 0) then { _delay = (0.5 + random 1) * (100 - _aggro + 22*A3A_enemyR
 
 private _targArray = [];
 if (_target isEqualType objNull and {!isNull _target}) then {
-    A3A_supportStrikes pushBack [_side, "TARGET", _target, time + 1200, 1200, 200];
+    A3A_supportStrikes pushBack [_side, "TARGET", _target, time + 1200, 1200, 100];
     _targArray = [_target, _targPos];
 };
 

--- a/A3A/addons/core/functions/Supports/fn_initSupports.sqf
+++ b/A3A/addons/core/functions/Supports/fn_initSupports.sqf
@@ -37,8 +37,8 @@ private _initData = [
     ["ARTILLERY",       "AREA", 0.5, 0.9, 150,  85,  "", "vehiclesArtillery"],           // balanced against mortars (50/50 at tier 10), total will be 0.5/0.9
     ["MORTAR",          "AREA", 0.5, 0.9, 100,  50,  "", "staticMortars"],
     ["ASF",           "TARGET", 1.0, 0.4,   0, 100,  "", "vehiclesPlanesAA"],            // balanced against SAMs (if available), 66/33 weighting
-    ["CAS",           "TARGET", 0.5, 0.3,   0, 100,  "", "vehiclesPlanesCAS"],
-    ["TANK",          "TARGET", 0.5, 0.7,   0, 100,  "", ""],                            // balanced against CAS, lowAir based
+    ["CAS",           "TARGET", 0.5, 0.5,   0, 100,  "", "vehiclesPlanesCAS"],
+    ["TANK",          "TARGET", 0.5, 0.5,   0, 100,  "", ""],                            // balanced against CAS, lowAir based
     ["QRFLAND",       "TROOPS", 1.0, 1.4,   0,   0,  "", ""],
     ["QRFAIR",        "TROOPS", 0.5, 0.1,   0,   0,  "", ""],
     ["CARPETBOMBS",     "AREA", 0.5, 0.1, 200,   0, "u", ""],                            // balanced against airstrikes
@@ -69,6 +69,20 @@ private _fnc_buildSupportHM =
 
 A3A_supportTypesOcc = A3A_faction_occ call _fnc_buildSupportHM;
 A3A_supportTypesInv = A3A_faction_inv call _fnc_buildSupportHM;
+
+// Generate anti-air support threshold for a faction, based on average ASF plane cost
+private _fnc_getAirThreshold =
+{
+    params ["_faction"];
+    private _planes = _faction get "vehiclesPlanesAA";
+    if (_planes isEqualTo []) exitWith { 200 };     // SAM price
+    private _cost = 0;
+    { _cost = _cost + (A3A_vehicleResourceCosts get _x) } forEach _planes;
+    _cost / count _planes;
+};
+
+A3A_airThresholdOcc = A3A_faction_occ call _fnc_getAirThreshold;
+A3A_airThresholdInv = A3A_faction_inv call _fnc_getAirThreshold;
 
 
 // Build marker lists for determining importance of target locations

--- a/A3A/addons/core/functions/Supports/fn_maxDefenceSpend.sqf
+++ b/A3A/addons/core/functions/Supports/fn_maxDefenceSpend.sqf
@@ -48,7 +48,8 @@ if (_target isEqualType objNull and {_target isKindOf "Air"}) exitWith
         if (_sside == _side && _starg isEqualTo _target) then { _targSpend = _targSpend + _pow };
     } forEach A3A_supportStrikes;
 
-    private _threshold = 150 * (4 min _maxResources / _curResources);
+    private _threshold = [A3A_airThresholdOcc, A3A_airThresholdInv] select (_side == Invaders);
+    private _threshold = _threshold * 0.6 * (4 min _maxResources / _curResources);
     private _maxSpendTarg = _targThreat - _targSpend - _threshold;
 
     private _maxAASpend = _maxResources * 0.3;


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
WW2 planes are not very effective but they were treated as such by the air support response. This PR adjusts air support responses based on the cost of ASF planes, making it more likely that multiple enemy aircraft are sent against one plane.

Also removed the lowAir adjustment for CAS vs tank platoon, as it doesn't make sense to reduce CAS for most lowAir factions. They're more low-heli than low-air.

Needs #3317 for the IFA planes.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
