### PR TITLE
Seat drawing dev function

### DIFF
--- a/A3A/addons/logistics/CfgFunctions.hpp
+++ b/A3A/addons/logistics/CfgFunctions.hpp
@@ -4,6 +4,7 @@ class CfgFunctions {
             file = QPATHTOFOLDER(Dev);
             class convertCargoToNew {};
             class convertNodesToNew {};
+            class drawSeats {};
             class generateCargoOffset {};
             class generateHardPoints {};
         };

--- a/A3A/addons/logistics/Dev/fn_drawSeats.sqf
+++ b/A3A/addons/logistics/Dev/fn_drawSeats.sqf
@@ -6,7 +6,7 @@
         Handles grabbing seat positions and index then drawing them to 3D space.
 
     Params:
-	    _vehicle    <OBJECT>
+	    _vehicle <OBJECT> <Default: ObjNull>
 
     Usage:
         [cursorObject] call A3A_logistics_fnc_drawSeats;
@@ -16,6 +16,7 @@ params [["_vehicle", ObjNull]];
 
 if (_vehicle isEqualTo ObjNull) exitWith {false};
 
+// Global so these can easily be changed whilst already drawing
 textSize = 0.05;
 iconSize = 1.5;
 icon = "a3\ui_f\data\Map\Markers\Military\dot_ca.paa";
@@ -34,12 +35,14 @@ private _selectionsCoords = [];
     private _inModelPosition = _vehicle selectionPosition [_x, "FireGeometry", "FirstPoint"];
 
 	private _splitSelections = _x splitString "";
-	private _splitSelection = (_splitSelections select -3) + (_splitSelections select -2) + (_splitSelections select -1); // get the last 3 numbers for index
+	private _splitSelection = parseNumber ((_splitSelections select -3) + (_splitSelections select -2) + (_splitSelections select -1)) - 1; // get the last 3 numbers
+	private _splitSelection = str _splitSelection; // Cargo index starts at 0 so we convert to int and -1 above
 
