### PR TITLE
Fix issue where running destroyCity with CUP interiors could crash

### DIFF
--- a/A3A/addons/core/functions/Base/fn_destroyCity.sqf
+++ b/A3A/addons/core/functions/Base/fn_destroyCity.sqf
@@ -1,21 +1,18 @@
-private ["_markerX","_positionX","_size","_buildings"];
+params ["_markerX"];
 
-_markerX = _this select 0;
+private _positionX = getMarkerPos _markerX;
+private _size = [_markerX] call A3A_fnc_sizeMarker;
 
-_positionX = getMarkerPos _markerX;
-_size = [_markerX] call A3A_fnc_sizeMarker;
-
-_buildings = _positionX nearobjects ["house",_size];
+private _buildings = _positionX nearobjects ["house",_size];
 
 {
-if (random 100 < 70) then
-	{
-	for "_i" from 1 to 7 do
-		{
-		_x sethit [format ["dam%1",_i],1];
-		_x sethit [format ["dam %1",_i],1];
-		};
-	}
+    private _hitpoints = getAllHitPointsDamage _x;
+    if (_hitpoints isEqualTo []) then { continue };
+    if (random 100 < 30) then { continue };
+    private _building = _x;
+    {
+        _building setHit [_x, 1];
+    } forEach (_hitpoints # 1 select { _x find "dam" == 0 });
 } forEach _buildings;
 
 [_markerX,false] spawn A3A_fnc_blackout;

--- a/A3A/addons/core/functions/Base/fn_destroyCity.sqf
+++ b/A3A/addons/core/functions/Base/fn_destroyCity.sqf
@@ -3,7 +3,7 @@ params ["_markerX"];
 private _positionX = getMarkerPos _markerX;
 private _size = [_markerX] call A3A_fnc_sizeMarker;
 
-private _buildings = _positionX nearobjects ["house",_size];
+private _buildings = _positionX nearObjects ["house",_size];
 
 {
     private _hitpoints = getAllHitPointsDamage _x;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
When loading the Interiors for CUP mod, destroyCity (used when a punishment fails) would crash on some cities. Apparently this is because the mod incorrectly removes the models for some sign objects, causing setHit to crash Arma. This PR works around the problem by not calling setHit on selections that don't exist, which was rather dangerous behaviour anyway.

Shouldn't have any functional changes in other cases. Note that CUP buildings are mostly lacking in building damage modelling compared to vanilla A3 buildings, so destroyed cities don't look much different.

### Please specify which Issue this PR Resolves.
closes #3357

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Load CUP maps with Interiors for CUP. Run `["Pustoshka"] call A3A_fnc_destroyCity;` on Chernarus Autumn, see if it crashes.
