### PR TITLE
Fix ancient specops bug with missing UAVs

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_createAIcontrols.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIcontrols.sqf
@@ -189,12 +189,12 @@ else
 
 		[_groupX, "Patrol_Area", 25, 150, 300, false, [], false] call A3A_fnc_patrolLoop;
 		_groups pushBack _groupX;
+		{_soldiers pushBack _x} forEach units _groupX;
 
 		_typeVehX = selectRandom (_faction get "uavsPortable");
 		if !(isNil "_typeVehX") then
 			{
 			sleep 1;
-			{_soldiers pushBack _x} forEach units _groupX;
 			_uav = createVehicle [_typeVehX, _positionX, [], 0, "FLY"];
 			[_sideX, _uav] call A3A_fnc_createVehicleCrew;
 			_vehiclesX pushBack _uav;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed an ancient bug with specops control points not registering their soldiers if there's nothing in the uavsPortable array. This has two effects:
- The specops do not despawn.
- The specops point is immediately marked as captured.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
