### PR TITLE
Airstrike/Napalm Nerfs

### DIFF
--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -2366,8 +2366,8 @@
       </Key>
       <Key ID="STR_A3A_fn_base_statistics_isComm">
         <Original>Rank: %5 | HR: %1 | Your Money: %6 € | %10 Money: %2 € | %8 Aggr: %3 | %9 Aggr: %4 | War Level: %7 | Undercover Mode: %11</Original>
-        <Korean>계급: %5 | 인력: %1 | 당신의 자금: %6 € | %11의 자금: %2 € | 공습: %7 | %9 공격성: %3 | %10 공격성: %4 | 전쟁 레벨: %8 | 위장 모드: %12</Korean>
-        <Russian>Ранг: %5 | HR: %1 | Ваши деньги: %6 € | Деньги %11: %2 € | Авиаудары: %7 | %9 Агрессия: %3 | %10 Агрессия: %4 | Уровень войны: %8 | Режим скрытности: %12</Russian>
+        <Korean>계급: %5 | 인력: %1 | 당신의 자금: %6 € | %10의 자금: %2 € | %8 공격성: %3 | %9 공격성: %4 | 전쟁 레벨: %7 | 위장 모드: %11</Korean>
+        <Russian>Ранг: %5 | HR: %1 | Ваши деньги: %6 € | Деньги %10: %2 € | %8 Агрессия: %3 | %9 Агрессия: %4 | Уровень войны: %7 | Режим скрытности: %11</Russian>
       </Key>
       <Key ID="STR_A3A_fn_base_statistics_notComm">
         <Original>Commander: %3 | Rank: %2 | HR: %1 | Your Money: %4 € | %8 Aggr: %5 | %9 Aggr: %6 | War Level: %7 | Undercover Mode: %10</Original>

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -2365,7 +2365,7 @@
         <Chinesesimp>载具已出售</Chinesesimp>
       </Key>
       <Key ID="STR_A3A_fn_base_statistics_isComm">
-        <Original>Rank: %5 | HR: %1 | Your Money: %6 € | %11 Money: %2 € | Airstrikes: %7 | %9 Aggr: %3 | %10 Aggr: %4 | War Level: %8 | Undercover Mode: %12</Original>
+        <Original>Rank: %5 | HR: %1 | Your Money: %6 € | %10 Money: %2 € | %8 Aggr: %3 | %9 Aggr: %4 | War Level: %7 | Undercover Mode: %11</Original>
         <Korean>계급: %5 | 인력: %1 | 당신의 자금: %6 € | %11의 자금: %2 € | 공습: %7 | %9 공격성: %3 | %10 공격성: %4 | 전쟁 레벨: %8 | 위장 모드: %12</Korean>
         <Russian>Ранг: %5 | HR: %1 | Ваши деньги: %6 € | Деньги %11: %2 € | Авиаудары: %7 | %9 Агрессия: %3 | %10 Агрессия: %4 | Уровень войны: %8 | Режим скрытности: %12</Russian>
       </Key>
@@ -6498,6 +6498,9 @@
         <Czech>Ty a letecké vozidlo musí být v oblasti %1 letiště nebo HQ aby jsi ho mohl převést na body leteckého úderu.</Czech>
         <Chinesesimp>你在友军控制范围内的机场或者总部才能将空中载具转换成空中打击.</Chinesesimp>
       </Key>
+      <Key ID="STR_A3A_fn_reinf_bombrun_no_cap">
+        <Original>You cannot convert this vehicle as it would give you %1 airstrike points, which brings you over the cap of %2 points.</Original>
+      </Key>
       <Key ID="STR_A3A_fn_reinf_bombrun_no_destr">
         <Original>You can't convert a destroyed Air vehicle to Airstrikes.</Original>
         <Italian>Non puoi convertire Velivoli distrutt in Attacchi Aerei.</Italian>
@@ -7226,6 +7229,9 @@
         <Polish>Aby spełnić tą prośbe, musisz kontrolować lotnisko.</Polish>
         <Czech>Pro splnění tohoto požadavku musíte ovládat letiště.</Czech>
         <Chinesesimp>该请求要求你控制最起码一座机场.</Chinesesimp>
