### PR TITLE
Fix misplaced camp on Napf plus an incorrect log line

### DIFF
--- a/A3A/addons/core/functions/MinorSites/fn_generateCamps.sqf
+++ b/A3A/addons/core/functions/MinorSites/fn_generateCamps.sqf
@@ -95,7 +95,7 @@ while {true} do {
     } forEach (_sites inAreaArrayIndexes [_pos, CAMP_MAX, CAMP_MAX]);
 };
 
-if (_added != _numToAdd) then {
+if (_added < _numToAdd) then {
     Info_1("Ran out of valid camp positions for %1", _side);
 };
 

--- a/A3A/addons/maps/Antistasi_Napf.Napf/mission.sqm
+++ b/A3A/addons/maps/Antistasi_Napf.Napf/mission.sqm
@@ -41980,7 +41980,7 @@ class Mission
 						class Item119
 						{
 							dataType="Marker";
-							position[]={6710.126,0.00048828125,16964.457};
+							position[]={6721.23,0.00136328,16955.1};
 							name="control_90";
 							markerType="RECTANGLE";
 							type="rectangle";

--- a/A3A/addons/maps/Antistasi_NapfWinter.NapfWinter/mission.sqm
+++ b/A3A/addons/maps/Antistasi_NapfWinter.NapfWinter/mission.sqm
@@ -41985,7 +41985,7 @@ class Mission
 						class Item119
 						{
 							dataType="Marker";
-							position[]={6713.9346,14.515488,16965.604};
+							position[]={6721.23,0.00136328,16955.1};
 							name="control_90";
 							markerType="RECTANGLE";
 							type="rectangle";


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
One specops camp on Napf was placed on the end of a road so it became a roadblock. Fixed. Also fixed one log line that was firing incorrectly.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
