### PR TITLE
Fix skill upgrade tooltip not updating

### DIFF
--- a/A3A/addons/core/functions/REINF/fn_FIAskillAdd.sqf
+++ b/A3A/addons/core/functions/REINF/fn_FIAskillAdd.sqf
@@ -15,6 +15,15 @@ skillFIA = skillFIA + 1;
 [_titleStr, format [localize "STR_A3A_fn_reinf_FIASkAdd_upgraded",skillFIA,FactionGet(reb,"name")]] call A3A_fnc_customHint;
 publicVariable "skillFIA";
 server setVariable ["resourcesFIA",_resourcesFIA,true];
+
+//update tooltip
+_display = findDisplay 100;
+if (str (_display) != "no display") then
+{
+	_ChildControl = _display displayCtrl 109;
+	_ChildControl  ctrlSetTooltip format [localize "STR_A3A_fn_dialogs_dialogHQ_upgrade",1000 + (1.5*((skillFIA) *750)),skillFIA];
+};
+
 [] spawn A3A_fnc_statistics;
 {
     _costs = server getVariable _x;


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
- Button tooltip did not update after upgrading ai skill.
- Copied update functionality from dialogHQ

### Please specify which Issue this PR Resolves.
closes #3351

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)