### PR TITLE
Default Arsenal Magazine Limits

### DIFF
--- a/A3A/addons/gui/functions/GUI/fn_arsenalLimitsDialog.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_arsenalLimitsDialog.sqf
@@ -23,7 +23,7 @@ FIX_LINE_NUMBERS()
 
 params ["_mode", "_params"];
 
-private _fnc_defaultLimit = { [A3A_guestItemLimit, 3*A3A_guestItemLimit] select (_this == 26) };
+private _fnc_defaultLimit = { jna_minItemMember select _this;};
 
 private _display = findDisplay A3A_IDD_ARSENALLIMITSDIALOG;
 private _listBox = _display displayCtrl A3A_IDC_ARSLIMLISTBOX;

--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_init.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_init.sqf
@@ -47,8 +47,13 @@ IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL		26
 jna_minItemMember = [-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1];
 //jna_minItemMember = [24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,memberOnlyMagLimit,24,24,24,24,memberOnlyMagLimit];
 jna_minItemMember = jna_minItemMember apply { A3A_guestItemLimit };
-jna_minItemMember set [IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG, A3A_guestItemLimit*3];
-jna_minItemMember set [IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL, A3A_guestItemLimit*3];
+jna_minItemMember set [IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG, minWeaps];
+jna_minItemMember set [IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL, minWeaps];
+
+if (minWeaps == -1) then {
+	jna_minItemMember set [IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG, A3A_guestItemLimit*3];
+	jna_minItemMember set [IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL, A3A_guestItemLimit*3];
+};
 
 //server
 if(isServer)then{

--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_init.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_init.sqf
@@ -51,8 +51,8 @@ jna_minItemMember set [IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG, minWeaps];
 jna_minItemMember set [IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL, minWeaps];
 
 if (minWeaps == -1) then {
-	jna_minItemMember set [IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG, A3A_guestItemLimit*3];
-	jna_minItemMember set [IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL, A3A_guestItemLimit*3];
+    jna_minItemMember set [IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG, A3A_guestItemLimit*3];
+    jna_minItemMember set [IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL, A3A_guestItemLimit*3];
 };
 
 //server


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Sets magazine limits to equal unlock limit rather than 3 times guest limit - adjusting the limit of magazines from either direction proved to be an absolute chore and a nuisance.
Still uses the 3 * guest limit in cases of games ran with no unlocks, as i find that a reasonable case. 
Changed arsenalLimitsDialog to reduce duplicate code, RFC.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
