### PR TITLE
Fix towns on Napf and Napf Winter

### DIFF
--- a/A3A/addons/config_fixes/Napf/config.cpp
+++ b/A3A/addons/config_fixes/Napf/config.cpp
@@ -1,0 +1,119 @@
+//IslaDuala3 - config.cpp
+
+#include "..\script_component.hpp"
+
+
+class CfgPatches 
+{
+    class PATCHNAME(Napf) 
+    {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"A3_Data_F_AoW_Loadorder","Napf"};
+        skipWhenMissingDependencies = 1;
+        author = AUTHOR;
+        authors[] = { AUTHORS };
+        authorUrl = "";
+        VERSION_CONFIG;
+    };
+};
+class CfgWorlds {
+    class CAWorld;
+    class Napf : CAWorld {
+        class Names {
+            // These are marked as "Name". Fix to "NameVillage".
+            class vil_Bunig {
+                name = "Bunig";
+                position[] = {12578.2,14238.8};
+                radiusA = 200;                      // I think these are supposed to be outer/inner radius but Antistasi uses them as X/Y. Probably a bug.
+                radiusB = 200;
+                type = "NameVillage";               // NameCity also works, I don't think Antistasi cares
+            };
+            class vil_Magden {
+                name = "Magden";
+                position[] = {10742.6,17071.8};
+                radiusA = 100;
+                radiusB = 100;
+                type = "NameVillage";
+            };
+            class vil_Malters {
+                name = "Malters";
+                position[] = {13595.8,13989.5};
+                radiusA = 100;
+                radiusB = 100;
+                type = "NameVillage";
+            };
+            class vil_Seltishafen {
+                name = "Seltishafen";
+                position[] = {5466.87,15935};
+                radiusA = 150;
+                radiusB = 150;
+                type = "NameVillage";
+            };
+            class vil_Abach {
+                name = "Abach";
+                position[] = {6491.27,15964.4};
+                radiusA = 100;
+                radiusB = 100;
+                type = "NameVillage";
+            };
+            class vil_Wasen {
+                name = "Wasen";
+                position[] = {7385.5,15887};
+                radiusA = 150;
+                radiusB = 150;
+                type = "NameVillage";
+            };
+        };
+    };
+    class NapfWinter : CAWorld {
+        class Names {
+            // These are marked as "Name". Fix to "NameVillage".
+            class vil_Bunig {
+                name = "Bunig";
+                position[] = {12578.2,14238.8};
+                radiusA = 200;                      // I think these are supposed to be outer/inner radius but Antistasi uses them as X/Y. Probably a bug.
+                radiusB = 200;
+                type = "NameVillage";               // NameCity also works, I don't think Antistasi cares
+            };
+            class vil_Magden {
+                name = "Magden";
+                position[] = {10742.6,17071.8};
+                radiusA = 100;
+                radiusB = 100;
+                type = "NameVillage";
+            };
+            class vil_Malters {
+                name = "Malters";
+                position[] = {13595.8,13989.5};
+                radiusA = 100;
+                radiusB = 100;
+                type = "NameVillage";
+            };
+            class vil_Seltishafen {
+                name = "Seltishafen";
+                position[] = {5466.87,15935};
+                radiusA = 150;
+                radiusB = 150;
+                type = "NameVillage";
+            };
+            class vil_Abach {
+                name = "Abach";
+                position[] = {6491.27,15964.4};
+                radiusA = 100;
+                radiusB = 100;
+                type = "NameVillage";
+            };
+            class vil_Wasen {
+                name = "Wasen";
+                position[] = {7385.5,15887};
+                radiusA = 150;
+                radiusB = 150;
+                type = "NameVillage";
+            };
+        };
+    };
+
+};

