### PR TITLE
Replace all uses of GETOUT waypoints

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_createVehicleQRFBehaviour.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createVehicleQRFBehaviour.sqf
@@ -138,7 +138,7 @@ else            // ground vehicle
 
         //Set the waypoints for cargoGroup
         private _cargoWP0 = _cargoGroup addWaypoint [_landpos, 0];
-        _cargoWP0 setWaypointType "GETOUT";
+        //_cargoWP0 setWaypointType "GETOUT";
         _cargoWP0 setWaypointStatements ["true", "if !(local this) exitWith {}; (group this) leaveVehicle (assignedVehicle this); (group this) spawn A3A_fnc_attackDrillAI"];
         private _cargoWP1 = _cargoGroup addWaypoint [_posDestination, 0];
         _cargoWP1 setWaypointBehaviour "AWARE";
@@ -170,7 +170,7 @@ else            // ground vehicle
 
         //Set the waypoints for cargoGroup
         private _cargoWP0 = _cargoGroup addWaypoint [_landpos, 0];
-        _cargoWP0 setWaypointType "GETOUT";
+        //_cargoWP0 setWaypointType "GETOUT";
         _cargoWP0 setWaypointStatements ["true", "if !(local this) exitWith {}; (group this) leaveVehicle (assignedVehicle this); (group this) spawn A3A_fnc_attackDrillAI"];
         private _cargoWP1 = _cargoGroup addWaypoint [_posDestination, 0];
         _cargoWP1 setWaypointBehaviour "AWARE";

--- a/A3A/addons/core/functions/CREATE/fn_patrolReinf.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_patrolReinf.sqf
@@ -88,7 +88,8 @@ else
 		_returnWP setWaypointStatements ["true", "if (!local this or !alive this) exitWith {}; deleteVehicle (vehicle this); {deleteVehicle _x} forEach thisList"];
 
 		_getoutWP = _cargoGroup addWaypoint [_landpos, 0];
-		_getoutWP setWaypointType "GETOUT";
+		//_getoutWP setWaypointType "GETOUT";
+		_getoutWP setWaypointStatements ["true", "if !(local this) exitWith {}; (group this) leaveVehicle (assignedVehicle this)"];
 		_reinfWP = _cargoGroup addWaypoint [_posDest, 0];
 		_reinfWP setWaypointBehaviour "AWARE";
 		_landWP synchronizeWaypoint [_getoutWP];

--- a/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
@@ -167,7 +167,8 @@ deleteGroup _groupX;
 
 //moving to crash site
 private _escortWP = _groupVeh addWaypoint [_posCrash, 0];
-_escortWP setWaypointType "GETOUT";
+//_escortWP setWaypointType "GETOUT";
+_escortWP setWaypointStatements ["true", "if !(local this) exitWith {}; (group this) leaveVehicle (assignedVehicle this)"];
 _escortWP setWaypointBehaviour "SAFE";
 Debug_2("Placed Group: %1 in Lite Vehicle and set waypoint %2", _typeGroup, _posCrash);
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Arma bug workaround
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The GETOUT waypoint is very broken and can cause squads to leave their transport vehicle for no good reason. Fortunately it is relatively straightforward to replace, so this PR does so.

Tested all uses except the destroy heli mission. It's probably fine.  

### Please specify which Issue this PR Resolves.
closes #3374

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Create land QRFs like this:
```
_destPos = markerPos "Outpost_13";
["QRFLAND", Occupants, "defence", 500, objNull, _destPos, 0.8, -1] call A3A_fnc_createSupport;
```

Or more specific vehicle types and source/dest:
```
_sourceMrk = "Airport_3";
_destPos = markerPos "Outpost_18";
["LIB_US_M3_Halftrack", "Normal", "defence", [], Occupants, _sourceMrk, _destPos] call A3A_fnc_createAttackVehicle;
```
