### PR TITLE
Skip time improvements

### DIFF
--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -3444,7 +3444,7 @@
         <Czech>Nemůžeš odpočívat když HQ je pod útokem.</Czech>
       </Key>
       <Key ID="STR_A3A_fn_dialogs_skiptime_no_radius">
-        <Original>All players must be in a 100m radius from HQ to be able to rest.&lt;br/&gt;More than 10 players are absent from HQ currently.</Original>
+        <Original>All players must be in a 100m radius from HQ to be able to rest.&lt;br/&gt;&lt;br/&gt;More than 10 players are absent from HQ currently.</Original>
         <Italian>Tutti i giocatori devono trovarsi entro 100m dal QG per riposare.</Italian>
         <Spanish>Todos los jugadores deben estar en un radio de 100m del CG para poder descansar.</Spanish>
         <French>Tous les joueurs doivent se trouver dans un rayon de 100 m du QG pour pouvoir se reposer.</French>
@@ -3455,6 +3455,9 @@
       </Key>
       <Key ID="STR_A3A_fn_dialogs_skiptime_no_radius_players">
         <Original>All players must be in a 100m radius from HQ to be able to rest.&lt;br/&gt;The following players are not at HQ: %1, and %2.</Original>
+      </Key>
+      <Key ID="STR_A3A_fn_dialogs_skiptime_no_radius_singleplayer">
+        <Original>All players must be in a 100m radius from HQ to be able to rest.&lt;br/&gt;&lt;br/&gt;%1 is currently not at HQ.</Original>
       </Key>
       <Key ID="STR_A3A_fn_dialogs_skiptime_title">
         <Original>Skip Time / Rest</Original>

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -3444,7 +3444,7 @@
         <Czech>Nemůžeš odpočívat když HQ je pod útokem.</Czech>
       </Key>
       <Key ID="STR_A3A_fn_dialogs_skiptime_no_radius">
-        <Original>All players must be in a 100m radius from HQ to be able to rest.</Original>
+        <Original>All players must be in a 100m radius from HQ to be able to rest.&lt;br/&gt;More than 10 players are absent from HQ currently.</Original>
         <Italian>Tutti i giocatori devono trovarsi entro 100m dal QG per riposare.</Italian>
         <Spanish>Todos los jugadores deben estar en un radio de 100m del CG para poder descansar.</Spanish>
         <French>Tous les joueurs doivent se trouver dans un rayon de 100 m du QG pour pouvoir se reposer.</French>
@@ -3452,6 +3452,9 @@
         <Russian>Все игроки должны находиться в радиусе 100 метров от штаба, чтобы иметь возможность отдохнуть.</Russian>
         <Polish>Wszyscy gracze muszą znajdować się w promieniu 100 m od siedziby głównej, aby móc odpocząć.</Polish>
         <Czech>Všichni hráči musí být v okruhu 100M od HQ abys mohl pustit odpočinek.</Czech>
+      </Key>
+      <Key ID="STR_A3A_fn_dialogs_skiptime_no_radius_players">
+        <Original>All players must be in a 100m radius from HQ to be able to rest.&lt;br/&gt;The following players are not at HQ: %1, and %2.</Original>
       </Key>
       <Key ID="STR_A3A_fn_dialogs_skiptime_title">
         <Original>Skip Time / Rest</Original>

--- a/A3A/addons/core/functions/Dialogs/fn_skiptime.sqf
+++ b/A3A/addons/core/functions/Dialogs/fn_skiptime.sqf
@@ -3,7 +3,6 @@
 private _titleStr = localize "STR_A3A_fn_dialogs_skiptime_title";
 
 if (player!= theBoss) exitWith {[_titleStr, localize "STR_A3A_fn_dialogs_skiptime_no_commander"] call A3A_fnc_customHint;};
-_presente = false;
 
 private _rebelSpawners = units teamPlayer select { _x getVariable ["spawner",false] };
 private _presente = (-1 != (_rebelSpawners findIf { [getPosATL _x] call A3A_fnc_enemyNearCheck }));
