### PR TITLE
Increase AI AA awareness

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -144,6 +144,7 @@ class CfgFunctions
             class arePositionsConnected {};
             class joinMultipleGroups {};
             class localizar {};
+            class localReveal {};
             class lockStatic {};
             class logPerformance {};
             class markerChange {};
@@ -233,6 +234,7 @@ class CfgFunctions
         class CREATE {
             file = QPATHTOFOLDER(functions\CREATE);
             class AAFroadPatrol {};
+            class aaReveal {};
             class airportCanAttack {};
             class AIVEHinit {};
             class attackHQ {};
@@ -253,6 +255,7 @@ class CfgFunctions
             class createAttackForceMixed {};
             class createAttackVehicle {};
             class createFIAOutposts2 {};
+            class createHunterKillerTeam {};
             class createSDKGarrisons {};
             class createSDKgarrisonsTemp {};
             class createUnit {};

--- a/A3A/addons/core/functions/Base/fn_localReveal.sqf
+++ b/A3A/addons/core/functions/Base/fn_localReveal.sqf
@@ -1,0 +1,16 @@
+/*
+    Reveal a unit to another unit. Only used for aaReveal, can be expanded if neccesary
+Parameters:
+    0. <OBJECT> Unit to reveal to. Typically the machine remoteExeced onto
+    1. <OBJECT> Unit to be revealed
+Returns:
+    Nothing
+Environment:
+    Scheduled, any machine
+*/
+
+params ["_unit","_veh"];
+private _accuracy = linearConversion [250,2000,_unit distance2D _veh,4,2,true];
+_unit reveal [_veh,_accuracy];
+if (getAttackTarget _unit isKindOf "Air") exitWith {diag_log "Unit has air target already, exiting."};
+_unit commandTarget _veh;

--- a/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
@@ -82,10 +82,20 @@ else
 {
 	if ( _typeX in (FactionGet(all,"vehiclesFixedWing") + FactionGet(all,"vehiclesHelis")) ) then
 	{
+		[_veh] spawn {
+			params ["_veh"];
+			sleep 10;
+			if !(isNull driver _veh) then {[_veh] spawn A3A_fnc_aaReveal;};
+		};
 		_veh addEventHandler ["GetIn",
 		{
-			if (_this select 1 != "driver") exitWith {};
-			_unit = _this select 2;
+			params ["_vehicle", "_role", "_unit", "_turret"];
+			if (isNull (_vehicle getVariable ["aaRevealHandle", scriptNull])) then 
+			{
+				private _handle = [_vehicle] spawn A3A_fnc_aaReveal;
+				_vehicle setVariable ["aaRevealHandle",_handle];
+			};
+			if (_role != "driver") exitWith {};
 			if ((!isPlayer _unit) and (_unit getVariable ["spawner",false]) and (side group _unit == teamPlayer)) then
 			{
 				moveOut _unit;

--- a/A3A/addons/core/functions/CREATE/fn_aaReveal.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_aaReveal.sqf
@@ -1,0 +1,26 @@
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+
+params ["_veh"];
+private _oldPos = getPos _veh;
+while {(alive _veh) and !(isNull _veh)} do {
+    sleep 10; // vehicles heading over 720kmh have a chance of not being caught by AA, which is a fair sacrifice for performance
+    private _newPos = getPos _veh;
+    private _posDifference = _oldPos distance2D _newPos;
+    _oldPos = _newPos;
+    private _side = side _veh;
+    if (_posDifference < 5) then {continue};
+    if (_side == civilian) then {continue};
+    // we actually reveal to all nearby units now
+    private _enemySides = [Occupants,Invaders,teamPlayer] - [_side]; // this is horrible but its the best way I think we can avoid pulling all the units for performance
+    private _enemySide1 = _enemySides select 0;
+    private _enemySide2 = _enemySides select 1; 
+    private _nearbyUnitsEnemySides = (units _enemySide1 + units _enemySide2) inAreaArray [_oldPos, 2000, 2000];
+    private _aaUnits = _nearbyUnitsEnemySides select {("AA" in (_x getVariable "unitType")) || !(isNull objectParent _x)};
+    {
+        [_x,_veh] remoteExec ["A3A_fnc_localReveal",_x]; // this is also horrible,
+    } forEach _aaUnits;
+
+};
+_veh setVariable ["aaRevealHandle",scriptNull];
+Debug_1("Vehicle %1 was destroyed or deleted aborting air reveal routine",_veh)

--- a/A3A/addons/core/functions/CREATE/fn_createHunterKillerTeam.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createHunterKillerTeam.sqf
@@ -1,0 +1,4 @@
+params [["_type","AA"],["_motorized",false]];
+
+// Placeholder function. When fixed-wings do flyovers of unspawned enemy garrisons, they should get a chance of spawning a Hunter-Killer team that targets the plane.
+// Options for AA/AT and an attached vehicle

--- a/A3A/addons/core/functions/CREATE/fn_milBuildings.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_milBuildings.sqf
@@ -34,6 +34,7 @@ while {_count > 0} do
     _veh = createVehicle [_typeVehX, (_spawnParameter select 0), [],0, "CAN_COLLIDE"];
     _veh setDir (_spawnParameter select 1);
     _vehiclesX pushBack _veh;
+    [_veh, _sideX] call A3A_fnc_AIVEHinit;
     _count = _count - 1;
 };
 


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Information: UNFINISHED
Makes AI AA units a bit less deaf and capable of engaging aircraft more often, by brute forcing the reveal and target.
Airbase/outpost heli spawns will get AIVEHInited

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

********************************************************
Notes: Needs implementation of the hunter-killer teams to really be relevant, and its worth questioning if this is neccesary at all. The main issue being solved here is using napalm airstrikes to eliminate armored convoys and recover the vehicles, but another solution is possible. This could also really use the buff to vanilla static AA, as well as an increase in the price of static AA across the board.
