### PR TITLE
Seaport Ammobox Protection

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
@@ -104,7 +104,7 @@ else
 			_veh addEventHandler ["RopeAttach", {
 				params ["_object1", "_rope", "_object2"];
 				{
-					_x setCaptive false;
+					[_x, false] remoteExec ["setCaptive", _x];
 				} forEach crew _object1;
 			}];
 		};

--- a/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
@@ -80,7 +80,7 @@ if (_veh isKindOf "Car" or _veh isKindOf "Tank") then
 }
 else
 {
-	if ( _typeX in (FactionGet(all,"vehiclesFixedWing") + FactionGet(all,"vehiclesHelis")) ) then
+	if (_veh isKindOf "Air") then
 	{
 		_veh addEventHandler ["GetIn",
 		{
@@ -101,6 +101,12 @@ else
 				_veh addEventHandler ["GetOut", {private ["_veh"];_veh = _this select 0; if ((isTouchingGround _veh) and (isEngineOn _veh)) then {if (side (_this select 2) != teamPlayer) then {if (_veh getVariable "within") then {_veh setVariable ["within",false]; [_veh] call A3A_fnc_smokeCoverAuto}}}}];
 				_veh addEventHandler ["GetIn", {private ["_veh"];_veh = _this select 0; if (side (_this select 2) != teamPlayer) then {_veh setVariable ["within",true]}}];
 			};
+			_veh addEventHandler ["RopeAttach", {
+				params ["_object1", "_rope", "_object2"];
+				{
+					_x setCaptive false;
+				} forEach crew _object1;
+			}];
 		};
 	}
 	else

--- a/A3A/addons/core/functions/CREATE/fn_createAIAirbase.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIAirbase.sqf
@@ -253,7 +253,7 @@ private _ammoBox = if (garrison getVariable [_markerX + "_lootCD", 0] == 0) then
 	// Otherwise when destroyed, ammoboxes sink 100m underground and are never cleared up
 	_ammoBox addEventHandler ["Killed", { [_this#0] spawn { sleep 10; deleteVehicle (_this#0) } }];
 	[_ammoBox] spawn A3A_fnc_fillLootCrate;
-	[_ammoBox] call A3A_Logistics_fnc_addLoadAction;
+	[_ammoBox, nil, true] call A3A_Logistics_fnc_addLoadAction;
 
 	[_ammoBox] spawn {
 		sleep 1;    //make sure fillLootCrate finished clearing the crate

--- a/A3A/addons/core/functions/CREATE/fn_createAIOutposts.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIOutposts.sqf
@@ -155,7 +155,7 @@ private _ammoBox = if (garrison getVariable [_markerX + "_lootCD", 0] == 0) then
 	// Otherwise when destroyed, ammoboxes sink 100m underground and are never cleared up
 	_ammoBox addEventHandler ["Killed", { [_this#0] spawn { sleep 10; deleteVehicle (_this#0) } }];
 	[_ammoBox] spawn A3A_fnc_fillLootCrate;
-	[_ammoBox] call A3A_Logistics_fnc_addLoadAction;
+	[_ammoBox, nil, true] call A3A_Logistics_fnc_addLoadAction;
 
 	if (_markerX in seaports) then {
 		[_ammoBox] spawn {

--- a/A3A/addons/logistics/Private/fn_addAction.sqf
+++ b/A3A/addons/logistics/Private/fn_addAction.sqf
@@ -36,7 +36,7 @@ switch (_action) do {
             {
                 params ["_target","_caller","_actionID","_breakUC"];
                 [_target] remoteExecCall ["A3A_Logistics_fnc_tryLoad",2];
-                if (_breakUC) then (_caller setCaptive false);
+                if (_breakUC) then {_caller setCaptive false};
             },
             _breakUC,
             -5,

--- a/A3A/addons/logistics/Private/fn_addAction.sqf
+++ b/A3A/addons/logistics/Private/fn_addAction.sqf
@@ -6,6 +6,8 @@
     Arguments:
     0. <Object> Object to add action to
     1. <String> Which action to add ("load"/"unload")
+    2. <String> JIP key
+    3. <Bool> Whether loading should break undercover
 
     Return Value:
     <nil>
@@ -17,7 +19,7 @@
 
     Example: [_object , _action] remoteExec ["A3A_Logistics_fnc_addAction", 0, _object];
 */
-params [["_object", objNull, [objNull]], "_action", ["_jipKey", "", [""]]];
+params [["_object", objNull, [objNull]], "_action", ["_jipKey", "", [""]], ["_breakUC",false]];
 if (isNull _object) exitWith {
     remoteExec ["", _jipKey]; //clear custom JIP
 };
@@ -32,10 +34,11 @@ switch (_action) do {
         [
             _loadText,
             {
-                params ["_target"];
+                params ["_target","_caller","_actionID","_breakUC"];
                 [_target] remoteExecCall ["A3A_Logistics_fnc_tryLoad",2];
+                if (_breakUC) then (_caller setCaptive false);
             },
-            nil,
+            _breakUC,
             -5,
             true,
             true,

--- a/A3A/addons/logistics/Public/fn_addLoadAction.sqf
+++ b/A3A/addons/logistics/Public/fn_addLoadAction.sqf
@@ -6,6 +6,7 @@
     Arguments:
     0. <Object> Cargo that you want to be able to load in a vehicle
     1. <String> "load" or "unload" action (optional - should not really be used)
+    2. <Bool> Whether loading the object should break undercover
 
     Return Value:
     <Nil>
@@ -19,7 +20,7 @@
 */
 #include "..\script_component.hpp"
 FIX_LINE_NUMBERS()
-params [["_object", objNull, [objNull]], ["_action", "load"]];
+params [["_object", objNull, [objNull]], ["_action", "load"],["_breakUC",false]];
 
 if (isNull _object) exitWith {
     Error("No object passed, aborting");
@@ -34,5 +35,5 @@ if (!alive _object) exitWith {
 if (([_object] call A3A_Logistics_fnc_getCargoNodeType) isEqualTo -1) exitWith {nil};
 
 private _jipKey = "A3A_Logistics_" + _action + ((str _object splitString ":") joinString "");
-[_object, _action, _jipKey] remoteExec ["A3A_Logistics_fnc_addAction", 0, _jipKey];
+[_object, _action, _jipKey,_breakUC] remoteExec ["A3A_Logistics_fnc_addAction", 0, _jipKey];
 nil


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Information: Ammoboxes now have rudimentary protection to prevent unintended yoinking.
Attempting to load an outpost/seaport ammobox into a vehicle will break undercover.
Slingloading an ammbox will break undercover when the ropes are attached. Players can still potentially get away, so it's a bit exploity still, but it's a fair risk/reward payoff
    

### Please specify which Issue this PR Resolves.
closes #3347 

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:  Logic can probably be checked and should be double-checked if the change to `isKindOf "Air"` will break anything, but it all works in testing.
