### PR TITLE
Removed: AA Trucks and AA Statics

### DIFF
--- a/A3A/addons/core/dialogs.hpp
+++ b/A3A/addons/core/dialogs.hpp
@@ -733,7 +733,7 @@ class buy_vehicle 			{
 			y = 0.612025 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
-			action = "closeDialog 0;nul = [(A3A_faction_reb get 'staticAA') # 0] spawn A3A_fnc_addFIAveh;";
+			action = "closeDialog 0;";
 		};
 	};
 };
@@ -2226,12 +2226,12 @@ class squad_recruit 			{
 		class HQ_button_ATteamM: A3A_core_BattleMenuRedButton
 		{
 			idc = 110;
-			text = $STR_antistasi_dialogs_squad_recruit_aa_car;
+			text = "";
 			x = 0.272481 * safezoneW + safezoneX;
 			y = 0.612025 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
-			action = "closeDialog 0;nul = [(A3A_faction_reb get 'staticAA') # 0] spawn A3A_fnc_addFIAsquadHC";
+			//action = "closeDialog 0;";
 		};
 
 		class HQ_button_mortar: A3A_core_BattleMenuRedButton

--- a/A3A/addons/core/functions/Dialogs/fn_squadRecruit.sqf
+++ b/A3A/addons/core/functions/Dialogs/fn_squadRecruit.sqf
@@ -54,11 +54,6 @@ if (str (_display) != "no display") then
 	_costs = 2*_crewCost + ([(FactionGet(reb,"vehiclesAT")) # 0] call A3A_fnc_vehiclePrice);
 	_ChildControl  ctrlSetTooltip format [localize "STR_A3A_fn_dialogs_squadOptions",_costs,_costHR];
 
-	_ChildControl = _display displayCtrl 110;
-	_costHR = 2;
-	_costs = 2*_crewCost + ([(FactionGet(reb,"vehiclesTruck")) # 0] call A3A_fnc_vehiclePrice) + ([(FactionGet(reb,"staticAA")) # 0] call A3A_fnc_vehiclePrice);
-	_ChildControl  ctrlSetTooltip format [localize "STR_A3A_fn_dialogs_squadOptions",_costs,_costHR];
-
 	_ChildControl = _display displayCtrl 111;
 	_costHR = 2;
 	_costs = 2*_crewCost + ([(FactionGet(reb,"staticMortars")) # 0] call A3A_fnc_vehiclePrice);

--- a/A3A/addons/core/functions/REINF/fn_spawnHCGroup.sqf
+++ b/A3A/addons/core/functions/REINF/fn_spawnHCGroup.sqf
@@ -90,6 +90,7 @@ switch _special do {
     };
 
     //vehicle squad
+    // aa is dead code
     case "BuildAA": {
         private _static = ((attachedObjects _vehicle) select {typeOf _x in FactionGet(reb,"staticAA")})#0;
         (_units # (_countUnits -1)) moveInDriver _vehicle;

--- a/A3A/addons/gui/functions/GUI/fn_buyVehicleDialog.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_buyVehicleDialog.sqf
@@ -95,15 +95,13 @@ switch (_mode) do
         (A3A_faction_reb get 'vehiclesLightArmed') +
         (A3A_faction_reb get 'vehiclesMedical') +
         (A3A_faction_reb get 'vehiclesAT') +
-        (A3A_faction_reb get 'vehiclesAA') +
         (A3A_faction_reb get 'vehiclesBoat') +
         (A3A_faction_reb get 'vehiclesPlane');
 
         private _statics = 
         (A3A_faction_reb get 'staticMGs') +
         (A3A_faction_reb get 'staticMortars') +
-        (A3A_faction_reb get 'staticAT') +
-        (A3A_faction_reb get 'staticAA');
+        (A3A_faction_reb get 'staticAT');
 
         ["vehicles", [A3A_IDC_BUYCIVVEHICLEMAIN, A3A_IDC_CIVVEHICLESGROUP, _civilianVehicles]] call A3A_GUI_fnc_buyVehicleTabs;
         ["vehicles", [A3A_IDC_BUYREBVEHICLEMAIN, A3A_IDC_REBVEHICLESGROUP, _militaryVehicles]] call A3A_GUI_fnc_buyVehicleTabs;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [x] Enhancement

### What have you changed and why?
Information:
    Removed AA Trucks and AA Statics from being purchased. This was done, as AA is too over powered and significantly weakens the core game play loop of looting, and cheats the QRF and CAS system. AA should be found either at INV or OCC outposts, looted from enemies, or captured at airfields. 

### Please specify which Issue this PR Resolves.
N/A

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
N/A
********************************************************
Notes:
