### PR TITLE
Fix errors caused by tags function

### DIFF
--- a/A3A/addons/core/functions/init/fn_tags.sqf
+++ b/A3A/addons/core/functions/init/fn_tags.sqf
@@ -22,11 +22,11 @@ while{true}do{
    // PLAYER NAME CHECK AND DISPLAY
         _target = cursorTarget;
         if (_target isKindOf "CAManBase" && player == vehicle player) then{
-                if((side _target == playerSide) && ((player distance _target) < _distance))then
+                if((side group _target == playerSide) && ((player distance _target) < _distance))then
                 	{
 					_weaponsplayer = weapons _target;
 					_name = name _target;
-                    _nameString = "<t size='0.5' shadow='2' color='#7FFF00'>" + format['%1 %2',_target getVariable ['unitname', name _target]] + "</t>";
+                    _nameString = "";
                     _rank = [_target,"displayNameShort"] call BIS_fnc_rankParams;
                     if (count _weaponsPlayer > 0) then
                     	{


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information:
     Looking at friendly units no longer causes script errors
     Now tags are displayed for downed/killed units as well

### Please specify which Issue this PR Resolves.
closes #3394

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
see issue.
********************************************************
Notes:
