### PR TITLE
Add some mapInfo features (banks, distances)

### DIFF
--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -35,6 +35,9 @@ private _declareServerVariable = {
 ////////////////////////////////////////
 Info("initialising general server variables");
 
+private _mapInfo = missionConfigFile/"A3A"/"mapInfo"/toLower worldName;
+if (!isClass _mapInfo) then {_mapInfo = configFile/"A3A"/"mapInfo"/toLower worldName};
+
 //initial spawn distance. Less than 1Km makes parked vehicles spawn in your nose while you approach.
 //User-adjustable variables are now declared in initParams
 //DECLARE_SERVER_VAR(distanceSPWN, 1000);
@@ -42,10 +45,15 @@ DECLARE_SERVER_VAR(distanceSPWN1, distanceSPWN*1.3);
 DECLARE_SERVER_VAR(distanceSPWN2, distanceSPWN*0.5);
 //Quantity of Civs to spawn in (most likely per client - Bob Murphy 26.01.2020)
 //DECLARE_SERVER_VAR(globalCivilianMax, 5);
+
 //The furthest distance the AI can attack from using helicopters or planes
-DECLARE_SERVER_VAR(distanceForAirAttack, 10000);
+distanceForAirAttack = if (isNumber (_mapInfo/"distanceForAirAttack")) then { getNumber (_mapInfo/"distanceForAirAttack") } else { 10000 };
+ONLY_DECLARE_SERVER_VAR(distanceForAirAttack);
+
 //The furthest distance the AI can attack from using trucks and armour
-DECLARE_SERVER_VAR(distanceForLandAttack, 3000);			// now faction-adjusted  - if (A3A_hasIFA) then {5000} else {3000});
+distanceForLandAttack = if (isNumber (_mapInfo/"distanceForLandAttack")) then { getNumber (_mapInfo/"distanceForLandAttack") } else { 3000 };
+ONLY_DECLARE_SERVER_VAR(distanceForLandAttack);
+
 //Max units we aim to spawn in. Still declared in initParams and modifiable in game options, but unused
 //DECLARE_SERVER_VAR(maxUnits, 140);
 

--- a/A3A/addons/core/functions/init/fn_initZones.sqf
+++ b/A3A/addons/core/functions/init/fn_initZones.sqf
@@ -133,26 +133,35 @@ sidesX setVariable ["NATO_carrier", Occupants, true];
 sidesX setVariable ["CSAT_carrier", Invaders, true];
 
 
+Info("Setting up banks");
+
+banks = [];
+
+private _posBank = getArray (_mapInfo/"banks");
+if (_posBank isEqualTo []) then {banks = nearestObjects [[worldSize/2, worldSize/2], ["Land_Offices_01_V1_F"], worldSize]};
+
+{
+	private _bank = nearestObject [_x, "house"];
+	if (isNull _bank) then {
+		Error_1("Building not found at %1", _x);
+		continue;
+	};
+	banks pushBack _bank;
+} forEach _posBank;
+
+
 Info("Setting up antennas");
 
 antennasDead = [];
-banks = [];
 mrkAntennas = [];
 antennas = [];
-private _banktypes = ["Land_Offices_01_V1_F"];
 private _antennatypes = ["Land_TTowerBig_1_F", "Land_TTowerBig_2_F", "Land_Communication_F",
 "Land_Vysilac_FM","Land_A_TVTower_base","Land_Telek1", "Land_vn_tower_signal_01","land_gm_radio_antenna_01"];
 private ["_antenna", "_mrkFinal", "_antennaProv"];
-if (debug) then {
-    Debug("Setting up Radio Towers.");
-};
 
 private _posAntennas = getArray (_mapInfo/"antennas");
 private _blacklistIndex = getArray (_mapInfo/"antennasBlacklistIndex");
 private _hardCodedAntennas = _posAntennas isNotEqualTo [];
-
-private _posBank = getArray (_mapInfo/"banks");
-if ( _posBank isEqualTo []) then {banks = nearestObjects [[worldSize/2, worldSize/2], _banktypes, worldSize]};
 
 // Land_A_TVTower_base can't be destroyed, Land_Communication_F and Land_Vysilac_FM are not replaced with "Ruins" when destroyed.
 // This causes issues with persistent load and rebuild scripts, so we replace those with antennas that work properly.
@@ -264,16 +273,7 @@ if (count _posAntennas > 0) then {
 if (debug) then {
 	Error("Broken Radio Towers identified.");
 };
-if (count _posBank > 0) then {
-	for "_i" from 0 to (count _posBank - 1) do {
-		_bankProv = nearestObjects [_posBank select _i, _banktypes, 30];
 
-		if (count _bankProv > 0) then {
-			private _banco = _bankProv select 0;
-			banks = banks + [_banco];
-		};
-	};
-};
 
 // Make list of markers that don't have a proper road nearby
 // TODO: Nearly obsolete. Switch convoy code to road distance checks & markerNavPoint


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Added mapInfo parameters for air & land attack distances, for maps where the default 3km/10km didn't work due to larger spacing between locations. These use default fallbacks, so that older extensions still work.

Changed the mapInfo banks specification to be type-agnostic. If you put a position into the banks array then it will simply look for the nearest house object. Won't change behaviour on any current maps unless the positions were very inaccurate. Altis works fine at least.

### Please specify which Issue this PR Resolves.
closes #3485

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
