### PR TITLE
Improve CUP and IFA plane turn rates when flown by AI

### DIFF
--- a/A3A/addons/config_fixes/CUP/CfgVehicles.hpp
+++ b/A3A/addons/config_fixes/CUP/CfgVehicles.hpp
@@ -2,5 +2,37 @@
 
 class CfgVehicles 
 {
-#include "sfp_air.hpp"
+    #include "sfp_air.hpp"
+
+    // Nose-fall tweaks to make planes turn at a semi-decent rate when flown by AI
+	class Plane_Base_F;
+	class CUP_A10_Base : Plane_Base_F
+	{
+		draconicTorqueXCoef = 2;
+	};
+	class CUP_L39_base : Plane_base_F
+	{
+		draconicTorqueXCoef = 2;
+	};
+
+    // The faster planes benefit slightly from more torque, so we use the array form
+	class Plane;
+	class CUP_AV8B_Base : Plane
+	{
+		draconicTorqueXCoef[] = {2,3,4,5,6,7,8,9,10,10.1,10.2};
+	};
+	class CUP_Su25_base : Plane
+	{
+		draconicTorqueXCoef[] = {2,3,4,5,6,7,8,9,10,10.1,10.2};
+		//speeds in m/s: {0, 37.5, 75, 112.5, 150, 187.5, 225, 262.5, 300, 337.5, 375m/s}
+	};
+	class CUP_F35B_base : Plane
+	{
+		draconicTorqueXCoef[] = {2,3.5,5,6.5,8,9,10,11,12,12.1,12.2};
+		//speeds in m/s: {0, 58.3, 117, 175, 233, 292, 350, 408, 467, 525, 583m/s}
+	};
+	class CUP_SU34_BASE : Plane
+	{
+		draconicTorqueXCoef[] = {2,3.5,5,6.5,8,9,10,11,12,12.1,12.2};
+	};
 };

--- a/A3A/addons/config_fixes/IFA/CfgVehicles.hpp
+++ b/A3A/addons/config_fixes/IFA/CfgVehicles.hpp
@@ -62,4 +62,26 @@ class CfgVehicles
 	class LIB_Armored_Target_Dummy : Tank {
 		delete EventHandlers;
 	};
+
+	// Nose-fall tweaks to make planes turn at a semi-decent rate when flown by AI
+	// Note: LIB_Ju87 not adjusted because planes with low maxSpeed use different AI logic
+	class LIB_GER_Plane_base;
+	class LIB_FW190F8 : LIB_GER_Plane_base
+	{
+		draconicTorqueXCoef = 2;
+	};
+	class LIB_SU_Plane_base;
+	class LIB_P39 : LIB_SU_Plane_base
+	{
+		draconicTorqueXCoef = 2;
+	};
+	class LIB_Pe2 : LIB_SU_Plane_base
+	{
+		draconicTorqueXCoef = 2;
+	};
+	class LIB_US_Plane_base;
+	class LIB_P47 : LIB_US_Plane_base
+	{
+		draconicTorqueXCoef = 2;
+	};
 };


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Most planes with "airplane" simulation have absolutely horrible turn rates when flown by AIs. A major reason for this seems to be that the planes gain too much altitude while banked, causing the AI to back off the elevators until it levels out.

We can't improve this behaviour directly, but it turns out that increasing the value that causes the nose of the plane to dip when banked helps a lot. This is the time in seconds for a 180 degree waypoint turn at normal speed before and after the changes:
```
           before    after
CUP A-10     48       16
CUP AV-8B    37       17
CUP F-35B    33       17
CUP LZ-39    40        9
CUP SU-25    50       16
CUP SU-34    54       19

IFA FW-190   26       13
IFA P39      18       13
IFA Pe2      31       15
```

As a minor added benefit, it feels a bit more like flying a plane for player flight.

I didn't check the transport planes as it takes ages and their turn rate isn't as important. Planes with maxSpeed below ~450 seem to use a different AI anyway, and don't benefit from the change as they only bank to 45 degrees in a turn.

I don't know of any other supported mods that use aircraft with airplane (as against airplanex) simulation. Let me know if there are any others that need fixing.

### Please specify which Issue this PR Resolves.
Maybe a partial fix for #3302. Probably need to look at the missiles used too.

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
