### PR TITLE
Remove CUP Cluster MLRS

### DIFF
--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_BW_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_BW_Arid.sqf
@@ -45,10 +45,9 @@
 ["vehiclesHelisLightAttack", ["CUP_B_UH1D_armed_GER_KSK_Des", "CUP_B_UH1D_gunship_GER_KSK_Des", "CUP_B_AW159_GER"]] call _fnc_saveToTemplate;
 ["vehiclesHelisAttack", ["CUP_B_AH1Z_Dynamic_USMC"]] call _fnc_saveToTemplate;
 
-["vehiclesArtillery", ["CUP_B_M270_DPICM_USA","CUP_B_M270_HE_USA"]] call _fnc_saveToTemplate;
+["vehiclesArtillery", ["CUP_B_M270_HE_USA"]] call _fnc_saveToTemplate;
 ["magazines", createHashMapFromArray [
-["CUP_B_M270_HE_USA", ["CUP_12Rnd_MLRS_HE"]],
-["CUP_B_M270_DPICM_USA", ["CUP_12Rnd_MLRS_DPICM"]]
+["CUP_B_M270_HE_USA", ["CUP_12Rnd_MLRS_HE"]]
 ]] call _fnc_saveToTemplate;
 
 ["uavsAttack", ["CUP_B_USMC_DYN_MQ9"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_BW_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_BW_Temperate.sqf
@@ -45,10 +45,9 @@
 ["vehiclesHelisLightAttack", ["CUP_B_UH1D_armed_GER_KSK", "CUP_B_UH1D_gunship_GER_KSK", "CUP_B_AW159_GER"]] call _fnc_saveToTemplate;
 ["vehiclesHelisAttack", ["CUP_B_AH1Z_Dynamic_USMC"]] call _fnc_saveToTemplate;
 
-["vehiclesArtillery", ["CUP_B_M270_HE_USMC", "CUP_B_M270_DPICM_USMC"]] call _fnc_saveToTemplate;
+["vehiclesArtillery", ["CUP_B_M270_HE_USMC"]] call _fnc_saveToTemplate;
 ["magazines", createHashMapFromArray [
-["CUP_B_M270_HE_USMC", ["CUP_12Rnd_MLRS_HE"]],
-["CUP_B_M270_DPICM_USMC", ["CUP_12Rnd_MLRS_DPICM"]]
+["CUP_B_M270_HE_USMC", ["CUP_12Rnd_MLRS_HE"]]
 ]] call _fnc_saveToTemplate;
 
 ["uavsAttack", ["CUP_B_USMC_DYN_MQ9"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_HIL.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_HIL.sqf
@@ -45,10 +45,9 @@
 ["vehiclesHelisLightAttack", ["CUP_B_AW159_HIL","CUP_B_412_Military_Armed_AT_HIL","CUP_B_412_Military_Armed_HIL","CUP_B_412_dynamicLoadout_HIL"]] call _fnc_saveToTemplate;
 ["vehiclesHelisAttack", ["CUP_B_AH1Z_Dynamic_USMC"]] call _fnc_saveToTemplate;
 
-["vehiclesArtillery", ["CUP_B_M270_HE_HIL", "CUP_B_M270_DPICM_HIL"]] call _fnc_saveToTemplate;
+["vehiclesArtillery", ["CUP_B_M270_HE_HIL"]] call _fnc_saveToTemplate;
 ["magazines", createHashMapFromArray [
-["CUP_B_M270_HE_HIL", ["CUP_12Rnd_MLRS_HE"]],
-["CUP_B_M270_DPICM_HIL", ["CUP_12Rnd_MLRS_DPICM"]]
+["CUP_B_M270_HE_HIL", ["CUP_12Rnd_MLRS_HE"]]
 ]] call _fnc_saveToTemplate;
 
 ["uavsAttack", ["CUP_B_USMC_DYN_MQ9"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_ION_Arctic.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_ION_Arctic.sqf
@@ -45,8 +45,8 @@
 ["vehiclesHelisLightAttack", ["CUP_I_412_dynamicLoadout_PMC", "CUP_I_412_Military_Armed_AT_PMC"]] call _fnc_saveToTemplate;
 ["vehiclesHelisAttack", ["CUP_I_Mi24_Mk3_ION"]] call _fnc_saveToTemplate;
 
-["vehiclesArtillery", ["CUP_B_M270_DPICM_BAF_DES"]] call _fnc_saveToTemplate;
-["magazines", createHashMapFromArray [["CUP_B_M270_DPICM_BAF_DES", ["CUP_12Rnd_MLRS_DPICM"]]]] call _fnc_saveToTemplate; //element format: [Vehicle class, [Magazines]]
+["vehiclesArtillery", ["CUP_B_M270_HE_BAF"]] call _fnc_saveToTemplate;
+["magazines", createHashMapFromArray [["CUP_B_M270_HE_BAF", ["CUP_12Rnd_MLRS_HE"]]]] call _fnc_saveToTemplate; //element format: [Vehicle class, [Magazines]]
 
 ["uavsAttack", ["CUP_B_USMC_DYN_MQ9"]] call _fnc_saveToTemplate;
 ["uavsPortable", ["B_UAV_01_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_ION_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_ION_Arid.sqf
@@ -45,8 +45,8 @@
 ["vehiclesHelisLightAttack", ["CUP_I_412_dynamicLoadout_PMC", "CUP_I_412_Military_Armed_AT_PMC"]] call _fnc_saveToTemplate;
 ["vehiclesHelisAttack", ["CUP_I_Mi24_Mk3_ION"]] call _fnc_saveToTemplate;
 
-["vehiclesArtillery", ["CUP_B_M270_DPICM_BAF_DES"]] call _fnc_saveToTemplate;
-["magazines", createHashMapFromArray [["CUP_B_M270_DPICM_BAF_DES", ["CUP_12Rnd_MLRS_DPICM"]]]] call _fnc_saveToTemplate; //element format: [Vehicle class, [Magazines]]
+["vehiclesArtillery", ["CUP_B_M270_HE_BAF_DES"]] call _fnc_saveToTemplate;
+["magazines", createHashMapFromArray [["CUP_B_M270_HE_BAF_DES", ["CUP_12Rnd_MLRS_HE"]]]] call _fnc_saveToTemplate; //element format: [Vehicle class, [Magazines]]
 
 ["uavsAttack", ["CUP_B_USMC_DYN_MQ9"]] call _fnc_saveToTemplate;
 ["uavsPortable", ["B_UAV_01_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Marine_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Marine_Arid.sqf
@@ -45,10 +45,9 @@
 ["vehiclesHelisLightAttack", ["CUP_B_MH60L_DAP_4x_USN", "CUP_B_UH1Y_Gunship_Dynamic_USMC"]] call _fnc_saveToTemplate;
 ["vehiclesHelisAttack", ["CUP_B_AH1Z_Dynamic_USMC"]] call _fnc_saveToTemplate;
 
-["vehiclesArtillery", ["CUP_B_M270_DPICM_USA","CUP_B_M270_HE_USA"]] call _fnc_saveToTemplate;
+["vehiclesArtillery", ["CUP_B_M270_HE_USA"]] call _fnc_saveToTemplate;
 ["magazines", createHashMapFromArray [
-["CUP_B_M270_HE_USA", ["CUP_12Rnd_MLRS_HE"]],
-["CUP_B_M270_DPICM_USA", ["CUP_12Rnd_MLRS_DPICM"]]
+["CUP_B_M270_HE_USA", ["CUP_12Rnd_MLRS_HE"]]
 ]] call _fnc_saveToTemplate;
 
 ["uavsAttack", ["CUP_B_USMC_DYN_MQ9"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Marine_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Marine_Temperate.sqf
@@ -45,10 +45,9 @@
 ["vehiclesHelisLightAttack", ["CUP_B_MH60L_DAP_4x_USN", "CUP_B_UH1Y_Gunship_Dynamic_USMC"]] call _fnc_saveToTemplate;
 ["vehiclesHelisAttack", ["CUP_B_AH1Z_Dynamic_USMC"]] call _fnc_saveToTemplate;
 
-["vehiclesArtillery", ["CUP_B_M270_HE_USMC","CUP_B_M270_DPICM_USMC"]] call _fnc_saveToTemplate;
+["vehiclesArtillery", ["CUP_B_M270_HE_USMC"]] call _fnc_saveToTemplate;
 ["magazines", createHashMapFromArray [
-["CUP_B_M270_HE_USMC", ["CUP_12Rnd_MLRS_HE"]],
-["CUP_B_M270_DPICM_USMC", ["CUP_12Rnd_MLRS_DPICM"]]
+["CUP_B_M270_HE_USMC", ["CUP_12Rnd_MLRS_HE"]]
 ]] call _fnc_saveToTemplate;
 
 ["uavsAttack", ["CUP_B_USMC_DYN_MQ9"]] call _fnc_saveToTemplate;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Information: Removed CUP Cluster MLRS from a few templates, specifically the M270 DPICM, as the cluster munitions it uses are absolutely devastating against infantry and are unfun to play against.

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: `["ARTILLERY", Occupants, "defence", 10000, player, getPosATL player, 1, 1] spawn A3A_fnc_createSupport;`
