### PR TITLE
Vehicle Buying Fixes

### DIFF
--- a/A3A/addons/gui/functions/GUI/fn_buyVehicleDialog.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_buyVehicleDialog.sqf
@@ -111,9 +111,11 @@ switch (_mode) do
         ["other"] call A3A_GUI_fnc_buyVehicleTabs;
 
         // show the vehicle tab so that user don't freak out
+        _defaultTab = [A3A_IDC_BUYCIVVEHICLEMAIN, A3A_IDC_BUYREBVEHICLEMAIN] select (count _civilianVehicles == 0);
         private _display = findDisplay A3A_IDD_BUYVEHICLEDIALOG;
-        private _selectedTabCtrl = _display displayCtrl A3A_IDC_BUYCIVVEHICLEMAIN;
+        private _selectedTabCtrl = _display displayCtrl _defaultTab;
         _selectedTabCtrl ctrlShow true;
+        player setCaptive false;
 
     };
 


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Undercover now breaks when you try to buy a vehicle, fixing a bug where no vehicles could be placed undercover.
The menu will also now default to the military vic tab if no civ vics are present

### Please specify which Issue this PR Resolves.
closes #3630

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
