### PR TITLE
Improve dive bombing accuracy

### DIFF
--- a/A3A/addons/config_fixes/IFA/CfgAmmo.hpp
+++ b/A3A/addons/config_fixes/IFA/CfgAmmo.hpp
@@ -12,4 +12,10 @@ class CfgAmmo {
     class LIB_Sh_60_HE : LIB_Sh_82_HE {
         indirectHitRange = 11;
     };
+
+    // Make the bombs more consistent
+    class BombCore;
+    class LIB_Bomb_base : BombCore {
+        sideAirFriction = 0;
+    };
 };

--- a/A3A/addons/config_fixes/SPE/CfgAmmo.hpp
+++ b/A3A/addons/config_fixes/SPE/CfgAmmo.hpp
@@ -1,0 +1,9 @@
+// IFA - CfgAmmo.hpp
+
+class CfgAmmo {
+    // Make the bombs non-weird
+    class BombCore;
+    class SPE_Bomb_base : BombCore {
+        sideAirFriction = 0;
+    };
+};

--- a/A3A/addons/config_fixes/SPE/config.cpp
+++ b/A3A/addons/config_fixes/SPE/config.cpp
@@ -1,0 +1,26 @@
+//SPE - config.cpp
+
+#include "..\script_component.hpp"
+
+
+class CfgPatches 
+{
+    class PATCHNAME(SPE)
+    {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"WW2_SPE_Assets_c_Vehicles_Weapons_c"};
+        skipWhenMissingDependencies = 1;
+        author = AUTHOR;
+        authors[] = { AUTHORS };
+        authorUrl = "";
+        VERSION_CONFIG;
+    };
+};
+
+// Uncomment when needed
+//#include "CfgVehicles.hpp"
+//#include "CfgWeapons.hpp"
+#include "CfgAmmo.hpp"

--- a/A3A/addons/core/Templates/AircraftLoadouts/IFA/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/IFA/config.cpp
@@ -26,42 +26,38 @@ class A3A {
                 mainGun[] = {"LIB_2xMG151_JU87"};
                 rocketLauncher[] = {"LIB_2xMG151_JU87"};
                 bombRacks[] = {"LIB_SC500_Bomb_Mount","LIB_SC50_Bomb_Mount"};
-                diveParams[] = {1200, 300, 110, 55, 15, {15, -2}};
+                diveParams[] = {800, 350, 110, 55, 15, {18, -2}};
             };
             class LIB_Pe2 : baseCAS {
                 loadout[] = {"LIB_1Rnd_FAB250","LIB_1Rnd_FAB250","LIB_1Rnd_FAB250","LIB_1Rnd_FAB250"};
                 mainGun[] = {"LIB_UBK_PE2", "LIB_ShKAS_PE2"};
                 rocketLauncher[] = {"LIB_UBK_PE2"};
                 bombRacks[] = {"LIB_FAB250_Bomb_Mount"};
-                diveParams[] = {1200, 300, 110, 55, 15, {12, 0}};
+                diveParams[] = {800, 300, 110, 55, 15, {9, 0}};
             };
             class LIB_FW190F8_2 : baseCAS {
                 loadout[] = {"LIB_1Rnd_SC50","LIB_1Rnd_SC50","LIB_1Rnd_SC500","LIB_1Rnd_SC50","LIB_1Rnd_SC50", "LIB_2000Rnd_MG131_FW190","LIB_500Rnd_MG151_FW190"};
                 mainGun[] = {"LIB_2xMG131_FW190","LIB_2xMG151_FW190"};
                 rocketLauncher[] = {"LIB_2xMG151_FW190"};
                 bombRacks[] = {"LIB_SC500_Bomb_Mount","LIB_SC50_Bomb_Mount"};
-                diveParams[] = {1200, 300, 110, 55, 15, {15, -2}};
+                diveParams[] = {800, 350, 110, 55, 15, {16.5, 0}};
             };
             class LIB_P47 : baseCAS {
                 loadout[] = {"LIB_1Rnd_US_500lb","LIB_1Rnd_US_500lb","LIB_1Rnd_US_500lb", "LIB_6Rnd_M8_P47", "LIB_6Rnd_M8_P47", "LIB_4000Rnd_M2_P47"};
                 mainGun[] = {"LIB_8xM2_P47"};
                 rocketLauncher[] = {"LIB_M8_Launcher_P47"};
                 bombRacks[] = {"LIB_US_500lb_Bomb_Mount"};
-                diveParams[] = {1200, 350, 110, 55, 15, {20, 0}};
+                diveParams[] = {800, 350, 110, 55, 15, {16.5, 0}};
             };
             class LIB_P39 : baseCAS {
                 loadout[] = {"LIB_1Rnd_US_500lb","LIB_30Rnd_M4_P39","LIB_1000Rnd_M2_P39"};
                 mainGun[] = {"LIB_4xM2_P39"};
                 rocketLauncher[] = {"LIB_M4_P39"};
                 bombRacks[] = {"LIB_US_500lb_Bomb_Mount"};
-                diveParams[] = {1200, 350, 110, 55, 15, {20, 0}};
+                diveParams[] = {800, 350, 110, 55, 15, {17, -3}};
             };
