### PR TITLE
Preload map icons in attempt to workaround Arma crash bug

### DIFF
--- a/A3A/addons/gui/dialogues/mainDialog.hpp
+++ b/A3A/addons/gui/dialogues/mainDialog.hpp
@@ -7,8 +7,57 @@
 class A3A_DummyDialog
 {
     idd = -1;
-    // Do we need anything here?
-    class Controls {};
+    // Dumbass attempt to stop Arma crashing in map icon code: Preload the damned things.
+    class Controls {
+        class icon_0 : A3A_Picture {
+            text = A3A_Icon_Map_Airport;
+            colorText[] = {1,1,1,0.1};
+            x = 0;
+            y = 0;
+            w = 32*pixelW;
+            h = 32*pixelH;
+        };
+        class icon_1 : icon_0 {
+            text = A3A_Icon_Map_Outpost;
+            x = 32*pixelW;
+        };
+        class icon_2 : icon_0 {
+            text = A3A_Icon_Map_Seaport;
+            x = 64*pixelW;
+        };
+        class icon_3 : icon_0 {
+            text = A3A_Icon_Map_Factory;
+            x = 96*pixelW;
+        };
+        class icon_4 : icon_0 {
+            text = A3A_Icon_Map_Resource;
+            x = 128*pixelW;
+        };
+        class icon_5 : icon_0 {
+            text = A3A_Icon_Map_City;
+            x = 160*pixelW;
+        };
+        class icon_6 : icon_0 {
+            text = A3A_Icon_Map_Roadblock;
+            x = 192*pixelW;
+        };
+        class icon_7 : icon_0 {
+            text = A3A_Icon_Map_Watchpost;
+            x = 224*pixelW;
+        };
+        class icon_8 : icon_0 {
+            text = A3A_Icon_Map_HQ;
+            x = 256*pixelW;
+        };
+        class icon_9 : icon_0 {
+            text = A3A_Icon_Map_Blank;
+            x = 288*pixelW;
+        };
+        class icon_10 : icon_0 {
+            text = A3A_Select_Marker;
+            y = 32*pixelH;
+        };
+    };
 };
 
 class A3A_MainDialog : A3A_TabbedDialog


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement
4. [X] Fuck Arma

### What have you changed and why?
Preload most map icons in a desperate speculative attempt to stop rare Arma crashes on map icon rendering. Don't know whether it's a valid idea or not. Did the rendering in the dummy menu that's used as part of the battle menu opening hack, so it should definitely render before any map icon drawing.

This doesn't preload the high command map icons because they're a lot trickier to look up. They're also routinely shown on the main map to players using high command so hopefully less risk.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
