### PR TITLE
Fix support crew being provided for free and then refunded

### DIFF
--- a/A3A/addons/core/functions/Supports/fn_SUP_ASFRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_ASFRoutine.sqf
@@ -35,6 +35,7 @@ _plane setVariable ["SupportData", _suppData];        // for use in EHs
 private _group = [_side, _plane] call A3A_fnc_createVehicleCrew;
 { [_x, nil, false, _resPool] call A3A_fnc_NATOinit } forEach units _group;
 _group deleteGroupWhenEmpty true;
+[-10 * count units _group, _side, _resPool] call A3A_fnc_addEnemyResources;
 
 _plane addEventHandler ["Killed", {
     params ["_plane"];

--- a/A3A/addons/core/functions/Supports/fn_SUP_CASRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_CASRoutine.sqf
@@ -35,6 +35,8 @@ private _group = [_side, _plane] call A3A_fnc_createVehicleCrew;
 { [_x, nil, false, _resPool] call A3A_fnc_NATOinit } forEach units _group;
 _group deleteGroupWhenEmpty true;
 _group setBehaviourStrong "CARELESS";
+[-10 * count units _group, _side, _resPool] call A3A_fnc_addEnemyResources;
+
 
 _plane addEventHandler ["Killed", {
     params ["_plane"];

--- a/A3A/addons/core/functions/Supports/fn_SUP_UAVRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_UAVRoutine.sqf
@@ -27,6 +27,7 @@ private _uav = createVehicle [_planeType, _spawnPos, [], 0, "FLY"];
 [_side, _uav] call A3A_fnc_createVehicleCrew;
 _groupVeh = group driver _uav;
 { [_x, nil, false, _resPool] call A3A_fnc_NATOinit } forEach (crew _uav);           // arguable
+[-10 * count units _group, _side, _resPool] call A3A_fnc_addEnemyResources;
 [_uav, _side, _resPool] call A3A_fnc_AIVEHinit;
 
 _wp = _groupVeh addWayPoint [_suppCenter, 0];

--- a/A3A/addons/core/functions/Supports/fn_SUP_UAVRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_UAVRoutine.sqf
@@ -27,7 +27,7 @@ private _uav = createVehicle [_planeType, _spawnPos, [], 0, "FLY"];
 [_side, _uav] call A3A_fnc_createVehicleCrew;
 _groupVeh = group driver _uav;
 { [_x, nil, false, _resPool] call A3A_fnc_NATOinit } forEach (crew _uav);           // arguable
-[-10 * count units _group, _side, _resPool] call A3A_fnc_addEnemyResources;
+[-10 * count units _groupVeh, _side, _resPool] call A3A_fnc_addEnemyResources;
 [_uav, _side, _resPool] call A3A_fnc_AIVEHinit;
 
 _wp = _groupVeh addWayPoint [_suppCenter, 0];

--- a/A3A/addons/core/functions/Supports/fn_SUP_airstrikeRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_airstrikeRoutine.sqf
@@ -38,6 +38,7 @@ _group deleteGroupWhenEmpty true;
     _x disableAI "TARGET";
     _x disableAI "AUTOTARGET";
 } forEach units _group;
+[-10 * count units _group, _side, _resPool] call A3A_fnc_addEnemyResources;
 
 // Should we really have these?
 _plane addEventHandler ["Killed", {

--- a/A3A/addons/core/functions/Supports/fn_SUP_artillery.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_artillery.sqf
@@ -64,4 +64,4 @@ A3A_activeSupports pushBack _suppData;
 [_reveal, _side, "ARTILLERY", _targPos, _delay] spawn A3A_fnc_showInterceptedSetupCall;
 
 // Vehicle cost + extra support cost for balance
-(A3A_vehicleResourceCosts get _vehType) + 200;
+(A3A_vehicleResourceCosts get _vehType) + (10 * count units _group) + 200;

--- a/A3A/addons/core/functions/Supports/fn_SUP_mortar.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_mortar.sqf
@@ -83,4 +83,4 @@ A3A_activeSupports pushBack _suppData;
 [_reveal, _side, "MORTAR", _targPos, _delay] spawn A3A_fnc_showInterceptedSetupCall;
 
 // Mortar cost (might be free?) + extra support cost for balance
-(A3A_vehicleResourceCosts getOrDefault [_vehType, 0]) + 100;
+(A3A_vehicleResourceCosts getOrDefault [_vehType, 0]) + (10 * count units _group) + 100;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Vehicle crew for most supports weren't being paid for up-front, but were being "refunded" on support completion, which meant that enemy factions had an unintended income stream. The effect is small for most factions but relatively large for WW2 due to the cheap planes with multiple crew.

Tested all six affected supports, works correctly. For the late-spawning supports (ASF, CAS, airstrike) the crew cost isn't applied to supportSpends, but that value only needs to be approximate.

### Please specify which Issue this PR Resolves.
closes #3340

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
