### PR TITLE
Arty rangetable in start gear

### DIFF
--- a/A3A/addons/core/functions/Templates/fn_aceModCompat.sqf
+++ b/A3A/addons/core/functions/Templates/fn_aceModCompat.sqf
@@ -12,7 +12,7 @@ aceItems = [
 	"ACE_MapTools",
 	"ACE_Flashlight_MX991",
 	"ACE_wirecutter",
-	"ACE_RangeTable_82mm",
+	"ACE_artilleryTable",
 	"ACE_PlottingBoard",
 	"ACE_EntrenchingTool",
 	"ACE_Cellphone",


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Information: changes fixed/deprecated 82mm rangetable to universal one that adapts to any nearby pieces
this also works better with modded mortars which may be highly accessible

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: Load the arsenal, has the universal table now