### PR TITLE
Radio key saving

### DIFF
--- a/A3A/addons/core/functions/Intel/fn_selectIntel.sqf
+++ b/A3A/addons/core/functions/Intel/fn_selectIntel.sqf
@@ -89,11 +89,11 @@ if (_intelType == "Small") then
         {
             if(_side == Occupants) then
             {
-                occupantsRadioKeys = occupantsRadioKeys + 1;
+                occRadioKeys = occRadioKeys + 1;
             }
             else
             {
-                invaderRadioKeys = invaderRadioKeys + 1;
+                invRadioKeys = invRadioKeys + 1;
             };
             _text = format [localize "STR_A3A_fn_intel_select_decry_1", _sideName];
         };
@@ -133,11 +133,11 @@ if (_intelType == "Medium") then
             private _keyCount = round (3 + random 3);
             if(_side == Occupants) then
             {
-                occupantsRadioKeys = occupantsRadioKeys + _keyCount;
+                occRadioKeys = occRadioKeys + _keyCount;
             }
             else
             {
-                invaderRadioKeys = invaderRadioKeys + _keyCount;
+                invRadioKeys = invRadioKeys + _keyCount;
             };
             _text = format [localize "STR_A3A_fn_intel_select_decry_2", _sideName];
         };

--- a/A3A/addons/core/functions/Save/fn_deleteSave.sqf
+++ b/A3A/addons/core/functions/Save/fn_deleteSave.sqf
@@ -47,7 +47,7 @@ private _savedPlayers = _namespace getVariable ["savedPlayers" + _postfix, []];
 	"attackCountdownOccupants", "attackCountdownInvaders", "prestigeNATO", "prestigeCSAT",
 	"savedPlayers", "testingTimerIsActive", "HR_Garage", "A3A_fuelAmountleftArray", "HQKnowledge", "enemyResources",
 	"version", "name", "saveTime", "ended", "factions", "addonVics", "DLC", "arsenalLimits", "rebelLoadouts",
-	"minorSites"];
+	"minorSites", "occRadioKeys", "invRadioKeys"];
 
 
 // Remove this campaign from the save list, if present

--- a/A3A/addons/core/functions/Save/fn_deleteSave.sqf
+++ b/A3A/addons/core/functions/Save/fn_deleteSave.sqf
@@ -47,7 +47,7 @@ private _savedPlayers = _namespace getVariable ["savedPlayers" + _postfix, []];
 	"attackCountdownOccupants", "attackCountdownInvaders", "prestigeNATO", "prestigeCSAT",
 	"savedPlayers", "testingTimerIsActive", "HR_Garage", "A3A_fuelAmountleftArray", "HQKnowledge", "enemyResources",
 	"version", "name", "saveTime", "ended", "factions", "addonVics", "DLC", "arsenalLimits", "rebelLoadouts",
-	"minorSites", "occRadioKeys", "invRadioKeys"];
+	"minorSites", "radioKeys"];
 
 
 // Remove this campaign from the save list, if present

