### PR TITLE
Fix SoldierGB inheritance chain for CBA XEH. Probably.

### DIFF
--- a/A3A/addons/core/CfgVehicles.hpp
+++ b/A3A/addons/core/CfgVehicles.hpp
@@ -1,16 +1,21 @@
 class CfgVehicles
 {
-    class CAManBase;
-    class SoldierGB : CAManBase {
+    // Unbreak the vanilla inheritance chain
+    class Man;
+    class CAManBase : Man {
         class EventHandlers;
     };
+    class SoldierGB : CAManBase {
+        class EventHandlers : EventHandlers {};
+    };
     class I_G_Soldier_base_F : SoldierGB {
-        class EventHandlers : EventHandlers //Unbreaking the broken EventHandlers chain of inheritance 
+        class EventHandlers : EventHandlers
         {
             init = "if (local (_this select 0)) then {[(_this select 0), [], []] call BIS_fnc_unitHeadgear;};";
             //init line to perserve the behaviour BI intended for the I_G_Soldier_base_F classs
         };
     };
+
     // Rebel AI unit types
     
     //don't need to change this one?


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
#3377 broke the CBA XEH event handlers for SoldierGB onwards, I guess because CBA works around the broken inheritance by selectively spamming the event handlers into various places, and our new inheritance chain didn't touch any of those. Fixing the link from SoldierGB -> CAManBase seems to work, although I'm not 100% sure that I've tested both load orders. Because our config doesn't have a dependency on CBA, it's possible for CBA to be loaded either before or after. Either way it's better than it was, but we might need to handle the inheritance patch differently.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

### How can the changes be tested?
I don't know.