### PR TITLE
Ensure return value of HandleDisconnect is correct

### DIFF
--- a/A3A/addons/core/functions/Base/fn_onPlayerDisconnect.sqf
+++ b/A3A/addons/core/functions/Base/fn_onPlayerDisconnect.sqf
@@ -38,3 +38,4 @@ if (side group _unit == teamPlayer || side group _unit == sideUnknown) then
 // Preventing duping due to weapon loadout saves
 if (alive _realUnit && {!(_realUnit getVariable ["incapacitated", false])} ) then { deleteVehicle _realUnit }
 else { _realUnit setDamage 1 };			// finish off, if incapped
+false;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug?
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
There have been occasional reports of an AI with a player's name being generated after they disconnect. This could in theory happen due to a `true` return value in handleDisconnect. There's no obvious way that this can happen in the code, but we don't enforce a return value and the return values of setDamage or deleteVehicle might be unreliable. This PR enforces the return value, so it should at least rule out that problem.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
