### PR TITLE
Fix case where gun shop mission may be started without a city

### DIFF
--- a/A3A/addons/core/functions/Missions/fn_missionRequest.sqf
+++ b/A3A/addons/core/functions/Missions/fn_missionRequest.sqf
@@ -96,10 +96,13 @@ switch (_type) do {
 	case "LOG": {
 		// role three dice
 		private _spawnGunShop = random 12 + random 12 + random 12 + tierWar > 29;
-		private _gunShopCities = citiesX select {(getMarkerPos _x) distance2d (getMarkerPos respawnTeamPlayer) < distanceMission }
-			select { sidesX getVariable _x == Occupants } select { spawner getVariable _x != 0 };
 
-		if (_spawnGunShop && !bigAttackInProgress and tierWar > 3) exitWith {
+		private _gunShopCities = [];
+		if (_spawnGunShop && !bigAttackInProgress and tierWar > 3) then {
+			_gunShopCities = citiesX select {(getMarkerPos _x) distance2d (getMarkerPos respawnTeamPlayer) < distanceMission }
+				select { sidesX getVariable _x == Occupants } select { spawner getVariable _x != 0 };
+		};
+		if (_gunShopCities isNotEqualTo []) exitWith {
 			[selectRandom _gunShopCities] remoteExec ["A3A_fnc_GSMission", 2];		// Always on server to simplify shopping list
 		};
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The gun shop mission request code had no check for the case where there are no valid cities available. The mission does not work without a city. Fixed the mission request logic.

### Please specify which Issue this PR Resolves.
closes #3557

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
