### PR TITLE
Rebel loadout fixes

### DIFF
--- a/A3A/addons/core/dialogs.hpp
+++ b/A3A/addons/core/dialogs.hpp
@@ -1774,7 +1774,7 @@ class commander_comm 		{
 		class 10slots_R2: A3A_core_BattleMenuRedButton
 		{
 			idc = -1;
-			text = "Customize loadouts"; //$STR_antistasi_dialogs_commander_comm_customLoadouts;
+			text = "Customize Loadouts"; //$STR_antistasi_dialogs_commander_comm_customLoadouts;
 			x = 0.482498 * safezoneW + safezoneX;
 			y = 0.365981 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;

--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -181,8 +181,11 @@ switch (_typeTag) do
         [_unit, _priWeapon, "OpticsMid", 50*_ammoMod] call A3A_fnc_addPrimaryAndMags;
         if (_smokes isNotEqualTo []) then { _unit addMagazines [selectRandomWeighted _smokes, 2] };
     };
+    case ("staticCrew"): {
+        [_unit, _priWeapon, "OpticsClose", 50*_ammoMod] call A3A_fnc_addPrimaryAndMags;
+    };
     default {
-        [_unit, _priWeapon, "OpticClose", 50*_ammoMod] call A3A_fnc_addPrimaryAndMags;
+        [_unit, _priWeapon, "OpticsClose", 50*_ammoMod] call A3A_fnc_addPrimaryAndMags;
         Error_1("Unknown unit class: %1", _typeTag);
     };
 };

--- a/A3A/addons/gui/functions/GUI/fn_customLoadoutsDialog.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_customLoadoutsDialog.sqf
@@ -42,12 +42,16 @@ private _unitTypesData = [
     ["AA", "Missile AA", "", "MissileLaunchersAA"]
 ];
 
+// Should be ready for all commands except init
+private _loadouts = _display getVariable "loadouts";
+
 switch (_mode) do
 {
     case ("init"):
     {
         // sync data from server
         call A3A_fnc_fetchRebelGear;
+        _display setVariable ["loadouts", +A3A_rebelLoadouts];      // work with temporary copy
 
         // Fill out the listbox
         { _listBox lbAdd (_x#1) } forEach _unitTypesData;
@@ -65,7 +69,7 @@ switch (_mode) do
         _display setVariable ["currentRole", _roleIndex];
 
         private _roleData = _unitTypesData # _roleIndex;
-        private _roleGear = A3A_rebelLoadouts getOrDefaultCall [_roleData#0, {createHashMap}, true];
+        private _roleGear = _loadouts getOrDefaultCall [_roleData#0, {createHashMap}, true];
 
         private _fnc_addItems = {
             params ["_control", "_itemType", "_selClass"];
@@ -112,6 +116,9 @@ switch (_mode) do
         _curClass = _roleGear getOrDefault ["SecWeapon", "Random"];
         if (_roleData#3 != "") then { [_secWeapon, _roleData#3, _curClass] call _fnc_addItems };
         // disable if not valid?
+
+        private _priOptic = _display displayCtrl A3A_IDC_CUSLOAD_PRIOPTIC;
+        _priOptic ctrlEnable false;                  // disabled for now
 
         private _ammoQuant = _display displayCtrl A3A_IDC_CUSLOAD_AMMOQUANT;
         lbClear _ammoQuant;
@@ -171,13 +178,13 @@ switch (_mode) do
     case ("close"):
     {
         ["saveRole"] call A3A_GUI_fnc_customLoadoutsDialog;
-        A3A_rebelLoadouts remoteExecCall ["A3A_fnc_setRebelLoadouts", 2];
+        _loadouts remoteExecCall ["A3A_fnc_setRebelLoadouts", 2];
     };
 
     case ("saveRole"):
     {
         private _roleData = _unitTypesData # _roleIndex;
-        private _roleGear = A3A_rebelLoadouts getOrDefaultCall [_roleData#0, {createHashMap}, true];
+        private _roleGear = _loadouts getOrDefaultCall [_roleData#0, {createHashMap}, true];
         {
             _x params ["_tag", "_ctrl"];
             if (lbCurSel _ctrl == 0) then { _roleGear deleteAt _tag; continue };
@@ -191,7 +198,7 @@ switch (_mode) do
         private _copyPrimary = _unitTypesData#_roleIndex#2 == "";
         {
             private _roleData = _x;
-            private _roleGear = A3A_rebelLoadouts getOrDefaultCall [_roleData#0, {createHashMap}, true];
+            private _roleGear = _loadouts getOrDefaultCall [_roleData#0, {createHashMap}, true];
             {
                 _x params ["_tag", "_ctrl"];
                 if (_tag == "SecWeapon" or (_tag == "PriWeapon" and _roleData#2 != "")) then { continue };
@@ -204,13 +211,13 @@ switch (_mode) do
     case ("resetRoleButton"):
     {
         private _roleData = _unitTypesData # _roleIndex;
-        A3A_rebelLoadouts set [_roleData#0, createHashMap];
+        _loadouts set [_roleData#0, createHashMap];
         ["selectRole", [_roleIndex, false]] call A3A_GUI_fnc_customLoadoutsDialog;
     };
 
     case ("resetAllButton"):
     {
-        A3A_rebelLoadouts = createHashMap;
+        _display setVariable ["loadouts", createHashMap];
         ["selectRole", [_roleIndex, false]] call A3A_GUI_fnc_customLoadoutsDialog;
     };
 };


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
- Changed custom loadout UI to work with temporary copy. Safer, and fixes serious bug with Reset All button.
- Added case for static crew (eg mortar team units) and fixed optics typo in fallback case.
- Disabled optics UI control so that players are less likely to expect it to do something.
- Fixed casing on button to open custom loadouts UI.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
