### PR TITLE
Fix loot crate text overlap

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_ammunitionTransfer.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_ammunitionTransfer.sqf
@@ -170,11 +170,17 @@ if (_destinationX == boxX) then
 	{
 //	{if (_x distance boxX < 10) then {[petros,"hint","Ammobox Loaded", "Cargo"] remoteExec ["A3A_fnc_commsMP",_x]}} forEach (call A3A_fnc_playableUnits);
 	if ((_originX isKindOf "ReammoBox_F") and (_originX != vehicleBox)) then {deleteVehicle _originX};
+	private _moneyText = "";
+	if (count _this > 3) then {
+		[0,_this select 3, true] spawn A3A_fnc_resourcesFIA;
+		private _resourcesText = format ["<t size='0.6' color='#C1C0BB'>" + localize "STR_A3A_fn_base_resourcesFIA_resources" + "<br/><br/></t>", FactionGet(reb,"name")];
+		private _moneyText = format ["<t size='0.5' color='#C1C0BB'>" + localize "STR_A3A_fn_base_resourcesFIA_money" + "</t><br/><br/><br/>","+", _resourcesFIA toFixed 0];
+	};
 	_updated = [] call A3A_fnc_arsenalManage;
 	if (_updated != "") then
 		{
-		_updated = format ["<t size='0.5' color='#C1C0BB'>" + localize "STR_A3A_fn_init_resourceCheck_arsenal" + "<br/><br/>%1</t>",_updated];
-		[petros,"income",_updated] remoteExec ["A3A_fnc_commsMP",[teamPlayer,civilian]];
+		_moneyText = _moneyText + format ["<t size='0.5' color='#C1C0BB'>" + localize "STR_A3A_fn_init_resourceCheck_arsenal" + "<br/><br/>%1</t>",_updated];
+		[petros,"income",_resourcesText + _moneyText] remoteExec ["A3A_fnc_commsMP",[teamPlayer,civilian]];
 		};
 	}
 else

--- a/A3A/addons/core/functions/Base/fn_resourcesFIA.sqf
+++ b/A3A/addons/core/functions/Base/fn_resourcesFIA.sqf
@@ -1,6 +1,6 @@
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
-params [["_hr",""],["_resourcesFIA",""]]; // nil protection
+params [["_hr",""],["_resourcesFIA",""],["_silent",false]]; // nil protection
 
 if !(_hr isEqualType 0) exitWith {Error("The first parameter, the added HR, must be a number");};
 if !(_resourcesFIA isEqualType 0) exitWith {Error("The second parameter, the added money, must be a number");};
@@ -20,6 +20,8 @@ if (_resourcesFIAT < 0) then {_resourcesFIAT = 0};
 server setVariable ["hr",_hrT,true];
 server setVariable ["resourcesFIA",_resourcesFIAT,true];
 resourcesIsChanging = false;
+
+if (_silent) exitWith {};
 
 _textX = "";
 _hrSim = "";

--- a/A3A/addons/garage/Public/fn_addVehicle.sqf
+++ b/A3A/addons/garage/Public/fn_addVehicle.sqf
@@ -69,9 +69,10 @@ private _utilityRefund = {
     } else {
         _toRefund = _object getVariable ['A3A_itemPrice', 0];
     };
-    if ("loot" in _flags) then {
-        _feedBack = "STR_HR_GRG_Feedback_addVehicle_LTC";
-        [_object, boxX, true] call A3A_fnc_ammunitionTransfer;
+    if ("loot" in _flags) exitWith {
+        ["STR_HR_GRG_Feedback_addVehicle_LTC"] remoteExec ["HR_GRG_fnc_Hint", _client];
+        [_object, boxX, true, _toRefund] call A3A_fnc_ammunitionTransfer;
+        true;
     };
 
     deleteVehicle _object;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Garaging a loot crate that unlocks an item will first print the unlocked item and immediately overwrite the message with the refund profit from the crate. This PR should allow it to display both items.

### Please specify which Issue this PR Resolves.
closes #3048 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
