### PR TITLE
Workaround Arma bug with CDLC detection and arma3.cfg mod loading method

### DIFF
--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -262,10 +262,12 @@ FIX_LINE_NUMBERS()
 //////////////////////////////////////
 Info("Setting up faction and DLC equipment flags");
 
+// Arma bug: Need to hardcode CDLC because arma3.cfg mod loading method doesn't register CDLC as "official"
+private _loadedDLC = getLoadedModsInfo select { (_x#2) and !(_x#1 in ["A3","curator","argo","tacops"]) };
+_loadedDLC append (getLoadedModsInfo select { tolower (_x#1) in ["gm", "rf", "spe", "vn", "ws"] });
+_loadedDLC = _loadedDLC apply { tolower (_x#1) };
+
 // Set enabled & disabled DLC/CDLC arrays for faction/equipment modification
-private _loadedDLC = getLoadedModsInfo select {
-	(_x#3) and {!(_x#1 in ["A3","curator","argo","tacops"])}
-} apply {tolower (_x#1)};
 A3A_enabledDLC = (_saveData get "DLC") apply {tolower _x};                 // should be pre-checked against _loadedDLC
 {
 	A3A_enabledDLC insert [0, getArray (configFile/"A3A"/"Templates"/_x/"forceDLC"), true];		// add unique elements only
@@ -276,7 +278,7 @@ A3A_disabledMods = A3A_disabledDLC;                 // Split to allow CUP civili
 // Everything that counts as vanilla: Official DLC plus various junk tags
 A3A_vanillaMods = (getLoadedModsInfo select {_x#2 and _x#3} apply {tolower (_x#1)}) + ["", "officialmod"];
 
-Debug_3("DLC enabled: %1 Disabled: %2 Vanilla: %3", A3A_enabledDLC, A3A_disabledDLC, A3A_vanillaMods);
+Debug_4("DLC loaded: %1 Enabled: %2 Disabled: %3 Vanilla: %4", _loadedDLC, A3A_enabledDLC, A3A_disabledDLC, A3A_vanillaMods);
 
 // TODO: fix all allowDLCxxx and A3A_hasxxx references in templates
 // for the moment just fudge the ones that we're using

--- a/A3A/addons/core/functions/init/fn_setupMonitor.sqf
+++ b/A3A/addons/core/functions/init/fn_setupMonitor.sqf
@@ -15,10 +15,9 @@ private _addonVics = "true" configClasses (configFile/"A3A"/"AddonVics");
 
 // Ignore DLC without equipment and vehicles
 // Need the true names from here, so pass it all in
-private _loadedDLC = getLoadedModsInfo select {
-	(_x#3) and {!(_x#1 in ["A3","curator","argo","tacops"])}
-};
-
+// Arma bug: Need to hardcode CDLC because arma3.cfg mod loading method doesn't register CDLC as "official"
+private _loadedDLC = getLoadedModsInfo select { (_x#2) and !(_x#1 in ["A3","curator","argo","tacops"]) };
+_loadedDLC append (getLoadedModsInfo select { tolower (_x#1) in ["gm", "rf", "spe", "vn", "ws"] });
 
 private _autoLoadTime = "autoLoadLastGame" call BIS_fnc_getParamValue;
 private _autoLoadData = nil;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
If you use the "Arma 3 Unix Launcher" to start Arma with CDLC, they are not reported as official in the mod table. Can be replicated by seelecting mods to load from within Arma. This breaks Antistasi's CDLC detection logic. 

https://feedback.bistudio.com/T182946

This PR replaces the detection logic with a whitelist, which should at least work on all platforms. If further CDLC need to be supported then we'll need to add them to the list.

### Please specify which Issue this PR Resolves.
closes #3360

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