--- a/A3A/addons/maps/Antistasi_Napf.Napf/mapInfo.hpp
+++ b/A3A/addons/maps/Antistasi_Napf.Napf/mapInfo.hpp
@@ -1,9 +1,20 @@
 class Napf {
 	population[] = {
-		{"vil_Lenzburg",584},{"vil_Trueb",148},{"vil_Seltisberg",129},{"vil_NeueWelt",144},{"vil_Bubendorf",124},{"vil_Seewen",46},{"vil_Huttwil",134},{"lw_Ruchfeld",34},{"lw_Hagacher",16},{"vil_Oberdorf",69},{"vil_Muttenz",386},{"farm_HofHorn",11},{"lw_Lochacker",239},{"farm_Elbishof",21},{"farm_Rossbode",31},{"vil_Muenchenstein",368},{"vil_Chatzbach",163},{"vil_Bruderholz",36},{"farm_Aegerifeld",16},{"ind_Saegewerk",44},{"vil_Freidorf",83},{"vil_Olten",205},{"vil_Ruemlingen",184},{"Hof_KleineEgg",16},{"farm_Eichmatt",10},{"vil_Hirsegg",59},{"Insel_Hasenmatt",5},{"vil_Lausen",121},{"farm_Ey",16},{"farm_Rorighof",6},{"farm_Arxhof",11},{"farm_Ramsebode",12},{"vil_Unterdorf",94},{"vil_Luzern",750},{"vil_Emmen",422},{"vil_Wolhusen",151},{"vil_Horw",152},{"vil_Romoos",48},{"vil_Meggen",68},{"vil_Liestal",274},{"vil_Sachseln",91},{"vil_Sissach",104},{"vil_Buckten",35},{"vil_Eggwil",48},{"Insel_Pfeffikon",36},{"Insel_Suhrenfeld",54},{"vil_Signau",88},{"vil_Schangen",186},{"vil_Hasle",58},{"vil_Worb",458},{"vil_Munsingen",144},{"vil_Ittingen",152},{"vil_Hindelbank",91},{"castle_Homburg",46},{"for_Teufelsgraben",23},{"Hof_Goms",39},{"LandMark_Hubel",0},{"Hof_Hungerschwand",12},{"vil_Farnen",38},{"vil_Sorenberg",107},{"Island_Feldmoos",10},{"farm_Alpnach",15},{"vil_Giswil",44},{"pass_Rorenpass",7},{"Hof_Waldegg",10},{"mil_SouthAirstrip",13},{"Castle_Froburg",20},{"vil_Brienz",98},{"vil_Nordstern",55},{"Island_Bernerplatte",0},{"vil_Goldwil",20}
+		{"vil_Lenzburg",584},{"vil_Trueb",148},{"vil_Seltisberg",129},{"vil_NeueWelt",144},{"vil_Bubendorf",124},{"vil_Seewen",46},
+		{"vil_Huttwil",134},{"lw_Hagacher",16},{"vil_Oberdorf",69},{"vil_Muttenz",386},{"farm_HofHorn",11},
+		{"farm_Elbishof",21},{"farm_Rossbode",31},{"vil_Muenchenstein",368},{"vil_Chatzbach",163},{"vil_Bruderholz",36},{"farm_Aegerifeld",16},
+		{"vil_Freidorf",83},{"vil_Olten",205},{"vil_Ruemlingen",184},{"Hof_KleineEgg",16},{"farm_Eichmatt",10},
+		{"vil_Hirsegg",59},{"Insel_Hasenmatt",5},{"vil_Lausen",121},{"farm_Ey",16},{"farm_Rorighof",6},{"farm_Arxhof",11},{"farm_Ramsebode",12},
+		{"vil_Unterdorf",94},{"vil_Luzern",750},{"vil_Emmen",422},{"vil_Wolhusen",151},{"vil_Horw",152},{"vil_Romoos",48},{"vil_Meggen",68},
+		{"vil_Liestal",274},{"vil_Sachseln",91},{"vil_Sissach",104},{"vil_Buckten",35},{"vil_Eggwil",48},{"Insel_Pfeffikon",36},
+		{"vil_Signau",88},{"vil_Schangen",186},{"vil_Hasle",58},{"vil_Worb",458},{"vil_Munsingen",144},{"vil_Ittingen",152},{"vil_Hindelbank",91},
+		{"Hof_Goms",39},{"Hof_Hungerschwand",12},{"vil_Farnen",38},{"vil_Sorenberg",107},{"farm_Alpnach",15},{"vil_Giswil",44},
+		{"pass_Rorenpass",7},{"Hof_Waldegg",10},{"vil_Brienz",98},{"vil_Nordstern",55},{"vil_Goldwil",20},{"vil_Magden",52},
+		{"vil_Bunig", 100},{"vil_Malters",55},{"vil_Wasen",41},{"vil_Seltishafen",53},{"vil_Abach",46}
 	};
 	disabledTowns[] = {
-		"mil_SouthAirstrip","Island_Feldmoos","Island_Bernerplatte","castle_Homburg","Homburg","Castle_Froburg","Froburg"
+		"mil_SouthAirstrip","Island_Feldmoos","Island_Bernerplatte","castle_Homburg","Castle_Froburg","ind_Saegewerk",
+		"for_Teufelsgraben","lw_Ruchfeld","lw_Lochacker","LandMark_Hubel","Insel_Suhrenfeld","Insel_Hasenmatt"
 	};
 	antennas[] = {
 		{10987.7,9465.01,0.0774231},{9135.95,11027.4,-0.783722},{7672.83,9772.95,0.00149536},{8994.92,7573.55,0.0384521},{8994.92,7573.55,-0.444763},{6202.3,10639,-0.000984192},{6186.1,12025.9,-0.0628891},{7919.53,14442.1,0.219131},{15117.9,12586.8,0.00614929},{10898,4404.76,-0.135315},{9393.43,16246.8,-0.00434494},{9393.61,16247,0.0274506},{7021.62,4662.36,0.158585},{5852.23,15093.9,-0.0428619},{9676.3,2933.88,-0.334412},{5258.93,4510.2,-1.52588e-005},{698.401,6726.06,-0.179443},{16327.5,18434.2,-0.105293},{18743.5,2148.42,-0.226135}

--- a/A3A/addons/maps/Antistasi_NapfWinter.NapfWinter/mapInfo.hpp
+++ b/A3A/addons/maps/Antistasi_NapfWinter.NapfWinter/mapInfo.hpp
@@ -1,9 +1,20 @@
 class NapfWinter {
 	population[] = {
-		{"vil_Lenzburg",584},{"vil_Trueb",148},{"vil_Seltisberg",129},{"vil_NeueWelt",144},{"vil_Bubendorf",124},{"vil_Seewen",46},{"vil_Huttwil",134},{"lw_Ruchfeld",34},{"lw_Hagacher",16},{"vil_Oberdorf",69},{"vil_Muttenz",386},{"farm_HofHorn",11},{"lw_Lochacker",239},{"farm_Elbishof",21},{"farm_Rossbode",31},{"vil_Muenchenstein",368},{"vil_Chatzbach",163},{"vil_Bruderholz",36},{"farm_Aegerifeld",16},{"ind_Saegewerk",44},{"vil_Freidorf",83},{"vil_Olten",205},{"vil_Ruemlingen",184},{"Hof_KleineEgg",16},{"farm_Eichmatt",10},{"vil_Hirsegg",59},{"Insel_Hasenmatt",5},{"vil_Lausen",121},{"farm_Ey",16},{"farm_Rorighof",6},{"farm_Arxhof",11},{"farm_Ramsebode",12},{"vil_Unterdorf",94},{"vil_Luzern",750},{"vil_Emmen",422},{"vil_Wolhusen",151},{"vil_Horw",152},{"vil_Romoos",48},{"vil_Meggen",68},{"vil_Liestal",274},{"vil_Sachseln",91},{"vil_Sissach",104},{"vil_Buckten",35},{"vil_Eggwil",48},{"Insel_Pfeffikon",36},{"Insel_Suhrenfeld",54},{"vil_Signau",88},{"vil_Schangen",186},{"vil_Hasle",58},{"vil_Worb",458},{"vil_Munsingen",144},{"vil_Ittingen",152},{"vil_Hindelbank",91},{"castle_Homburg",46},{"for_Teufelsgraben",23},{"Hof_Goms",39},{"LandMark_Hubel",0},{"Hof_Hungerschwand",12},{"vil_Farnen",38},{"vil_Sorenberg",107},{"Island_Feldmoos",10},{"farm_Alpnach",15},{"vil_Giswil",44},{"pass_Rorenpass",7},{"Hof_Waldegg",10},{"mil_SouthAirstrip",13},{"Castle_Froburg",20},{"vil_Brienz",98},{"vil_Nordstern",55},{"Island_Bernerplatte",0},{"vil_Goldwil",20}
+		{"vil_Lenzburg",584},{"vil_Trueb",148},{"vil_Seltisberg",129},{"vil_NeueWelt",144},{"vil_Bubendorf",124},{"vil_Seewen",46},
+		{"vil_Huttwil",134},{"lw_Hagacher",16},{"vil_Oberdorf",69},{"vil_Muttenz",386},{"farm_HofHorn",11},
+		{"farm_Elbishof",21},{"farm_Rossbode",31},{"vil_Muenchenstein",368},{"vil_Chatzbach",163},{"vil_Bruderholz",36},{"farm_Aegerifeld",16},
+		{"vil_Freidorf",83},{"vil_Olten",205},{"vil_Ruemlingen",184},{"Hof_KleineEgg",16},{"farm_Eichmatt",10},
+		{"vil_Hirsegg",59},{"Insel_Hasenmatt",5},{"vil_Lausen",121},{"farm_Ey",16},{"farm_Rorighof",6},{"farm_Arxhof",11},{"farm_Ramsebode",12},
+		{"vil_Unterdorf",94},{"vil_Luzern",750},{"vil_Emmen",422},{"vil_Wolhusen",151},{"vil_Horw",152},{"vil_Romoos",48},{"vil_Meggen",68},
+		{"vil_Liestal",274},{"vil_Sachseln",91},{"vil_Sissach",104},{"vil_Buckten",35},{"vil_Eggwil",48},{"Insel_Pfeffikon",36},
+		{"vil_Signau",88},{"vil_Schangen",186},{"vil_Hasle",58},{"vil_Worb",458},{"vil_Munsingen",144},{"vil_Ittingen",152},{"vil_Hindelbank",91},
+		{"Hof_Goms",39},{"Hof_Hungerschwand",12},{"vil_Farnen",38},{"vil_Sorenberg",107},{"farm_Alpnach",15},{"vil_Giswil",44},
+		{"pass_Rorenpass",7},{"Hof_Waldegg",10},{"vil_Brienz",98},{"vil_Nordstern",55},{"vil_Goldwil",20},{"vil_Magden",52},
+		{"vil_Bunig", 100},{"vil_Malters",55},{"vil_Wasen",41},{"vil_Seltishafen",53},{"vil_Abach",46}
 	};
 	disabledTowns[] = {
-		"mil_SouthAirstrip","Island_Feldmoos","Island_Bernerplatte","castle_Homburg","Homburg","Castle_Froburg","Froburg"
+		"mil_SouthAirstrip","Island_Feldmoos","Island_Bernerplatte","castle_Homburg","Castle_Froburg","ind_Saegewerk",
+		"for_Teufelsgraben","lw_Ruchfeld","lw_Lochacker","LandMark_Hubel","Insel_Suhrenfeld","Insel_Hasenmatt"
 	};
 	antennas[] = {
 		{10987.7,9465.01,0.0774231},{9135.95,11027.4,-0.783722},{7672.83,9772.95,0.00149536},{8994.92,7573.55,0.0384521},{8994.92,7573.55,-0.444763},{6202.3,10639,-0.000984192},{6186.1,12025.9,-0.0628891},{7919.53,14442.1,0.219131},{15117.9,12586.8,0.00614929},{10898,4404.76,-0.135315},{9393.43,16246.8,-0.00434494},{9393.61,16247,0.0274506},{7021.62,4662.36,0.158585},{5852.23,15093.9,-0.0428619},{9676.3,2933.88,-0.334412},{5258.93,4510.2,-1.52588e-005},{698.401,6726.06,-0.179443},{16327.5,18434.2,-0.105293},{18743.5,2148.42,-0.226135}


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Napf (and Napf Winter, identical config) have very bad config types for their names. There were about half a dozen clear villages marked as "Name" rather than "NameVillage", and a similar number of woods and industrial complexes marked as NameVillage. Cleared up everything I could find.

It still has a lot of tiny villages which are really farms, but that's more arguable and doesn't make a big difference either way, so I left them alone.

Both the roadblock pair and load/save code correctly handled adding and removing towns, although there's probably some data loss on town support.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
