### PR TITLE
Dev1 Vehicle balance changes

### DIFF
--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Reb_FIA.sqf
@@ -49,7 +49,7 @@
 private _initialRebelEquipment = [
 "UK3CB_BHP", "rhs_weap_tt33",
 "uk3cb_enfield_l8", "uk3cb_enfield_l8_walnut",
-["rhs_weap_rpg75", 50],
+["rhs_weap_rpg75", 10],
 ["IEDUrbanSmall_Remote_Mag", 10], ["IEDLandSmall_Remote_Mag", 10], ["IEDUrbanBig_Remote_Mag", 3], ["IEDLandBig_Remote_Mag", 3],
 "UK3CB_BHP_9_13Rnd", "rhs_mag_762x25_8", "uk3cb_l42_enfield_762_10Rnd_magazine", "uk3cb_l42_enfield_762_10Rnd_magazine_WT", "uk3cb_1rnd_riflegrenade_mas_flare", "rhs_grenade_mkii_mag", "rhs_grenade_mki_mag", "rhs_mag_rdg2_black", "rhs_grenade_m15_mag",
 "UK3CB_CHC_C_B_MED", "UK3CB_B_Bedroll_Backpack", "UK3CB_TKC_C_B_Sidor_MED", "UK3CB_CW_SOV_O_LATE_B_Sidor_RIF", "UK3CB_CW_SOV_O_EARLY_B_Sidor_RIF",

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_Reb_NAPA.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_Reb_NAPA.sqf
@@ -51,7 +51,7 @@ private _initialRebelEquipment = [
     "CUP_sgun_slamfire", "CUP_srifle_LeeEnfield", "CUP_srifle_LeeEnfield_rail",
     "CUP_1Rnd_12Gauge_Pellets_No00_Buck", "CUP_1Rnd_12Gauge_Pellets_No3_Buck", "CUP_10x_303_M",
     "CUP_hgun_TaurusTracker455", "CUP_6Rnd_45ACP_M",
-    ["CUP_launch_RPG18", 50],
+    ["CUP_launch_RPG18", 10],
     ["IEDUrbanSmall_Remote_Mag", 10], ["IEDLandSmall_Remote_Mag", 10], ["IEDUrbanBig_Remote_Mag", 3], ["IEDLandBig_Remote_Mag", 3],
     "CUP_HandGrenade_RGD5", "SmokeShell",
     "CUP_V_I_Carrier_Belt", "CUP_V_I_Guerilla_Jacket", "CUP_V_I_RACS_Carrier_Rig_2", "CUP_V_I_RACS_Carrier_Rig_wdl_2",

--- a/A3A/addons/core/Templates/Templates/RHS/RHS_Reb_NAPA.sqf
+++ b/A3A/addons/core/Templates/Templates/RHS/RHS_Reb_NAPA.sqf
@@ -47,7 +47,7 @@
 
 private _initialRebelEquipment = [
 "rhs_weap_type94_new", "rhs_weap_tt33", "rhs_weap_Izh18", "rhs_weap_kar98k",
-["rhs_weap_rpg75", 50],
+["rhs_weap_rpg75", 10],
 ["IEDUrbanSmall_Remote_Mag", 10], ["IEDLandSmall_Remote_Mag", 10], ["IEDUrbanBig_Remote_Mag", 3], ["IEDLandBig_Remote_Mag", 3],
 "rhs_mag_6x8mm_mhp", "rhs_mag_762x25_8", "rhsgref_1Rnd_00Buck", "rhsgref_1Rnd_Slug", "rhsgref_5Rnd_792x57_kar98k", "rhs_grenade_mkii_mag", "rhs_grenade_mki_mag", "rhs_mag_rdg2_black", "rhs_grenade_m15_mag",
 "B_FieldPack_blk", "B_FieldPack_cbr", "B_FieldPack_green_F", "B_FieldPack_khk", "B_FieldPack_oli",

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
@@ -91,9 +91,9 @@ private _initialRebelEquipment = [
 "acc_flashlight","acc_flashlight_smg_01","acc_flashlight_pistol"];
 
 if ("expansion" in A3A_enabledDLC) then {
-    _initialRebelEquipment append [["launch_RPG7_F", 15], ["RPG7_F", 45], "SMG_05_F", "hgun_Pistol_01_F", "10Rnd_9x21_Mag"];
+    _initialRebelEquipment append [["launch_RPG7_F", 5], ["RPG7_F", 15], "SMG_05_F", "hgun_Pistol_01_F", "10Rnd_9x21_Mag"];
 } else {
-    _initialRebelEquipment append [["launch_RPG32_F", 15], ["RPG32_F", 30]];
+    _initialRebelEquipment append [["launch_RPG32_F", 5], ["RPG32_F", 15]];
 };
 if ("rf" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["srifle_h6_tan_rf","10Rnd_556x45_AP_Stanag_red_Tan_RF","10Rnd_556x45_AP_Stanag_Tan_RF","10Rnd_556x45_AP_Stanag_green_Tan_RF"];

--- a/A3A/addons/core/dialogs.hpp
+++ b/A3A/addons/core/dialogs.hpp
@@ -2226,12 +2226,12 @@ class squad_recruit 			{
 		class HQ_button_ATteamM: A3A_core_BattleMenuRedButton
 		{
 			idc = 110;
-			text = $STR_antistasi_dialogs_squad_recruit_aa_car;
+			text = "";
 			x = 0.272481 * safezoneW + safezoneX;
 			y = 0.612025 * safezoneH + safezoneY;
 			w = 0.175015 * safezoneW;
 			h = 0.0560125 * safezoneH;
-			action = "closeDialog 0;nul = [(A3A_faction_reb get 'staticAA') # 0] spawn A3A_fnc_addFIAsquadHC";
+			// action = "closeDialog 0;nul = [(A3A_faction_reb get 'staticAA') # 0] spawn A3A_fnc_addFIAsquadHC";
 		};
 
 		class HQ_button_mortar: A3A_core_BattleMenuRedButton

--- a/A3A/addons/core/functions/Ammunition/fn_arsenalManage.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_arsenalManage.sqf
@@ -27,12 +27,14 @@ private _count = objNull;
 {
 	_type = _x select 0;
 	_magConfig = configFile >> "CfgMagazines" >> _type;
+	_ammo = getText(_magConfig >> "ammo");
+	_cfgAmmo = configFile >> "CfgAmmo" >> _ammo;
 	_capacity = 1 max getNumber (_magConfig >> "count");			// Avoid div-by-zero on broken/missing config
 
 	// control unlocking missile launcher magazines
 	// the capacity check is an optimisation to bypass the config check. ~18% perf gain on the loop.
 	if (_capacity != 1 || allowGuidedLaunchers isEqualTo 1 ||
-		{!(getText (_magConfig >> "ammo") isKindOf "MissileBase")}) then {
+		{!(tolower getText(_cfgAmmo >> "simulation") in ["shotrocket", "shotmissile"])}) then {
 		_bullets = _x select 1;
 		_count = floor (_bullets/_capacity);
 		_magazine pushBack [_type,_count];
@@ -49,6 +51,7 @@ private _categoriesToPublish = createHashMap;
 
 		private _categories = _item call A3A_fnc_equipmentClassToCategories;
 		if ("MissileLaunchers" in _categories && {allowGuidedLaunchers == 0}) exitWith {};
+		if ("RocketLaunchers" in _categories) exitWith {};
 		if ("Explosives" in _categories && {allowUnlockedExplosives == 0}) exitWith {};
 		if ("Backpacks" in _categories && {_item in allBackpacksTool}) exitWith {};			// should be UAV & static backpacks
 		if ("StaticWeaponParts" in _categories) exitWith {};

--- a/A3A/addons/core/functions/Base/fn_getVehiclesAirSupport.sqf
+++ b/A3A/addons/core/functions/Base/fn_getVehiclesAirSupport.sqf
@@ -21,8 +21,8 @@ private _fnc_addArrayToWeights = {
 
 private _vehWeights = [];
 
-private _lightAHWeight =   [70, 65, 60, 55, 50, 45, 40, 35, 30, 25] select _level;
-private _AHWeight =        [ 5, 10, 15, 20, 25, 30, 35, 40, 45, 50] select _level;
+private _lightAHWeight =   [70, 65, 62, 59, 55, 50, 44, 38, 32, 25] select _level;
+private _AHWeight =        [ 0, 2, 5, 9, 15, 21, 27, 34, 42, 50] select _level;
 private _casWeight =       [ 2,  4,  6,  8, 10, 12, 14, 16, 18, 20] select _level;
 
 // eventually add dive bombers?

--- a/A3A/addons/core/functions/Dialogs/fn_squadRecruit.sqf
+++ b/A3A/addons/core/functions/Dialogs/fn_squadRecruit.sqf
@@ -54,11 +54,6 @@ if (str (_display) != "no display") then
 	_costs = 2*_crewCost + ([(FactionGet(reb,"vehiclesAT")) # 0] call A3A_fnc_vehiclePrice);
 	_ChildControl  ctrlSetTooltip format [localize "STR_A3A_fn_dialogs_squadOptions",_costs,_costHR];
 
-	_ChildControl = _display displayCtrl 110;
-	_costHR = 2;
-	_costs = 2*_crewCost + ([(FactionGet(reb,"vehiclesTruck")) # 0] call A3A_fnc_vehiclePrice) + ([(FactionGet(reb,"staticAA")) # 0] call A3A_fnc_vehiclePrice);
-	_ChildControl  ctrlSetTooltip format [localize "STR_A3A_fn_dialogs_squadOptions",_costs,_costHR];
-
 	_ChildControl = _display displayCtrl 111;
 	_costHR = 2;
 	_costs = 2*_crewCost + ([(FactionGet(reb,"staticMortars")) # 0] call A3A_fnc_vehiclePrice);

--- a/A3A/addons/core/functions/Supports/fn_maxDefenceSpend.sqf
+++ b/A3A/addons/core/functions/Supports/fn_maxDefenceSpend.sqf
@@ -149,7 +149,7 @@ else
         //};
     } forEach _nearFriends;
 
-    _threatBalance = (2.6*_recentDamage + _enemyStr) / (1 + _friendStr + _recentDamage);
+    _threatBalance = (3.0*_recentDamage + _enemyStr) / (1 + _friendStr + _recentDamage);
     _threatBalance = 1 min (_threatBalance - 1);
     Debug_4("Threat balance %1 from: Recent damage %2 enemy strength %3 friend strength %4", _threatBalance, _recentDamage, _enemyStr, _friendStr);
 };

--- a/A3A/addons/core/functions/Templates/fn_compileGroups.sqf
+++ b/A3A/addons/core/functions/Templates/fn_compileGroups.sqf
@@ -54,14 +54,15 @@ _faction set ["unitPoliceGrunt", unit(police, "Standard")];
 _faction set ["groupSentry", [unit(military, "Grenadier"), unit(military, "Rifleman")]];
 _faction set ["groupSniper", [unit(military, "Sniper"), unit(military, "Rifleman")]];
 _faction set ["groupsSmall", [_faction get "groupSentry", _faction get "groupSniper"]];
-_faction set ["groupAA", [unit(military, "SquadLeader"), unit(military, "AA"), unit(military, "AA"), unit(military, "Rifleman")]];
-_faction set ["groupAT", [unit(military, "SquadLeader"), unit(military, "AT"), unit(military, "AT"), unit(military, "Rifleman")]];
+_faction set ["groupAA", [unit(military, "SquadLeader"), unit(military, "AA"), unit(military, "Rifleman"), unit(military, "Rifleman")]];
+_faction set ["groupAT", [unit(military, "SquadLeader"), unit(military, "AT"), unit(military, "LAT"), unit(military, "Rifleman")]];
 _faction set ["groupsMedium", [
     [unit(military, "SquadLeader"), unit(military, "MachineGunner"), unit(military, "Grenadier"), unit(military, "LAT")]
     , _faction get "groupAA", _faction get "groupAT"
 ]];
-
+/*
 //old randomised behaviour maintained because... reasons
+// not anymore!
 private _squads = [];
 for "_i" from 1 to 5 do {
     _squads pushBack [
@@ -74,8 +75,17 @@ for "_i" from 1 to 5 do {
         selectRandomWeighted [unit(military, "Rifleman"), 2, unit(military, "Marksman"), 1],
         unit(military, "Medic")
     ];
+    //                                                                              SquadLeader, Medic, MachineGunner, Rifleman, Grenadier, LAT, AT, AA, Engineer, Marksman
+    // unit(military, "")
 };
-_faction set ["groupsSquads", _squads];
+*/
+_faction set ["groupsSquads", [
+    [unit(military, "SquadLeader"), unit(military, "Medic"),unit(military, "MachineGunner"),unit(military, "Rifleman"),unit(military, "Rifleman"),unit(military, "Engineer"),unit(military, "Grenadier"),unit(military, "LAT")],
+    [unit(military, "SquadLeader"), unit(military, "Medic"),unit(military, "MachineGunner"),unit(military, "Rifleman"),unit(military, "Rifleman"),unit(military, "Engineer"),unit(military, "Marksman"),unit(military, "LAT")],
+    [unit(military, "SquadLeader"), unit(military, "Medic"),unit(military, "MachineGunner"),unit(military, "Rifleman"),unit(military, "Rifleman"),unit(military, "Engineer"),unit(military, "Grenadier"),unit(military, "Marksman")],
+    [unit(military, "SquadLeader"), unit(military, "Medic"),unit(military, "MachineGunner"),unit(military, "Rifleman"),unit(military, "Rifleman"),unit(military, "Medic"),unit(military, "Grenadier"),unit(military, "AA")],
+    [unit(military, "SquadLeader"), unit(military, "Medic"),unit(military, "MachineGunner"),unit(military, "Rifleman"),unit(military, "Rifleman"),unit(military, "Engineer"),unit(military, "MachineGunner"),unit(military, "AT")]
+]];
 
 //specops
 _faction set ["groupSpecOps", [
@@ -130,7 +140,7 @@ for "_i" from 1 to 6 do {
     ];
 };
 _faction set ["groupsMilitiaMedium", _militiaMid];
-
+/*
 private _militiaSquads = [];
 for "_i" from 1 to 5 do {
     _militiaSquads pushBack [
@@ -145,7 +155,13 @@ for "_i" from 1 to 5 do {
         unit(militia, "Medic")
     ];
 };
-_faction set ["groupsMilitiaSquads", _militiaSquads];
+*/
+_faction set ["groupsMilitiaSquads", [
+    [unit(militia, "SquadLeader"),unit(militia, "Medic"),unit(militia, "Rifleman"),unit(militia, "Rifleman"),unit(militia, "Rifleman"),unit(militia, "Grenadier"),unit(militia, "LAT"),unit(militia, "ExplosivesExpert")],
+    [unit(militia, "SquadLeader"),unit(militia, "Medic"),unit(militia, "Rifleman"),unit(militia, "Rifleman"),unit(militia, "Rifleman"),unit(militia, "MachineGunner"),unit(militia, "LAT"),unit(militia, "ExplosivesExpert")],
+    [unit(militia, "SquadLeader"),unit(militia, "Medic"),unit(militia, "Rifleman"),unit(militia, "Rifleman"),unit(militia, "Rifleman"),unit(militia, "Grenadier"),unit(militia, "LAT"),unit(militia, "Marksman")],
+    [unit(militia, "SquadLeader"),unit(militia, "Medic"),unit(militia, "Rifleman"),unit(militia, "Rifleman"),unit(militia, "Rifleman"),unit(militia, "MachineGunner"),unit(militia, "MachineGunner"),unit(militia, "Marksman")]
+]];
 
 //police
 _faction set ["groupPolice", [_faction get "unitPoliceOfficer", _faction get "unitPoliceGrunt"]];

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -486,7 +486,7 @@ private _vehicleResourceCosts = createHashMap;
 { _vehicleResourceCosts set [_x, 100] } forEach FactionGet(all, "vehiclesHelisTransport");
 { _vehicleResourceCosts set [_x, 130] } forEach FactionGet(all, "vehiclesHelisLightAttack") + FactionGet(all, "vehiclesPlanesTransport");
 { _vehicleResourceCosts set [_x, 250] } forEach FactionGet(all, "vehiclesPlanesCAS") + FactionGet(all, "vehiclesPlanesAA");
-{ _vehicleResourceCosts set [_x, 250] } forEach FactionGet(all, "vehiclesHelisAttack");
+{ _vehicleResourceCosts set [_x, 300] } forEach FactionGet(all, "vehiclesHelisAttack");
 
 
 // Threat table
@@ -516,14 +516,16 @@ _fnc_setPriceIfValid =
 };
 
 { [_rebelVehicleCosts, _x, 50] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesBasic");
-{ [_rebelVehicleCosts, _x, 200] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesCivCar") + FactionGet(reb, "vehiclesCivBoat");
+{ [_rebelVehicleCosts, _x, 400] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesCivCar") + FactionGet(reb, "vehiclesCivBoat");
 { [_rebelVehicleCosts, _x, 600] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesCivTruck") + FactionGet(reb, "vehiclesMedical");
 { [_rebelVehicleCosts, _x, 300] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesTruck");
-{ [_rebelVehicleCosts, _x, 200] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesLightUnarmed");
-{ [_rebelVehicleCosts, _x, 700] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesLightArmed") + FactionGet(reb, "vehiclesAT");
-{ [_rebelVehicleCosts, _x, 400] call _fnc_setPriceIfValid } forEach FactionGet(reb, "staticMGs") + FactionGet(reb, "vehiclesBoat");
-{ [_rebelVehicleCosts, _x, 800] call _fnc_setPriceIfValid } forEach FactionGet(reb, "staticAT") + FactionGet(reb, "staticAA") + FactionGet(reb, "staticMortars");
-{ [_rebelVehicleCosts, _x, 1200] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesAA");
+{ [_rebelVehicleCosts, _x, 150] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesLightUnarmed");
+{ [_rebelVehicleCosts, _x, 800] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesLightArmed");
+{ [_rebelVehicleCosts, _x, 150] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesBoat");
+{ [_rebelVehicleCosts, _x, 500] call _fnc_setPriceIfValid } forEach FactionGet(reb, "staticMGs");
+{ [_rebelVehicleCosts, _x, 2000] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesAT");
+{ [_rebelVehicleCosts, _x, 1500] call _fnc_setPriceIfValid } forEach FactionGet(reb, "staticAT");
+{ [_rebelVehicleCosts, _x, 2200] call _fnc_setPriceIfValid } forEach FactionGet(reb, "staticMortars");
 { [_rebelVehicleCosts, _x, 5000] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesCivHeli");
 { [_rebelVehicleCosts, _x, 5000] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesPlane") + FactionGet(reb, "vehiclesCivPlane");
 

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -523,8 +523,8 @@ _fnc_setPriceIfValid =
 { [_rebelVehicleCosts, _x, 800] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesLightArmed");
 { [_rebelVehicleCosts, _x, 150] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesBoat");
 { [_rebelVehicleCosts, _x, 500] call _fnc_setPriceIfValid } forEach FactionGet(reb, "staticMGs");
-{ [_rebelVehicleCosts, _x, 2000] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesAT");
-{ [_rebelVehicleCosts, _x, 1500] call _fnc_setPriceIfValid } forEach FactionGet(reb, "staticAT");
+{ [_rebelVehicleCosts, _x, 1300] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesAT");
+{ [_rebelVehicleCosts, _x, 1000] call _fnc_setPriceIfValid } forEach FactionGet(reb, "staticAT");
 { [_rebelVehicleCosts, _x, 2200] call _fnc_setPriceIfValid } forEach FactionGet(reb, "staticMortars");
 { [_rebelVehicleCosts, _x, 5000] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesCivHeli");
 { [_rebelVehicleCosts, _x, 5000] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesPlane") + FactionGet(reb, "vehiclesCivPlane");

--- a/A3A/addons/core/functions/init/fn_resourcecheck.sqf
+++ b/A3A/addons/core/functions/init/fn_resourcecheck.sqf
@@ -102,7 +102,7 @@ while {true} do
 	call A3A_fnc_updateMinorSites;
 
 	// Regular income of finite starting weapons
-	private _equipMul = A3A_balancePlayerScale / 30;		// difficulty scaled. Hmm.
+	private _equipMul = A3A_balancePlayerScale / 15;		// difficulty scaled. Hmm.
 	{
 		if (_x isEqualType "") then { continue };
 		_x params ["_class", "_initCount"];

--- a/A3A/addons/gui/functions/GUI/fn_buyVehicleDialog.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_buyVehicleDialog.sqf
@@ -102,8 +102,7 @@ switch (_mode) do
         private _statics = 
         (A3A_faction_reb get 'staticMGs') +
         (A3A_faction_reb get 'staticMortars') +
-        (A3A_faction_reb get 'staticAT') +
-        (A3A_faction_reb get 'staticAA');
+        (A3A_faction_reb get 'staticAT');
 
         ["vehicles", [A3A_IDC_BUYCIVVEHICLEMAIN, A3A_IDC_CIVVEHICLESGROUP, _civilianVehicles]] call A3A_GUI_fnc_buyVehicleTabs;
         ["vehicles", [A3A_IDC_BUYREBVEHICLEMAIN, A3A_IDC_REBVEHICLESGROUP, _militaryVehicles]] call A3A_GUI_fnc_buyVehicleTabs;

--- a/A3A/addons/gui/functions/GUI/fn_recruitSquadDialog.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_recruitSquadDialog.sqf
@@ -79,6 +79,10 @@ switch (_mode) do
         private _aaTruckPriceText = _display displayCtrl A3A_IDC_RECRUITAATRUCKPRICE;
         private _aaTruckButton = _display displayCtrl A3A_IDC_RECRUITAATRUCKBUTTON;
 
+        _aaTruckButton ctrlEnable false;
+        _aaTruckButton ctrlSetTooltip "AA truck squads cannot be purchased in the current testing phase";
+        _aaTruckIcon ctrlSetTextColor ([A3A_COLOR_BUTTON_BACKGROUND_DISABLED] call FUNC(configColorToArray));
+
         private _includeVehicleCheckbox = _display displayCtrl A3A_IDC_SQUADINCLUDEVEHICLECHECKBOX;
 
         // Get vehicle CB state
@@ -94,10 +98,6 @@ switch (_mode) do
         private _groupsSDKSniper = FactionGet(reb,"groupSniper");
         private _vehSDKMG = FactionGet(reb,"vehiclesLightArmed")#0;
         private _vehSDKAT = FactionGet(reb,"vehiclesAT")#0;
-
-        // Special case for AA: Specify static AA if there are no AA vehicles
-        private _rebAACars = FactionGet(reb,"vehiclesAA");
-        private _vehSDKAA = if (_rebAACars isEqualTo []) then { FactionGet(reb,"staticAA")#0 } else { _rebAACars#0 };
         
         // Classnames for vehicles
         private _infSquadVehicle = "";
@@ -138,8 +138,6 @@ switch (_mode) do
         _mgCarButton setVariable ["vehicle", ""];
         _atCarButton setVariable ["squadType", _vehSDKAT];
         _atCarButton setVariable ["vehicle", ""];
-        _aaTruckButton setVariable ["squadType", _vehSDKAA];
-        _aaTruckButton setVariable ["vehicle", ""];
 
         // Get prices
         private _infSquadPrice = [_groupsSDKSquad, _infSquadVehicle] call A3A_fnc_getHCSquadPrice;
@@ -151,7 +149,6 @@ switch (_mode) do
         private _sniperTeamPrice = [_groupsSDKSniper, _sniperTeamVehicle] call A3A_fnc_getHCSquadPrice;
         private _mgCarPrice = [_vehSDKMG] call A3A_fnc_getHCSquadPrice;
         private _atCarPrice = [_vehSDKAT] call A3A_fnc_getHCSquadPrice;
-        private _aaTruckPrice = [_vehSDKAA] call A3A_fnc_getHCSquadPrice;
 
         // Split money and HR from price array
         _infSquadPrice params ["_infSquadMoney", "_infSquadHr"];
@@ -163,7 +160,6 @@ switch (_mode) do
         _sniperTeamPrice params ["_sniperTeamMoney", "_sniperTeamHr"];
         _mgCarPrice params ["_mgCarMoney", "_mgCarHr"];
         _atCarPrice params ["_atCarMoney", "_atCarHr"];
-        _aaTruckPrice params ["_aaTruckMoney", "_aaTruckHr"];
 
         // Update price labels
         _infSquadPriceText ctrlSetText (format ["%1 € %2 HR", _infSquadMoney, _infSquadHr]);
@@ -175,7 +171,6 @@ switch (_mode) do
         _sniperTeamPriceText ctrlSetText (format ["%1 € %2 HR", _sniperTeamMoney, _sniperTeamHr]);
         _mgCarPriceText ctrlSetText (format ["%1 € %2 HR", _mgCarMoney, _mgCarHr]);
         _atCarPriceText ctrlSetText (format ["%1 € %2 HR", _atCarMoney, _atCarHr]);
-        _aaTruckPriceText ctrlSetText (format ["%1 € %2 HR", _aaTruckMoney, _aaTruckHr]);
 
         // Disable buttons and darken icon if not enough money or HR for the squad
         private _money = server getVariable "resourcesFIA";
@@ -225,11 +220,6 @@ switch (_mode) do
             _atCarButton ctrlEnable false;
             _atCarButton ctrlSetTooltip localize "STR_antistasi_recruit_squad_error";
             _atCarIcon ctrlSetTextColor ([A3A_COLOR_BUTTON_BACKGROUND_DISABLED] call FUNC(configColorToArray));
-        };
-        if (_money < _aaTruckMoney || _hr < _aaTruckHr) then {
-            _aaTruckButton ctrlEnable false;
-            _aaTruckButton ctrlSetTooltip localize "STR_antistasi_recruit_squad_error";
-            _aaTruckIcon ctrlSetTextColor ([A3A_COLOR_BUTTON_BACKGROUND_DISABLED] call FUNC(configColorToArray));
         };
     };
 


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Disabled AA truck squads on old and new UIs
Disallowed unlocking of all launchers
Reduced weight of attack helicopters
Rebalanced vehicle prices:

- 800 -> 1500 for AT Static;
- 700 -> 2000 for AT Car;
- 800 -> 2200 for Mortar;
- 200 -> 400 for Civ Car;
- 200 -> 150 for Reb Car;
- 400 -> 500 for MG static;
- 700 -> 800 for Light Armed;

Doubled income tick weapon rewards
Increased support threat balance
Created fixed groups using less anti-vehicle weapons overall 
Reduced number of starting RPGs in Vanilla FIA, CUP NAPA, RHS NAPA, and 3CB FIA 
Removed buyable static AA

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
