### PR TITLE
Fix inability to rebuild non-outpost radio towers

### DIFF
--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -2144,7 +2144,7 @@
         <Chinesesimp>总部位置</Chinesesimp>
       </Key>
       <Key ID="STR_A3A_fn_base_rebasset_click_marker">
-        <Original>You must click near a map marker.</Original>
+        <Original>You must click near a rebel map marker.</Original>
         <Italian>Devi cliccare vicino a un marcatore sulla mappa.</Italian>
         <Spanish>Debe clicar cerca de un marcador de mapa.</Spanish>
         <French>Vous devez cliquer à côté d'un marqueur de carte.</French>
@@ -2197,8 +2197,8 @@
         <Turkish>Radyo Kulesi yeniden yapıldı.</Turkish>
         <Chinesesimp>通信塔已被重建</Chinesesimp>
       </Key>
-      <Key ID="STR_A3A_fn_base_rebasset_no">
-        <Original>You cannot rebuild that.</Original>
+      <Key ID="STR_A3A_fn_base_rebasset_no_nothing">
+        <Original>There is nothing to rebuild on this site.</Original>
         <Italian>Non puoi ricostruire ciò.</Italian>
         <Spanish>No puede reconstruir esto.</Spanish>
         <French>Vous ne pouvez pas reconstruire ceci.</French>
@@ -2222,30 +2222,6 @@
         <Portuguese>Não tens dinheiro suficiente para reconstruir qualquer Ativo. Precisas de 5.000€.</Portuguese>
         <Turkish>Yeni ekipman yapmak için yeterinde paranız yok. 5.000 €'ya ihtiyacınız var.</Turkish>
         <Chinesesimp>你当前的资金不足以重建任何资产. 你需要 5.000 €.</Chinesesimp>
-      </Key>
-      <Key ID="STR_A3A_fn_base_rebasset_no_notower">
-        <Original>That Outpost does not have a destroyed Radio Tower.</Original>
-        <Italian>Quell'Avamposto non ha un Torre Radio distrutta.</Italian>
-        <Spanish>Esa base no tiene una torre de radio destruida.</Spanish>
-        <French>Cet Avant-Poste n'a pas de Tour Radio détruite.</French>
-        <Korean>이 전초기지는 파괴된 송신탑을 가지고 있지 않습니다.</Korean>
-        <Russian>На этом аванпосте нет разрушенной радиовышки.</Russian>
-        <Czech>Toto stanoviště nemá zničenou Rádiovou Věž.</Czech>
-        <Portuguese>Este Posto Avançado não tem Torre de Rádio.</Portuguese>
-        <Turkish>O karakolun yıkılmış bir Radyo Kulesi yok.</Turkish>
-        <Chinesesimp>那个哨站没有被摧毁的通信塔</Chinesesimp>
-      </Key>
-      <Key ID="STR_A3A_fn_base_rebasset_no_owner">
-        <Original>You cannot rebuild a Radio Tower in an Outpost which does not belong to %1.</Original>
-        <Italian>Non puoi ricostruire una Torre Radio in un Avamposto che non appartiene a %1.</Italian>
-        <Spanish>No puede reconstruir una torre de radio en una base que no pertenezca a %1.</Spanish>
-        <French>Vous ne pouvez pas reconstruire une Tour Radio dans un Avant-Poste qui n'appartient pas à %1.</French>
-        <Korean>%1의 소유가 아닌 전초기지의 송신탑은 재건축할 수 없습니다.</Korean>
-        <Russian>Вы не можете перестроить радиовышку на аванпосте, который не принадлежит %1.</Russian>
-        <Czech>Nemůžeš znovu postavit Radiovou věž na základně, která nespadá pod %1.</Czech>
-        <Portuguese>Não podes reconstruir a Torre de Rádio num Posto Avançado que não pertence a %1.</Portuguese>
-        <Turkish>%1 'e ait olmayan bir Karakola Radyo Kulesi dikemezsiniz.</Turkish>
-        <Chinesesimp>你无法在一个不属于 %1 的哨站里重建通信塔</Chinesesimp>
       </Key>
       <Key ID="STR_A3A_fn_base_rebasset_title">
         <Original>Rebuild Assets</Original>

--- a/A3A/addons/core/functions/Base/fn_rebuildAssets.sqf
+++ b/A3A/addons/core/functions/Base/fn_rebuildAssets.sqf
@@ -3,11 +3,8 @@ FIX_LINE_NUMBERS()
 
 private _titleStr = localize "STR_A3A_fn_base_rebasset_title";
 
-_resourcesFIA = server getVariable "resourcesFIA";
-
+private _resourcesFIA = server getVariable "resourcesFIA";
 if (_resourcesFIA < 5000) exitWith {[_titleStr, localize "STR_A3A_fn_base_rebasset_no_money"] call A3A_fnc_customHint;};
