### PR TITLE
Add explanatory tooltips to some setup UI new-game options

### DIFF
--- a/A3A/addons/gui/Stringtable.xml
+++ b/A3A/addons/gui/Stringtable.xml
@@ -4135,6 +4135,9 @@
         <Turkish>Eski Oyunu Kopyala</Turkish>
         <Chinesesimp>加载之前的存档</Chinesesimp>
       </Key>
+      <Key ID="STR_antistasi_dialogs_setup_copy_old_game_tooltip">
+        <Original>Load an old campaign with a new ID. This option can be used to move a campaign to or from the new save method, or just to make an additional copy for experiments. The new game won't exist on disk until it's saved.</Original>
+      </Key>
       <Key ID="STR_antistasi_dialogs_setup_create_new_game">
         <Original>Create new game</Original>
         <German>Erstelle neuen Spielstand</German>
@@ -4216,6 +4219,9 @@
         <Portuguese>Copiar parametros anteriores</Portuguese>
         <Turkish>Eski parametreleri yükle</Turkish>
         <Chinesesimp>复制之前的参数</Chinesesimp>
+      </Key>
+      <Key ID="STR_antistasi_dialogs_setup_load_old_params_tooltip">
+        <Original>Use the parameters from the selected campaign when creating the new one.</Original>
       </Key>
       <Key ID="STR_antistasi_dialogs_setup_loadgame_tab_button">
         <Original>Load Game</Original>
@@ -4440,7 +4446,7 @@
         <Russian>Переключить на ДЛС</Russian>
       </Key>
       <Key ID="STR_antistasi_dialogs_setup_use_new_namespace">
-        <Original>Use New Save file</Original>
+        <Original>New save method</Original>
         <German>Nutze neue Spielstand Datei</German>
         <Italian>Usa Nuovo File di Salvataggio</Italian>
         <Spanish>Usar fichero de Partida nueva</Spanish>
@@ -4452,6 +4458,9 @@
         <Portuguese>Usar novo ficheiro</Portuguese>
         <Turkish>Yeni kayıt dosyası kullan</Turkish>
         <Chinesesimp>使用新的存档文件</Chinesesimp>
+      </Key>
+      <Key ID="STR_antistasi_dialogs_setup_use_new_namespace_tooltip">
+        <Original>Save the new campaign to AntistasiCommunity.vars instead of the main profile vars file. Warning: This may not work correctly on Linux servers due to an Arma bug.</Original>
       </Key>
     </Container>
   </Package>

--- a/A3A/addons/gui/dialogues/setupDialog.hpp
+++ b/A3A/addons/gui/dialogues/setupDialog.hpp
@@ -164,6 +164,7 @@ class A3A_SetupDialog : A3A_TabbedDialog
                 class CopyGameCheck: A3A_Checkbox {
                     idc = A3A_IDC_SETUP_COPYGAMECHECKBOX;
                     onCheckedChanged = "['copyGameCheck'] call A3A_GUI_fnc_setupLoadgameTab";
+                    tooltip = $STR_antistasi_dialogs_setup_copy_old_game_tooltip;
                     x = 126 * GRID_W;
                     y = 18 * GRID_H;
                     w = 4 * GRID_W;
@@ -172,6 +173,7 @@ class A3A_SetupDialog : A3A_TabbedDialog
                 class CopyGameText: A3A_text {
                     idc = A3A_IDC_SETUP_COPYGAMETEXT;
                     text = $STR_antistasi_dialogs_setup_copy_old_game;
+                    tooltip = $STR_antistasi_dialogs_setup_copy_old_game_tooltip;
                     x = 130 * GRID_W;
                     y = 18 * GRID_H;
                     w = 26 * GRID_W;
@@ -180,6 +182,7 @@ class A3A_SetupDialog : A3A_TabbedDialog
                 class OldParamsCheck: A3A_Checkbox {
                     idc = A3A_IDC_SETUP_OLDPARAMSCHECKBOX;
                     onCheckedChanged = "['oldParamsCheck'] call A3A_GUI_fnc_setupLoadgameTab";
+                    tooltip = $STR_antistasi_dialogs_setup_load_old_params_tooltip;
                     x = 126 * GRID_W;
                     y = 24 * GRID_H;
                     w = 4 * GRID_W;
@@ -188,6 +191,7 @@ class A3A_SetupDialog : A3A_TabbedDialog
                 class OldParamsText: A3A_text {
                     idc = A3A_IDC_SETUP_OLDPARAMSTEXT;
                     text = $STR_antistasi_dialogs_setup_load_old_params;
+                    tooltip = $STR_antistasi_dialogs_setup_load_old_params_tooltip;
                     x = 130 * GRID_W;
                     y = 24 * GRID_H;
                     w = 26 * GRID_W;
@@ -196,6 +200,7 @@ class A3A_SetupDialog : A3A_TabbedDialog
                 class NewNamespaceCheck: A3A_Checkbox {
                     idc = A3A_IDC_SETUP_NAMESPACECHECKBOX;
                     onCheckedChanged = "['newNamespaceCheck'] call A3A_GUI_fnc_setupLoadgameTab";
+                    tooltip = $STR_antistasi_dialogs_setup_use_new_namespace_tooltip;
                     x = 126 * GRID_W;
                     y = 30 * GRID_H;
                     w = 4 * GRID_W;
@@ -204,6 +209,7 @@ class A3A_SetupDialog : A3A_TabbedDialog
                 class NewNamespaceText: A3A_text {
                     idc = A3A_IDC_SETUP_NAMESPACETEXT;
                     text = $STR_antistasi_dialogs_setup_use_new_namespace;
+                    tooltip = $STR_antistasi_dialogs_setup_use_new_namespace_tooltip;
                     x = 130 * GRID_W;
                     y = 30 * GRID_H;
                     w = 26 * GRID_W;


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Added some explanatory tooltips to the weirder setup UI new-campaign options. Hopefully reduces the number of people trying to use missionProfileNamespace on Linux servers.

### Please specify which Issue this PR Resolves.
closes #3500

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
