### PR TITLE
SPE flashlight fix

### DIFF
--- a/A3A/addons/core/CfgVehicles.hpp
+++ b/A3A/addons/core/CfgVehicles.hpp
@@ -1,12 +1,21 @@
 class CfgVehicles
 {
+    class CAManBase;
+    class SoldierGB : CAManBase {
+        class EventHandlers;
+    };
+    class I_G_Soldier_base_F : SoldierGB {
+        class EventHandlers : EventHandlers{
+            init = "if (local (_this select 0)) then {[(_this select 0), [], []] call BIS_fnc_unitHeadgear;};";
+        };
+    };
     // Rebel AI unit types
     
     //don't need to change this one?
-    class I_G_Survivor_F;
+    class I_G_Survivor_F : I_G_Soldier_base_F{};
     class a3a_unit_reb_unarmed : I_G_Survivor_F {};
 
-    class I_G_Soldier_F;
+    class I_G_Soldier_F : I_G_Soldier_base_F{};
     class a3a_unit_reb : I_G_Soldier_F {
         backpack = "";
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
@@ -14,7 +23,7 @@ class CfgVehicles
         weapons[] = {"Throw","Put"};
     };
 
-    class I_G_medic_F;
+    class I_G_medic_F : I_G_Soldier_base_F{};
     class a3a_unit_reb_medic : I_G_medic_F {
         backpack = "";
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
@@ -22,7 +31,7 @@ class CfgVehicles
         weapons[] = {"Throw","Put"};
     };
 
-    class I_G_Sharpshooter_F;
+    class I_G_Sharpshooter_F : I_G_Soldier_base_F{};
     class a3a_unit_reb_sniper : I_G_Sharpshooter_F {
         backpack = "";
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
@@ -30,7 +39,7 @@ class CfgVehicles
         weapons[] = {"Throw","Put"};
     };
 
-    class I_G_Soldier_M_F;
+    class I_G_Soldier_M_F : I_G_Soldier_base_F{};
     class a3a_unit_reb_marksman : I_G_Soldier_M_F {
         backpack = "";
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
@@ -38,7 +47,7 @@ class CfgVehicles
         weapons[] = {"Throw","Put"};
     };
 
-    class I_G_Soldier_LAT_F;
+    class I_G_Soldier_LAT_F : I_G_Soldier_base_F{};
     class a3a_unit_reb_lat : I_G_Soldier_LAT_F {
         backpack = "";
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
@@ -46,7 +55,7 @@ class CfgVehicles
         weapons[] = {"Throw","Put"};
     };
 
-    class I_G_Soldier_AR_F;
+    class I_G_Soldier_AR_F : I_G_Soldier_base_F{};
     class a3a_unit_reb_mg : I_G_Soldier_AR_F {
         backpack = "";
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
@@ -54,7 +63,7 @@ class CfgVehicles
         weapons[] = {"Throw","Put"};
     };
 
-    class I_G_Soldier_exp_F;
+    class I_G_Soldier_exp_F : I_G_Soldier_base_F{};
     class a3a_unit_reb_exp : I_G_Soldier_exp_F {
         backpack = "";
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
@@ -62,7 +71,7 @@ class CfgVehicles
         weapons[] = {"Throw","Put"};
     };
 
-    class I_G_Soldier_GL_F;
+    class I_G_Soldier_GL_F : I_G_Soldier_base_F{};
     class a3a_unit_reb_gl : I_G_Soldier_GL_F {
         backpack = "";
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
@@ -70,7 +79,7 @@ class CfgVehicles
         weapons[] = {"Throw","Put"};
     };
 
-    class I_G_Soldier_SL_F;
+    class I_G_Soldier_SL_F : I_G_Soldier_base_F{};
     class a3a_unit_reb_sl : I_G_Soldier_SL_F {
         backpack = "";
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
@@ -78,7 +87,7 @@ class CfgVehicles
         weapons[] = {"Throw","Put"};
     };
 
-    class I_G_engineer_F;
+    class I_G_engineer_F : I_G_Soldier_base_F{};
     class a3a_unit_reb_eng : I_G_engineer_F {
         backpack = "";
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
@@ -102,7 +111,7 @@ class CfgVehicles
         weapons[] = {"Throw","Put"};
     };
 
-    class I_G_officer_F;
+    class I_G_officer_F : I_G_Soldier_base_F{};
     class a3a_unit_reb_petros : I_G_officer_F {
         backpack = "";
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};

--- a/A3A/addons/core/CfgVehicles.hpp
+++ b/A3A/addons/core/CfgVehicles.hpp
@@ -5,8 +5,10 @@ class CfgVehicles
         class EventHandlers;
     };
     class I_G_Soldier_base_F : SoldierGB {
-        class EventHandlers : EventHandlers{
+        class EventHandlers : EventHandlers //Unbreaking the broken EventHandlers chain of inheritance 
+        {
             init = "if (local (_this select 0)) then {[(_this select 0), [], []] call BIS_fnc_unitHeadgear;};";
+            //init line to perserve the behaviour BI intended for the I_G_Soldier_base_F classs
         };
     };
     // Rebel AI unit types

--- a/A3A/addons/core/CfgVehicles.hpp
+++ b/A3A/addons/core/CfgVehicles.hpp
@@ -121,7 +121,7 @@ class CfgVehicles
 
     // Base side types
 
-    class B_G_Soldier_F;
+    class B_G_Soldier_F : I_G_Soldier_base_F{};
     class a3a_unit_west : B_G_Soldier_F {
         backpack = "";
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};
@@ -129,7 +129,7 @@ class CfgVehicles
         weapons[] = {"Throw","Put"};
     };
 
