### PR TITLE
Fix CUP disposable missile launchers breaking init after CBA 3.18 update

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_equipmentClassToCategories.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_equipmentClassToCategories.sqf
@@ -163,8 +163,8 @@ call {
         if (getNumber (_config >> "rhs_disposable") == 1 or _mainmag == "CBA_fakeLauncherMagazine") then {
             _categories pushBack "Disposable";
             if (getNumber (_config >> "scope") == 1) exitWith { _categories set [0, "UsedLaunchers"] };
-            if (_mainmag == "CBA_fakeLauncherMagazine" and !isNil "cba_disposable_normalLaunchers") then {
-                _mainmag = (cba_disposable_normalLaunchers getVariable _classname) # 1;     // format is [realLauncher, magazine]
+            if (_mainmag == "CBA_fakeLauncherMagazine" and !isNil "cba_disposable_normalLaunchers" and {typeName cba_disposable_normalLaunchers == "HASHMAP"}) then {
+                _mainmag = (cba_disposable_normalLaunchers get _classname) # 1;     // format is [realLauncher, magazine]
             };
         };
         if (_categories#0 == "UsedLaunchers") exitWith {};


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement
4. [X] Fuck CBA

### What have you changed and why?
A variable used for detecting disposable missile launcher types was changed in CBA 3.18, breaking Antistasi init when CUP weapons is loaded. This PR works around it. Also doesn't break in older CBA, although it won't detect the missiles correctly.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)
