### PR TITLE
Carpet bombing turned into triple airstrike

### DIFF
--- a/A3A/addons/core/functions/Supports/fn_SUP_airstrikeRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_airstrikeRoutine.sqf
@@ -22,6 +22,11 @@ params ["_supportName", "_side", "_sleepTime", "_targetPos", "_airport", "_resPo
 //Sleep to simulate preparation time
 sleep _sleepTime;
 
+private _isCarpetBombing = false;
+if (_bombType == "CARPET") then {
+	_bombType = "HE";
+	_isCarpetBombing = true;
+};
 private _isHelicopter = _planeType isKindOf "Helicopter";
 private _spawnPos = (getMarkerPos _airport) vectorAdd [0, 0, if (_isHelicopter) then {150} else {500}];
 private _plane = createVehicle [_planeType, _spawnPos, [], 0, "FLY"];     // FLY forces 100m alt
@@ -59,6 +64,11 @@ private _bombParams = [_plane, _bombType, _bombCount, 200];
 private _flightSpeed = ["LIMITED", "NORMAL", "FULL"] select (round random [1, _aggroValue / 50, 0]);
 if (_isHelicopter) then {_flightSpeed = "FULL"};
 Info_5("Airstrike %1 against %2 with %3 %4 bombs at %5 speed", _supportName, _targetPos, _bombCount, _bombType, toLower _flightSpeed);
+
+if (_isCarpetBombing) then {
+	_bombParams set [2, 5 max _bombCount];
+	_flightSpeed = "FULL";
+};
 
 _plane flyInHeight 150;
 private _minAltASL = (ATLToASL [_targetPos select 0, _targetPos select 1, 0])#2 +150;

--- a/A3A/addons/core/functions/Supports/fn_SUP_airstrikeRoutine.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_airstrikeRoutine.sqf
@@ -65,11 +65,6 @@ private _flightSpeed = ["LIMITED", "NORMAL", "FULL"] select (round random [1, _a
 if (_isHelicopter) then {_flightSpeed = "FULL"};
 Info_5("Airstrike %1 against %2 with %3 %4 bombs at %5 speed", _supportName, _targetPos, _bombCount, _bombType, toLower _flightSpeed);
 
-if (_isCarpetBombing) then {
-	_bombParams set [2, 5 max _bombCount];
-	_flightSpeed = "FULL";
-};
-
 _plane flyInHeight 150;
 private _minAltASL = (ATLToASL [_targetPos select 0, _targetPos select 1, 0])#2 +150;
 _plane flyInHeightASL [_minAltASL, _minAltASL, _minAltASL];
@@ -78,6 +73,16 @@ private _startBombPosition = _targetPos getPos [100, _targDir + 180];
 _startBombPosition set [2, 150];
 private _endBombPosition = _targetPos getPos [100, _targDir];
 _endBombPosition set [2, 150];
+
+if (_isCarpetBombing) then {
+    _bombParams set [2, 5 max _bombCount];
+    _flightSpeed = "FULL";
+    //Extends and wiggles the start and end position to make it feel just a little more organic
+    _startBombPosition = _startBombPosition getPos [45 + random 10, _targDir + 180];
+    _startBombPosition set [2, 150];
+    _endBombPosition = _endBombPosition getPos [45 + random 10, _targDir];
+    _endBombPosition set [2, 150];
+};
 
 private _wp2 = _group addWaypoint [_startBombPosition, 0];
 _wp2 setWaypointType "MOVE";

--- a/A3A/addons/core/functions/Supports/fn_SUP_carpetBombs.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_carpetBombs.sqf
@@ -33,9 +33,9 @@ if (_delay < 0) then { _delay = (0.5 + random 1) * (350 - 15*tierWar - 1*_aggroV
 // ["_side", "_basetype", "_target", "_endtime", "_duration", "_power"]
 A3A_supportStrikes pushBack [_side, "AREA", _targPos, time + 1200, 1200, 300];
 
-[_supportName, _side, _delay, _targPos getPos [_offset, _dir+90], _airport, _resPool, _planeType, "CARPET", 0] spawn A3A_fnc_SUP_airstrikeRoutine;
+[_supportName, _side, _delay, _targPos getPos [_offset + random 2, _dir+90], _airport, _resPool, _planeType, "CARPET", 0] spawn A3A_fnc_SUP_airstrikeRoutine;
 [_supportName, _side, _delay +1, _targPos, _airport, _resPool, _planeType, "CARPET", 0] spawn A3A_fnc_SUP_airstrikeRoutine;
-[_supportName, _side, _delay +2, _targPos getPos [_offset, _dir-90], _airport, _resPool, _planeType, "CARPET", 0] spawn A3A_fnc_SUP_airstrikeRoutine;
+[_supportName, _side, _delay +2, _targPos getPos [_offset + random 2, _dir-90], _airport, _resPool, _planeType, "CARPET", 0] spawn A3A_fnc_SUP_airstrikeRoutine;
 
 [_reveal, _side, "CARPETBOMBS", _targPos, _delay] spawn A3A_fnc_showInterceptedSetupCall;
 [_reveal, _targPos, _side, "CarpetBombs", 200, 120] spawn A3A_fnc_showInterceptedSupportCall;

--- a/A3A/addons/core/functions/Supports/fn_SUP_carpetBombs.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_carpetBombs.sqf
@@ -24,17 +24,18 @@ params ["_supportName", "_side", "_resPool", "_maxSpend", "_target", "_targPos",
 private _airport = [_side, _targPos] call A3A_fnc_availableBasesAir;
 if(isNil "_airport") exitWith { Debug_1("No airport found for %1 support", _supportName); -1; };
 
-private _dir = _targPos getDir markerPos _airport;
-private _planeType = selectRandom (Faction(_side) get "vehiclesPlanesAA");
+private _dir = (_targPos getDir markerPos _airport) + random 10;
+private _offset = 25 + (random 20);
+private _planeType = selectRandom (Faction(_side) get "vehiclesPlanesCAS");
 private _aggroValue = if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
 if (_delay < 0) then { _delay = (0.5 + random 1) * (350 - 15*tierWar - 1*_aggroValue) };
 
 // ["_side", "_basetype", "_target", "_endtime", "_duration", "_power"]
 A3A_supportStrikes pushBack [_side, "AREA", _targPos, time + 1200, 1200, 300];
 
-[_supportName, _side, _delay, _targPos, _airport, _resPool, _planeType, "CARPET", 0] spawn A3A_fnc_SUP_airstrikeRoutine;
-[_supportName, _side, _delay +1, _targPos getPos [15, _dir+90], _airport, _resPool, _planeType, "CARPET", 0] spawn A3A_fnc_SUP_airstrikeRoutine;
-[_supportName, _side, _delay +2, _targPos getPos [15, _dir-90], _airport, _resPool, _planeType, "CARPET", 0] spawn A3A_fnc_SUP_airstrikeRoutine;
+[_supportName, _side, _delay, _targPos getPos [_offset, _dir+90], _airport, _resPool, _planeType, "CARPET", 0] spawn A3A_fnc_SUP_airstrikeRoutine;
+[_supportName, _side, _delay +1, _targPos, _airport, _resPool, _planeType, "CARPET", 0] spawn A3A_fnc_SUP_airstrikeRoutine;
+[_supportName, _side, _delay +2, _targPos getPos [_offset, _dir-90], _airport, _resPool, _planeType, "CARPET", 0] spawn A3A_fnc_SUP_airstrikeRoutine;
 
 [_reveal, _side, "CARPETBOMBS", _targPos, _delay] spawn A3A_fnc_showInterceptedSetupCall;
 [_reveal, _targPos, _side, "CarpetBombs", 200, 120] spawn A3A_fnc_showInterceptedSupportCall;

--- a/A3A/addons/core/functions/Supports/fn_SUP_carpetBombs.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_carpetBombs.sqf
@@ -21,15 +21,23 @@ FIX_LINE_NUMBERS()
 
 params ["_supportName", "_side", "_resPool", "_maxSpend", "_target", "_targPos", "_reveal", "_delay"];
 
+private _airport = [_side, _targPos] call A3A_fnc_availableBasesAir;
+if(isNil "_airport") exitWith { Debug_1("No airport found for %1 support", _supportName); -1; };
+
+private _dir = _targPos getDir markerPos _airport;
+private _planeType = selectRandom (Faction(_side) get "vehiclesPlanesAA");
 private _aggroValue = if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
 if (_delay < 0) then { _delay = (0.5 + random 1) * (350 - 15*tierWar - 1*_aggroValue) };
 
 // ["_side", "_basetype", "_target", "_endtime", "_duration", "_power"]
 A3A_supportStrikes pushBack [_side, "AREA", _targPos, time + 1200, 1200, 300];
 
-[_supportName, _side, _delay, _targPos, _reveal] spawn A3A_fnc_SUP_carpetBombsRoutine;
+[_supportName, _side, _delay, _targPos, _airport, _resPool, _planeType, "CARPET", 0] spawn A3A_fnc_SUP_airstrikeRoutine;
+[_supportName, _side, _delay +1, _targPos getPos [15, _dir+90], _airport, _resPool, _planeType, "CARPET", 0] spawn A3A_fnc_SUP_airstrikeRoutine;
+[_supportName, _side, _delay +2, _targPos getPos [15, _dir-90], _airport, _resPool, _planeType, "CARPET", 0] spawn A3A_fnc_SUP_airstrikeRoutine;
 
 [_reveal, _side, "CARPETBOMBS", _targPos, _delay] spawn A3A_fnc_showInterceptedSetupCall;
+[_reveal, _targPos, _side, "CarpetBombs", 200, 120] spawn A3A_fnc_showInterceptedSupportCall;
 
 // Return resource cost of support
 200;

--- a/A3A/addons/core/functions/Supports/fn_initSupports.sqf
+++ b/A3A/addons/core/functions/Supports/fn_initSupports.sqf
@@ -41,7 +41,7 @@ private _initData = [
     ["TANK",          "TARGET", 0.5, 0.5,   0, 100,  "", ""],                            // balanced against CAS, lowAir based
     ["QRFLAND",       "TROOPS", 1.0, 1.4,   0,   0,  "", ""],
     ["QRFAIR",        "TROOPS", 0.5, 0.1,   0,   0,  "", ""],
-    ["CARPETBOMBS",     "AREA", 0.5, 0.1, 200,   0, "u", ""],                            // balanced against airstrikes
+    ["CARPETBOMBS",     "AREA", 0.5, 0.1, 200,   0, "u", "vehiclesPlanesCAS"],            // balanced against airstrikes
     ["SAM",           "TARGET", 1.0, 1.0,   0, 100,  "", ""],                             // balanced against ASF
     ["ORBITALSTRIKE",   "AREA", 0.2, 0.0, 300,   0, "f", ""]
 //    ["GUNSHIP",    ["AREA",   0.2,  50,   0]],                 // uh. Does AREA work for this? Only lasts 5 minutes so maybe...


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [x] Enhancement

### What have you changed and why?
Information:
Replaces previous functionality with three parallel airstrikes dropping a minimum of 5 bombs each, up to 8 bombs depending on aggression.
Notable improvement is that the support is now tied to some actual aircrafts instead of being bombes just thrown at you.

a "CARPET" behaviour has been added to the airstrike routine setting the speed and minimum bomb count to a higher minimum.

### Please specify which Issue this PR Resolves.
closes #3426 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
