### PR TITLE
Fix some Petros death handling

### DIFF
--- a/A3A/addons/core/functions/AI/fn_airbomb.sqf
+++ b/A3A/addons/core/functions/AI/fn_airbomb.sqf
@@ -58,15 +58,15 @@ for "_i" from 1 to _bombCount do
         if (_bombType == "NAPALM") then
         {
             // Pass the position in because it might detonate pre-spawn
-            [_bomb, _bombPos] spawn
+            [_bomb, _bombPos, side group _plane] spawn
             {
-                params ["_bomb", "_bombPos"];
+                params ["_bomb", "_bombPos", "_bombSide"];
                 while {!isNull _bomb} do
                 {
                     _bombPos = getPosATL _bomb;
                     sleep 0.1;
                 };
-                [_bombPos] remoteExec ["A3A_fnc_napalm",2];
+                [_bombPos, _bombSide] remoteExec ["A3A_fnc_napalm",2];
             };
         };
     };

--- a/A3A/addons/core/functions/AI/fn_napalm.sqf
+++ b/A3A/addons/core/functions/AI/fn_napalm.sqf
@@ -4,6 +4,7 @@ Author: Caleb Serafin
 
 Arguments:
     <POS3|POS2> AGL centre of effect.
+    <SIDE> Side that deals the napalm damage
     <STRING> CancellationTokenUUID. Provisioning for implementation of cancellationTokens (Default = "");
 
 Return Value:
@@ -36,6 +37,7 @@ Example:
 */
 params [
     ["_pos",[],[ [] ], [2,3]],
+    ["_side",sideUnknown,[sideUnknown]],
     ["_cancellationTokenUUID","",[ "" ]]
 ];
 if (!isServer) exitWith {false};
