### PR TITLE
Reduce punishment chance after successful punishment defence

### DIFF
--- a/A3A/addons/core/functions/Base/fn_chooseAttack.sqf
+++ b/A3A/addons/core/functions/Base/fn_chooseAttack.sqf
@@ -15,6 +15,8 @@ params ["_side"];
 
 Info_1("Starting attack choice script for side %1", _side);
 
+// Decrease the punishment defence adjustment a bit each time invaders generate an attack
+if (_side == Invaders) then { A3A_punishmentDefBuff = 0 max (A3A_punishmentDefBuff - 0.25) };
 
 // Make a weighted list of rebel attack targets
 private _targetsAndWeights = [teamPlayer, _side] call A3A_fnc_findAttackTargets;

--- a/A3A/addons/core/functions/Base/fn_findAttackTargets.sqf
+++ b/A3A/addons/core/functions/Base/fn_findAttackTargets.sqf
@@ -94,7 +94,7 @@ private _finalWeights = [];
         // just base this on population?
         private _baseValue = sqrt ((server getVariable _x) # 0);                   // Low-value but threat is probably low too due to lack of garrison
         if (_side == Occupants) exitWith { _baseValue * (1.5 - tierWar / 10) };    // Occupants more likely to care about towns at low tiers
-        _baseValue * (tierWar / 5);                                                // Invaders more likely to care at high tiers
+        _baseValue * (tierWar / 5) / (1 + A3A_punishmentDefBuff);                  // Invaders more likely to care at high tiers but devalued by failed punishments
     } else {
         private _baseValue = call {
             if (_x in outposts) exitWith { [20, 25] select (count (_radioTowers inAreaArray _x) > 0) };

--- a/A3A/addons/core/functions/CREATE/fn_invaderPunish.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_invaderPunish.sqf
@@ -113,6 +113,7 @@ if (({_x call A3A_fnc_canFight} count _soldiers < count _soldiers / 3) or (time 
     [_taskId, "invaderPunish", "SUCCEEDED"] call A3A_fnc_taskSetState;
     [_posDest, 30, 3000] call _fnc_adjustNearCities;
 
+    A3A_punishmentDefBuff = A3A_punishmentDefBuff + 1.25;
     [Occupants, -10, 90] remoteExec ["A3A_fnc_addAggression",2];
     {if (isPlayer _x) then {[10,_x] call A3A_fnc_playerScoreAdd}} forEach ([500,0,_posDest,teamPlayer] call A3A_fnc_distanceUnits);
     [10,theBoss] call A3A_fnc_playerScoreAdd;

--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -259,6 +259,7 @@ if (_varName in _specialVarLoads) then {
         A3A_resourcesDefenceInv = _varValue#1;
         A3A_resourcesAttackOcc = _varValue#2;
         A3A_resourcesAttackInv = _varValue#3;
+        if (count _varValue > 4) then { A3A_punishmentDefBuff = _varValue#4 };
     };
     if (_varname == 'HQKnowledge') then {
         A3A_curHQInfoOcc = _varValue#0;

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -326,7 +326,7 @@ _resDefOcc = _resDefOcc / A3A_balancePlayerScale;
 _resDefInv = _resDefInv / A3A_balancePlayerScale;
 
 // Enemy resources. Could hashmap this instead...
-["enemyResources", [_resDefOcc, _resDefInv, _resAttOcc, _resAttInv]] call A3A_fnc_setStatVariable;
+["enemyResources", [_resDefOcc, _resDefInv, _resAttOcc, _resAttInv, A3A_punishmentDefBuff]] call A3A_fnc_setStatVariable;
 
 // HQ knowledge
 ["HQKnowledge", [A3A_curHQInfoOcc, A3A_curHQInfoInv, A3A_oldHQInfoOcc, A3A_oldHQInfoInv]] call A3A_fnc_setStatVariable;

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -131,6 +131,8 @@ A3A_resourcesDefenceInv = A3A_balanceResourceRate * (A3A_invaderBalanceMul / 10)
 A3A_resourcesAttackOcc = -10 * A3A_balanceResourceRate * (A3A_enemyAttackMul / 10);								// ~100 min to attack
 A3A_resourcesAttackInv = -10 * A3A_balanceResourceRate * (A3A_enemyAttackMul / 10) * (A3A_invaderBalanceMul / 10) * 0.5;	// ~50 min to attack
 
+A3A_punishmentDefBuff = 0;
+
 // HQ knowledge values
 A3A_curHQInfoOcc = 0;			// 0-1 ranges for current HQ
 A3A_curHQInfoInv = 0;


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement
4. [X] Balance

### What have you changed and why?
If rebels don't put garrisons in towns, they can be spammed with punishment attacks even if they're defeating them consistently. This is quite annoying. This PR reduces the chance of punishment attack after a successful defence, gradually increasing again each time invaders decide to do something else.

Tested every code path. Which was a pain.

Could be easily adjusted if the resulting number of punishment attacks is too low.

### Please specify which Issue this PR Resolves.
closes #3578

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
