### PR TITLE
Fix up and re-enable UAV support for major attacks and HQ attacks

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_attackHQ.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_attackHQ.sqf
@@ -32,7 +32,7 @@ private _taskId = "DEF_HQ" + str A3A_taskCount;
 private _uavSupp = ["UAV", _side, "attack", 500, objNull, _targPos, 0, 0] call A3A_fnc_createSupport;
 
 // Create the attacking force
-private _vehCount = round (1 + random 1 + 2 * A3A_balancePlayerScale + ([0, 0.5] select (_uavSupp == "")));
+private _vehCount = round (1.5 + random 1 + 2 * A3A_balancePlayerScale + ([0, 0.5] select (_uavSupp == "")));
 
 // Give smaller player groups a bit more time to respond
 if (isNil "_delay") then { _delay = 300 / A3A_balancePlayerScale };

--- a/A3A/addons/core/functions/Supports/fn_initSupports.sqf
+++ b/A3A/addons/core/functions/Supports/fn_initSupports.sqf
@@ -43,7 +43,8 @@ private _initData = [
     ["QRFAIR",        "TROOPS", 0.5, 0.1,   0,   0,  "", ""],
     ["CARPETBOMBS",     "AREA", 0.5, 0.1, 200,   0, "u", "vehiclesPlanesCAS"],            // balanced against airstrikes
     ["SAM",           "TARGET", 1.0, 1.0,   0, 100,  "", ""],                             // balanced against ASF
-    ["ORBITALSTRIKE",   "AREA", 0.2, 0.0, 300,   0, "f", ""]
+    ["ORBITALSTRIKE",   "AREA", 0.2, 0.0, 300,   0, "f", ""],
+    ["UAV",             "AREA", 0.0, 0.0,   0,   0,  "", "uavsAttack"]                    // Not used for support calls 
 //    ["GUNSHIP",    ["AREA",   0.2,  50,   0]],                 // uh. Does AREA work for this? Only lasts 5 minutes so maybe...
 ];
 

--- a/A3A/addons/core/functions/Supports/fn_requestArtillery.sqf
+++ b/A3A/addons/core/functions/Supports/fn_requestArtillery.sqf
@@ -58,6 +58,7 @@ private _availParams = [_target, _side, 200, keys _supportTypesHM];
 {
     _y params ["_class", "_typeWeight", "_effRadius"];
     if (_class != "AREA") then { continue };            // only care about area-effect for requestArtillery
+    if (_typeWeight == 0) then { continue };            // special cases (eg. UAV) not used here
 
     // call the availability function for each support type
     private _availFunc = missionNamespace getVariable format ["A3A_fnc_SUP_%1Available", _x];

--- a/A3A/addons/core/functions/Supports/fn_requestSupport.sqf
+++ b/A3A/addons/core/functions/Supports/fn_requestSupport.sqf
@@ -136,6 +136,7 @@ private _availParams = [_target, _side, _maxSpend, keys _supportTypesHM];
 {
     if (_maxSpend <= 0 and !(_x in _actSuppHM)) then { continue };          // Skip if we have no money and support type isn't active
     _y params ["_class", "_typeWeight", "_effRadius"];
+    if (_typeWeight == 0) then { continue };                        // special cases (eg. UAV) not used here
 
     // First fetch the weight factor derived from other recent strikes near target
     private _proxWeight = _classWeightsHM get _class;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [X] Change
3. [X] Enhancement

### What have you changed and why?
The UAV support that reveals targets for major attacks and HQ attacks was accidentally disabled at some point in the 3.0+ process. I have simplified, optimized and re-tested it.

The principle was that attacks often stall or take an excessive time because they can't see enemies in buildings. The UAV-reveal gives them an assist, which should give them half a chance of dealing with hidden units.

### Please specify which Issue this PR Resolves.
closes #3466

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