+      </Key>
+      <Key ID="STR_A3A_fn_reinf_NatoBomb_no_distanceHQ">
+        <Original>Airstrike called off, this position is too close to HQ.</Original>
       </Key>
       <Key ID="STR_A3A_fn_reinf_NatoBomb_no_radio">
         <Original>You need a radio in your inventory to be able to give orders to other squads.</Original>

--- a/A3A/addons/core/functions/AI/fn_airbomb.sqf
+++ b/A3A/addons/core/functions/AI/fn_airbomb.sqf
@@ -10,7 +10,7 @@ FIX_LINE_NUMBERS()
 Debug_1("Executing on: %1", clientOwner);
 
 //Ensure reasonable bomb run lenght
-if(_bombRunLength < 100) then {_bombRunLength = 100};
+if(_bombRunLength < 40) then {_bombRunLength = 40};
 
 private _ammo = "";
 private _bombOffset = 0;

--- a/A3A/addons/core/functions/AI/fn_airbomb.sqf
+++ b/A3A/addons/core/functions/AI/fn_airbomb.sqf
@@ -10,7 +10,8 @@ FIX_LINE_NUMBERS()
 Debug_1("Executing on: %1", clientOwner);
 
 //Ensure reasonable bomb run lenght
-if(_bombRunLength < 40) then {_bombRunLength = 40};
+private _minLength = [100,40] select (_bombType isEqualTo "NAPALM");
+_bombRunLength = _bombRunLength max _minLength;
 
 private _ammo = "";
 private _bombOffset = 0;

--- a/A3A/addons/core/functions/Base/fn_statistics.sqf
+++ b/A3A/addons/core/functions/Base/fn_statistics.sqf
@@ -26,7 +26,7 @@ if (_player != theBoss) then
 	}
 else
 	{
-	_textX = format ["<t size='0.67' shadow='2'>" + localize "STR_A3A_fn_base_statistics_isComm", (server getVariable "hr") toFixed 0, (server getVariable "resourcesFIA") toFixed 0, [aggressionLevelOccupants] call A3A_fnc_getAggroLevelString,[aggressionLevelInvaders] call A3A_fnc_getAggroLevelString,rank _player, (_player getVariable "moneyX") toFixed 0,floor bombRuns,tierWar,FactionGet(occ,"name"),FactionGet(inv,"name"),FactionGet(reb,"name"),_ucovertxt];
+	_textX = format ["<t size='0.67' shadow='2'>" + localize "STR_A3A_fn_base_statistics_isComm", (server getVariable "hr") toFixed 0, (server getVariable "resourcesFIA") toFixed 0, [aggressionLevelOccupants] call A3A_fnc_getAggroLevelString,[aggressionLevelInvaders] call A3A_fnc_getAggroLevelString,rank _player, (_player getVariable "moneyX") toFixed 0,tierWar,FactionGet(occ,"name"),FactionGet(inv,"name"),FactionGet(reb,"name"),_ucovertxt];
 	};
 
 //if (captive player) then {_textX = format ["%1 ON",_textX]} else {_textX = format ["%1 OFF",_textX]};

--- a/A3A/addons/core/functions/REINF/fn_NATObomb.sqf
+++ b/A3A/addons/core/functions/REINF/fn_NATObomb.sqf
@@ -53,8 +53,11 @@ positionTel = [];
 private _posHQ = markerPos "Synd_HQ";
 ServerInfo_6("Commander %1 [%2] called %3 airstrike from %4 to %5, %6m from HQ", name theBoss, getPlayerUID theBoss, _typeX, _pos1, _pos2, _pos1 distance _posHQ);
 
