### PR TITLE
Change UI setting to a per-user toggle in game options

### DIFF
--- a/A3A/addons/core/Params.hpp
+++ b/A3A/addons/core/Params.hpp
@@ -570,11 +570,4 @@ class Params
         texts[] = {$STR_A3A_Params_generic_none, $STR_A3A_Params_logDebugConsole_nondev, $STR_A3A_Params_generic_all};
         default = 1;
     };
-    class A3A_GUIDevPreview
-    {
-        title = $STR_A3A_Params_GUIDevPreview_title;
-        values[] = {0,1};
-        texts[] = {$STR_antistasi_dialogs_generic_button_no_tooltip, $STR_antistasi_dialogs_generic_button_yes_text};
-        default = 0;
-    };
 };

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -13070,6 +13070,12 @@
         <Turkish>Performansı etkiler. Lütfen bunu dikkatli kullanın. Antistasi'nin kötü çalıştığını düşünüyorsanız daha düşük mesafelere ayarlayın.</Turkish>
         <Chinesesimp>影响性能。请小心使用。如果你觉得 Antistasi 运行不够流畅, 把它调到更低的距离。</Chinesesimp>
       </Key>
+      <Key ID="STR_antistasi_dialogs_maps_toggle_ui">
+        <Original>Toggle UI mode</Original>
+      </Key>
+      <Key ID="STR_antistasi_dialogs_maps_toggle_ui_tooltip">
+        <Original>Switch between opening old and new UI dialogs by default.</Original>
+      </Key>
     </Container>
     <Container name="gameMode_menu">
       <Key ID="STR_antistasi_dialogs_gameMode_menu">

--- a/A3A/addons/core/dialogs.hpp
+++ b/A3A/addons/core/dialogs.hpp
@@ -874,13 +874,13 @@ class game_options 		{
 		class 8slots_L2: A3A_core_BattleMenuRedButton
 		{
 			idc = -1;
-			text = "";	//$STR_antistasi_dialogs_maps_ai_limiter;
+			text = $STR_antistasi_dialogs_maps_toggle_ui;
 			x = 0.272481 * safezoneW + safezoneX;
 			y = 0.415981 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
-			tooltip = "";	//$STR_antistasi_dialogs_maps_ai_limiter_tooltip;
-			//action = "if (call BIS_fnc_admin > 0 || isServer) then {closeDialog 0; nul = createDialog ""fps_limiter""} else {[""AI Limiter"", ""Only admins have access to this function.""] call A3A_fnc_customHint;};";
+			tooltip = $STR_antistasi_dialogs_maps_toggle_ui_tooltip;
+			action = "A3A_GUIDevPreview = !A3A_GUIDevPreview; profileNamespace setVariable ['AntistasiUseNewUI', A3A_GUIDevPreview]; ['UI toggle', format ['Switching to the %1 UI', ['old', 'new'] select A3A_GUIDevPreview]] call A3A_fnc_customHint;";
 		};
 		class 8slots_R2: A3A_core_BattleMenuRedButton
 		{

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -108,6 +108,7 @@ player setVariable ["punish",0,true];
 player setVariable ["eligible",player call A3A_fnc_isMember,true];
 player setVariable ["A3A_playerUID",getPlayerUID player,true];			// Mark so that commander routines know for remote-controlling
 
+A3A_GUIDevPreview = profileNamespace getVariable ["AntistasiUseNewUI", true];
 musicON = false;
 recruitCooldown = 0;			//Prevents units being recruited too soon after being dismissed.
 incomeRep = false;


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Switched the old/new UI switch from a global parameter to a per-user setting, which can be toggled live in the game options menu on the map board. Kinda janky but it'll do what we need. The global parameter was bad if specific players are running into issues with the new UI and want to switch back.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