-    if !("cargo" in _x && {!("gunner" in _x)}) then {continue}; // if seat is not a cargo or gunner seat, do not add to the drawing list
-
-    _selectionsCoords pushBack _inModelPosition;
-    _selectionsNames pushBack _splitSelection;
+    // The below could be a false positive if a selection isn't a seat but does have cargo/gunner in its name, though I have not encountered this yet
+    if ("cargo" in _x || {"gunner" in _x}) then {
+        _selectionsCoords pushBack _inModelPosition;
+        _selectionsNames pushBack _splitSelection;
+    };
 } forEach _selections;
 
 private _helperID = addMissionEventHandler ["Draw3D", {

--- a/A3A/addons/logistics/Dev/fn_drawSeats.sqf
+++ b/A3A/addons/logistics/Dev/fn_drawSeats.sqf
@@ -1,0 +1,66 @@
+/*
+    Author:
+        Silence
+
+    Description:
+        Handles grabbing seat positions and index then drawing them to 3D space.
+
+    Params:
+	    _vehicle    <OBJECT>
+
+    Usage:
+        [cursorObject] call A3A_logistics_fnc_drawSeats;
+*/
+
+params [["_vehicle", ObjNull]];
+
+if (_vehicle isEqualTo ObjNull) exitWith {false};
+
+textSize = 0.05;
+iconSize = 1.5;
+icon = "a3\ui_f\data\Map\Markers\Military\dot_ca.paa";
+colour = [1,1,1,0.8];
+canDraw = true;
+
+if (_vehicle getVariable ["A3A_helper_seatDrawer", ""] isNotEqualTo "") then {
+    removeMissionEventHandler ["Draw3D", _vehicle getVariable "A3A_helper_seatDrawer"];
+};
+
+private _selections = _vehicle selectionNames "FireGeometry";
+private _selectionsNames = [];
+private _selectionsCoords = [];
+
+{
+    private _inModelPosition = _vehicle selectionPosition [_x, "FireGeometry", "FirstPoint"];
+
+	private _splitSelections = _x splitString "";
+	private _splitSelection = (_splitSelections select -3) + (_splitSelections select -2) + (_splitSelections select -1); // get the last 3 numbers for index
+
+    if !("cargo" in _x && {!("gunner" in _x)}) then {continue}; // if seat is not a cargo or gunner seat, do not add to the drawing list
+
+    _selectionsCoords pushBack _inModelPosition;
+    _selectionsNames pushBack _splitSelection;
+} forEach _selections;
+
+private _helperID = addMissionEventHandler ["Draw3D", {
+    private _selectionsNames = (_thisArgs select 0);
+    private _selectionsCoords = (_thisArgs select 1);
+    private _vehicle = (_thisArgs select 2);
+    
+    if !(canDraw) exitWith {nil};
+
+    {
+        private _name = _selectionsNames select _forEachIndex;
+        drawIcon3D [
+            icon,
+            colour,
+            _vehicle modelToWorldVisual (_selectionsCoords select _forEachIndex),
+            iconSize,iconSize,0,
+            _name,
+            0,
+            textSize
+        ];
+    } forEach _selectionsCoords;
+}, [_selectionsNames, _selectionsCoords, _vehicle]];
+
+_vehicle setVariable ["A3A_helper_seatDrawer", _helperID];

--- a/A3A/addons/logistics/Dev/fn_drawSeats.sqf
+++ b/A3A/addons/logistics/Dev/fn_drawSeats.sqf
@@ -12,19 +12,19 @@
         [cursorObject] call A3A_logistics_fnc_drawSeats;
 */
 
+#define SIZETEXT 0.05
+#define SIZEICON 1.2
+#define ICON "a3\ui_f\data\Map\Markers\Military\dot_ca.paa"
+#define COLOUR [1,1,1,0.8]
+
 params [["_vehicle", ObjNull]];
 
 if (_vehicle isEqualTo ObjNull) exitWith {false};
 
-// Global so these can easily be changed whilst already drawing
-textSize = 0.05;
-iconSize = 1.5;
-icon = "a3\ui_f\data\Map\Markers\Military\dot_ca.paa";
-colour = [1,1,1,0.8];
-canDraw = true;
-
-if (_vehicle getVariable ["A3A_helper_seatDrawer", ""] isNotEqualTo "") then {
+if (_vehicle getVariable ["A3A_helper_seatDrawer", ""] isNotEqualTo "") exitWith {
     removeMissionEventHandler ["Draw3D", _vehicle getVariable "A3A_helper_seatDrawer"];
+    
+    _vehicle setVariable ["A3A_helper_seatDrawer", ""];
 };
 
 private _selections = _vehicle selectionNames "FireGeometry";
@@ -36,12 +36,13 @@ private _selectionsCoords = [];
 
 	private _splitSelections = _x splitString "";
 	private _splitSelection = parseNumber ((_splitSelections select -3) + (_splitSelections select -2) + (_splitSelections select -1)) - 1; // get the last 3 numbers
-	private _splitSelection = str _splitSelection; // Cargo index starts at 0 so we convert to int and -1 above
+
+	private _seatIndex = str _splitSelection; // Converts the int back to a string
 
     // The below could be a false positive if a selection isn't a seat but does have cargo/gunner in its name, though I have not encountered this yet
     if ("cargo" in _x || {"gunner" in _x}) then {
         _selectionsCoords pushBack _inModelPosition;
-        _selectionsNames pushBack _splitSelection;
+        _selectionsNames pushBack _seatIndex;
     };
 } forEach _selections;
 
@@ -49,19 +50,17 @@ private _helperID = addMissionEventHandler ["Draw3D", {
     private _selectionsNames = (_thisArgs select 0);
     private _selectionsCoords = (_thisArgs select 1);
     private _vehicle = (_thisArgs select 2);
-    
-    if !(canDraw) exitWith {nil};
 
     {
         private _name = _selectionsNames select _forEachIndex;
         drawIcon3D [
-            icon,
-            colour,
+            ICON,
+            COLOUR,
             _vehicle modelToWorldVisual (_selectionsCoords select _forEachIndex),
-            iconSize,iconSize,0,
+            SIZEICON,SIZEICON,0,
             _name,
             0,
-            textSize
+            SIZETEXT
         ];
     } forEach _selectionsCoords;
 }, [_selectionsNames, _selectionsCoords, _vehicle]];


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information:
Added a new function in `logistics/Dev` called `fn_drawSeats`. Similar to the hardpoints function, it draws cargo/gunner seat proxy locations on a vehicle along with each seat index.

May be useful for getting a nice visualization of what seats should be locked when loading cargo.

---
> You can figure out which seats were locked quite easily.
![image](https://github.com/user-attachments/assets/649b65dd-c713-4ce0-91fc-b1e6945d3458)
---

### Please specify which Issue this PR Resolves.
N/A

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

Look at a vehicle and run the following locally
```sqf
[cursorObject] call A3A_logistics_fnc_drawSeats;
```

********************************************************
Notes:
