### PR TITLE
Add attributeMoreTrucks and IFV-only option to ground transport selection

### DIFF
--- a/A3A/addons/core/functions/Base/fn_getVehiclesGroundTransport.sqf
+++ b/A3A/addons/core/functions/Base/fn_getVehiclesGroundTransport.sqf
@@ -30,10 +30,19 @@ private _lapcWeight =      [30, 40, 50, 50, 45, 40, 35, 30, 25, 20] select _leve
 private _apcWeight =       [ 0, 10, 15, 20, 25, 30, 35, 40, 40, 40] select _level;
 private _ifvWeight =       [ 0,  0,  2,  4,  6,  8, 12, 16, 20, 25] select _level;
 
-// Assumption is that at least one of APC or battle bus exists
-if (_faction get "vehiclesIFVs" isEqualTo []) then { _apcWeight = _apcWeight + _ifvWeight };
-if (_faction get "vehiclesAPCs" isEqualTo []) then { _lapcWeight = _lapcWeight + _apcWeight };
+if (_faction getOrDefault ["attributeMoreTrucks", false]) then {
+    _truckWeight =     [60, 60, 60, 60, 60, 60, 55, 50, 45, 40] select _level;
+    _lapcWeight =      [10, 15, 20, 20, 20, 20, 20, 20, 20, 20] select _level;
+    _apcWeight =       [ 0,  4,  8, 12, 16, 20, 20, 20, 20, 20] select _level;
+    _ifvWeight =       [ 0,  0,  2,  4,  6,  8, 12, 16, 20, 25] select _level;
+};
+
 if (_faction get "vehiclesLightAPCs" isEqualTo []) then { _apcWeight = _apcWeight + _lapcWeight/2; _truckWeight = _truckWeight + _lapcWeight/2; };
+if (_faction get "vehiclesIFVs" isEqualTo []) then { _apcWeight = _apcWeight + _ifvWeight };
+if (_faction get "vehiclesAPCs" isEqualTo []) then {
+    if (_faction get "vehiclesLightAPCs" isEqualTo []) exitWith { _ifvWeight = _ifvWeight + _apcWeight };
+    _lapcWeight = _lapcWeight + _apcWeight;
+};
 
 // only occupants use militia vehicle types?
 if (_side == Occupants) then


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Added some extra options to getVehiclesGroundTransport to better handle some WW2 and Vietnam-era modsets:
- Faction attributeMoreTrucks will bias the table heavily towards trucks, for when APCs should have limited use even at high war tiers.
- Having no APC or LAPC entries is now allowed.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
