### PR TITLE
Remove invisible map icon usage with 360 angle trick

### DIFF
--- a/A3A/addons/gui/functions/GUI/fn_mapDrawHcGroupsEH.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_mapDrawHcGroupsEH.sqf
@@ -62,7 +62,7 @@ _map setVariable ["hcGroupData", _hcGroupData];
         "_groupIconColor"
     ];
 
-    private _position = getPos leader _group;
+    private _position = getPosATL leader _group;
 
     // Shorten group name if it's over 16 characters
     if (count _groupID > 16) then
@@ -77,9 +77,9 @@ _map setVariable ["hcGroupData", _hcGroupData];
         _position, // position
         32, // width
         32, // height
-        0, // angle
-        "", // text, no text for this
-        0 // shadow (outline if 2)
+        360, // angle
+        _groupID, // text, no text for this
+        2 // shadow (outline if 2)
     ];
 
     // Draw size indicator
@@ -104,16 +104,4 @@ _map setVariable ["hcGroupData", _hcGroupData];
         0 // shadow (outline if 2)
     ];
 
-
-    // Draw group name text
-    _map drawIcon [
-        "#(argb,1,1,1)color(0,0,0,0)", // transparent
-        _groupIconColor, // colour
-        _position, // position
-        32, // width
-        32, // height
-        0, // angle
-        _groupID, // text
-        2 // shadow (outline if 2)
-    ];
 } forEach _hcGroupData;

--- a/A3A/addons/gui/functions/GUI/fn_mapDrawOutpostsEH.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_mapDrawOutpostsEH.sqf
@@ -64,28 +64,14 @@ private _sideFadeHM = keys _sideColorHM createHashMapFromArray (values _sideColo
 private _colorBlack = [A3A_COLOR_BLACK] call FUNC(configColorToArray);
 
 private _fnc_drawIcon = {
-    params ["_pos", "_color", "_icon"];
+    params ["_pos", "_color", "_icon", "_name"];
     _map drawIcon [
         _icon, // texture
         _color,
         _pos,
         _markerSize, // width
         _markerSize, // height
-        0, // angle
-        "", // text
-        0 // shadow (outline if 2)
-    ];
-};
-
-private _fnc_drawLabel = {
-    params ["_pos", "_color", "_name"];
-    _map drawIcon [
-        "#(argb,1,1,1)color(0,0,0,0)", // the icon itself is transparent
-        _color, // colour
-        _pos, // position
-        _markerSize, // width
-        _markerSize, // height
-        0, // angle
+        360, // angle: non-zero means it won't be outlined?
         _name, // text
         2 // shadow (outline if 2)
     ];
@@ -96,14 +82,12 @@ private _fnc_drawMarkers = {
 
     // cull to window boundaries
     _markers = _markers inAreaArrayIndexes [_mapCenter, _mapWidth, _mapHeight, 0, true] apply {_markers#_x};
-    if (_mapScale >= _fadeEnd) then { _icon = A3A_Icon_Map_Blank };
+    if (_mapScale >= _fadeEnd) then { _icon = A3A_Icon_Map_Blank; _name = "" };
 
     {
         private _side = sidesX getVariable _x;
         private _pos = markerPos _x;
-        [_pos, _sideColorHM get _side, _icon] call _fnc_drawIcon;
-        if (_mapScale >= _fadeEnd) then { continue };
-        [_pos, _sideFadeHM get _side, _name] call _fnc_drawLabel;
+        [_pos, _sideColorHM get _side, _icon, _name] call _fnc_drawIcon;
     } forEach _markers;
 };
 
@@ -123,9 +107,7 @@ private _cityIcon = [A3A_Icon_Map_City, A3A_Icon_Map_Blank] select (_mapScale >=
 {
     private _color = _sideColorHM get (sidesX getVariable _x);
     if (_x in destroyedSites) then { _color = _colorBlack };
-    [markerPos _x, _color, _cityIcon] call _fnc_drawIcon;
-    [markerPos _x, _color, _x] call _fnc_drawLabel;
+    [markerPos _x, _color, _cityIcon, _x] call _fnc_drawIcon;
 } forEach _visCities;
 
-[markerPos "Synd_HQ", [0,1,0,1], A3A_Icon_Map_HQ] call _fnc_drawIcon;
-[markerPos "Synd_HQ", [0,1,0,1], "HQ"] call _fnc_drawLabel;
+[markerPos "Synd_HQ", [0,1,0,1], A3A_Icon_Map_HQ, "HQ"] call _fnc_drawIcon;


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Simplified some UI icon drawing code by using a 360 degree icon angle to block outlining rather than two draw calls. Should be faster and is a potential (unlikely again) crash fix, as it removes the one-pixel dynamic icons.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
