### PR TITLE
Clean up orphaned towing helpers to prevent log spam

### DIFF
--- a/A3A/addons/config_fixes/Vanilla/CfgVehicles.hpp
+++ b/A3A/addons/config_fixes/Vanilla/CfgVehicles.hpp
@@ -2,6 +2,10 @@
 
 class CfgVehicles 
 {
+    // Just so that we can identify them reliably with typeOf
+    class Land_Can_V2_F;
+    class a3a_tow_helper : Land_Can_V2_F {};
+
 #include "air.hpp"
 #include "armor.hpp"
 #include "ifv.hpp"

--- a/A3A/addons/core/Scripts/fn_advancedTowingInit.sqf
+++ b/A3A/addons/core/Scripts/fn_advancedTowingInit.sqf
@@ -370,7 +370,7 @@ SA_Attach_Tow_Ropes = {
 					[["The tow ropes are too short. Move vehicle closer.", false],"SA_Hint",_player] call SA_RemoteExec;
 				} else {
 					[_vehicle,_player] call SA_Drop_Tow_Ropes;
-					_helper = "Land_Can_V2_F" createVehicle position _cargo;
+					_helper = "a3a_tow_helper" createVehicle position _cargo;
 					_helper attachTo [_cargo, _cargoHitch];
 					_helper setVariable ["SA_Cargo",_cargo,true];
 					hideObject _helper;
@@ -419,7 +419,7 @@ SA_Pickup_Tow_Ropes = {
 			detach _attachedObj;
 			deleteVehicle _attachedObj;
 		} forEach ropeAttachedObjects _vehicle;
-		_helper = "Land_Can_V2_F" createVehicle position _player;
+		_helper = "a3a_tow_helper" createVehicle position _player;
 		{
 			[_helper, [0, 0, 0], [0,0,-1]] ropeAttachTo _x;
 			_helper attachTo [_player, [-0.1, 0.1, 0.15], "Pelvis"];
@@ -730,7 +730,7 @@ SA_Hint = {
 
 SA_Hide_Object_Global = {
 	params ["_obj"];
-	if ( _obj isKindOf "Land_Can_V2_F" ) then {
+	if ( _obj isKindOf "a3a_tow_helper" ) then {
 		hideObjectGlobal _obj;
 	};
 };
@@ -803,6 +803,17 @@ if (hasInterface) then {
 			};
 			missionNamespace setVariable ["SA_Nearby_Tow_Vehicles", (call SA_Find_Nearby_Tow_Vehicles)];
 			sleep 2;
+		};
+	};
+};
+
+if (isServer) then {
+	[] spawn {
+		while {true} do {
+			// Delete any (leftover) helper objects attached to dead or deleted objects
+			private _helpers = 8 allObjects 1 select { typeOf _x == "a3a_tow_helper" };
+			{ if (!alive attachedTo _x) then { deleteVehicle _x } } forEach _helpers;
+			sleep 600;
 		};
 	};
 };


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Added a server-side loop to cleanup orphaned towing helper objects (was Land_Can_V2_F), which should prevent them from occasionally spamming the RPT. The routine's fast (0.07ms here with a lot of units on the server) so I put it on a 10min loop in the towing code rather than relying on the manual GC.

Created a separate object class for the towing helper so that it can be identified quicker and with no risk of mod collisions.

There are more precise ways of managing the helper objects, but they involve multiple killed & deleted object handlers so it's probably not worth the complexity. Maybe when we try rewriting the thing for Arma towing logic.

### Please specify which Issue this PR Resolves.
closes #2543

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Deploy tow ropes, respawn.
Attach other tow ropes to a vehicle. Delete that vehicle.
Wait 10 minutes.

I suspect the cans aren't simulated until their owner client disconnects and they switch back to the server, so normally they don't generate the log spam in testing anyway. Either way this will work.