@@ -12,12 +11,19 @@ if ("rebelAttack" in A3A_activeTasks) exitWith {[_titleStr, localize "STR_A3A_fn
 if ("invaderPunish" in A3A_activeTasks) exitWith {[_titleStr, localize "STR_A3A_fn_dialogs_skiptime_no_civatt"] call A3A_fnc_customHint;};
 if ("DEF_HQ" in A3A_activeTasks) exitWith {[_titleStr, localize "STR_A3A_fn_dialogs_skiptime_no_hqatt"] call A3A_fnc_customHint;};
 
-_checkX = false;
-_posHQ = getMarkerPos respawnTeamPlayer;
+private _absentPlayers = [];
+private _posHQ = getMarkerPos respawnTeamPlayer;
 {
-if ((_x distance _posHQ > 100) and (side _x == teamPlayer)) then {_checkX = true};
+if ((_x distance _posHQ > 100) and (side _x in [teamPlayer,civilian])) then {_absentPlayers pushBackUnique name _x;};
 } forEach (allPlayers - (entities "HeadlessClient_F"));
 
-if (_checkX) exitWith {[_titleStr, localize "STR_A3A_fn_dialogs_skiptime_no_radius"] call A3A_fnc_customHint;};
+if (count _absentPlayers > 0) exitWith {
+	if (count _absentPlayers > 10) then {
+		[_titleStr, localize "STR_A3A_fn_dialogs_skiptime_no_radius"] call A3A_fnc_customHint;};
+	} else {
+		private _lastPlayer = _absentPlayers deleteAt (count _absentPlayers - 1);
+		private _absentString = _absentPlayers joinString ", ";
+		[_titleStr, format [localize "STR_A3A_fn_dialogs_skiptime_no_radius",_absentString,_lastPlayer]] call A3A_fnc_customHint;
+	};
 
 remoteExec ["A3A_fnc_resourcecheckSkipTime", 0];

--- a/A3A/addons/core/functions/Dialogs/fn_skiptime.sqf
+++ b/A3A/addons/core/functions/Dialogs/fn_skiptime.sqf
@@ -17,13 +17,23 @@ private _posHQ = getMarkerPos respawnTeamPlayer;
 if ((_x distance _posHQ > 100) and (side _x in [teamPlayer,civilian])) then {_absentPlayers pushBackUnique name _x;};
 } forEach (allPlayers - (entities "HeadlessClient_F"));
 
-if (count _absentPlayers > 0) exitWith {
-	if (count _absentPlayers > 10) then {
-		[_titleStr, localize "STR_A3A_fn_dialogs_skiptime_no_radius"] call A3A_fnc_customHint;};
-	} else {
-		private _lastPlayer = _absentPlayers deleteAt (count _absentPlayers - 1);
-		private _absentString = _absentPlayers joinString ", ";
-		[_titleStr, format [localize "STR_A3A_fn_dialogs_skiptime_no_radius",_absentString,_lastPlayer]] call A3A_fnc_customHint;
+switch (true) do {
+	case (count _absentPlayers == 0): 
+	{
+		remoteExec ["A3A_fnc_resourcecheckSkipTime", 0];
 	};
-
-remoteExec ["A3A_fnc_resourcecheckSkipTime", 0];
+	case (count _absentPlayers == 1): 
+	{
+		[_titleStr, format [localize "STR_A3A_fn_dialogs_skiptime_no_radius_singleplayer",_absentPlayers#0]] call A3A_fnc_customHint;
+	};
+	case (count _absentPlayers > 10): 
+	{
+		[_titleStr, localize "STR_A3A_fn_dialogs_skiptime_no_radius"] call A3A_fnc_customHint;
+	};
+	default 
+	{
+		private _lastPlayer = _absentPlayers deleteAt 0;
+		private _absentString = _absentPlayers joinString ", ";
+		[_titleStr, format [localize "STR_A3A_fn_dialogs_skiptime_no_radius_players",_absentString,_lastPlayer]] call A3A_fnc_customHint;
+	};
+};


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Information:
Skip time will now check for undercover players as well when looking for absent players.
Depending on how many players are missing, the action will display a hint. 0, 1, 2-9, and 10+ will display different messages.

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: Push players away from HQ, try the tent action.
