### PR TITLE
Fix doubled war tier in mixed attacks

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_createAttackForceMixed.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAttackForceMixed.sqf
@@ -31,7 +31,7 @@ private _targPos = if (_target isEqualType []) then { _target } else { markerPos
 
 private _faction = Faction(_side);
 private _lowAir = _faction getOrDefault ["attributeLowAir", false];
-private _tier = [tierWar, tierWar+2] select ("tierboost" in _modifiers);
+private _tier = [0,2] select ("tierboost" in _modifiers);
 
 private _resourcesSpent = 0;
 private _vehicles = [];


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
See title

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: Spawn attacks at WL4 and notice the lack of MBTs