### PR TITLE
Implement loading of binocular magazine from arsenal

### DIFF
--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_loadInventory.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_loadInventory.sqf
@@ -173,7 +173,7 @@ _itemCounts =+ _availableItems;
 } forEach _availableItems;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////  assinged items
-_assignedItems = ((_inventory select 9) + [_inventory select 3] + [_inventory select 4] + [_inventory select 5]);					//todo add binocular batterys
+_assignedItems = ((_inventory select 9) + [_inventory select 3] + [_inventory select 4] + [_inventory select 5]);
 {
 	_item = _x;
 	_amount = 1;
@@ -232,6 +232,18 @@ _assignedItems = ((_inventory select 9) + [_inventory select 3] + [_inventory se
 
 	};
 } forEach _assignedItems - [""];
+
+if (binocular player != "" && count (binocularMagazine player) == 0) then {
+	// Add first infinite binocular magazine to binocular if available
+	{
+		_item = _x;
+		_index = _item call jn_fnc_arsenal_itemType;
+
+		if ([_itemCounts select _index, _item] call jn_fnc_arsenal_itemCount == -1) exitWith {
+			player addBinocularItem _item;
+		};
+	} forEach (getArray (configFile >> "CfgWeapons" >> (binocular player) >> "magazines"));
+};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////// weapons and attachments
 removebackpack player;


### PR DESCRIPTION
At present, laser designator batteries are not loaded into laser designators when a loadout is loaded from JNA. This PR implements loading of desginator batteries by taking a more general approach to load the first binocular magazine that is fully unlocked from the arsenal.

## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information:

[Line 176](https://github.com/official-antistasi-community/A3-Antistasi/blob/3.8.0/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_loadInventory.sqf#L176) of `fn_arsenal_loadInventory.sqf` as of 3.8.0 indicates that designator battery loading is unimplemented.

We implement the loading of designator batteries by considering all the possible magazines that can be loaded into the equipped binocular and finding the first one that is unlocked/infinite in the arsenal and loading it into the binocular.

This handles the case with designator batteries in vanilla laser designators but should also handle modded designators/bincoulars that use different batteries/magazines without needing to hard-code support.

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes

This potentially introduces a behaviour change for mods that use the binocular slot in an atypical way where loadouts now auto-load the first of (potentially) many different magazines. I have not looked or encountered any mod that actually do this though. The fix for this would be to simply implement storage of the binocular magazine into loadout presets as well.

### How can the changes be tested?
Steps: 

1. Ensure infinite laser designator batteries are available in the arsenal
2. Create a loadout preset with a laser designator
3. Observe that upon selecting and loading the loadout, the laser designator already has a designator battery loaded
