### PR TITLE
Create new classes for Antistasi AI units, block those from group join

### DIFF
--- a/A3A/addons/core/CfgVehicles.hpp
+++ b/A3A/addons/core/CfgVehicles.hpp
@@ -1,0 +1,149 @@
+class CfgVehicles
+{
+    // Rebel AI unit types
+    
+    //don't need to change this one?
+    //class I_G_Survivor_F;
+
+    class I_G_Soldier_F;
+    class a3a_unit_reb : I_G_Soldier_F {
+        backpack = "";
+        headgearProbability = 0;
+        linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
+        magazines[] = {};
+        weapons[] = {"Throw","Put"};
+    };
+
+    class I_G_medic_F;
+    class a3a_unit_reb_medic : I_G_medic_F {
+        backpack = "";
+        headgearProbability = 0;
+        linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
+        magazines[] = {};
+        weapons[] = {"Throw","Put"};
+    };
+
+    class I_G_Sharpshooter_F;
+    class a3a_unit_reb_sniper : I_G_Sharpshooter_F {
+        backpack = "";
+        headgearProbability = 0;
+        linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
+        magazines[] = {};
+        weapons[] = {"Throw","Put"};
+    };
+
+    class I_G_Soldier_M_F;
+    class a3a_unit_reb_marksman : I_G_Soldier_M_F {
+        backpack = "";
+        headgearProbability = 0;
+        linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
+        magazines[] = {};
+        weapons[] = {"Throw","Put"};
+    };
+
+    class I_G_Soldier_LAT_F;
+    class a3a_unit_reb_lat : I_G_Soldier_LAT_F {
+        backpack = "";
+        headgearProbability = 0;
+        linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
+        magazines[] = {};
+        weapons[] = {"Throw","Put"};
+    };
+
+    class I_G_Soldier_AR_F;
+    class a3a_unit_reb_mg : I_G_Soldier_AR_F {
+        backpack = "";
+        headgearProbability = 0;
+        linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
+        magazines[] = {};
+        weapons[] = {"Throw","Put"};
+    };
+
+    class I_G_Soldier_exp_F;
+    class a3a_unit_reb_exp : I_G_Soldier_exp_F {
+        backpack = "";
+        headgearProbability = 0;
+        linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
+        magazines[] = {};
+        weapons[] = {"Throw","Put"};
+    };
+
+    class I_G_Soldier_GL_F;
+    class a3a_unit_reb_gl : I_G_Soldier_GL_F {
+        backpack = "";
+        headgearProbability = 0;
+        linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
+        magazines[] = {};
+        weapons[] = {"Throw","Put"};
+    };
+
+    class I_G_Soldier_SL_F;
+    class a3a_unit_reb_sl : I_G_Soldier_SL_F {
+        backpack = "";
+        headgearProbability = 0;
+        linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
+        magazines[] = {};
+        weapons[] = {"Throw","Put"};
+    };
+
+    class I_G_engineer_F;
+    class a3a_unit_reb_eng : I_G_engineer_F {
+        backpack = "";
+        headgearProbability = 0;
+        linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
+        magazines[] = {};
+        weapons[] = {"Throw","Put"};
+    };
+
+    class I_Soldier_AT_F;
+    class a3a_unit_reb_at : I_Soldier_AT_F {
+        backpack = "";
+        headgearProbability = 0;
+        linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
+        magazines[] = {};
+        weapons[] = {"Throw","Put"};
+    };
+
+    class I_Soldier_AA_F;
+    class a3a_unit_reb_aa : I_Soldier_AA_F {
+        backpack = "";
+        headgearProbability = 0;
+        linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
+        magazines[] = {};
+        weapons[] = {"Throw","Put"};
+    };
+
+    class I_G_officer_F;
+    class a3a_unit_reb_petros : I_G_officer_F {
+        backpack = "";
+        headgearProbability = 0;
+        linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
+        magazines[] = {};
+        weapons[] = {"Throw","Put"};
+    };
+
+    // Base side types
+
+    class B_G_Soldier_F;
+    class a3a_unit_west : B_G_Soldier_F {
+        backpack = "";
+        headgearProbability = 0;
+        linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
+        magazines[] = {};
+        weapons[] = {"Throw","Put"};
+    };
+
+    class O_G_Soldier_F;
+    class a3a_unit_east : O_G_Soldier_F {
+        backpack = "";
+        headgearProbability = 0;
+        linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
+        magazines[] = {};
+        weapons[] = {"Throw","Put"};
+    };
+
+    class C_Man_1;
+    class a3a_unit_civ : C_Man_1 {
+    };
+
+};

