### PR TITLE
IFA divebomb param adjustments

### DIFF
--- a/A3A/addons/core/Templates/AircraftLoadouts/IFA/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/IFA/config.cpp
@@ -54,13 +54,9 @@ class A3A {
                 mainGun[] = {"LIB_4xM2_P39"};
                 rocketLauncher[] = {"LIB_M4_P39"};
                 bombRacks[] = {"LIB_US_500lb_Bomb_Mount"};
-                diveParams[] = {1200, 350, 110, 55, 15, {20, 0}};
+                diveParams[] = {800, 350, 110, 55, 15, {20, -2}};
             };
-            class LIB_RAF_P39 : LIB_P39 {
-                loadout[] = {"LIB_1Rnd_US_500lb","LIB_30Rnd_M4_P39","LIB_1000Rnd_M2_P39"};
-                bombRacks[] = {"LIB_US_500lb_Bomb_Mount"};
-                diveParams[] = {1200, 350, 110, 55, 15, {20, 0}};
-            };
+            class LIB_RAF_P39 : LIB_P39 {};
             class LIB_US_P39 : LIB_RAF_P39 {};
         };
         class CAPPlane

--- a/A3A/addons/core/Templates/AircraftLoadouts/IFA/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/IFA/config.cpp
@@ -26,28 +26,28 @@ class A3A {
                 mainGun[] = {"LIB_2xMG151_JU87"};
                 rocketLauncher[] = {"LIB_2xMG151_JU87"};
                 bombRacks[] = {"LIB_SC500_Bomb_Mount","LIB_SC50_Bomb_Mount"};
-                diveParams[] = {1200, 300, 110, 55, 15, {15, -2}};
+                diveParams[] = {700, 350, 110, 55, 15, {10, 0}};
             };
             class LIB_Pe2 : baseCAS {
                 loadout[] = {"LIB_1Rnd_FAB250","LIB_1Rnd_FAB250","LIB_1Rnd_FAB250","LIB_1Rnd_FAB250"};
                 mainGun[] = {"LIB_UBK_PE2", "LIB_ShKAS_PE2"};
                 rocketLauncher[] = {"LIB_UBK_PE2"};
                 bombRacks[] = {"LIB_FAB250_Bomb_Mount"};
-                diveParams[] = {1200, 300, 110, 55, 15, {12, 0}};
+                diveParams[] = {700, 300, 110, 55, 15, {5, 0}};
             };
             class LIB_FW190F8_2 : baseCAS {
                 loadout[] = {"LIB_1Rnd_SC50","LIB_1Rnd_SC50","LIB_1Rnd_SC500","LIB_1Rnd_SC50","LIB_1Rnd_SC50", "LIB_2000Rnd_MG131_FW190","LIB_500Rnd_MG151_FW190"};
                 mainGun[] = {"LIB_2xMG131_FW190","LIB_2xMG151_FW190"};
                 rocketLauncher[] = {"LIB_2xMG151_FW190"};
                 bombRacks[] = {"LIB_SC500_Bomb_Mount","LIB_SC50_Bomb_Mount"};
-                diveParams[] = {1200, 300, 110, 55, 15, {15, -2}};
+                diveParams[] = {800, 350, 110, 55, 15, {15, 0}};
             };
             class LIB_P47 : baseCAS {
                 loadout[] = {"LIB_1Rnd_US_500lb","LIB_1Rnd_US_500lb","LIB_1Rnd_US_500lb", "LIB_6Rnd_M8_P47", "LIB_6Rnd_M8_P47", "LIB_4000Rnd_M2_P47"};
                 mainGun[] = {"LIB_8xM2_P47"};
                 rocketLauncher[] = {"LIB_M8_Launcher_P47"};
                 bombRacks[] = {"LIB_US_500lb_Bomb_Mount"};
-                diveParams[] = {1200, 350, 110, 55, 15, {20, 0}};
+                diveParams[] = {800, 350, 110, 55, 15, {15, 2}};
             };
             class LIB_P39 : baseCAS {
                 loadout[] = {"LIB_1Rnd_US_500lb","LIB_30Rnd_M4_P39","LIB_1000Rnd_M2_P39"};


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:

Overall reduced the altitude the aircraft divebomb from, this should reduce how unexpected it feels to get divebombed.
Adjusted the offsets and altitudes such that all planes will completely disable or outright destroy a churchill tank with their bombs.
The P-39 Airacobra should now be effective against King Tigers

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