@@ -101,7 +103,7 @@ while {_endTime > serverTime && !([_cancellationTokenUUID] call _fnc_cancelReque
     {
         private _owner = owner _x;
         if (_owner isEqualTo 0) then { _owner = 2; };
-        [_x, true,_cancellationTokenUUID] remoteExecCall ["A3A_fnc_napalmDamage",_owner];
+        [_x, true, _side,_cancellationTokenUUID] remoteExecCall ["A3A_fnc_napalmDamage",_owner];
     } forEach _victims;
 
     uiSleep 5;

--- a/A3A/addons/core/functions/AI/fn_napalmDamage.sqf
+++ b/A3A/addons/core/functions/AI/fn_napalmDamage.sqf
@@ -8,6 +8,7 @@ Author: Caleb Serafin
 Arguments:
     <OBJECT> The targeted object. Is filtered within this function.
     <BOOL> If allowed to create particles and lights. Only set to true if this used on few objects at a time.
+    <SIDE> Side that deals the napalm damage
     <STRING> CancellationToken; pass with element 0 = true; if element 0 is false effects stop as-soon as possible.
 
 Return Value:
@@ -25,6 +26,7 @@ Example:
 params [
     ["_victim",objNull,[objNull]],
     ["_particles",false,[false]],
+    ["_side",sideUnknown,[sideUnknown]],
     ["_cancellationTokenUUID","",[ "" ]]
 ];
 private _filename = "functions\AI\fn_napalmDamage.sqf";
@@ -50,10 +52,9 @@ private _fnc_final = 'params ["_victim"];';                 // params ["_victim"
 private _invalidVictim = false;
 switch (true) do {
     case (_victim isKindOf "CAManBase"): {  // Man includes everything biological, even animals such as goats ect...
-        if (_victim == petros) then {
-            // Should probably pass in the napalm source side but this will do for now
-            _victim setVariable ["A3A_napalmHit", true, 2];
-            _fnc_final = _fnc_final + 'if (alive _victim) then { _victim setVariable ["A3A_napalmHit", nil, 2] };';
+        if (_victim == petros and _side in [Occupants, Invaders]) then {
+            _victim setVariable ["A3A_napalmHit", true, 2];         // Need to set in advance so it's there when the unit dies
+            _fnc_final = _fnc_final + 'if (alive _victim and !(_victim getVariable ["incapacitated", false])) then { _victim setVariable ["A3A_napalmHit", nil, 2] };';
         };
         if (A3A_hasACEMedical) then {
             _fnc_onTick = _fnc_onTick +

--- a/A3A/addons/core/functions/AI/fn_napalmDamage.sqf
+++ b/A3A/addons/core/functions/AI/fn_napalmDamage.sqf
@@ -50,6 +50,11 @@ private _fnc_final = 'params ["_victim"];';                 // params ["_victim"
 private _invalidVictim = false;
 switch (true) do {
     case (_victim isKindOf "CAManBase"): {  // Man includes everything biological, even animals such as goats ect...
+        if (_victim == petros) then {
+            // Should probably pass in the napalm source side but this will do for now
+            _victim setVariable ["A3A_napalmHit", true, 2];
+            _fnc_final = _fnc_final + 'if (alive _victim) then { _victim setVariable ["A3A_napalmHit", nil, 2] };';
+        };
         if (A3A_hasACEMedical) then {
             _fnc_onTick = _fnc_onTick +
             'if (alive _victim) then {

--- a/A3A/addons/core/functions/Base/fn_initPetros.sqf
+++ b/A3A/addons/core/functions/Base/fn_initPetros.sqf
@@ -28,57 +28,21 @@ if (petros == leader group petros) then {
 
 [petros,true] call A3A_fnc_punishment_FF_addEH;
 
-petros addEventHandler
-[
-    "HandleDamage",
-    {
-    _part = _this select 1;
-    _damage = _this select 2;
-    _injurer = _this select 3;
-
-    _victim = _this select 0;
-    _instigator = _this select 6;
-    if (isPlayer _injurer) then
-    {
-        _damage = (_this select 0) getHitPointDamage (_this select 7);
-    };
-    if ((isNull _injurer) or (_injurer == petros)) then {_damage = 0};
-        if (_part == "") then
-        {
-            if (_damage > 1) then
-            {
-                if (!(petros getVariable ["incapacitated",false])) then
-                {
-                    petros setVariable ["incapacitated",true,true];
-                    _damage = 0.9;
-                    if (!isNull _injurer) then {[petros,side _injurer] spawn A3A_fnc_unconscious} else {[petros,sideUnknown] spawn A3A_fnc_unconscious};
-                }
-                else
-                {
-                    _overall = (petros getVariable ["overallDamage",0]) + (_damage - 1);
-                    if (_overall > 1) then
-                    {
-                        petros removeAllEventHandlers "HandleDamage";
-                    }
-                    else
-                    {
-                        petros setVariable ["overallDamage",_overall];
-                        _damage = 0.9;
-                    };
-                };
-            };
-        };
-    _damage;
-    }
-];
+// Install the handleDamage EH on server & commander machines
+//call A3A_fnc_addPetrosEventHandlers;
+//if (!isNull theBoss) then { remoteExecCall ["A3A_fnc_addPetrosEventHandlers", theBoss] };
 
 petros addMPEventHandler ["mpkilled",
 {
     removeAllActions petros;
     if (!isServer) exitWith {};
 
+    // Because setDamage 1 sets the killer to self, replace it if possible
     _killer = _this select 1;
-    if ((side _killer == Invaders) or (side _killer == Occupants) and !(isPlayer _killer) and !(isNull _killer)) then
+    _killer = petros getVariable ["ace_medical_lastDamageSource", _killer];
+    //_killer = petros getVariable ["A3A_downedBy", _killer];			// this one can't exist atm
+
+    if ((side _killer == Invaders) or (side _killer == Occupants) or petros getVariable ["A3A_napalmHit", false]) then
     {
         garrison setVariable ["Synd_HQ", [], true];
         _hr = server getVariable "hr";


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Some of this really needs a broader rework due to locality switch issues, but that's not really workable within 3.9.0 so I've just removed the busted vanilla handleDamage and fixed up the MPKilled handler to take up the slack. Don't really want Petros rolling around on the floor for 5min in vanilla anyway.

Also thrown in a slightly hacky fix so that Petros can die to napalm.

### Please specify which Issue this PR Resolves.
closes #3275

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Shoot Petros (should respawn nearby), spawn in enemy to kill petros (should work), call napalm airstrike on petros (should work). Not that after every respawn petros gets allowDamage false for 120 seconds, so make sure to clear that before testing. Tested in both ACE and vanilla.