### PR TITLE
Fix arsenal not clearing client IDs on disconnect

### DIFF
--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -231,7 +231,14 @@ call A3A_fnc_createPetros;
 //HandleDisconnect doesn't get 'owner' param, so we can't use it to handle headless client disconnects.
 addMissionEventHandler ["HandleDisconnect",{_this call A3A_fnc_onPlayerDisconnect;false}];
 //PlayerDisconnected doesn't get access to the unit, so we shouldn't use it to handle saving.
-addMissionEventHandler ["PlayerDisconnected",{_this call A3A_fnc_onHeadlessClientDisconnect;false}];
+addMissionEventHandler ["PlayerDisconnected",{
+    // Remove player from arsenal in case they disconnected while in it
+    private _temp = server getVariable ["jna_playersInArsenal",[]];
+    _temp = _temp - [param [4]];
+    server setVariable ["jna_playersInArsenal",_temp,true];
+    _this call A3A_fnc_onHeadlessClientDisconnect;
+    false;
+}];
 
 addMissionEventHandler ["BuildingChanged", {
     params ["_oldBuilding", "_newBuilding", "_isRuin"];


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
-     Owner ID now gets removed from playersInArsenal when player disconnects while in arsenal

### Please specify which Issue this PR Resolves.
closes #3344 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

1. Open the arsenal on a dedicated server and disconnect while in it
2. Log back in and check jna_playersInArsenal, (if you were the only player) the array should be empty

********************************************************
Notes:
