### PR TITLE
Added: Medical Boxes are now medically facilities.

### DIFF
--- a/A3A/addons/core/Templates/Templates/FactionDefaults/RebelDefaults.sqf
+++ b/A3A/addons/core/Templates/Templates/FactionDefaults/RebelDefaults.sqf
@@ -26,7 +26,7 @@
 
 private _medBox = ["Box_AAF_Equip_F", 5];
 if(A3A_hasACE) then {
-	_medBox = ["ACE_medicalSupplyCrate_advanced", 5];
+	_medBox = ["ACE_medicalSupplyCrate_advanced", 40];
 };
 
 ["vehicleMedicalBox", _medBox] call _fnc_saveToTemplate;

--- a/A3A/addons/core/functions/UtilityItems/fn_initObjectRemote.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_initObjectRemote.sqf
@@ -95,6 +95,12 @@ if ("unpack" in _flags) then {
     ];
 };
 
+if("medfacility") then {
+    if(A3A_hasACEMedical) then {
+        _object setVariable ["ace_medical_isMedicalVehicle", true];
+    };
+};
+
 // specific to the tent
 if (typeOf _object == "Land_MedicalTent_01_MTP_closed_F") then {
     _object addAction [

--- a/A3A/addons/core/functions/init/fn_initUtilityItems.sqf
+++ b/A3A/addons/core/functions/init/fn_initUtilityItems.sqf
@@ -39,7 +39,7 @@ private _items = [
 if (LootToCrateRadius == 0) then { _items deleteAt 0 };
 
 if(A3A_hasACE) then {
-    _items pushBack [_medCrate#0, _medCrate#1, "medicalbox", "heal", ["noclear", "move"]];
+    _items pushBack [_medCrate#0, _medCrate#1, "medicalbox", "heal", ["noclear", "move", "medfacility"]];
     _items pushBack ["ACE_Wheel", 5, "", "", []];
     _items pushBack ["ACE_Track", 5, "", "", []];       // check names
 };


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [x] Enhancement

### What have you changed and why?
Information:
    Medical tents break too easily. This is annoying for low pop servers or squads that don't have medics. We can change the functional requirement to address this. For ACE Medical, both the medical tent and medical box shall function as ace medical facilities.

### Please specify which Issue this PR Resolves.
N/A

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
