### PR TITLE
Fixed wrong owner check in fn_addBombRun.sqf

### DIFF
--- a/A3A/addons/core/functions/REINF/fn_addBombRun.sqf
+++ b/A3A/addons/core/functions/REINF/fn_addBombRun.sqf
@@ -4,7 +4,7 @@ FIX_LINE_NUMBERS()
 #define OccAndInv(VEH) (FactionGet(occ, VEH) + FactionGet(inv, VEH))
 private _titleStr = localize "STR_A3A_fn_reinf_bombrun_title";
 private _owner = _veh getVariable "ownerX";
-private _wrongOwner = !(isNil "_owner" || {getPlayerUID player == _owner});   //Returns false if no owner, false if is owner, true if is not owner
+private _wrongOwner = !(isNil "_owner" || {getPlayerUID player isEqualTo _owner});   //Returns false if no owner, false if is owner, true if is not owner
 
 private _exitReason = switch (true) do {
 	case (isNull _veh):                                         {"looking"};

--- a/A3A/addons/core/functions/REINF/fn_addBombRun.sqf
+++ b/A3A/addons/core/functions/REINF/fn_addBombRun.sqf
@@ -4,7 +4,7 @@ FIX_LINE_NUMBERS()
 #define OccAndInv(VEH) (FactionGet(occ, VEH) + FactionGet(inv, VEH))
 private _titleStr = localize "STR_A3A_fn_reinf_bombrun_title";
 private _owner = _veh getVariable "ownerX";
-private _wrongOwner = !(isNil "_owner" && {_owner isEqualType ""} && {getPlayerUID player != _owner});
+private _wrongOwner = !(isNil "_owner" || {getPlayerUID player == _owner});   //Returns false if no owner, false if is owner, true if is not owner
 
 private _exitReason = switch (true) do {
 	case (isNull _veh):                                         {"looking"};


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Unowned aircraft and aircrafts owned by the commander are now correctly able to be converted into airstrike points.
Wrong owner variable now blocks the commander from converting aircrafts that aren't theirs

### Please specify which Issue this PR Resolves.
closes #3341

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
Tested by buying two helicopters.
Setting the ownerX variable on one of them prevents that helicopter from being converted, setting the variable to the commander's UID premits you to convert it again.
The other helicopter does not have its ownerX variable set, and it permits you to convert it.

********************************************************
Notes:
