### PR TITLE
Fix conflicting addon messages from aircraft loadout configs

### DIFF
--- a/A3A/addons/core/Templates/AircraftLoadouts/3CB/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/3CB/config.cpp
@@ -1,7 +1,7 @@
 #include "..\..\..\script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
+    class PATCHNAME(AirLoadout_3CB) {
         name = COMPONENT_NAME;
         units[] = {};
         weapons[] = {};

--- a/A3A/addons/core/Templates/AircraftLoadouts/CUP/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/CUP/config.cpp
@@ -1,7 +1,7 @@
 #include "..\..\..\script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
+    class PATCHNAME(AirLoadout_CUP) {
         name = COMPONENT_NAME;
         units[] = {};
         weapons[] = {};

--- a/A3A/addons/core/Templates/AircraftLoadouts/IFA/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/IFA/config.cpp
@@ -1,7 +1,7 @@
 #include "..\..\..\script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
+    class PATCHNAME(AirLoadout_IFA) {
         name = COMPONENT_NAME;
         units[] = {};
         weapons[] = {};

--- a/A3A/addons/core/Templates/AircraftLoadouts/RHS/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/RHS/config.cpp
@@ -1,7 +1,7 @@
 #include "..\..\..\script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
+    class PATCHNAME(AirLoadout_RHS) {
         name = COMPONENT_NAME;
         units[] = {};
         weapons[] = {};

--- a/A3A/addons/core/Templates/AircraftLoadouts/SFP/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/SFP/config.cpp
@@ -1,7 +1,7 @@
 #include "..\..\..\script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
+    class PATCHNAME(AirLoadout_SFP) {
         name = COMPONENT_NAME;
         units[] = {};
         weapons[] = {};

--- a/A3A/addons/core/Templates/AircraftLoadouts/SPE/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/SPE/config.cpp
@@ -1,7 +1,7 @@
 #include "..\..\..\script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
+    class PATCHNAME(AirLoadout_SPE) {
         name = COMPONENT_NAME;
         units[] = {};
         weapons[] = {};

--- a/A3A/addons/core/Templates/AircraftLoadouts/Tornado_AWS/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/Tornado_AWS/config.cpp
@@ -1,7 +1,7 @@
 #include "..\..\..\script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
+    class PATCHNAME(AirLoadout_Tornado_AWS) {
         name = COMPONENT_NAME;
         units[] = {};
         weapons[] = {};

--- a/A3A/addons/core/Templates/AircraftLoadouts/UNS/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/UNS/config.cpp
@@ -1,7 +1,7 @@
 #include "..\..\..\script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
+    class PATCHNAME(AirLoadout_UNS) {
         name = COMPONENT_NAME;
         units[] = {};
         weapons[] = {};

--- a/A3A/addons/core/Templates/AircraftLoadouts/VN/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/VN/config.cpp
@@ -1,7 +1,7 @@
 #include "..\..\..\script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
+    class PATCHNAME(AirLoadout_VN) {
         name = COMPONENT_NAME;
         units[] = {};
         weapons[] = {};

--- a/A3A/addons/core/Templates/AircraftLoadouts/Vanilla/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/Vanilla/config.cpp
@@ -1,7 +1,7 @@
 #include "..\..\..\script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
+    class PATCHNAME(AirLoadout_Vanilla) {
         name = COMPONENT_NAME;
         units[] = {};
         weapons[] = {};

--- a/A3A/addons/core/Templates/AircraftLoadouts/WS/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/WS/config.cpp
@@ -1,7 +1,7 @@
 #include "..\..\..\script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
+    class PATCHNAME(AirLoadout_WS) {
         name = COMPONENT_NAME;
         units[] = {};
         weapons[] = {};

--- a/A3A/addons/core/Templates/AircraftLoadouts/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/config.cpp
@@ -1,7 +1,7 @@
 #include "..\..\script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
+    class PATCHNAME(AirLoadout_defaults) {
         name = COMPONENT_NAME;
         units[] = {};
         weapons[] = {};

--- a/A3A/addons/core/script_component.hpp
+++ b/A3A/addons/core/script_component.hpp
@@ -1,2 +1,3 @@
 #define COMPONENT core
 #include "Includes\script_mod.hpp"
+#define PATCHNAME(x) ADDON##_##x


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The aircraft loadout configs all had the same CfgPatches name as core (A3A_core), which caused RPT errors. Not sure it did anything else important, but it should be cleaned up.   

### Please specify which Issue this PR Resolves.
closes #3314

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
