### PR TITLE
Napf town edits, Seap_5_Mortar fix, capitalisation of Napf winter's climate

### DIFF
--- a/A3A/addons/config_fixes/Napf/config.cpp
+++ b/A3A/addons/config_fixes/Napf/config.cpp
@@ -66,6 +66,62 @@ class CfgWorlds {
                 radiusB = 150;
                 type = "NameVillage";
             };
+            class vil_Worb {
+                name = "Worb";
+                position[] = {2523,7656};
+                radiusA = 150;
+                radiusB = 100;
+                type = "NameVillage";
+            };
+            class vil_Horw {
+                name = "Horw";
+                position[] = {17231,13916};
+                radiusA = 100;
+                radiusB = 100;
+                type = "NameVillage";
+            };
+            class vil_Brienz {
+                name = "Brienz";
+                position[] = {14420.4,2956.29};
+                radiusA = 100;
+                radiusB = 100;
+                type = "NameVillage";
+            };
+            class vil_Sissach {
+                name = "Sissach";
+                position[] = {11224.5,8632.69};
+                radiusA = 100;
+                radiusB = 100;
+                type = "NameVillage";
+            };
+            class vil_Luzern {
+                name = "Luzern";
+                position[] = {14503.1,14136.4};
+                radiusA = 200;
+                radiusB = 200;
+                type = "NameCity";
+            };
+            class vil_Muttenz {
+                name = "Muttenz";
+                position[] = {6259.56,10349.7};
+                radiusA = 100;
+                radiusB = 100;
+                type = "NameVillage";
+            };
+            class Hof_Hungerschwand {
+                name = "Hof Hungerschwand";
+                position[] = {9009.93,3397.32};
+                radiusA = 100;
+                radiusB = 100;
+                type = "NameVillage";
+            };
+            class vil_Liestal {
+                name = "Liestal";
+                position[] = {12746.8,9583.47};
+                radiusA = 150;
+                radiusB = 150;
+                type = "NameVillage";
+            };
         };
     };
     class NapfWinter : CAWorld {
@@ -109,6 +165,62 @@ class CfgWorlds {
             class vil_Wasen {
                 name = "Wasen";
                 position[] = {7385.5,15887};
+                radiusA = 150;
+                radiusB = 150;
+                type = "NameVillage";
+            };
+            class vil_Worb {
+                name = "Worb";
+                position[] = {2523,7656};
+                radiusA = 150;
+                radiusB = 100;
+                type = "NameVillage";
+            };
+            class vil_Horw {
+                name = "Horw";
+                position[] = {17231,13916};
+                radiusA = 100;
+                radiusB = 100;
+                type = "NameVillage";
+            };
+            class vil_Brienz {
+                name = "Brienz";
+                position[] = {14420.4,2956.29};
+                radiusA = 100;
+                radiusB = 100;
+                type = "NameVillage";
+            };
+            class vil_Sissach {
+                name = "Sissach";
+                position[] = {11224.5,8632.69};
+                radiusA = 100;
+                radiusB = 100;
+                type = "NameVillage";
+            };
+            class vil_Luzern {
+                name = "Luzern";
+                position[] = {14503.1,14136.4};
+                radiusA = 200;
+                radiusB = 200;
+                type = "NameCity";
+            };
+            class vil_Muttenz {
+                name = "Muttenz";
+                position[] = {6259.56,10349.7};
+                radiusA = 100;
+                radiusB = 100;
+                type = "NameVillage";
+            };
+            class Hof_Hungerschwand {
+                name = "Hof Hungerschwand";
+                position[] = {9009.93,3397.32};
+                radiusA = 100;
+                radiusB = 100;
+                type = "NameVillage";
+            };
+            class vil_Liestal {
+                name = "Liestal";
+                position[] = {12746.8,9583.47};
                 radiusA = 150;
                 radiusB = 150;
                 type = "NameVillage";

--- a/A3A/addons/maps/Antistasi_Napf.Napf/mapInfo.hpp
+++ b/A3A/addons/maps/Antistasi_Napf.Napf/mapInfo.hpp
@@ -1,20 +1,20 @@
 class Napf {
 	population[] = {
 		{"vil_Lenzburg",584},{"vil_Trueb",148},{"vil_Seltisberg",129},{"vil_NeueWelt",144},{"vil_Bubendorf",124},{"vil_Seewen",46},
-		{"vil_Huttwil",134},{"lw_Hagacher",16},{"vil_Oberdorf",69},{"vil_Muttenz",386},{"farm_HofHorn",11},
+		{"vil_Huttwil",134},{"vil_Oberdorf",69},{"vil_Muttenz",386},{"farm_HofHorn",11},
 		{"farm_Elbishof",21},{"farm_Rossbode",31},{"vil_Muenchenstein",368},{"vil_Chatzbach",163},{"vil_Bruderholz",36},{"farm_Aegerifeld",16},
 		{"vil_Freidorf",83},{"vil_Olten",205},{"vil_Ruemlingen",184},{"Hof_KleineEgg",16},{"farm_Eichmatt",10},
 		{"vil_Hirsegg",59},{"Insel_Hasenmatt",5},{"vil_Lausen",121},{"farm_Ey",16},{"farm_Rorighof",6},{"farm_Arxhof",11},{"farm_Ramsebode",12},
 		{"vil_Unterdorf",94},{"vil_Luzern",750},{"vil_Emmen",422},{"vil_Wolhusen",151},{"vil_Horw",152},{"vil_Romoos",48},{"vil_Meggen",68},
 		{"vil_Liestal",274},{"vil_Sachseln",91},{"vil_Sissach",104},{"vil_Buckten",35},{"vil_Eggwil",48},{"Insel_Pfeffikon",36},
 		{"vil_Signau",88},{"vil_Schangen",186},{"vil_Hasle",58},{"vil_Worb",458},{"vil_Munsingen",144},{"vil_Ittingen",152},{"vil_Hindelbank",91},
-		{"Hof_Goms",39},{"Hof_Hungerschwand",12},{"vil_Farnen",38},{"vil_Sorenberg",107},{"farm_Alpnach",15},{"vil_Giswil",44},
+		{"Hof_Goms",39},{"Hof_Hungerschwand",12},{"vil_Farnen",38},{"vil_Sorenberg",107},
 		{"pass_Rorenpass",7},{"Hof_Waldegg",10},{"vil_Brienz",98},{"vil_Nordstern",55},{"vil_Goldwil",20},{"vil_Magden",52},
 		{"vil_Bunig", 100},{"vil_Malters",55},{"vil_Wasen",41},{"vil_Seltishafen",53},{"vil_Abach",46}
 	};
 	disabledTowns[] = {
 		"mil_SouthAirstrip","Island_Feldmoos","Island_Bernerplatte","castle_Homburg","Castle_Froburg","ind_Saegewerk",
-		"for_Teufelsgraben","lw_Ruchfeld","lw_Lochacker","LandMark_Hubel","Insel_Suhrenfeld","Insel_Hasenmatt"
+		"for_Teufelsgraben","lw_Ruchfeld","lw_Lochacker","LandMark_Hubel","Insel_Suhrenfeld","Insel_Hasenmatt","vil_Giswil","farm_Alpnach","lw_Hagacher"
 	};
 	antennas[] = {
 		{10987.7,9465.01,0.0774231},{9135.95,11027.4,-0.783722},{7672.83,9772.95,0.00149536},{8994.92,7573.55,0.0384521},{8994.92,7573.55,-0.444763},{6202.3,10639,-0.000984192},{6186.1,12025.9,-0.0628891},{7919.53,14442.1,0.219131},{15117.9,12586.8,0.00614929},{10898,4404.76,-0.135315},{9393.43,16246.8,-0.00434494},{9393.61,16247,0.0274506},{7021.62,4662.36,0.158585},{5852.23,15093.9,-0.0428619},{9676.3,2933.88,-0.334412},{5258.93,4510.2,-1.52588e-005},{698.401,6726.06,-0.179443},{16327.5,18434.2,-0.105293},{18743.5,2148.42,-0.226135}

--- a/A3A/addons/maps/Antistasi_Napf.Napf/mission.sqm
+++ b/A3A/addons/maps/Antistasi_Napf.Napf/mission.sqm
@@ -17491,7 +17491,7 @@ class Mission
 									class PositionInfo
 									{
 										position[]={16886.121,43.474831,13762.59};
-										angles[]={6.2531958,4.042305,0.015998369};
+										angles[]={0,4.042305,0};
 									};
 									side="Empty";
 									flags=4;
@@ -40402,7 +40402,7 @@ class Mission
 								{
 									dataType="Marker";
 									position[]={14502.611,5.072,2783.48};
-									name="seap_5_mortar";
+									name="outp_25_mortar";
 									markerType="ELLIPSE";
 									type="ellipse";
 									colorName="ColorYellow";

--- a/A3A/addons/maps/Antistasi_NapfWinter.NapfWinter/mapInfo.hpp
+++ b/A3A/addons/maps/Antistasi_NapfWinter.NapfWinter/mapInfo.hpp
@@ -1,20 +1,20 @@
 class NapfWinter {
 	population[] = {
 		{"vil_Lenzburg",584},{"vil_Trueb",148},{"vil_Seltisberg",129},{"vil_NeueWelt",144},{"vil_Bubendorf",124},{"vil_Seewen",46},
-		{"vil_Huttwil",134},{"lw_Hagacher",16},{"vil_Oberdorf",69},{"vil_Muttenz",386},{"farm_HofHorn",11},
+		{"vil_Huttwil",134},{"vil_Oberdorf",69},{"vil_Muttenz",386},{"farm_HofHorn",11},
 		{"farm_Elbishof",21},{"farm_Rossbode",31},{"vil_Muenchenstein",368},{"vil_Chatzbach",163},{"vil_Bruderholz",36},{"farm_Aegerifeld",16},
 		{"vil_Freidorf",83},{"vil_Olten",205},{"vil_Ruemlingen",184},{"Hof_KleineEgg",16},{"farm_Eichmatt",10},
 		{"vil_Hirsegg",59},{"Insel_Hasenmatt",5},{"vil_Lausen",121},{"farm_Ey",16},{"farm_Rorighof",6},{"farm_Arxhof",11},{"farm_Ramsebode",12},
 		{"vil_Unterdorf",94},{"vil_Luzern",750},{"vil_Emmen",422},{"vil_Wolhusen",151},{"vil_Horw",152},{"vil_Romoos",48},{"vil_Meggen",68},
 		{"vil_Liestal",274},{"vil_Sachseln",91},{"vil_Sissach",104},{"vil_Buckten",35},{"vil_Eggwil",48},{"Insel_Pfeffikon",36},
 		{"vil_Signau",88},{"vil_Schangen",186},{"vil_Hasle",58},{"vil_Worb",458},{"vil_Munsingen",144},{"vil_Ittingen",152},{"vil_Hindelbank",91},
-		{"Hof_Goms",39},{"Hof_Hungerschwand",12},{"vil_Farnen",38},{"vil_Sorenberg",107},{"farm_Alpnach",15},{"vil_Giswil",44},
+		{"Hof_Goms",39},{"Hof_Hungerschwand",12},{"vil_Farnen",38},{"vil_Sorenberg",107},
 		{"pass_Rorenpass",7},{"Hof_Waldegg",10},{"vil_Brienz",98},{"vil_Nordstern",55},{"vil_Goldwil",20},{"vil_Magden",52},
 		{"vil_Bunig", 100},{"vil_Malters",55},{"vil_Wasen",41},{"vil_Seltishafen",53},{"vil_Abach",46}
 	};
 	disabledTowns[] = {
 		"mil_SouthAirstrip","Island_Feldmoos","Island_Bernerplatte","castle_Homburg","Castle_Froburg","ind_Saegewerk",
-		"for_Teufelsgraben","lw_Ruchfeld","lw_Lochacker","LandMark_Hubel","Insel_Suhrenfeld","Insel_Hasenmatt"
+		"for_Teufelsgraben","lw_Ruchfeld","lw_Lochacker","LandMark_Hubel","Insel_Suhrenfeld","Insel_Hasenmatt","vil_Giswil","farm_Alpnach","lw_Hagacher"
 	};
 	antennas[] = {
 		{10987.7,9465.01,0.0774231},{9135.95,11027.4,-0.783722},{7672.83,9772.95,0.00149536},{8994.92,7573.55,0.0384521},{8994.92,7573.55,-0.444763},{6202.3,10639,-0.000984192},{6186.1,12025.9,-0.0628891},{7919.53,14442.1,0.219131},{15117.9,12586.8,0.00614929},{10898,4404.76,-0.135315},{9393.43,16246.8,-0.00434494},{9393.61,16247,0.0274506},{7021.62,4662.36,0.158585},{5852.23,15093.9,-0.0428619},{9676.3,2933.88,-0.334412},{5258.93,4510.2,-1.52588e-005},{698.401,6726.06,-0.179443},{16327.5,18434.2,-0.105293},{18743.5,2148.42,-0.226135}

--- a/A3A/addons/maps/Antistasi_NapfWinter.NapfWinter/mapInfo.hpp
+++ b/A3A/addons/maps/Antistasi_NapfWinter.NapfWinter/mapInfo.hpp
@@ -32,7 +32,7 @@ class NapfWinter {
 	fuelStationTypes[] = {
 		"Land_Fuelstation_Feed_F","Land_fs_feed_F","Land_FuelStation_01_pump_F","Land_FuelStation_01_pump_malevil_F","Land_FuelStation_03_pump_F","Land_FuelStation_02_pump_F","Land_Benzina_schnell","Land_A_FuelStation_Feed",
 	};
-	climate = "Arctic";
+	climate = "arctic";
 	buildObjects[] = {
 		{"Land_fortified_nest_big_EP1", 300}, {"Land_Fort_Watchtower_EP1", 300}, {"Fortress2", 200}, {"Fortress1", 100}, {"Fort_Nest", 60},
 		{"Land_Shed_09_F", 120}, {"Land_Shed_10_F", 140}, {"ShedBig", 100}, {"Shed", 100}, {"ShedSmall", 60}, {"Land_GuardShed", 30},

--- a/A3A/addons/maps/Antistasi_NapfWinter.NapfWinter/mission.sqm
+++ b/A3A/addons/maps/Antistasi_NapfWinter.NapfWinter/mission.sqm
@@ -17491,7 +17491,7 @@ class Mission
 									class PositionInfo
 									{
 										position[]={16886.121,43.474831,13762.59};
-										angles[]={6.2531958,4.042305,0.015998369};
+										angles[]={0,4.042305,0};
 									};
 									side="Empty";
 									flags=4;
@@ -40402,7 +40402,7 @@ class Mission
 								{
 									dataType="Marker";
 									position[]={14502.611,5.072,2783.48};
-									name="seap_5_mortar";
+									name="outp_25_mortar";
 									markerType="ELLIPSE";
 									type="ellipse";
 									colorName="ColorYellow";


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why? 
Changes mentioned from the discord
Information: Alpnach, Giswil and Hagacher blacklisted. 
Worb Horw, Brienz, Sissach, Mutternz, Hungerschwand, Luzern and Liestal moved away from outposts or just more to where the marker would be expected.
Seap_5_Mortar changed to it's accompanied outpost name, was missed during the inital changing of markers.
Changed a military towers rotation.
    

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: Load branch, check town postions. RPT no longer shows error for marker.

********************************************************
Notes:
