### PR TITLE
Fix RHS M252 appearing in armour category in garage

### DIFF
--- a/A3A/addons/garage/Core/fn_getCatIndex.sqf
+++ b/A3A/addons/garage/Core/fn_getCatIndex.sqf
@@ -37,6 +37,9 @@ switch (true) do {
     case ([_class] call HR_GRG_fnc_isAmmoSource): { 6 };
     case ([_class] call HR_GRG_fnc_isFuelSource): { 6 };
     case ([_class] call HR_GRG_fnc_isRepairSource): { 6 };
+
+    case (_class isKindOf "staticWeapon"): { 7 };   //some non-vanilla artillery is statics
+
     case (_editorCat isEqualTo "EdSubcat_Cars"): { [_class] call HR_GRG_isCivilian }; // Returns 0 (undercover) or 1 (not undercover) 
     case (_editorCat in ["EdSubcat_Tanks","EdSubcat_APCs","EdSubcat_AAs","EdSubcat_Artillery"]): { 2 };
     case (_editorCat in ["EdSubcat_Helicopters"]): { 3 };
@@ -62,7 +65,6 @@ switch (true) do {
     case (_class isKindOf "Helicopter"): { 3 };
     case (_class isKindOf "Plane"): { 4 };
     case (_class isKindOf "Ship"): { 5 };
-    case (_class isKindOf "staticWeapon"): { 7 }; //some non-vanilla artillery is statics
 
     default { -1 };
 };


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The RHS M252 mortar and possibly some other non-vanilla static weapons were being placed in the armour category rather than the statics category in the garage. Changed the check order to fix it. I don't think it'll break anything else.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

