### PR TITLE
Fix dead pop in new UI displaying wrong

### DIFF
--- a/A3A/addons/gui/functions/GUI/fn_hqDialog.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_hqDialog.sqf
@@ -265,10 +265,9 @@ switch (_mode) do
             _cityData params ["_numCiv", "_numVeh", "_supportGov", "_supportReb"];
 
             _totalPopulation = _totalPopulation + _numCiv;
-            _rebelPopulation = _rebelPopulation + (_numCiv * (_supportReb / 100));
-
-            if (_city in destroyedSites) then {
-                _deadPopulation = _deadPopulation + _numCiv;
+            if (_city in destroyedSites) then { _deadPopulation = _deadPopulation + _numCiv} else 
+            {
+                _rebelPopulation = _rebelPopulation + (_numCiv * (_supportReb / 100));
             };
         } forEach citiesX;
 


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The dead population were incorrectly counted as part of the support calculations. This was purely a display bug and has been fixed.
    

### Please specify which Issue this PR Resolves.
closes #3649 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
