### PR TITLE
Reduce Osprey speed before combat landing

### DIFF
--- a/A3A/addons/core/functions/AI/fn_combatLanding.sqf
+++ b/A3A/addons/core/functions/AI/fn_combatLanding.sqf
@@ -31,6 +31,8 @@ _vehWP0 setWaypointBehaviour "CARELESS";
 private _midHeight = [100, 150] select (A3A_climate isEqualTo "tropical");
 _helicopter flyInHeight _midHeight;
 
+waitUntil {sleep 1; (_helicopter distance2D _landPos) < 1500};
+_helicopter limitSpeed 250;         // just so the Osprey slows down a bit, really
 waitUntil {sleep 1; (_helicopter distance2D _landPos) < 600};
 
 _helicopter flyInHeight 0;                  // helps to keep it near the ground after landing


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Used limitSpeed to cap transport heli speeds once they're within 1.5km of the objective. Shouldn't do anything noticeable to normal helis but makes Ospreys look a lot more plausible.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
`["UK3CB_B_Osprey_USMC_WD", "Normal", "defence", [], Occupants, "airport_3", markerPos "Sachseln"] call A3A_fnc_createAttackVehicle;`