-    class O_G_Soldier_F;
+    class O_G_Soldier_F : I_G_Soldier_base_F{};
     class a3a_unit_east : O_G_Soldier_F {
         backpack = "";
         linkedItems[] = {"ItemMap","ItemCompass","ItemWatch"};

--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_US.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_US.sqf
@@ -169,7 +169,7 @@ _loadoutData set ["watches", ["SPE_US_ItemWatch"]];
 _loadoutData set ["compasses", ["SPE_US_ItemCompass"]];
 _loadoutData set ["radios", ["ItemRadio"]];
 _loadoutData set ["binoculars", ["SPE_Binocular_US"]];
-_loadoutData set ["NVGs", ["SPE_US_FL_TL122"]];
+_loadoutData set ["Flashlight", ["SPE_US_FL_TL122"]];
 
 _loadoutData set ["uniforms", ["U_SPE_US_Private", "U_SPE_US_Private_1st", "U_SPE_US_Private_late"]];
 _loadoutData set ["medUniforms", ["U_SPE_US_Med"]];
@@ -419,6 +419,7 @@ private _squadLeaderTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 
     ["binoculars"] call _fnc_addBinoculars;
 };
@@ -441,6 +442,7 @@ private _riflemanTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 
 private _medicTemplate = {
@@ -464,6 +466,7 @@ private _medicTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 
 private _grenadierTemplate = {
@@ -486,6 +489,7 @@ private _grenadierTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 
 private _explosivesExpertTemplate = {
@@ -517,6 +521,7 @@ private _explosivesExpertTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 
 private _engineerTemplate = {
@@ -544,6 +549,7 @@ private _engineerTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 
 private _latTemplate = {
@@ -568,6 +574,7 @@ private _latTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 
 private _atTemplate = {
@@ -592,6 +599,7 @@ private _atTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 
 private _aaTemplate = {
@@ -616,6 +624,7 @@ private _aaTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 
 private _machineGunnerTemplate = {
@@ -640,6 +649,7 @@ private _machineGunnerTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 
 private _marksmanTemplate = {
@@ -663,6 +673,7 @@ private _marksmanTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
     ["binoculars"] call _fnc_addBinoculars;
 };
 
@@ -710,6 +721,7 @@ private _policeTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 private _policeSLTemplate = {
     call _policeTemplate;
@@ -751,6 +763,7 @@ private _unarmedTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 
 private _traitorTemplate = {

--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_WEH.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_WEH.sqf
@@ -151,7 +151,7 @@ _loadoutData set ["watches", ["SPE_GER_ItemWatch"]];
 _loadoutData set ["compasses", ["SPE_GER_ItemCompass", "SPE_GER_ItemCompass_deg"]];
 _loadoutData set ["radios", ["ItemRadio"]];
 _loadoutData set ["binoculars", ["SPE_Binocular_GER"]];
-_loadoutData set ["NVGs", ["SPE_GER_FL_Signal_Flashlight"]];
+_loadoutData set ["Flashlight", ["SPE_GER_FL_Signal_Flashlight"]];
 
 _loadoutData set ["uniforms", ["U_SPE_GER_Soldier_Boots", "U_SPE_GER_Soldier_Gaiters", "U_SPE_GER_MG_schutze", "U_SPE_GER_Gefreiter_Gaiters", "U_SPE_GER_Gefreiter", "U_SPE_GER_Oberschutze"]];
 _loadoutData set ["sniUniforms", []];
@@ -406,6 +406,7 @@ private _squadLeaderTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 
     ["binoculars"] call _fnc_addBinoculars;
 };
@@ -431,6 +432,7 @@ private _riflemanTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 
 private _medicTemplate = {
@@ -454,6 +456,7 @@ private _medicTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 
 private _grenadierTemplate = {
@@ -480,6 +483,7 @@ private _grenadierTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 
 private _explosivesExpertTemplate = {
@@ -511,6 +515,7 @@ private _explosivesExpertTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 
 private _engineerTemplate = {
@@ -538,6 +543,7 @@ private _engineerTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 
 private _latTemplate = {
@@ -564,6 +570,7 @@ private _latTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 
 private _atTemplate = {
@@ -592,6 +599,7 @@ private _atTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 
 private _aaTemplate = {
@@ -618,6 +626,7 @@ private _aaTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 
 private _machineGunnerTemplate = {
@@ -642,6 +651,7 @@ private _machineGunnerTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 
 private _marksmanTemplate = {
@@ -712,6 +722,7 @@ private _policeTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 private _policeSLTemplate = {
     call _policeTemplate;
@@ -753,6 +764,7 @@ private _unarmedTemplate = {
     ["watches"] call _fnc_addWatch;
     ["compasses"] call _fnc_addCompass;
     ["radios"] call _fnc_addRadio;
+    ["Flashlight"] call _fnc_addNVGs;
 };
 
 private _traitorTemplate = {


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Adds flashlights to the unit definitions
Fixes eventhandler inheritance by making I_G_Soldier_base_F inherit the EHs from SoldierGB correctly - this permits units derived from the vanilla FIA classes to use SPE flashlights, hipfire, some flamethrower hose stuff, SPE static weapons, fixes for the SPE alt reloads.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
