### PR TITLE
Not the final baseWeapon fix

### DIFF
--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_addItem.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_addItem.sqf
@@ -31,8 +31,9 @@ if(typeName (_this select 0) isEqualTo "SCALAR")then{//[_index, _item] and [_ind
 				if!(_radioName isEqualTo "")then{_item = _radioName};
 
 				//Weapon Stack fix
-				private _weaponname = _item call bis_fnc_baseWeapon;
-				if!(_weaponname isEqualTo "")then{_item = _weaponname};
+				if (isClass (configFile >> "CfgWeapons" >> _item)) then {
+					_item = _item call bis_fnc_baseWeapon;
+				};
 
 				//RHS Sight Stack fix
 				private _sightname = getText(configfile >> "CfgWeapons" >> _item >> "rhs_optic_base");

--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_loadInventory.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_loadInventory.sqf
@@ -195,11 +195,10 @@ _assignedItems = ((_inventory select 9) + [_inventory select 3] + [_inventory se
 			_item =_radioName;
 		};
 		
-        //Weapon Stack fix
-        private _weaponname = _item call bis_fnc_baseWeapon;
-        if!(_weaponname isEqualTo "")then{
-            _item = _weaponname
-        };
+		//Weapon Stack fix
+		if (isClass (configFile >> "CfgWeapons" >> _item)) then {
+			_item = _item call bis_fnc_baseWeapon;
+		};
 
         //RHS Sight Stack fix
         private _sightname = getText(configfile >> "CfgWeapons" >> _item >> "rhs_optic_base");


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
BIS_fnc_baseWeapon was being called on things that were not necessarily items from CfgWeapons, causing it to spam errors into the log. This PR fixes it.

Tested with various gear including non-base weapons. Seems fine. BIS_fnc_baseWeapon returns the input classname by default so you don't need to test the return.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
