### PR TITLE
Apply unscheduled optimization to configSort

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_configSort.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_configSort.sqf
@@ -49,8 +49,8 @@ private _allConfigs = _allWeaponConfigs + _allMagazineConfigs + _allBackpackConf
 //////////////////////////////
 //    Sorting Function     ///
 //////////////////////////////
-private ["_nameX", "_item", "_itemMod", "_itemType", "_categories"];           // pretty daft optimization, not likely to make much difference
-{
+private ["_cfg", "_nameX", "_item", "_itemMod", "_itemType", "_categories"];           // pretty daft optimization, not likely to make much difference
+/*{
     _nameX = configName _x;
 
     // If in disabledMods, remove. Don't need itemType for this so we do it first
@@ -69,3 +69,29 @@ private ["_nameX", "_item", "_itemMod", "_itemType", "_categories"];           /
     } forEach _categories;
 
 } forEach _allConfigs;
+*/
+while {_allConfigs isNotEqualTo []} do {
+    isNil {
+        private _startTime = diag_deltaTime;
+        while {_allConfigs isNotEqualTo [] and diag_deltaTime - _startTime < 0.02} do {
+ 
+            _cfg = _allConfigs deleteAt (count _allConfigs - 1);
+            _nameX = configName _cfg;
+
+            // If in disabledMods, remove. Don't need itemType for this so we do it first
+            _itemMod = _cfg call A3A_fnc_getModOfConfigClass;
+            if (_itemMod in A3A_disabledMods) then { continue };
+
+            // Filter items by current factions/modset
+            _itemType = _nameX call A3A_fnc_itemType;
+            if !([_cfg, _itemMod, _itemType] call _fnc_filter) then { continue };
+
+            _categories = [_nameX, _itemType] call A3A_fnc_equipmentClassToCategories;
+            {
+                //We're not returning a default value with getVariable, becuase it *must* be instantiated before now. If it isn't, we *need* it to error.
+                // allweapons, allrifles are pushedback here!!!!
+                (missionNamespace getVariable ("all" + _x)) pushBack _nameX;         // uniqueness should be guaranteed by base weapon filtering
+            } forEach _categories;
+        };
+    };
+};

--- a/A3A/addons/core/functions/Ammunition/fn_configSort.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_configSort.sqf
@@ -50,30 +50,11 @@ private _allConfigs = _allWeaponConfigs + _allMagazineConfigs + _allBackpackConf
 //    Sorting Function     ///
 //////////////////////////////
 private ["_cfg", "_nameX", "_item", "_itemMod", "_itemType", "_categories"];           // pretty daft optimization, not likely to make much difference
-/*{
-    _nameX = configName _x;
 
-    // If in disabledMods, remove. Don't need itemType for this so we do it first
-    _itemMod = _x call A3A_fnc_getModOfConfigClass;
-    if (_itemMod in A3A_disabledMods) then { continue };
-
-    // Filter items by current factions/modset
-    _itemType = _nameX call A3A_fnc_itemType;
-    if !([_x, _itemMod, _itemType] call _fnc_filter) then { continue };
-
-    _categories = [_nameX, _itemType] call A3A_fnc_equipmentClassToCategories;
-    {
-        //We're not returning a default value with getVariable, becuase it *must* be instantiated before now. If it isn't, we *need* it to error.
-        // allweapons, allrifles are pushedback here!!!!
-        (missionNamespace getVariable ("all" + _x)) pushBack _nameX;         // uniqueness should be guaranteed by base weapon filtering
-    } forEach _categories;
-
-} forEach _allConfigs;
-*/
 while {_allConfigs isNotEqualTo []} do {
     isNil {
-        private _startTime = diag_deltaTime;
-        while {_allConfigs isNotEqualTo [] and diag_deltaTime - _startTime < 0.02} do {
+        private _endTime = diag_tickTime + 0.02;
+        while {_allConfigs isNotEqualTo [] and diag_tickTime < _endTime} do {
  
             _cfg = _allConfigs deleteAt (count _allConfigs - 1);
             _nameX = configName _cfg;
@@ -95,3 +76,26 @@ while {_allConfigs isNotEqualTo []} do {
         };
     };
 };
+
+/*
+// Without the unscheduled optimization, for reference
+{
+    _nameX = configName _x;
+
+    // If in disabledMods, remove. Don't need itemType for this so we do it first
+    _itemMod = _x call A3A_fnc_getModOfConfigClass;
+    if (_itemMod in A3A_disabledMods) then { continue };
+
+    // Filter items by current factions/modset
+    _itemType = _nameX call A3A_fnc_itemType;
+    if !([_x, _itemMod, _itemType] call _fnc_filter) then { continue };
+
+    _categories = [_nameX, _itemType] call A3A_fnc_equipmentClassToCategories;
+    {
+        //We're not returning a default value with getVariable, becuase it *must* be instantiated before now. If it isn't, we *need* it to error.
+        // allweapons, allrifles are pushedback here!!!!
+        (missionNamespace getVariable ("all" + _x)) pushBack _nameX;         // uniqueness should be guaranteed by base weapon filtering
+    } forEach _categories;
+
+} forEach _allConfigs;
+*/

--- a/A3A/addons/core/functions/Templates/fn_loadFaction.sqf
+++ b/A3A/addons/core/functions/Templates/fn_loadFaction.sqf
@@ -55,9 +55,9 @@ private _fnc_saveUnitToTemplate = {
 };
 
 private _fnc_generateAndSaveUnitToTemplate = {
-	params ["_name", "_template", "_loadoutData", ["_traits", []]];
+	params ["_name", "_template", "_loadoutData", "_traits", "_count"];
 	private _loadouts = [];
-	for "_i" from 1 to 5 do {
+	for "_i" from 1 to _count do {
 		_loadouts pushBack ([_template, _loadoutData] call A3A_fnc_loadout_builder);
 	};
 	[_name, _loadouts, _traits] call _fnc_saveUnitToTemplate;
@@ -65,11 +65,27 @@ private _fnc_generateAndSaveUnitToTemplate = {
 
 private _fnc_generateAndSaveUnitsToTemplate = {
 	params ["_prefix", "_unitTemplates", "_loadoutData"];
+
+	while {_unitTemplates isNotEqualTo []} do {
+		isNil {
+			private _endTime = diag_tickTime + 0.02;
+			while {_unitTemplates isNotEqualTo [] and diag_tickTime < _endTime} do {
+				private _unitLine = _unitTemplates deleteAt 0;			// not many of these, array shuffle is cheap
+
+				_unitLine params ["_name", "_template", ["_traits", []], ["_count", 5]];
+				private _finalName = format ["%1_%2", _prefix, _name];
+				[_finalName, _template, _loadoutData, _traits, _count] call _fnc_generateAndSaveUnitToTemplate;
+			};
+		};
+	};
+/*
+	// Without the unscheduled optimization, for reference
 	{
-		_x params ["_name", "_template", ["_traits", []]];
+		_x params ["_name", "_template", ["_traits", []], ["_count", 5]];
 		private _finalName = format ["%1_%2", _prefix, _name];
 		[_finalName, _template, _loadoutData, _traits] call _fnc_generateAndSaveUnitToTemplate;
 	} forEach _unitTemplates;
+*/
 };
 
 private _fnc_saveNames = {


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement
4. [X] Performance

### What have you changed and why?
Ported the unscheduled double-loop optimization to configSort. This effectively increases the per-frame script time allowance from 3ms to 20ms. This reduces startup equipment categorization for a 3CBF (non-ACE) modset from 12 seconds to 2 seconds on my PC.

I don't think this has any additional risks as the code isn't spawned anyway. Gonna think on it a bit though, so maybe not for 3.9.0.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Start a game with a heavy modset, check the time taken. The log entry for this is:
`A3A_fnc_initVarServer | Scanning config entries for items`
