### PR TITLE
Injector success and UID logging

### DIFF
--- a/A3A/addons/core/functions/init/fn_initACE.sqf
+++ b/A3A/addons/core/functions/init/fn_initACE.sqf
@@ -21,10 +21,12 @@
 if (A3A_hasACEMedical) then { 
     // log atropine, epinephrine, and morphine use
     // Appears to be local to the medic
-    ["ace_treatmentStarted", {
+    ["ace_treatmentSucceded", {
         params ["_caller", "_target", "_selectionName", "_className", "_itemUser", "_usedItem"];
-        if (_usedItem in ["ACE_atropine", "ACE_epinephrine", "ACE_morphine"]) then {
-            ServerInfo_3("Player: %1 used %2 on %3",name _caller,_usedItem,name _target);
+        if (_usedItem in ["ACE_adenosine", "ACE_epinephrine", "ACE_morphine"]) then {
+            private _callerUID = ["AI",getPlayerUID _caller] select (isPlayer _caller);
+            private _targetUID = ["AI",getPlayerUID _target] select (isPlayer _target);
+            ServerInfo_5("Player %1 [%2] used %3 on %4 [%5]",name _caller,_callerUID,_usedItem,name _target,_targetUID);
         };
     }] call CBA_fnc_addEventHandler;
 };

--- a/A3A/addons/core/functions/init/fn_initACE.sqf
+++ b/A3A/addons/core/functions/init/fn_initACE.sqf
@@ -23,7 +23,7 @@ if (A3A_hasACEMedical) then {
     // Appears to be local to the medic
     ["ace_treatmentSucceded", {
         params ["_caller", "_target", "_selectionName", "_className", "_itemUser", "_usedItem"];
-        if (_usedItem in ["ACE_adenosine", "ACE_epinephrine", "ACE_morphine"]) then {
+        if (_usedItem in ["ACE_adenosine", "ACE_epinephrine", "ACE_morphine", "ACE_painkillers"]) then {
             private _callerUID = ["AI",getPlayerUID _caller] select (isPlayer _caller);
             private _targetUID = ["AI",getPlayerUID _target] select (isPlayer _target);
             ServerInfo_5("Player %1 [%2] used %3 on %4 [%5]",name _caller,_callerUID,_usedItem,name _target,_targetUID);


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [X] Enhancement

### What have you changed and why?
Information: ACE Injector use is now logged on success, not on beginning the action. This helps server admins identify medical malpractice.
Injector use now has UIDs attached.
Fixed mis-named case for using adenosine injectors. Added painkillers.

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
