### PR TITLE
Fix controlsX remnant in HQ position setup dialog

### DIFF
--- a/A3A/addons/gui/functions/SetupGUI/fn_setupHQPosDialog.sqf
+++ b/A3A/addons/gui/functions/SetupGUI/fn_setupHQPosDialog.sqf
@@ -37,7 +37,7 @@ switch (_mode) do
     case ("onLoad"):
     {
         // Draw hatched danger zones
-        private _mainMarkers = (markersX - controlsX - ["Synd_HQ"]);
+        private _mainMarkers = markersX - ["Synd_HQ"];
         private _mrkDangerZone = [];
         {
             _mrk = createMarkerLocal [format ["dangerzone%1", count _mrkDangerZone], markerPos _x];


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed now-incorrect use of controlsX in HQ position setup dialog.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
