### PR TITLE
Slow down self-revive timeout when downed

### DIFF
--- a/A3A/addons/core/functions/Revive/fn_unconscious.sqf
+++ b/A3A/addons/core/functions/Revive/fn_unconscious.sqf
@@ -87,6 +87,10 @@ while {(time < _bleedOut) and (_unit getVariable ["incapacitated",false]) and (a
 	};
 
 	if (_isPlayer) then	{
+		// Slow down self-revive timeout expiry while downed
+		private _timeout = _unit getVariable ["A3A_selfReviveTimeout", -1];
+		if (_timeout > 0) then { _unit setVariable ["A3A_selfReviveTimeout", _timeout + 0.5] };
+
 		private _helpText = "<t size='0.8'>" + call {
 			if (isNull _helper) exitWith {localize "STR_A3A_fn_revive_unconscious_noAI"};
 			if (_helper distance _unit < 3) exitWith { format [localize "STR_A3A_fn_revive_unconscious_helping", name _helper] };


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement
4. [X] Exploit

### What have you changed and why?
Because the self-revive timeout and unconscious bleeding timeout were both five minutes, it was possible to self-revive indefinitely. Mostly not an issue (laying on the floor for five minutes is not productive), but it enables some degenerate behaviour with missions and vehicle stealing.

The fix adds half a second to the self-revive timeout for each second a player was downed. This means that you'd need to stay alive for ~150 seconds to self-revive successfully before bleeding to death.

### Please specify which Issue this PR Resolves.
closes #3342

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
