### PR TITLE
Update findBasesForConvoy to use new navgrid-based logic

### DIFF
--- a/A3A/addons/core/functions/Missions/fn_missionRequest.sqf
+++ b/A3A/addons/core/functions/Missions/fn_missionRequest.sqf
@@ -187,14 +187,12 @@ switch (_type) do {
 		};
 		// only do the city convoys on flip?
 		private _markers = (airportsX + resourcesX + factories + seaports + outposts - blackListDest);
-		// Pre-filter the possible source bases to make this less n-squared
-		private _possibleBases = (airportsX + outposts) select { (getMarkerPos _x) distance (getMarkerPos respawnTeamPlayer) < distanceMission + 3000 };
 		private _convoyPairs = [];
 		{
 			private _site = _x;
-			if ((getMarkerPos _site) distance (getMarkerPos respawnTeamPlayer) > distanceMission) then {continue};
-			if (sidesX getVariable [_site, teamPlayer] == teamPlayer) then {continue};
-			private _base = [_site, _possibleBases] call A3A_fnc_findBasesForConvoy;
+			if (markerPos _site distance2d markerPos respawnTeamPlayer > distanceMission) then {continue};
+			if (sidesX getVariable _site == teamPlayer) then {continue};
+			private _base = [_site] call A3A_fnc_findBasesForConvoy;
 			if (_base != "") then {
 				_possibleMarkers pushBack _site;
 				_convoyPairs pushBack [_site, _base];


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Rewrote findBasesForConvoy to use navgrid-based logic properly. findLandSupportMarkers is essentially perfect for this. Will give more reliable results for cases with short direct distance and long paths, like crossing Regero's bridges. Also faster.

### Please specify which Issue this PR Resolves.
closes #3567

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
