### PR TITLE
Optimized mapDrawOutpostsEH

### DIFF
--- a/A3A/addons/gui/functions/GUI/fn_mapDrawHcGroupsEH.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_mapDrawHcGroupsEH.sqf
@@ -107,7 +107,7 @@ _map setVariable ["hcGroupData", _hcGroupData];
 
     // Draw group name text
     _map drawIcon [
-        "#(rgb,1,1,1)color(0,0,0,0)", // transparent
+        "#(argb,1,1,1)color(0,0,0,0)", // transparent
         _groupIconColor, // colour
         _position, // position
         32, // width

--- a/A3A/addons/gui/functions/GUI/fn_mapDrawOutpostsEH.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_mapDrawOutpostsEH.sqf
@@ -43,68 +43,28 @@ private _minMarkerSize = 12;
 private _maxMarkerSize = 32;
 private _markerSize = ((_maxMarkerSize + (_minMarkerSize - _maxMarkerSize) * ((_mapScale - _fadeStart) / (_fadeEnd - _fadeStart))) max _minMarkerSize) min _maxMarkerSize;
 
-// Get marker data
-private _outpostIconData = [];
-{
-    private _marker = _x;
-    private _type = _marker call A3A_GUI_fnc_getLocationMarkerType;
-    private _name = _marker call A3A_GUI_fnc_getLocationMarkerName;
-    private _isCity = _marker in citiesX;
-    private _isDestroyed = _marker in destroyedSites;
-    private _pos = getMarkerPos _marker;
-    private _side = sidesX getVariable [_marker,sideUnknown];
-    private _color = [1,1,1,1];
+private _mapPos = ctrlMapPosition _map;
+private _iconSize = [_markerSize*pixelW/2, _markerSize*pixelH/2];
+private _topLeft = _map ctrlMapScreenToWorld [_mapPos#0 - _iconSize#0, _mapPos#1 - _iconSize#1];
+private _botRight = _map ctrlMapScreenToWorld [_mapPos#0 + _mapPos#2 + _iconSize#0, _mapPos#1 + _mapPos#3 + _iconSize#1];
 
-    switch (true) do {
-        case (_isDestroyed && _isCity): {
-            _color = [A3A_COLOR_BLACK] call FUNC(configColorToArray);
-        };
-        case (_side == teamPlayer): {
-            _color = ["Map", "Independent"] call BIS_fnc_displayColorGet;
-        };
+private _mapCenter = (_topLeft vectorAdd _botRight) vectorMultiply 0.5;
+private _mapWidth = ((_botRight#0) - (_topLeft#0)) / 2;
+private _mapHeight = ((_botRight#1) - (_topLeft#1)) / 2;
 
-        case (_side == Occupants): {
-            _color = ["Map", "BLUFOR"] call BIS_fnc_displayColorGet;
-        };
+// Precache all the colours
+private _sideColorHM = createHashMapFromArray [
+    [teamPlayer, ["Map", "Independent"] call BIS_fnc_displayColorGet],
+    [Occupants, ["Map", "BLUFOR"] call BIS_fnc_displayColorGet],
+    [Invaders, ["Map", "OPFOR"] call BIS_fnc_displayColorGet],
+    [civilian, ["Map", "Civilian"] call BIS_fnc_displayColorGet],
+    [sideUnknown, ["Map", "Unknown"] call BIS_fnc_displayColorGet]
+];
+private _sideFadeHM = keys _sideColorHM createHashMapFromArray (values _sideColorHM apply { [_x#0, _x#1, _x#2, _alpha] });
+private _colorBlack = [A3A_COLOR_BLACK] call FUNC(configColorToArray);
 
-        case (_side == Invaders): {
-            _color = ["Map", "OPFOR"] call BIS_fnc_displayColorGet;
-        };
-
-        case (_side == civilian): {
-            _color = ["Map", "Civilian"] call BIS_fnc_displayColorGet;
-        };
-
-        case (_side == sideUnknown): {
-            _color = ["Map", "Unknown"] call BIS_fnc_displayColorGet;
-        };
-    };
-
-    private _fadedColor = [_color # 0, _color # 1, _color # 2, _alpha];
-    private _icon = A3A_Icon_Map_Blank;
-    if (_mapScale < _fadeEnd) then {
-       _icon = switch (_type) do {
-            case ("hq"): { A3A_Icon_Map_HQ; };
-            case ("city"): { A3A_Icon_Map_City; };
-            case ("factory"): { A3A_Icon_Map_Factory; };
-            case ("resource"): { A3A_Icon_Map_Resource; };
-            case ("seaport"): { A3A_Icon_Map_Seaport; };
-            case ("airbase"): { A3A_Icon_Map_Airport; };
-            case ("outpost"): { A3A_Icon_Map_Outpost; };
-            case ("watchpost"): { A3A_Icon_Map_Watchpost; };
-            case ("roadblock"): { A3A_Icon_Map_Roadblock; };
-            default { "\A3\ui_f\data\Map\Markers\Military\flag_CA.paa"; };
-        };
-    };
-
-    _outpostIconData pushBack [_name, _pos, _type, _icon, _color, _fadedColor];
-} forEach airportsX + resourcesX + factories + outposts + seaports + citiesX + outpostsFIA + ["Synd_HQ"];
-
-// TODO UI-update: add warning symbol for outposts under attack/enemies near
-
-{
-    // Draw icon
-    _x params ["_name", "_pos", "_type", "_icon", "_color", "_fadedColor"];
+private _fnc_drawIcon = {
+    params ["_pos", "_color", "_icon"];
     _map drawIcon [
         _icon, // texture
         _color,
@@ -115,9 +75,10 @@ private _outpostIconData = [];
         "", // text
         0 // shadow (outline if 2)
     ];
+};
 
-    // Draw text
-    if !(_type in ["city","hq"]) then {_color = _fadedColor};
+private _fnc_drawLabel = {
+    params ["_pos", "_color", "_name"];
     _map drawIcon [
         "#(rgb,1,1,1)color(0,0,0,0)", // the icon itself is transparent
         _color, // colour
@@ -128,4 +89,42 @@ private _outpostIconData = [];
         _name, // text
         2 // shadow (outline if 2)
     ];
-} forEach _outpostIconData;
+};
+
+private _fnc_drawMarkers = {
+    params ["_markers", "_icon", "_name"];
+
+    // cull to window boundaries
+    _markers = _markers inAreaArrayIndexes [_mapCenter, _mapWidth, _mapHeight, 0, true] apply {_markers#_x};
+    if (_mapScale >= _fadeEnd) then { _icon = A3A_Icon_Map_Blank };
+
+    {
+        private _side = sidesX getVariable _x;
+        private _pos = markerPos _x;
+        [_pos, _sideColorHM get _side, _icon] call _fnc_drawIcon;
+        if (_mapScale >= _fadeEnd) then { continue };
+        [_pos, _sideFadeHM get _side, _name] call _fnc_drawLabel;
+    } forEach _markers;
+};
+
+[airportsX, A3A_Icon_Map_Airport, "Airbase"] call _fnc_drawMarkers;
+[outposts, A3A_Icon_Map_Outpost, "Outpost"] call _fnc_drawMarkers;
+[factories, A3A_Icon_Map_Factory, "Factory"] call _fnc_drawMarkers;
+[resourcesX, A3A_Icon_Map_Resource, "Resource"] call _fnc_drawMarkers;
+[seaports, A3A_Icon_Map_Seaport, "Seaport"] call _fnc_drawMarkers;
+
+private _roadblocks = outpostsFIA select { isOnRoad markerPos _x };
+[_roadblocks, A3A_Icon_Map_Roadblock, "Roadblock"] call _fnc_drawMarkers;
+[outpostsFIA - _roadblocks, A3A_Icon_Map_Watchpost, "Watchpost"] call _fnc_drawMarkers;
+
+// Cities are heavily special-case
+private _visCities = citiesX inAreaArrayIndexes [_mapCenter, _mapWidth, _mapHeight, 0, true] apply {citiesX#_x};
+{
+    private _color = _sideColorHM get (sidesX getVariable _x);
+    if (_x in destroyedSites) then { _color = _colorBlack };
+    [markerPos _x, _color, A3A_Icon_Map_City] call _fnc_drawIcon;
+    [markerPos _x, _color, _x] call _fnc_drawLabel;
+} forEach _visCities;
+
+[markerPos "Synd_HQ", [0,1,0,1], A3A_Icon_Map_HQ] call _fnc_drawIcon;
+[markerPos "Synd_HQ", [0,1,0,1], "HQ"] call _fnc_drawLabel;

--- a/A3A/addons/gui/functions/GUI/fn_mapDrawOutpostsEH.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_mapDrawOutpostsEH.sqf
@@ -80,7 +80,7 @@ private _fnc_drawIcon = {
 private _fnc_drawLabel = {
     params ["_pos", "_color", "_name"];
     _map drawIcon [
-        "#(rgb,1,1,1)color(0,0,0,0)", // the icon itself is transparent
+        "#(argb,1,1,1)color(0,0,0,0)", // the icon itself is transparent
         _color, // colour
         _pos, // position
         _markerSize, // width
@@ -119,10 +119,11 @@ private _roadblocks = outpostsFIA select { isOnRoad markerPos _x };
 
 // Cities are heavily special-case
 private _visCities = citiesX inAreaArrayIndexes [_mapCenter, _mapWidth, _mapHeight, 0, true] apply {citiesX#_x};
+private _cityIcon = [A3A_Icon_Map_City, A3A_Icon_Map_Blank] select (_mapScale >= _fadeEnd);
 {
     private _color = _sideColorHM get (sidesX getVariable _x);
     if (_x in destroyedSites) then { _color = _colorBlack };
-    [markerPos _x, _color, A3A_Icon_Map_City] call _fnc_drawIcon;
+    [markerPos _x, _color, _cityIcon] call _fnc_drawIcon;
     [markerPos _x, _color, _x] call _fnc_drawLabel;
 } forEach _visCities;
 


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement
4. [X] Performance

### What have you changed and why?
Optimized mapDrawOutpostsEH as it was a pretty big hit when you had a UI map open. Main changes:
- Pre-culling icons in world space.
- No label rendering when faded out.
- Color precaching.
- Icon type precaching.

Bumps from 45 -> 60 vsync cap here unless you zoom out all the way. 

Includes limeified HQ.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