-
-_destroyedSites = destroyedSites - citiesX;
 
 if (!visibleMap) then {openMap true};
 positionTel = [];
@@ -20,55 +17,31 @@ onMapSingleClick "";
 
 if (!visibleMap) exitWith {};
 
-_positionTel = positionTel;
+private _positionTel = positionTel;
 
-_siteX = [markersX,_positionTel] call BIS_fnc_nearestPosition;
+private _siteX = [markersX,_positionTel] call BIS_fnc_nearestPosition;
 
-if (getMarkerPos _siteX distance _positionTel > 50) exitWith {[_titleStr, localize "STR_A3A_fn_base_rebasset_click_marker"] call A3A_fnc_customHint;};
+if (getMarkerPos _siteX distance2d _positionTel > 50) exitWith {[_titleStr, localize "STR_A3A_fn_base_rebasset_click_marker"] call A3A_fnc_customHint;};
+if (sidesX getVariable [_siteX, sideUnknown] != teamPlayer) exitWith {[_titleStr, localize "STR_A3A_fn_base_rebasset_click_marker"] call A3A_fnc_customHint;};
 
-if ((not(_siteX in _destroyedSites)) and (!(_siteX in outposts))) exitWith {[_titleStr, localize "STR_A3A_fn_base_rebasset_no"] call A3A_fnc_customHint;};
+private _destroyedSites = destroyedSites - citiesX;
+if (_siteX in _destroyedSites) exitWith {
+    private _nameX = [_siteX] call A3A_fnc_localizar;
+    [_titleStr, format [localize "STR_A3A_fn_base_rebasset_done_1", _nameX]] call A3A_fnc_customHint;
 
-_leave = false;
-_antennaDead = objNull;
-_textX = localize "STR_A3A_fn_base_rebasset_no_notower";
-if (_siteX in outposts) then
-	{
-	_antennasDead = antennasDead select {_x inArea _siteX};
-	if (count _antennasDead > 0) then
-		{
-		if (sidesX getVariable [_siteX, sideUnknown] != teamPlayer) then
-			{
-			_leave = true;
-			_textX = format [localize "STR_A3A_fn_base_rebasset_no_owner",FactionGet(reb,"name")];
-			}
-		else
-			{
-			_antennaDead = _antennasDead select 0;
-			};
-		}
-	else
-		{
-		_leave = true
-		};
-	};
-
-if (_leave) exitWith {[_titleStr, format ["%1",_textX]] call A3A_fnc_customHint;};
-
-if (isNull _antennaDead) then
-	{
-	_nameX = [_siteX] call A3A_fnc_localizar;
-
-	[_titleStr, format [localize "STR_A3A_fn_base_rebasset_done_1", _nameX]] call A3A_fnc_customHint;
-
-	[0,10,_positionTel] remoteExec ["A3A_fnc_citySupportChange",2];
+    [0,10,_positionTel] remoteExec ["A3A_fnc_citySupportChange",2];
     [Occupants, 10, 30] remoteExec ["A3A_fnc_addAggression",2];
     [Invaders, 10, 30] remoteExec ["A3A_fnc_addAggression",2];
-	destroyedSites = destroyedSites - [_siteX];
-	publicVariable "destroyedSites";
-	}
-else
-	{
-	[_titleStr, localize "STR_A3A_fn_base_rebasset_done_2"] call A3A_fnc_customHint;
-	[_antennaDead] remoteExec ["A3A_fnc_rebuildRadioTower", 2];
-	};
-[0,-5000] remoteExec ["A3A_fnc_resourcesFIA",2];
+    destroyedSites = destroyedSites - [_siteX];
+    publicVariable "destroyedSites";
+    [0,-5000] remoteExec ["A3A_fnc_resourcesFIA",2];
+};
+
+private _radioTowers = antennasDead select {_x inArea _siteX};
+if (_radioTowers isNotEqualTo []) exitWith {
+    [_titleStr, localize "STR_A3A_fn_base_rebasset_done_2"] call A3A_fnc_customHint;
+    [_radioTowers#0] remoteExec ["A3A_fnc_rebuildRadioTower", 2];
+    [0,-5000] remoteExec ["A3A_fnc_resourcesFIA",2];
+};
+
+[_titleStr, localize "STR_A3A_fn_base_rebasset_no_nothing"] call A3A_fnc_customHint;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Some maps have radio towers on non-outpost markers, but it was impossible to rebuild these. This has been fixed.

Refactored the code because it was too spaghetti to fix sensibly. Also improved the text feedback.

Tested every code path.

### Please specify which Issue this PR Resolves.
closes #3339

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
