### PR TITLE
Rebel airstrike fixes

### DIFF
--- a/A3A/addons/core/functions/REINF/fn_NATObomb.sqf
+++ b/A3A/addons/core/functions/REINF/fn_NATObomb.sqf
@@ -108,7 +108,7 @@ waitUntil { sleep 2; (currentWaypoint group _plane == 4) or (time > _timeOut) or
 deleteMarkerLocal _mrkOrig;
 deleteMarkerLocal _mrkDest;
 
-if !(canMove _plane) then { sleep cleantime };		// let wreckage hang around for a bit
+if !(canMove _plane) then { sleep 3600 };		// let wreckage hang around for a bit
 deleteVehicle _plane;
 {deleteVehicle _x} forEach _planeCrew;
 deleteGroup _groupPlane;

--- a/A3A/addons/core/functions/REINF/fn_addBombRun.sqf
+++ b/A3A/addons/core/functions/REINF/fn_addBombRun.sqf
@@ -5,6 +5,7 @@ FIX_LINE_NUMBERS()
 private _titleStr = localize "STR_A3A_fn_reinf_bombrun_title";
 private _owner = _veh getVariable "ownerX";
 private _wrongOwner = !(isNil "_owner" || {getPlayerUID player isEqualTo _owner});   //Returns false if no owner, false if is owner, true if is not owner
+private _typeX = typeOf _veh;
 
 private _exitReason = switch (true) do {
 	case (isNull _veh):                                         {"looking"};


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
addBombRun actually checks the vehicle type now
NATObomb will now properly clean up vehicles, a sleep for an unknown variable caused stuff to be instantly deleted
Hopefully the entire natoBomb function can be reworked with the GUI update

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
addBombRun: attempt to sell a helicopter or plane from the enemy factions for airstrikes, it returns the proper amount
NATObomb: call an airstrike, shoot down the plane on approach. it crashes and despawns an hour later.