-            class LIB_RAF_P39 : LIB_P39 {
-                loadout[] = {"LIB_1Rnd_US_500lb","LIB_30Rnd_M4_P39","LIB_1000Rnd_M2_P39"};
-                bombRacks[] = {"LIB_US_500lb_Bomb_Mount"};
-                diveParams[] = {1200, 350, 110, 55, 15, {20, 0}};
-            };
-            class LIB_US_P39 : LIB_RAF_P39 {};
+            class LIB_RAF_P39 : LIB_P39 {};
+            class LIB_US_P39 : LIB_P39 {};
         };
         class CAPPlane
         {

--- a/A3A/addons/core/Templates/AircraftLoadouts/SPE/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/SPE/config.cpp
@@ -15,6 +15,9 @@ class CfgPatches {
     };
 };
 
+// Warning: SPE has its own bomb hack (SPE_fnc_aiBombHelper_Fired). It seems to be deterministic so we can counter it,
+// but I haven't checked their logic, and it might change in future.
+
 class A3A {
     class Loadouts
     {
@@ -25,14 +28,14 @@ class A3A {
                 loadout[] = {"SPE_250Rnd_MG151","SPE_250Rnd_MG151","SPE_400Rnd_MG131","SPE_400Rnd_MG131","SPE_1Rnd_SC50","SPE_1Rnd_SC50","SPE_1Rnd_SC500","SPE_1Rnd_SC50","SPE_1Rnd_SC50"};
                 mainGun[] = {"SPE_2xMG151"};
                 bombRacks[] = {"SPE_SC500_Bomb_Mount","SPE_SC50_Bomb_Mount"};
-                diveParams[] = {1200, 300, 110, 55, 15, {0, 0}};
+                diveParams[] = {800, 300, 110, 55, 15, {1.5, -1}};
             };
             class SPE_P47 : baseCAS {
                 loadout[] = {"SPE_425rnd_M2_P47","SPE_425rnd_M2_P47","SPE_425rnd_M2_P47","SPE_425rnd_M2_P47","SPE_425rnd_M2_P47","SPE_425rnd_M2_P47","SPE_425rnd_M2_P47","SPE_425rnd_M2_P47","SPE_3Rnd_M8_P47","SPE_3Rnd_M8_P47","SPE_1Rnd_US_500lb","SPE_1Rnd_US_500lb","SPE_1Rnd_US_500lb"};
                 mainGun[] = {"SPE_8xM2_P47"};
                 rocketLauncher[] = {"SPE_M8_Launcher_P47"};
                 bombRacks[] = {"SPE_US_500lb_Bomb_Mount"};
-                diveParams[] = {1200, 350, 110, 55, 15, {3, 0}};
+                diveParams[] = {800, 350, 110, 55, 15, {-6, 0}};
             };
         };
         class CAPPlane

--- a/A3A/addons/core/functions/Supports/fn_SUP_CASDiveBombRun.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_CASDiveBombRun.sqf
@@ -16,6 +16,7 @@ params ["_plane", "_target", "_supportName", "_waypoint"];
 private _group = group driver _plane;
 
 (_plane getVariable "diveParams") params ["_startAlt", "_endAlt", "_diveSpeed", "_diveAngle", "_turnRate", "_bombDrag"];
+//_plane setVariable ["A3A_diveSpeed", _diveSpeed];       // used for bomb correction
 
 // Reduce accuracy against foot troops
 private _targetOffset = [0,0,0];
@@ -57,11 +58,18 @@ if (!_inPosition) exitWith { false };
 Debug_1("Divebomb dive started for %1", _supportName);
 
 
-// Remove weapon inaccuracy from bombs
+// Remove weapon & plane sim inaccuracy from bombs
 private _firedEH = _plane addEventHandler ["Fired", {
     params ["_plane", "_weapon", "_muzzle", "_mode", "_ammo", "_magazine", "_projectile", "_gunner"];
+
+    private _dir = _plane getVariable "A3A_diveLastDir";
+    Debug_3("Correcting bomb trajectory: old %1, new %2, plane %3", asin -(vectorDir _projectile#2), asin -(_dir#2), asin -(vectorDir _plane#2));
     _projectile setVelocity (velocity _plane);
     _projectile setVectorDir (vectorDir _plane);
+
+// Apparently bombs drop before the false simulation update happens, so this isn't required
+//    _projectile setVelocity (_dir vectorMultiply (_plane getVariable "A3A_diveSpeed"));
+//    _projectile setVectorDir (_dir);        //vectorDir _plane);
 }];
 
 driver _plane disableAI "All";
@@ -80,6 +88,8 @@ private _ehID = addMissionEventHandler ["EachFrame", {
     private _dir = _plane getVariable "A3A_diveLastDir";   //vectorDir _plane;
     private _bombOffset = vectorNormalized [_dir#0, _dir#1, 0] vectorMultiply (_bombDrag#0);
     private _bombOffset = _bombOffset vectorAdd (vectorNormalized [_dir#1, -(_dir#0), 0] vectorMultiply (_bombDrag#1));
+    //Debug_1("Bomb offset = %1", _bombOffset);
+
     private _timeToTarget = (_plane distance _target) / _diveSpeed;
     private _targetPos = getPosASL _target vectorAdd (velocity _target vectorMultiply _timeToTarget) vectorAdd _bombOffset;
     _targetPos = _targetPos vectorAdd _targetOffset;
@@ -96,26 +106,36 @@ private _ehID = addMissionEventHandler ["EachFrame", {
         private _rotDir = vectorNormalized _rotVec;
         private _newDir = (_dir vectorMultiply cos _maxAng) vectorAdd ((_rotDir vectorCrossProduct _dir) vectorMultiply sin _maxAng);
         _dir = _newDir vectorAdd (_rotDir vectorMultiply ((_rotDir vectorDotProduct _dir) * (1 - cos _maxAng)));
-//        Debug_2("Old dir %1, new dir %2", _dir, _newDir);
     };
+    Debug_3("Old dir %1, new dir %2, alt %3", asin -(vectorDir _plane#2), asin -(_dir#2), getPosASL _plane#2 - getPosASL _target#2);
 
     // Need to force position for "airplanex" simulation. "airplane" is fine without it.
     private _nextPos = (_plane getVariable "A3A_diveLastPos") vectorAdd (_dir vectorMultiply _diveSpeed*diag_deltaTime);
     _plane setVariable ["A3A_diveLastDir", _dir];
     _plane setVariable ["A3A_diveLastPos", _nextPos];
 
+// Seems to have identical behaviour, still doesn't suppress extra simulation at least with "airplane"
+//    private _velocity = _dir vectorMultiply _diveSpeed;
+//    private _updir = _dir vectorCrossProduct [0,0,1] vectorCrossProduct _dir;
+//    _plane setVelocityTransformation [_nextPos, _nextPos, _velocity, _velocity, _dir, _dir, _updir, _updir, 0];
+
     _plane setPosASL _nextPos;
     _plane setVectorDirAndUp [_dir, _dir vectorCrossProduct [0,0,1] vectorCrossProduct _dir];
     _plane setVelocity (_dir vectorMultiply _diveSpeed);
 
-    if (getPosASL _plane#2 - getPosASL _target#2 < _endAlt) exitWith {
+    if (_plane getVariable ["bombsDropped", false]) exitWith {
+        Debug("Exiting bomb run loop");
         removeMissionEventHandler ["EachFrame", _thisEventHandler];
         driver _plane enableAI "All";
+    };
+
+    if (getPosASL _plane#2 - getPosASL _target#2 < _endAlt) exitWith {
         if (_targetDir vectorDotProduct vectorDir _plane < 0.9) exitWith {
             Debug("Bomb drop abandoned due to bad heading");
+            _plane setVariable ["bombsDropped", false];
         };
         Debug("Dropping bombs...");
-        //Debug_2("Plane dir %1 and velocity %2", vectorDir _plane, velocity _plane);
+        Debug_3("Plane dir %1, velocity %2, altitude %3", vectorDir _plane, velocity _plane, getPosASL _plane#2 - getPosASL _target#2);
         {
             private _bombMags = getArray (configFile >> "CfgWeapons" >> _x >> "magazines");
             private _ammoCount = 0;


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement
4. [X] Arma bullshit

### What have you changed and why?
Long research project into why dive bombing is less accurate than expected (+/-4m or so in the forward direction). Turns out the main reason is that bombs have airSideFriction which causes them to lift fairly drastically in flight. It's the same effect as the PCML's dumbfire flight path, as they have the same simulation type (shotMissile), but with the bombs it doesn't seem to be very deterministic. Setting the airSideFriction to zero makes the bombs much more accurate.

Of course I had to change all the numbers afterwards. The other changes in CASDiveBombRun are all test code and will be removed prior to merging.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Do we have any dive bombers outside SPE/IFA? I forget.

Test spam needs removing prior to merging.

### How can the changes be tested?
The standard CAS call can be used, but this is quite a bit quicker. Plonk down a tank (preferably with a gun barrel that doesn't hang over the model so it's easier to see the center point), select it in zeus and run this code as scheduled:

```
if (!canSuspend) exitWith {"Error: Run as scheduled"};
// Edit as required
private _planeType = "LIB_Pe2";
private _diveParams = [800, 350, 110, 55, 15, [-6, 0]];
private _bombRacks = ["SPE_SC500_Bomb_Mount"];//,"SPE_SC50_Bomb_Mount"}; 

private _targ = curatorSelected#0#0;
_targ allowDamage false;
private _targPosASL = getPosASL _targ;

private _plane = createVehicle [_planeType, [0,0,0], [], 0, "FLY"]; 
_plane setPosASL (_targPosASL vectorAdd [2000 + random 50, 0, _diveParams#0]); 
_plane setDir -90;
_plane setVelocityModelSpace [0, 150, 0]; 
[_plane, "CAS"] call A3A_fnc_setPlaneLoadout;

// Uncomment these two if required
//_plane setVariable ["diveParams", _diveParams];
//_plane setVariable ["bombRacks", _bombRacks];

private _group = [Occupants, _plane] call A3A_fnc_createVehicleCrew; 
_group setBehaviourStrong "CARELESS"; 

private _wpPos = _targPosASL vectorAdd [-1000, 0, _diveParams#0];
private _setupWP = _group addWaypoint [_wpPos, -1];
_group setCurrentWaypoint _setupWP;

[_plane, _targ, "TestDiveBomb", _setupWP] call A3A_fnc_SUP_CASDiveBombRun;

sleep 10;
{deleteVehicle _x} forEach units _group;
deleteGroup _group;
deleteVehicle _plane;
```
