### PR TITLE
Soften postmortem cleanup rules

### DIFF
--- a/A3A/addons/core/functions/Base/fn_postmortemLoop.sqf
+++ b/A3A/addons/core/functions/Base/fn_postmortemLoop.sqf
@@ -41,7 +41,7 @@ while {true} do
         if (time < _object getVariable ["A3A_gcTime", 0]) exitWith {};
 
         // If there are no players nearby then delete
-        if (_players inAreaArray [getPosATL _object, 100, 100] isEqualTo []) then { _object call _fnc_delete; continue };
+        if (_players inAreaArray [getPosATL _object, 500, 500] isEqualTo []) then { _object call _fnc_delete; continue };
 
         // If the object has been bumped too many times, delete it
         private _bumps = _object getVariable ["A3A_gcBumps", 0];

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -164,7 +164,7 @@ A3A_tasksData = [];
 A3A_buildingsToSave = [];
 
 A3A_gcQueue = [];				// List of postmortem objects to clean up
-A3A_gcCleanTime = 1800;			// Base time for deleting postmortem objects
+A3A_gcCleanTime = 3600;			// Base time for deleting postmortem objects
 A3A_gcMaxBumps = 3;				// Max times to delay cleanup for an object that's near players
 
 hcArray = [];					// array of headless client IDs


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Postmortem cleanup rules were overly strict, often causing corpses to be deleted prior to looting. This PR doubles the minimum cleanup time to 1 hour and also increases the radius at which it's extended further if players are nearby.

There's still the rule that corpses are deleted earlier if there are too many of them, so we can probably afford to be lenient here.

### Please specify which Issue this PR Resolves.
closes #3546

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
