### PR TITLE
IFA Config Fix, Supply/Box truck and IFA ammunition adjustments

### DIFF
--- a/A3A/addons/config_fixes/IFA/CfgAmmo.hpp
+++ b/A3A/addons/config_fixes/IFA/CfgAmmo.hpp
@@ -1,6 +1,12 @@
 // IFA - CfgAmmo.hpp
 
 class CfgAmmo {
+
+    class LIB_Bullet_Vehicle_base;
+    class LIB_B_127x99_Ball : LIB_Bullet_Vehicle_base {
+        caliber = 1.43;
+        hit = 20;
+    };
     // Buffs to bring mortar effectiveness against unarmoured somewhere near vanilla against armoured
     class Sh_82mm_AMOS;
     class LIB_Sh_82_HE : Sh_82mm_AMOS {

--- a/A3A/addons/config_fixes/IFA/CfgAmmo.hpp
+++ b/A3A/addons/config_fixes/IFA/CfgAmmo.hpp
@@ -1,11 +1,23 @@
 // IFA - CfgAmmo.hpp
 
-class CfgAmmo {
 
+class CfgAmmo {
+    class LIB_Bullet_Plane_base;
+    class LIB_Bullet_AP_base;
     class LIB_Bullet_Vehicle_base;
+
     class LIB_B_127x99_Ball : LIB_Bullet_Vehicle_base {
         caliber = 1.43;
         hit = 20;
+    };
+    class LIB_B_37mm_61k_AP : LIB_Bullet_AP_base {
+        ace_vehicle_damage_incendiary = 0.5;
+        caliber = 3.0;
+    };
+    class LIB_B_37mm_AP : LIB_Bullet_Plane_base {
+        ace_vehicle_damage_incendiary = 0.5;
+        indirectHit = 4;
+        indirectHitRange = 3;
     };
     // Buffs to bring mortar effectiveness against unarmoured somewhere near vanilla against armoured
     class Sh_82mm_AMOS;

--- a/A3A/addons/config_fixes/IFA/CfgVehicles.hpp
+++ b/A3A/addons/config_fixes/IFA/CfgVehicles.hpp
@@ -20,6 +20,7 @@ class CfgVehicles
 	class a3a_lib_Zis6_BOX : LIB_Zis6_Parm {
 		displayName = "ZIS-5V (Box)";
 		transportRepair = 0;
+		ace_repair_canRepair = 0;
 		typicalCargo[] = {"LIB_FFI_LAT_Soldier"};
 		faction = "LIB_FFI";
 		side = 2;

--- a/A3A/addons/config_fixes/IFA/CfgVehicles.hpp
+++ b/A3A/addons/config_fixes/IFA/CfgVehicles.hpp
@@ -38,9 +38,17 @@ class CfgVehicles
 	class HMG_02_high_base_F;
 	class B_G_HMG_02_high_F : HMG_02_high_base_F{
 		class AnimationSources;
+		class Turrets;
 	};
-	class a3a_hmg_02_high : B_G_HMG_02_high_F{
-		displayName = ".50 M2HB (Raised)";
+	class a3a_hmg_02_high_base : B_G_HMG_02_high_F{
+		scope = 0;
+		class Turrets : Turrets{
+			class MainTurret;
+		};
+	};
+	class a3a_hmg_02_high : a3a_hmg_02_high_base{
+		scope = 2;
+		displayName = ".50 M2HB (AA Tripod)";
 		class AnimationSources : AnimationSources{
 			class Hide_Shield {
 				animPeriod = 0.01;
@@ -53,6 +61,32 @@ class CfgVehicles
 				initPhase = 1;
 				source = "user";
 				useSource = 1;
+			};
+			class Revolving {
+				source = "revolving";
+				weapon = "LIB_M2";
+			};
+			class muzzle_source {
+				source = "reload";
+				weapon = "LIB_M2";
+			};
+			class muzzle_source_rot {
+				source = "ammorandom";
+				weapon = "LIB_M2";
+			};
+			class ReloadAnim {
+				source = "reload";
+				weapon = "LIB_M2";
+			};
+			class ReloadMagazine {
+				source = "reloadmagazine";
+				weapon = "LIB_M2";
+			};
+		};
+		class Turrets : Turrets{
+			class MainTurret : MainTurret{
+				magazines[] = {"LIB_100Rnd_127x99_M2","LIB_100Rnd_127x99_M2","LIB_100Rnd_127x99_M2","LIB_100Rnd_127x99_M2"};
+				weapons[] = {"LIB_M2"};
 			};
 		};
 		animationList[] ={};


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Makes the bespoke supply truck class not count as a repair vehicle with ACE

Reduced calibre and hit of LIB_B_127x99_Ball as it was overkill.
Made the AA mount .50 cal use the IFA gun and ammo.

Reduced calibre on the 37mm 61k AP ammo as it was killing heavy tanks easily.

marginally buffed the 37mm cannon ammo from the Airacobra

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
the 61k may be made buyable to the rebels again, possibly

********************************************************
Notes:
