### PR TITLE
Very small sell price rework

### DIFF
--- a/A3A/addons/core/functions/Base/fn_getVehicleSellPrice.sqf
+++ b/A3A/addons/core/functions/Base/fn_getVehicleSellPrice.sqf
@@ -15,6 +15,8 @@
     Dependencies:
 
     Example: [_vehicle] call A3A_getVehicleSellPrice
+
+    TODO: The sell prices themselves could do with a rework. Not even sure what's balanced
 */
 
 #include "..\..\script_component.hpp"
@@ -46,13 +48,16 @@ if (_typeX in _blacklistedAssets) exitWith {0};
 
 if (_veh isKindOf "StaticWeapon") exitWith {100};			// in case rebel static is same as enemy statics
 
-if (_typeX in FactionGet(all,"vehiclesReb")) exitWith { ([_typeX] call A3A_fnc_vehiclePrice) / 2 };
-
 if (
-    (_typeX in arrayCivVeh)
+    _typeX in FactionGet(all,"vehiclesReb")
+    or (_typeX in arrayCivVeh)
     or (_typeX in civBoats)
     or (_typeX in (FactionGet(reb,"vehiclesCivBoat") + FactionGet(reb,"vehiclesCivCar") + FactionGet(reb,"vehiclesCivTruck")))
-) exitWith {25};
+) exitWith {
+    private _vehiclePrice = ([_typeX] call A3A_fnc_vehiclePrice) / 2;
+    if (_vehiclePrice == 0) exitWith {25};
+    _vehiclePrice;
+};
 
 if (
     (_typeX in FactionGet(all,"vehiclesLight"))


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Information: Most buyable/civilian vehicles will now be sold for half of their buy price. This fixes an exploit where a Poseidon could be bought for 20 and sold for 25
    

### Please specify which Issue this PR Resolves.
closes #3350 

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