--- a/A3A/addons/core/functions/Save/fn_loadServer.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadServer.sqf
@@ -23,6 +23,8 @@ if (isServer) then {
 	["weather"] call A3A_fnc_getStatVariable;
 	["prestigeOPFOR"] call A3A_fnc_getStatVariable;
 	["prestigeBLUFOR"] call A3A_fnc_getStatVariable;
+	["occRadioKeys"] call A3A_fnc_getStatVariable;
+	["invRadioKeys"] call A3A_fnc_getStatVariable;
 	["resourcesFIA"] call A3A_fnc_getStatVariable;
 	["garrison"] call A3A_fnc_getStatVariable;
 	["usesWurzelGarrison"] call A3A_fnc_getStatVariable;

--- a/A3A/addons/core/functions/Save/fn_loadServer.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadServer.sqf
@@ -23,8 +23,7 @@ if (isServer) then {
 	["weather"] call A3A_fnc_getStatVariable;
 	["prestigeOPFOR"] call A3A_fnc_getStatVariable;
 	["prestigeBLUFOR"] call A3A_fnc_getStatVariable;
-	["occRadioKeys"] call A3A_fnc_getStatVariable;
-	["invRadioKeys"] call A3A_fnc_getStatVariable;
+	["radioKeys"] call A3A_fnc_getStatVariable;
 	["resourcesFIA"] call A3A_fnc_getStatVariable;
 	["garrison"] call A3A_fnc_getStatVariable;
 	["usesWurzelGarrison"] call A3A_fnc_getStatVariable;

--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -34,7 +34,7 @@ private _specialVarLoads = [
     "chopForest","weather","killZones","jna_dataList","mrkCSAT","nextTick",
     "bombRuns","wurzelGarrison","aggressionOccupants", "aggressionInvaders", "enemyResources", "HQKnowledge",
     "testingTimerIsActive", "version", "HR_Garage", "A3A_fuelAmountleftArray", "arsenalLimits", "rebelLoadouts",
-    "minorSites"
+    "minorSites", "radioKeys"
 ];
 
 private _varName = _this select 0;
@@ -60,6 +60,11 @@ if (_varName in _specialVarLoads) then {
     //Keeping these for older saves
     if (_varName == 'prestigeNATO') then {[Occupants, _varValue, 120] call A3A_fnc_addAggression};
     if (_varName == 'prestigeCSAT') then {[Invaders, _varValue, 120] call A3A_fnc_addAggression};
+    if (_varName == 'radioKeys') then 
+    {
+        occRadioKeys = _varValue#0;
+        invRadioKeys = _varValue#1;
+    };
     if (_varName == 'aggressionOccupants') then
     {
         aggressionLevelOccupants = _varValue select 0;

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -196,6 +196,9 @@ _prestigeBLUFOR = [];
 ["prestigeOPFOR", _prestigeOPFOR] call A3A_fnc_setStatVariable;
 ["prestigeBLUFOR", _prestigeBLUFOR] call A3A_fnc_setStatVariable;
 
+["occRadioKeys", occRadioKeys] call A3A_fnc_setStatVariable;
+["invRadioKeys", invRadioKeys] call A3A_fnc_setStatVariable;
+
 _markersX = markersX - outpostsFIA - controlsX;
 _garrison = [];
 _wurzelGarrison = [];

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -196,8 +196,7 @@ _prestigeBLUFOR = [];
 ["prestigeOPFOR", _prestigeOPFOR] call A3A_fnc_setStatVariable;
 ["prestigeBLUFOR", _prestigeBLUFOR] call A3A_fnc_setStatVariable;
 
-["occRadioKeys", occRadioKeys] call A3A_fnc_setStatVariable;
-["invRadioKeys", invRadioKeys] call A3A_fnc_setStatVariable;
+["radioKeys", [occRadioKeys,invRadioKeys]] call A3A_fnc_setStatVariable;
 
 _markersX = markersX - outpostsFIA - controlsX;
 _garrison = [];

--- a/A3A/addons/core/functions/Supports/fn_useRadioKey.sqf
+++ b/A3A/addons/core/functions/Supports/fn_useRadioKey.sqf
@@ -18,12 +18,12 @@ if (_reveal >= 0.8) exitWith { _reveal };
 
 if(_position distance2D markerPos "Synd_HQ" < distanceMission) then
 {
-    if(_side == Occupants && occupantsRadioKeys > 0) then {
-        occupantsRadioKeys = occupantsRadioKeys - 1;
+    if(_side == Occupants && occRadioKeys > 0) then {
+        occRadioKeys = occRadioKeys - 1;
         _reveal = 1;
     };
-    if(_side == Invaders && invaderRadioKeys > 0) then {
-        invaderRadioKeys = invaderRadioKeys - 1;
+    if(_side == Invaders && invRadioKeys > 0) then {
+        invRadioKeys = invRadioKeys - 1;
         _reveal = 1;
     };
 };

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -113,8 +113,8 @@ prestigeOPFOR = [75, 50] select cadetMode;												//Initial % support for NA
 prestigeBLUFOR = 0;																	//Initial % FIA support on each city
 
 // Don't need to be distributed
-occupantsRadioKeys = 0;
-invaderRadioKeys = 0;
+occRadioKeys = 0;
+invRadioKeys = 0;
 
 // Recent casualties/damage taken by enemies, format [X, Y, time * 1000 + value]
 A3A_recentDamageOcc = [];

--- a/A3A/addons/core/functions/init/fn_resourcecheck.sqf
+++ b/A3A/addons/core/functions/init/fn_resourcecheck.sqf
@@ -56,8 +56,7 @@ while {true} do
 		_resAdd = _resAdd + _resAddCity;
 		_hrAdd = _hrAdd + _hrAddCity;
 
-
-		// revuelta civil!!
+		// city flipping routine
 		if ((_supportGov < _supportReb) and (sidesX getVariable [_city,sideUnknown] == Occupants)) then
 		{
 			["TaskSucceeded", ["", format [localize "STR_A3A_fn_init_resourceCheck_cityChange",_city,FactionGet(reb,"name")]]] remoteExec ["BIS_fnc_showNotification",teamPlayer];
@@ -87,6 +86,8 @@ while {true} do
 			_resAdd = _resAdd + (300 * _resBoost);
 		};
 	} forEach resourcesX;
+
+	Debug_2("Occupant radio keys: %1 - Invader radio keys: %2", occRadioKeys, invRadioKeys);
 
 	_hrAdd = ceil _hrAdd;
 	_resAdd = ceil _resAdd;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
For some reason, enemy radio keys werent saved and were lost on server restart. This PR fixes that, and also renames the vars entirely because "occupants" vs "invader" is dumb    

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: Get in game, give yourself a few keys, go aggro a counterattack / QRF, check keys, save game, restart game, check keys
