### PR TITLE
Reduce artillery/mortar ratio at high war tiers

### DIFF
--- a/A3A/addons/core/functions/Supports/fn_SUP_artilleryAvailable.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_artilleryAvailable.sqf
@@ -19,4 +19,4 @@ if (_target isKindOf "Air") exitWith { 0 };     // can't hit air
 
 // Weighted against mortars
 if(tierWar < 5) exitWith { 0 };
-(tierWar - 4) / 8;          // ~12.5% at tier 5, 75% at tier 10 
+(tierWar - 4) / 12;          // ~8.3% at tier 5, 50% at tier 10 

--- a/A3A/addons/core/functions/Supports/fn_SUP_mortarAvailable.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_mortarAvailable.sqf
@@ -20,4 +20,4 @@ if (_target isKindOf "Air") exitWith { 0 };     // can't hit air
 // balance this one against artillery
 if (tierWar < 2) exitWith { 0 };
 if (tierWar < 5 or !("ARTILLERY" in _availTypes)) exitWith { 1 };
-1 - (tierWar - 4) / 8;       // // 87.5% at tier 5, 25% at tier 10
+1 - (tierWar - 4) / 12;       // // 91.7% at tier 5, 50% at tier 10


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
The ratio of artillery to mortar supports was apparently a bit excessive at high war tiers. This PR reduces it:

Tier 8: Was 50% artillery, now 33% artillery.
Tier 10: Was 75% artillery, now 50% artillery.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