-if ((tkPunish > 0) && (((_pos1 distance2D _posHQ) < 100) || ((_pos2 distance2D _posHQ) < 100))) exitWith {
+private _distanceToHQ = ((abs (((_pos2#1 - _pos1#1) * _posHQ#0) - ((_pos2#0 - _pos1#0) * _posHQ#1) + (_pos2#0 * _pos1#1) - (_pos2#1 * _pos1#0))) / (sqrt (((_pos2#1 - _pos1#1)^2) + ((_pos2#0 - _pos1#0)^2))));
+
+if ((tkPunish > 0) && (_distanceToHQ < 100)) exitWith {
     [_titleStr, localize "STR_A3A_fn_reinf_NatoBomb_no_distanceHQ"] call A3A_fnc_customHint;
+    deleteMarkerLocal _mrkOrig;
     ServerInfo("Rebel airstrike canceled due to distance from HQ");
 };
 

--- a/A3A/addons/core/functions/REINF/fn_NATObomb.sqf
+++ b/A3A/addons/core/functions/REINF/fn_NATObomb.sqf
@@ -51,9 +51,22 @@ _pos2 = positionTel;
 positionTel = [];
 
 private _posHQ = markerPos "Synd_HQ";
-ServerInfo_6("Commander %1 [%2] called %3 airstrike from %4 to %5, %6m from HQ", name theBoss, getPlayerUID theBoss, _typeX, _pos1, _pos2, _pos1 distance _posHQ);
+_posHQ set [2,0]; // convert to 3d for vector calc
+private _distanceToHQ = [_pos1, _pos2, _posHQ] call {
+    // Find closest approach of A->B to C
+    params ["_posA", "_posB", "_posC"];
 
-private _distanceToHQ = ((abs (((_pos2#1 - _pos1#1) * _posHQ#0) - ((_pos2#0 - _pos1#0) * _posHQ#1) + (_pos2#0 * _pos1#1) - (_pos2#1 * _pos1#0))) / (sqrt (((_pos2#1 - _pos1#1)^2) + ((_pos2#0 - _pos1#0)^2))));
+    private _relA = _posC vectorDiff _posA;
+    private _relB = _posC vectorDiff _posB;
+    private _dir = _posA vectorFromTo _posB;
+
+    if (_relA vectorDotProduct _dir <= 0) exitWith { _posA distance _posC };
+    if (_relB vectorDotProduct _dir >= 0) exitWith { _posB distance _posC };
+    vectorMagnitude (_relA vectorCrossProduct _dir);
+};
+
+ServerInfo_6("Commander %1 [%2] called %3 airstrike from %4 to %5, %6m from HQ", name theBoss, getPlayerUID theBoss, _typeX, _pos1, _pos2, _distanceToHQ);
+
 
 if ((tkPunish > 0) && (_distanceToHQ < 100)) exitWith {
     [_titleStr, localize "STR_A3A_fn_reinf_NatoBomb_no_distanceHQ"] call A3A_fnc_customHint;

--- a/A3A/addons/core/functions/REINF/fn_addBombRun.sqf
+++ b/A3A/addons/core/functions/REINF/fn_addBombRun.sqf
@@ -47,6 +47,13 @@ _pointsX = 2;
 
 if (_typeX in (FactionGet(all,"vehiclesHelisAttack") + FactionGet(all,"vehiclesHelisLightAttack"))) then {_pointsX = 5};
 if (_typeX in (OccAndInv("vehiclesPlanesCAS") + OccAndInv("vehiclesPlanesAA"))) then {_pointsX = 10};
+
+private _strikeCap = (4 + tierWar*2); // 10 when you unlock airstrikes, enough for a single CAS plane to be converted. 24 at WL10
+if ((floor bombRuns + _pointsX) > _strikeCap) exitWith {
+	[_titleStr, format [localize "STR_A3A_fn_reinf_bombrun_no_cap",_pointsX,_strikeCap]] call A3A_fnc_customHint;
+    false;
+};
+
 deleteVehicle _veh;
 [_titleStr, format [localize "STR_A3A_fn_reinf_bombrun_increased",_pointsX]] call A3A_fnc_customHint;
 bombRuns = bombRuns + _pointsX;

--- a/A3A/addons/core/functions/init/fn_resourcecheck.sqf
+++ b/A3A/addons/core/functions/init/fn_resourcecheck.sqf
@@ -94,11 +94,8 @@ while {true} do
 	server setVariable ["resourcesFIA", _resAdd + (server getVariable "resourcesFIA"), true];
 
 	private _newBombRuns = bombRuns + 0.25 * ({sidesX getVariable [_x,sideUnknown] == teamPlayer} count airportsX);
-	private _strikeCap = (4 + tierWar*2);
-	if (_newBombRuns < _strikeCap) then {
-		bombRuns = _newBombRuns;
-		publicVariable "bombRuns";
-	};
+	bombRuns = _newBombRuns max (4 + tierWar*2);
+	publicVariable "bombRuns";
 
 	// Add & delete enemy camps and roadblocks
 	call A3A_fnc_updateMinorSites;

--- a/A3A/addons/core/functions/init/fn_resourcecheck.sqf
+++ b/A3A/addons/core/functions/init/fn_resourcecheck.sqf
@@ -93,8 +93,12 @@ while {true} do
 	server setVariable ["hr", _hrAdd + (server getVariable "hr"), true];
 	server setVariable ["resourcesFIA", _resAdd + (server getVariable "resourcesFIA"), true];
 
-	bombRuns = bombRuns + 0.25 * ({sidesX getVariable [_x,sideUnknown] == teamPlayer} count airportsX);
-	publicVariable "bombRuns";
+	private _newBombRuns = bombRuns + 0.25 * ({sidesX getVariable [_x,sideUnknown] == teamPlayer} count airportsX);
+	private _strikeCap = (4 + tierWar*2);
+	if (_newBombRuns < _strikeCap) then {
+		bombRuns = _newBombRuns;
+		publicVariable "bombRuns";
+	};
 
 	// Add & delete enemy camps and roadblocks
 	call A3A_fnc_updateMinorSites;

--- a/A3A/addons/gui/Stringtable.xml
+++ b/A3A/addons/gui/Stringtable.xml
@@ -1925,7 +1925,7 @@
         <Chinesesimp>已使用的飞行器:</Chinesesimp>
       </Key>
       <Key ID="STR_antistasi_dialogs_main_air_support_carpet_bombing">
-        <Original>Carpet Bombing</Original>
+        <Original>CARPET BOMBING&lt;br /&gt;1 POINT</Original>
         <German>Flächenbombardierung</German>
         <Italian>Bombardamento a Tappeto</Italian>
         <Spanish>Bombardeo en Alfombra</Spanish>
@@ -1939,7 +1939,7 @@
         <Chinesesimp>地毯式轰炸</Chinesesimp>
       </Key>
       <Key ID="STR_antistasi_dialogs_main_air_support_he_bombs">
-        <Original>HE Bombs</Original>
+        <Original>HE BOMBS&lt;br /&gt;1 POINT</Original>
         <German>HE Bomben</German>
         <Italian>Bombe AE</Italian>
         <Spanish>Bombas HE</Spanish>
@@ -1967,7 +1967,7 @@
         <Chinesesimp>获得更多空袭点数来使用玩家选项卡-载具中的“加入至空袭”功能。</Chinesesimp>
       </Key>
       <Key ID="STR_antistasi_dialogs_main_air_support_napalm">
-        <Original>Napalm Bomb</Original>
+        <Original>NAPALM BOMBS&lt;br /&gt;3 POINTS</Original>
         <German>Napalm Bomben</German>
         <Italian>Bombardamento al Napalm</Italian>
         <Spanish>Bomba de Napalm</Spanish>
@@ -1984,7 +1984,7 @@
         <Original>You have no airbases under your control</Original>
       </Key>
       <Key ID="STR_antistasi_dialogs_main_air_support_no_points_tooltip">
-        <Original>You have no air support points</Original>
+        <Original>You do not have enough air support points</Original>
         <German>Du hast keine Luftunterstützungspunkte</German>
         <Italian>Non hai punti supporto aereo.</Italian>
         <Spanish>No tiene puntos de apoyo aéreo</Spanish>

--- a/A3A/addons/gui/functions/GUI/fn_airSupportTab.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_airSupportTab.sqf
@@ -63,33 +63,38 @@ switch (_mode) do
         private _carpetButton = _display displayCtrl A3A_IDC_AIRSUPPORTCARPETBUTTON;
         private _napalmIcon = _display displayCtrl A3A_IDC_AIRSUPPORTNAPALMICON;
         private _napalmButton = _display displayCtrl A3A_IDC_AIRSUPPORTNAPALMBUTTON;
+        _heButton ctrlSetStructuredText parseText localize "STR_antistasi_dialogs_main_air_support_he_bombs";
+        _carpetButton ctrlSetStructuredText parseText localize "STR_antistasi_dialogs_main_air_support_carpet_bombing";
+        _napalmButton ctrlSetStructuredText parseText localize "STR_antistasi_dialogs_main_air_support_napalm";
 
-        // Check if there are enough air support points
-        if ((_airSupportPoints < 1) || ({sidesX getVariable [_x,sideUnknown] == teamPlayer} count airportsX == 0)) then
+        private _bombRunCosts = createHashMapFromArray [
+            ["HE",1],
+            ["CARPET",1],
+            ["NAPALM",3]
+        ];
+        private _hasNoAirport = ({sidesX getVariable [_x,sideUnknown] == teamPlayer} count airportsX == 0);
+        private _colorDisabled = ([A3A_COLOR_BUTTON_BACKGROUND_DISABLED] call FUNC(configColorToArray));
         {
-            private _failMessage = "";
-            private _color = ([A3A_COLOR_BUTTON_BACKGROUND_DISABLED] call FUNC(configColorToArray));
-            if (_airSupportPoints < 1) then
+            _x params ["_type","_button","_icon"];
+            private _cost = _bombRunCosts get _type;
+            private _cannotAfford = (_cost > _airSupportPoints);
+            if (_cannotAfford || _hasNoAirport) then
             {
-                Trace("No air support points, disabling buttons");
-                _failMessage = localize "STR_antistasi_dialogs_main_air_support_no_points_tooltip";
-            } else {
-                Trace("No airports, disabling buttons");
-                _failMessage = localize "STR_antistasi_dialogs_main_air_support_no_base_tooltip";
+                private _failMessage = "";
+                if (_cannotAfford) then
+                {
+                    Trace_1("No air support points, disabling button %1",_type);
+                    _failMessage = localize "STR_antistasi_dialogs_main_air_support_no_points_tooltip";
+                } else {
+                    Trace_1("No airports, disabling button %1",_type);
+                    _failMessage = localize "STR_antistasi_dialogs_main_air_support_no_base_tooltip";
+                };
+                _icon ctrlSetTextColor _colorDisabled;
+                _icon ctrlSetTooltip _failMessage;
+                _button ctrlEnable false;
+                _button ctrlSetTooltip _failMessage;
             };
-            _heIcon ctrlSetTextColor _color;
-            _heIcon ctrlSetTooltip _failMessage;
-            _heButton ctrlEnable false;
-            _heButton ctrlSetTooltip _failMessage;
-            _carpetIcon ctrlSetTextColor _color;
-            _carpetIcon ctrlSetTooltip _failMessage;
-            _carpetButton ctrlEnable false;
-            _carpetButton ctrlSetTooltip _failMessage;
-            _napalmIcon ctrlSetTextColor _color;
-            _napalmIcon ctrlSetTooltip _failMessage;
-            _napalmButton ctrlEnable false;
-            _napalmButton ctrlSetTooltip _failMessage;
-        };
+        } forEach [["HE",_heButton,_heIcon],["CARPET",_carpetButton,_carpetIcon],["NAPALM",_napalmButton,_napalmIcon]];
     };
 
     default

--- a/A3A/addons/gui/functions/GUI/fn_airSupportTab.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_airSupportTab.sqf
@@ -45,9 +45,11 @@ switch (_mode) do
         _backButton ctrlShow true;
 
         // Display remaining air support points
-        private _airSupportPoints = round bombRuns;
+        private _airSupportPoints = floor bombRuns;
+        private _strikeCap = (4 + tierWar*2);
+        private _airStrikeCapInfo = format ["%1/%2",str _airSupportPoints,str _strikeCap];
         private _airSupportPointsText = _display displayCtrl A3A_IDC_AIRSUPPORTPOINTSTEXT;
-        _airSupportPointsText ctrlSetText str _airSupportPoints;
+        _airSupportPointsText ctrlSetText _airStrikeCapInfo;
 
         // Display name of aircraft used
         private _aircraftName = getText (configFile >> "CfgVehicles" >> ((FactionGet(reb,"vehiclesPlane")) # 0) >> "displayName");


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [X] Enhancement

### What have you changed and why?
Calling airstrikes near HQ is blocked with tkPunish on
Airstrike counter removed from top bar, cap added to new battle menu
Airstrike cap imposed as (4 + tierWar*2) which is 10 at WL3 when you unlock airport, which is enough to convert a full jet, and 24 at war level 10. You cannot gain more points or convert more vehicles that would pass this cap.
Rebel napalm strikes are now 2 bombs instead of 4
Napalm now costs 3 airstrike points

### Please specify which Issue this PR Resolves.
closes #3541

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes: Additional points integration still needs to be done for the new UI