### PR TITLE
Various gunshop/supply drop edge case fixes:

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_setCargoItems.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_setCargoItems.sqf
@@ -23,5 +23,7 @@ clearBackpackCargoGlobal _vehicle;
     sleep 0.01;    // sleep here in case someone buys 1000 of something
 } forEach _items;
 
-private _reqMaxLoad = load _vehicle * maxLoad _vehicle;
-[_vehicle, _reqMaxLoad] remoteExec ["setMaxLoad", 2];
+if (load _vehicle > 1) then {
+    private _reqMaxLoad = load _vehicle * maxLoad _vehicle;
+    [_vehicle, _reqMaxLoad] remoteExec ["setMaxLoad", 2];
+};

--- a/A3A/addons/core/functions/Missions/fn_GSMission.sqf
+++ b/A3A/addons/core/functions/Missions/fn_GSMission.sqf
@@ -41,7 +41,7 @@ private _identity = createHashMapFromArray [
     ["pitch", 1.1]
 ];
 
-private _coolerPetros = [createGroup teamPlayer, FactionGet(reb,"unitPetros"), getMarkerPos _city, [], 10, "NONE", _identity] call A3A_fnc_createUnit;
+private _coolerPetros = [createGroup [teamPlayer, true], FactionGet(reb,"unitPetros"), getMarkerPos _city, [], 10, "NONE", _identity] call A3A_fnc_createUnit;
 // copy his drip. 
 private _notCoolPetrosLoadout = getUnitLoadout petros;
 _coolerPetros setUnitLoadout _notCoolPetrosLoadout;
@@ -180,4 +180,10 @@ sleep 5;
 [_dropPos, _gunshopList, _patrolGroup] spawn A3A_fnc_supplyDrop;
 
 _coolerPetros enableAI "ALL";
-[group _coolerPetros] spawn A3A_fnc_groupDespawner;
+
+// Custom despawner because it's a weird case. Solomon vanishes back into the shadows once players are gone.
+while {true} do {
+    sleep 10;
+    private _players = allPlayers - entities "HeadlessClient_F";
+    if (_players inAreaArray [getPosATL _coolerPetros, 200, 200] isEqualTo []) exitWith { deleteVehicle _coolerPetros };
+};


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Various edge case fixes:
- Make Solomon despawn as soon as players are 200m away.
- Run supply drop cleanup if items in the box are changed.
- Don't set crate maximum load below default.

### Please specify which Issue this PR Resolves.
closes #3583

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
