### PR TITLE
Fix slow-server UI issue and incorrect licensing in arsenal limits

### DIFF
--- a/A3A/addons/gui/dialogues/arsenalLimitsDialog.hpp
+++ b/A3A/addons/gui/dialogues/arsenalLimitsDialog.hpp
@@ -76,6 +76,7 @@ class A3A_ArsenalLimitsDialog : A3A_DefaultDialog {
                     idc = A3A_IDC_ARSLIMTYPESBASE + 0;
                     text="\A3\Ui_f\data\GUI\Rsc\RscDisplayArsenal\PrimaryWeapon_ca.paa";
                     tooltip="$STR_A3_RscDisplayArsenal_tab_PrimaryWeapon";
+                    onLoad = "(_this # 0) ctrlEnable false";                // disable until init is complete
                     onButtonClick = "['typeSelect', [ctrlIDC (_this#0)]] call A3A_GUI_fnc_arsenalLimitsDialog";
                     colorDisabled[] = {0,0,0,1};
                     colorBackgroundDisabled[] = {1,1,1,1};

--- a/A3A/addons/gui/functions/GUI/fn_arsenalLimitsDialog.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_arsenalLimitsDialog.sqf
@@ -1,5 +1,5 @@
 /*
-Maintainer: Caleb Serafin, DoomMetal
+Maintainer: John Jordan
     Handles the initialization and updating of the arsenal guest limits dialog.
 
 Arguments:
@@ -11,8 +11,6 @@ Returns:
 
 Environment:
     Should not be called by onLoad because findDisplay and ctrlParent do not work in that context.
-
-License: APL-ND
 
 */
 
@@ -46,7 +44,7 @@ switch (_mode) do
             [localize "STR_antistasi_arsenal_limits_dialog_hint_title", localize "STR_antistasi_arsenal_limits_dialog_guest_warning"] call A3A_fnc_customHint;
             (_display displayctrl A3A_IDC_ARSLIMRESETBUTTON) ctrlEnable false;
         };
-        ["typeSelect", [A3A_IDC_ARSLIMTYPESBASE]] call A3A_GUI_fnc_ArsenalLimitsDialog;
+        ["typeSelect", [A3A_IDC_ARSLIMTYPESBASE]] call A3A_GUI_fnc_arsenalLimitsDialog;
     };
 
     case ("typeSelect"):
@@ -95,7 +93,7 @@ switch (_mode) do
                 _button ctrlCommit 0;
                 _button ctrlSetText _text;
                 _button setVariable ["A3A_params", [_valCtrl, _adjust]];
-                _button ctrlAddEventHandler ["ButtonClick", { ["listButton", _this] call A3A_GUI_fnc_ArsenalLimitsDialog }];
+                _button ctrlAddEventHandler ["ButtonClick", { ["listButton", _this] call A3A_GUI_fnc_arsenalLimitsDialog }];
             } forEach [["R", "R", 66], ["-", -5, 70], ["+", 5, 82], ["U", "U", 86]];
 
         } forEach (jna_datalist#_typeIndex select {_x#1>0});        // only show non-unlocked items
@@ -142,7 +140,7 @@ switch (_mode) do
             A3A_arsenalLimits deleteAt (_x#0);
         } forEach (jna_datalist#_typeIndex);
 
-        ["typeSelect", [_typeIndex + A3A_IDC_ARSLIMTYPESBASE]] call A3A_GUI_fnc_ArsenalLimitsDialog;          // refresh the display
+        ["typeSelect", [_typeIndex + A3A_IDC_ARSLIMTYPESBASE]] call A3A_GUI_fnc_arsenalLimitsDialog;          // refresh the display
     };
 
 /*    case ("stepButton"):


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
On slow dedicated servers, it was possible to select a category in the arsenal limits dialog before the arsenal data had been received. This could cause double-overlaid controls because the control creation routines would overlap. This PR fixes the problem by disabling the category controls until the initial setup and category rendering are complete.

The arsenal limits code also recently acquired incorrect attribution and licensing. This has been fixed.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Should test on a server that's slow enough to generate the problem, although I'm pretty sure this will work.
