### PR TITLE
SPE Rebel template tuned, enemy template adapted for #3370

### DIFF
--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_US.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_US.sqf
@@ -14,6 +14,7 @@
 //////////////////////////
 
 ["attributeLowAir", true] call _fnc_saveToTemplate;             // Use fewer air units in general
+["attributeMoreTrucks", true] call _fnc_saveToTemplate;         // Use more truck for transports
 ["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 
 ["ammobox", "B_supplyCrate_F"] call _fnc_saveToTemplate;
@@ -30,7 +31,7 @@
 ["vehiclesFuelTrucks", ["SPE_US_M3_Halftrack_Fuel","SPE_CCKW_353_Fuel","SPE_CCKW_353_Fuel"]] call _fnc_saveToTemplate;
 ["vehiclesMedical", ["SPE_US_M3_Halftrack_Ambulance","SPE_CCKW_353_Ambulance","SPE_US_G503_MB_Ambulance"]] call _fnc_saveToTemplate;
 ["vehiclesLightAPCs", []] call _fnc_saveToTemplate;
-["vehiclesAPCs", ["SPE_US_M3_Halftrack","SPE_M20_AUC"]] call _fnc_saveToTemplate; //These got no protected  turret, sufficent troop capacity, cost reduced - used here instead to not reduce weight of trucks
+["vehiclesAPCs", ["SPE_US_M3_Halftrack","SPE_M20_AUC"]] call _fnc_saveToTemplate; //These got no protected  turret, sufficent troop capacity, cost reduced
 ["vehiclesIFVs", ["SPE_M4A0_75_Early", "SPE_M4A0_75","SPE_M4A0_composite","SPE_M4A0_105","SPE_M4A3_105","SPE_M10"]] call _fnc_saveToTemplate;
 ["vehiclesLightTanks",["SPE_M18_Hellcat","SPE_M18_Hellcat","SPE_M10"]] call _fnc_saveToTemplate;
 ["vehiclesTanks", ["SPE_M4A1_75_erla","SPE_M4A1_76", "SPE_M4A1_75","SPE_M4A3_75","SPE_M4A3_76"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_WEH.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_WEH.sqf
@@ -14,6 +14,7 @@
 //////////////////////////
 
 ["attributeLowAir", true] call _fnc_saveToTemplate;             // Use fewer air units in general
+["attributeMoreTrucks", true] call _fnc_saveToTemplate;         // Use more truck for transports
 ["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 
 ["ammobox", "B_supplyCrate_F"] call _fnc_saveToTemplate;
@@ -30,7 +31,7 @@
 ["vehiclesFuelTrucks", ["SPE_ST_OpelBlitz_Fuel"]] call _fnc_saveToTemplate;
 ["vehiclesMedical", ["SPE_ST_OpelBlitz_Ambulance"]] call _fnc_saveToTemplate;
 ["vehiclesLightAPCs", []] call _fnc_saveToTemplate;
-["vehiclesAPCs", ["SPE_StuG_III_G_SKB","SPE_StuG_III_G_Late"]] call _fnc_saveToTemplate;
+["vehiclesAPCs", []] call _fnc_saveToTemplate;
 ["vehiclesIFVs", ["SPE_StuG_III_G_SKB","SPE_StuG_III_G_Late"]] call _fnc_saveToTemplate;
 ["vehiclesLightTanks",["SPE_PzKpfwIII_N", "SPE_PzKpfwIII_L", "SPE_PzKpfwIII_M", "SPE_PzKpfwIII_J", "SPE_StuG_III_G_Late", "SPE_Nashorn"]] call _fnc_saveToTemplate;
 ["vehiclesTanks", ["SPE_PzKpfwIII_M", "SPE_PzKpfwIV_G", "SPE_PzKpfwIV_G", "SPE_PzKpfwV_G"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_REB_FFF.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_REB_FFF.sqf
@@ -72,7 +72,7 @@
 
 private _initialRebelEquipment = [
     "SPE_Fusil_Mle_208_12", "SPE_Fusil_Mle_208_12_Sawedoff",
-    "SPE_2Rnd_12x65_Pellets", "SPE_2Rnd_12x65_Slug",
+    "SPE_2Rnd_12x65_Pellets", "SPE_2Rnd_12x65_Slug","SPE_2Rnd_12x65_No4_Buck",
     "SPE_P08", "SPE_8Rnd_9x19_P08",
     ["SPE_Faustpatrone", 50], ["SPE_1Rnd_Faustpatrone", 50],
     ["SPE_Ladung_Small_MINE_mag", 10], ["SPE_US_TNT_half_pound_mag", 10], ["SPE_US_TNT_4pound_mag", 3], ["SPE_Ladung_Big_MINE_mag", 3],

--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_REB_FFF.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_REB_FFF.sqf
@@ -73,9 +73,8 @@
 private _initialRebelEquipment = [
     "SPE_Fusil_Mle_208_12", "SPE_Fusil_Mle_208_12_Sawedoff",
     "SPE_2Rnd_12x65_Pellets", "SPE_2Rnd_12x65_Slug",
-    "SPE_MAS_36", "SPE_5Rnd_75x54",
     "SPE_P08", "SPE_8Rnd_9x19_P08",
-    ["SPE_PzFaust_30m", 50], ["SPE_1Rnd_PzFaust_30m", 50],
+    ["SPE_Faustpatrone", 50], ["SPE_1Rnd_Faustpatrone", 50],
     ["SPE_Ladung_Small_MINE_mag", 10], ["SPE_US_TNT_half_pound_mag", 10], ["SPE_US_TNT_4pound_mag", 3], ["SPE_Ladung_Big_MINE_mag", 3],
     "SPE_NB39", "SPE_Shg24",
     "V_SPE_FFI_Vest_Pouch","V_SPE_FFI_Vest_Pouch_frag", "V_SPE_FFI_Vest_rifle","V_SPE_FFI_Vest_rifle_frag",


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    
Adds "attributeMoreTrucks" to the US and WEH template.
WEH template loses the "APC" stugs, only "IFV" stugs remain.
Drops the rebel starting rifle - shotguns and pistols should be good enough in the WW2 setting.
Replaced the rebel's starting Panzerfaust 30 with the Faustpatrone.
Adds an additional nr4 buckshot ammo type for the shotgun.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
