### PR TITLE
More frequent militia vehicles/transports early game

### DIFF
--- a/A3A/addons/core/functions/Base/fn_getVehiclesGroundSupport.sqf
+++ b/A3A/addons/core/functions/Base/fn_getVehiclesGroundSupport.sqf
@@ -20,8 +20,8 @@ private _fnc_addArrayToWeights = {
 
 private _vehWeights = [];
 
-private _milCarWeight =     [50, 40, 30, 20, 10,  0,  0,  0,  0,  0] select _level;
-private _carWeight =        [50, 50, 50, 50, 50, 50, 50, 40, 35, 30] select _level;
+private _milCarWeight =     [100, 70, 50, 30, 10,  0,  0,  0,  0,  0] select _level;
+private _carWeight =        [ 0, 30, 30, 40, 50, 50, 50, 40, 35, 30] select _level;
 private _aaWeight =         [ 0,  0,  3,  5,  7,  8, 10, 12, 13, 14] select _level;
 private _ltWeight =         [ 0,  5,  7,  8,  8,  8,  8,  8,  8,  8] select _level;
 private _tankWeight =       [ 0,  0,  3,  5,  8, 11, 14, 17, 20, 28] select _level;

--- a/A3A/addons/core/functions/Base/fn_getVehiclesGroundSupport.sqf
+++ b/A3A/addons/core/functions/Base/fn_getVehiclesGroundSupport.sqf
@@ -33,7 +33,10 @@ if (_vehAA isEqualTo []) then { _tankWeight = _tankWeight + _aaWeight };
 
 // At least one lightTanks or Tanks is mandatory, HeavyTanks are entirely optional
 if (_faction get "vehiclesHeavyTanks" isEqualTo []) then { _ltWeight = _ltWeight + _hvytWeight/2;  _tankWeight = _tankWeight + _hvytWeight/2};
-if (_faction get "vehiclesLightTanks" isEqualTo []) then { _tankWeight = _tankWeight + _ltWeight };
+if (_faction get "vehiclesLightTanks" isEqualTo []) then { 
+    if (_level < 3) exitWith {_carWeight + _ltWeight};
+    _tankWeight = _tankWeight + _ltWeight 
+};
 if (_faction get "vehiclesTanks" isEqualTo []) then { _ltWeight = _ltWeight + _tankWeight };
 
 [_faction get "vehiclesLightTanks", _ltWeight] call _fnc_addArrayToWeights;

--- a/A3A/addons/core/functions/Base/fn_getVehiclesGroundSupport.sqf
+++ b/A3A/addons/core/functions/Base/fn_getVehiclesGroundSupport.sqf
@@ -35,7 +35,7 @@ if (_vehAA isEqualTo []) then { _tankWeight = _tankWeight + _aaWeight };
 if (_faction get "vehiclesHeavyTanks" isEqualTo []) then { _ltWeight = _ltWeight + _hvytWeight/2;  _tankWeight = _tankWeight + _hvytWeight/2};
 if (_faction get "vehiclesLightTanks" isEqualTo []) then { 
     if (_level < 3) exitWith {_carWeight + _ltWeight};
-    _tankWeight = _tankWeight + _ltWeight 
+    _tankWeight = _tankWeight + _ltWeight;
 };
 if (_faction get "vehiclesTanks" isEqualTo []) then { _ltWeight = _ltWeight + _tankWeight };
 

--- a/A3A/addons/core/functions/Base/fn_getVehiclesGroundTransport.sqf
+++ b/A3A/addons/core/functions/Base/fn_getVehiclesGroundTransport.sqf
@@ -20,21 +20,22 @@ private _fnc_addArrayToWeights = {
 
 private _vehWeights = [];
 
-private _policeWeight =    [40, 20,  0,  0,  0,  0,  0,  0,  0,  0] select _level;
-private _milCarWeight =    [40, 30, 20, 10,  5,  0,  0,  0,  0,  0] select _level;
-private _milTruckWeight =  [50, 40, 30, 20, 10,  0,  0,  0,  0,  0] select _level;
-private _carWeight =       [20, 25, 20, 10, 10, 10,  5,  5,  5,  5] select _level;
-private _armedCarWeight =  [20, 25, 30, 30, 30, 25, 20, 20, 15, 15] select _level;
-private _truckWeight =     [50, 45, 40, 35, 30, 25, 20, 15, 10,  5] select _level;
-private _lapcWeight =      [30, 40, 50, 50, 45, 40, 35, 30, 25, 20] select _level;
-private _apcWeight =       [ 0, 10, 15, 20, 25, 30, 35, 40, 40, 40] select _level;
-private _ifvWeight =       [ 0,  0,  2,  4,  6,  8, 12, 16, 20, 25] select _level;
+private _policeWeight =    [ 50, 20,  0,  0,  0,  0,  0,  0,  0,  0] select _level;
+private _milCarWeight =    [ 50, 50, 30, 10,  5,  0,  0,  0,  0,  0] select _level;
+private _milTruckWeight =  [100, 80, 60, 35, 15,  0,  0,  0,  0,  0] select _level;
+private _carWeight =       [  0,  5, 10, 10, 10, 10,  5,  5,  5,  5] select _level;
+private _armedCarWeight =  [ 20, 25, 30, 30, 30, 25, 20, 20, 15, 15] select _level;
+private _truckWeight =     [  0,  5, 10, 20, 25, 25, 20, 15, 10,  5] select _level;
+private _lapcWeight =      [ 30, 40, 50, 50, 45, 40, 35, 30, 25, 20] select _level;
+private _apcWeight =       [  0, 10, 15, 20, 25, 30, 35, 40, 40, 40] select _level;
+private _ifvWeight =       [  0,  0,  2,  4,  6,  8, 12, 16, 20, 25] select _level;
 
 if (_faction getOrDefault ["attributeMoreTrucks", false]) then {
-    _truckWeight =     [60, 60, 60, 60, 60, 60, 55, 50, 45, 40] select _level;
-    _lapcWeight =      [10, 15, 20, 20, 20, 20, 20, 20, 20, 20] select _level;
-    _apcWeight =       [ 0,  4,  8, 12, 16, 20, 20, 20, 20, 20] select _level;
-    _ifvWeight =       [ 0,  0,  2,  4,  6,  8, 12, 16, 20, 25] select _level;
+    _milTruckWeight =      [100, 80, 60, 35, 15,  0,  0,  0,  0,  0] select _level;
+    _truckWeight =         [ 10, 20, 30, 45, 55, 60, 55, 50, 45, 40] select _level;
+    _lapcWeight =          [ 10, 15, 20, 20, 20, 20, 20, 20, 20, 20] select _level;
+    _apcWeight =           [  0,  4,  8, 12, 16, 20, 20, 20, 20, 20] select _level;
+    _ifvWeight =           [  0,  0,  2,  4,  6,  8, 12, 16, 20, 25] select _level;
 };
 
 if (_faction get "vehiclesLightAPCs" isEqualTo []) then { _apcWeight = _apcWeight + _lapcWeight/2; _truckWeight = _truckWeight + _lapcWeight/2; };


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Shuffled around the weigh distributions of militia vs military vehicles to increase the probability of encountering militia troops in the early game - something i did not deem common enough.
weighed against all other transports the total should be the same unless i've made a lapse in my maths.

Adjusted the way the weights of light tanks are distributed if they are absent - there's probably a reason why MBTs and equivalent can be dispatched at war level 2 but i don't feel that's particularly fitting.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
