### PR TITLE
Fix base class for srifle_GM6_snake_lxWS 

### DIFF
--- a/A3A/addons/config_fixes/WS/CfgWeapons.hpp
+++ b/A3A/addons/config_fixes/WS/CfgWeapons.hpp
@@ -7,8 +7,8 @@ class CfgWeapons
     {
         baseWeapon = "arifle_VelkoR5_GL_lxWS";
     };
-	class srifle_GM6_F;
-	class srifle_GM6_snake_lxWS : srifle_GM6_F {
+    class srifle_GM6_F;
+    class srifle_GM6_snake_lxWS : srifle_GM6_F {
         baseWeapon = "srifle_GM6_snake_lxWS";
-	};
+    };
 };

--- a/A3A/addons/config_fixes/WS/CfgWeapons.hpp
+++ b/A3A/addons/config_fixes/WS/CfgWeapons.hpp
@@ -7,4 +7,9 @@ class CfgWeapons
     {
         baseWeapon = "arifle_VelkoR5_GL_lxWS";
     };
+    class arifle_VelkoR5_lxWS;
+	class srifle_GM6_F;
+	class srifle_GM6_snake_lxWS : srifle_GM6_F {
+        baseWeapon = "srifle_GM6_snake_lxWS";
+	};
 };

--- a/A3A/addons/config_fixes/WS/CfgWeapons.hpp
+++ b/A3A/addons/config_fixes/WS/CfgWeapons.hpp
@@ -7,7 +7,6 @@ class CfgWeapons
     {
         baseWeapon = "arifle_VelkoR5_GL_lxWS";
     };
-    class arifle_VelkoR5_lxWS;
 	class srifle_GM6_F;
 	class srifle_GM6_snake_lxWS : srifle_GM6_F {
         baseWeapon = "srifle_GM6_snake_lxWS";


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Fixes base weapon classname of the GM6 Snake - making it not convert into a blank element in the arsenal

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
loot srifle_GM6_snake_lxWS before and after this change.

********************************************************
Notes:
