### PR TITLE
Update garage count on load

### DIFF
--- a/A3A/addons/garage/Core/fn_onLoad.sqf
+++ b/A3A/addons/garage/Core/fn_onLoad.sqf
@@ -81,6 +81,7 @@ _disp displayAddEventHandler ["MouseZChanged","if !(HR_GRG_RMouseBtnDown) exitWi
     (_this#1) call HR_GRG_fnc_reciveBroadcast;
 };
 "HR_GRG_Vehicles" addPublicVariableEventHandler {
+    call HR_GRG_fnc_updateVehicleCount;
     private _disp = findDisplay HR_GRG_IDD_Garage;
     private _index = HR_GRG_Cats findIf {ctrlShown _x};
     private _ctrl = HR_GRG_Cats#_index;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information: Vehicle count of garage is now always updated when new garage data is received, not just on load. This fixes an issue where the garage count would be inaccurate when being loaded again in a session.


### Please specify which Issue this PR Resolves.
closes #3352 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: Host dedicated and add vehicles to garage
