### PR TITLE
Worst hack ever written

### DIFF
--- a/A3A/addons/core/keybinds/fn_keyActions.sqf
+++ b/A3A/addons/core/keybinds/fn_keyActions.sqf
@@ -16,21 +16,26 @@ switch (_key) do {
     case QGVAR(battleMenu): {
         if (player getVariable ["incapacitated",false]) exitWith {};
         if (player getVariable ["owner",player] != player) exitWith {};
+        if (GVAR(keys_battleMenu)) exitWith {};         // fucking thing actually refires on closeDialog?
+        GVAR(keys_battleMenu) = true; //used to block certain actions when menu is open
 
+        // So what the fuck is going on here? Let's see...
+        // Problem 1: If you open the dialog with the commanding menu open, the map controls cannot be zoomed.
+        // Problem 2: There is no known way to close the commanding menu immediately. It needs to fade out.
+        // Problem 3: The commanding menu will not fade out with a dialog open.
+        // Problem 4: Unless there's a dialog open, the default Y key bind will also open or ping Zeus.
+        // Problem 5: Arma likes to refire the key events when you close a dialog.
+        // tl;dr: Do not rearrange this logic or clowns will eat your children.
         if (A3A_GUIDevPreview) then {
+            createDialog "A3A_dummyDialog";
+            player setVariable ["autoSwitchGroups", hcSelected player];
             [] spawn {
-                if (player == theBoss) then {
-                    player setVariable ["autoSwitchGroups",hcSelected player];
-                    waitUntil { showCommandingMenu ""; hcSelected player isEqualTo [] };
-                };
-                createDialog "A3A_MainDialog";  
-                if (player == theBoss) then {
-                    sleep 1;  
-                    player setVariable ["selHcGroups",[]]; 
-                };
-            };  
+                closeDialog 0;
+                waitUntil { showCommandingMenu ""; hcSelected player isEqualTo [] };
+                createDialog "A3A_MainDialog";
+                sleep 1; GVAR(keys_battleMenu) = false;
+            };
         } else {
-            GVAR(keys_battleMenu) = true; //used to block certain actions when menu is open
     #ifdef UseDoomGUI
             ERROR("Disabled due to UseDoomGUI Switch.")
     #else

--- a/A3A/addons/gui/dialogues/mainDialog.hpp
+++ b/A3A/addons/gui/dialogues/mainDialog.hpp
@@ -4,6 +4,13 @@
 
 #include "ids.inc"
 
+class A3A_DummyDialog
+{
+    idd = -1;
+    // Do we need anything here?
+    class Controls {};
+};
+
 class A3A_MainDialog : A3A_TabbedDialog
 {
     idd = A3A_IDD_MAINDIALOG;


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement
4. [X] Clown fiesta

### What have you changed and why?
Rewrote the battle menu open action so that it no longer generates Zeus pings from players who didn't bother to rebind the key. Zeus seems to ignore the keypress if there's a dialog open, but this clashes with our code to delay opening the battle menu until the commanding menu is closed. The solution is to create a dummy dialog immediately and then close it before opening the real one. However, Arma appears to refire key events sometimes on closing a dialog, causing multiple battle menu UIs to open in quick succession. I have worked around this using a dumb global variable block.

Hopefully this works on other PCs as well. I do not have a whole lot of trust in it.

### Please specify which Issue this PR Resolves.
closes #3578

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Not merging this unless it's been tested on at least five different machines.

### How can the changes be tested?
1. Make sure Zeus is bound to the Y key (or Z if German?)
2. Open the battle menu. Buy a squad.
3. Select the squad in HC mode (ctrl+space, F1).
4. Open the battle menu again.
5. Close the battle menu.

If none of the following things happen then you're probably good:
- Zeus opening.
- Battle menu not showing all the controls.
- Close button reveals another battle menu behind.
