### PR TITLE
Prevent rebels AIs being equipped with VN melee weapons

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_categoryOverrides.sqf
@@ -264,6 +264,10 @@ private _categoryOverrideTable = [
 ["vn_fkb1_red", ["Unknown","Weapons"]],
 ["vn_fkb1", ["Unknown","Weapons"]],
 
+// Melee
+["vn_m_mk2_knife_01", ["Unknown","Weapons"]],
+["vn_m_axe_01", ["Unknown","Weapons"]],
+
 ["vn_default_helmetbase_09", ["Unknown","Headgear"]],	//Goat Hat
 ["vn_m1897", ["Shotguns","Weapons"]],
 ["vn_izh54", ["Shotguns","Weapons"]],


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
VN melee weapons were being autoclassified as handguns, which caused the rebel AI equipping code to use them in the early game. Fixed by overriding to "Unknown", which is basically where we put stuff that AI doesn't know how to use.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