--- a/A3A/addons/core/CfgVehicles.hpp
+++ b/A3A/addons/core/CfgVehicles.hpp
@@ -3,12 +3,12 @@ class CfgVehicles
     // Rebel AI unit types
     
     //don't need to change this one?
-    //class I_G_Survivor_F;
+    class I_G_Survivor_F;
+    class a3a_unit_reb_unarmed : I_G_Survivor_F {};
 
     class I_G_Soldier_F;
     class a3a_unit_reb : I_G_Soldier_F {
         backpack = "";
-        headgearProbability = 0;
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         magazines[] = {};
         weapons[] = {"Throw","Put"};
@@ -17,7 +17,6 @@ class CfgVehicles
     class I_G_medic_F;
     class a3a_unit_reb_medic : I_G_medic_F {
         backpack = "";
-        headgearProbability = 0;
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         magazines[] = {};
         weapons[] = {"Throw","Put"};
@@ -26,7 +25,6 @@ class CfgVehicles
     class I_G_Sharpshooter_F;
     class a3a_unit_reb_sniper : I_G_Sharpshooter_F {
         backpack = "";
-        headgearProbability = 0;
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         magazines[] = {};
         weapons[] = {"Throw","Put"};
@@ -35,7 +33,6 @@ class CfgVehicles
     class I_G_Soldier_M_F;
     class a3a_unit_reb_marksman : I_G_Soldier_M_F {
         backpack = "";
-        headgearProbability = 0;
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         magazines[] = {};
         weapons[] = {"Throw","Put"};
@@ -44,7 +41,6 @@ class CfgVehicles
     class I_G_Soldier_LAT_F;
     class a3a_unit_reb_lat : I_G_Soldier_LAT_F {
         backpack = "";
-        headgearProbability = 0;
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         magazines[] = {};
         weapons[] = {"Throw","Put"};
@@ -53,7 +49,6 @@ class CfgVehicles
     class I_G_Soldier_AR_F;
     class a3a_unit_reb_mg : I_G_Soldier_AR_F {
         backpack = "";
-        headgearProbability = 0;
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         magazines[] = {};
         weapons[] = {"Throw","Put"};
@@ -62,7 +57,6 @@ class CfgVehicles
     class I_G_Soldier_exp_F;
     class a3a_unit_reb_exp : I_G_Soldier_exp_F {
         backpack = "";
-        headgearProbability = 0;
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         magazines[] = {};
         weapons[] = {"Throw","Put"};
@@ -71,7 +65,6 @@ class CfgVehicles
     class I_G_Soldier_GL_F;
     class a3a_unit_reb_gl : I_G_Soldier_GL_F {
         backpack = "";
-        headgearProbability = 0;
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         magazines[] = {};
         weapons[] = {"Throw","Put"};
@@ -80,7 +73,6 @@ class CfgVehicles
     class I_G_Soldier_SL_F;
     class a3a_unit_reb_sl : I_G_Soldier_SL_F {
         backpack = "";
-        headgearProbability = 0;
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         magazines[] = {};
         weapons[] = {"Throw","Put"};
@@ -89,7 +81,6 @@ class CfgVehicles
     class I_G_engineer_F;
     class a3a_unit_reb_eng : I_G_engineer_F {
         backpack = "";
-        headgearProbability = 0;
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         magazines[] = {};
         weapons[] = {"Throw","Put"};
@@ -98,7 +89,6 @@ class CfgVehicles
     class I_Soldier_AT_F;
     class a3a_unit_reb_at : I_Soldier_AT_F {
         backpack = "";
-        headgearProbability = 0;
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         magazines[] = {};
         weapons[] = {"Throw","Put"};
@@ -107,7 +97,6 @@ class CfgVehicles
     class I_Soldier_AA_F;
     class a3a_unit_reb_aa : I_Soldier_AA_F {
         backpack = "";
-        headgearProbability = 0;
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         magazines[] = {};
         weapons[] = {"Throw","Put"};
@@ -116,7 +105,6 @@ class CfgVehicles
     class I_G_officer_F;
     class a3a_unit_reb_petros : I_G_officer_F {
         backpack = "";
-        headgearProbability = 0;
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         magazines[] = {};
         weapons[] = {"Throw","Put"};
@@ -127,7 +115,6 @@ class CfgVehicles
     class B_G_Soldier_F;
     class a3a_unit_west : B_G_Soldier_F {
         backpack = "";
-        headgearProbability = 0;
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         magazines[] = {};
         weapons[] = {"Throw","Put"};
@@ -136,14 +123,12 @@ class CfgVehicles
     class O_G_Soldier_F;
     class a3a_unit_east : O_G_Soldier_F {
         backpack = "";
-        headgearProbability = 0;
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
         magazines[] = {};
         weapons[] = {"Throw","Put"};
     };
 
     class C_Man_1;
-    class a3a_unit_civ : C_Man_1 {
-    };
+    class a3a_unit_civ : C_Man_1 {};
 
 };

--- a/A3A/addons/core/config.cpp
+++ b/A3A/addons/core/config.cpp
@@ -60,3 +60,6 @@ class CfgMPGameTypes {
 };
 
 #include "CfgMarkers.hpp"
+
+// Base AI unit definitions
+#include "CfgVehicles.hpp"

--- a/A3A/addons/core/functions/Templates/fn_compatibilityLoadFaction.sqf
+++ b/A3A/addons/core/functions/Templates/fn_compatibilityLoadFaction.sqf
@@ -26,29 +26,29 @@ missionNamespace setVariable ["A3A_faction_" + _factionPrefix, _faction];
 [_faction, _factionPrefix] call A3A_fnc_compileGroups;
 
 private _baseUnitClass = switch (_side) do {
-    case west: { "B_G_Soldier_F" };
-    case east: { "O_G_Soldier_F" };
-    case independent: { "I_G_Soldier_F" };
-    case civilian: { "C_Man_1" };
+    case west: { "a3a_unit_west" };
+    case east: { "a3a_unit_east" };
+    case independent: { "a3a_unit_reb" };
+    case civilian: { "a3a_unit_civ" };
 };
 
 private _unitClassMap = if (_side isNotEqualTo independent) then { createHashMap } else {
     createHashMapFromArray [                // Cases matter. Lower case here because allVariables on namespace returns lowercase
         ["militia_Unarmed", "I_G_Survivor_F"],
-        ["militia_Rifleman", "I_G_Soldier_F"],
-        ["militia_staticCrew", "I_G_Soldier_F"],
-        ["militia_Medic", "I_G_medic_F"],
-        ["militia_Sniper", "I_G_Sharpshooter_F"],
-        ["militia_Marksman", "I_G_Soldier_M_F"],
-        ["militia_LAT", "I_G_Soldier_LAT_F"],
-        ["militia_MachineGunner", "I_G_Soldier_AR_F"],
-        ["militia_ExplosivesExpert", "I_G_Soldier_exp_F"],
-        ["militia_Grenadier", "I_G_Soldier_GL_F"],
-        ["militia_SquadLeader", "I_G_Soldier_SL_F"],
-        ["militia_Engineer", "I_G_engineer_F"],
-        ["militia_AT", "I_Soldier_AT_F"],
-        ["militia_AA", "I_Soldier_AA_F"],
-        ["militia_Petros", "I_G_officer_F"]
+        ["militia_Rifleman", "a3a_unit_reb"],
+        ["militia_staticCrew", "a3a_unit_reb"],
+        ["militia_Medic", "a3a_unit_reb_medic"],
+        ["militia_Sniper", "a3a_unit_reb_sniper"],
+        ["militia_Marksman", "a3a_unit_reb_marksman"],
+        ["militia_LAT", "a3a_unit_reb_lat"],
+        ["militia_MachineGunner", "a3a_unit_reb_mg"],
+        ["militia_ExplosivesExpert", "a3a_unit_reb_exp"],
+        ["militia_Grenadier", "a3a_unit_reb_gl"],
+        ["militia_SquadLeader", "a3a_unit_reb_sl"],
+        ["militia_Engineer", "a3a_unit_reb_eng"],
+        ["militia_AT", "a3a_unit_reb_at"],
+        ["militia_AA", "a3a_unit_reb_aa"],
+        ["militia_Petros", "a3a_unit_reb_petros"]
     ]
 };
 //validate loadouts

--- a/A3A/addons/core/functions/Templates/fn_compatibilityLoadFaction.sqf
+++ b/A3A/addons/core/functions/Templates/fn_compatibilityLoadFaction.sqf
@@ -34,7 +34,7 @@ private _baseUnitClass = switch (_side) do {
 
 private _unitClassMap = if (_side isNotEqualTo independent) then { createHashMap } else {
     createHashMapFromArray [                // Cases matter. Lower case here because allVariables on namespace returns lowercase
-        ["militia_Unarmed", "I_G_Survivor_F"],
+        ["militia_Unarmed", "a3a_unit_reb_unarmed"],
         ["militia_Rifleman", "a3a_unit_reb"],
         ["militia_staticCrew", "a3a_unit_reb"],
         ["militia_Medic", "a3a_unit_reb_medic"],

--- a/A3A/addons/core/functions/init/fn_initACE.sqf
+++ b/A3A/addons/core/functions/init/fn_initACE.sqf
@@ -57,7 +57,7 @@ if (isNil "ace_interact_menu_fnc_compileMenu" || isNil "ace_interact_menu_fnc_co
 // Player units
 private _unitTypes = ["I_G_soldier_F", "I_G_Soldier_TL_F", "I_G_Soldier_AR_F", "I_G_medic_F", "I_G_engineer_F", "I_G_Soldier_GL_F"];
 // AI units
-_unitTypes append ["a3a_unit_west", "a3a_unit_east", "a3a_unit_civ", "a3a_unit_reb", "a3a_unit_reb_medic", "a3a_unit_reb_sniper", "a3a_unit_reb_marksman",
+_unitTypes append ["a3a_unit_west", "a3a_unit_east", "a3a_unit_civ", "a3a_unit_reb", "a3a_unit_reb_unarmed", "a3a_unit_reb_medic", "a3a_unit_reb_sniper", "a3a_unit_reb_marksman",
     "a3a_unit_reb_lat", "a3a_unit_reb_mg", "a3a_unit_reb_exp", "a3a_unit_reb_gl", "a3a_unit_reb_sl", "a3a_unit_reb_eng", "a3a_unit_reb_at", "a3a_unit_reb_aa", "a3a_unit_reb_petros"];
 
 {

--- a/A3A/addons/core/functions/init/fn_initACE.sqf
+++ b/A3A/addons/core/functions/init/fn_initACE.sqf
@@ -50,9 +50,16 @@ if (A3A_hasACEMedical) then {
 if (isNil "ace_interact_menu_fnc_compileMenu" || isNil "ace_interact_menu_fnc_compileMenuSelfAction") exitWith {
     Error("ACE non-public functions have changed, rebel group join/leave actions will not be removed.");
 };
-// Remove group join action from all rebel unit types
+
+// Remove actions from Antistasi unit types
 // Need to compile the menus first, because ACE delays creating menus until a unit of that class is created
-private _unitTypes = ["I_G_soldier_F", "I_G_Soldier_TL_F", "I_G_Soldier_AR_F", "I_G_medic_F", "I_G_engineer_F", "I_G_Soldier_GL_F", "I_G_officer_F"];
+
+// Player units
+private _unitTypes = ["I_G_soldier_F", "I_G_Soldier_TL_F", "I_G_Soldier_AR_F", "I_G_medic_F", "I_G_engineer_F", "I_G_Soldier_GL_F"];
+// AI units
+_unitTypes append ["a3a_unit_west", "a3a_unit_east", "a3a_unit_civ", "a3a_unit_reb", "a3a_unit_reb_medic", "a3a_unit_reb_sniper", "a3a_unit_reb_marksman",
+    "a3a_unit_reb_lat", "a3a_unit_reb_mg", "a3a_unit_reb_exp", "a3a_unit_reb_gl", "a3a_unit_reb_sl", "a3a_unit_reb_eng", "a3a_unit_reb_at", "a3a_unit_reb_aa", "a3a_unit_reb_petros"];
+
 {
     [_x] call ace_interact_menu_fnc_compileMenu;
     [_x] call ace_interact_menu_fnc_compileMenuSelfAction;
@@ -60,4 +67,3 @@ private _unitTypes = ["I_G_soldier_F", "I_G_Soldier_TL_F", "I_G_Soldier_AR_F", "
     [_x, 1, ["ACE_SelfActions", "ACE_TeamManagement", "ACE_LeaveGroup"]] call ace_interact_menu_fnc_removeActionFromClass;
     [_x, 0, ["ACE_MainActions", "ACE_JoinGroup"]] call ace_interact_menu_fnc_removeActionFromClass;
 } forEach _unitTypes;			// TODO: add raw unit types from new templates
-


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Created new classes for Antistasi AI units, giving us better control over ACE actions and slightly better server & client performance. Removes ACE group join & handcuff actions from those classes.

Mostly works. Doesn't touch headgear/glasses/identity stuff but stripping more of that would have further performance benefits if I can be bothered to do the research. `headgearProbability = 0` doesn't seem to do anything.

### Please specify which Issue this PR Resolves.
closes #3348

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Probably needs a test server run in case I overlooked something.
