### PR TITLE
Balance changes and fixes, mostly for city/HR rework. (#3673)

### DIFF
--- a/A3A/addons/core/functions/AI/fn_enemyReturnToBase.sqf
+++ b/A3A/addons/core/functions/AI/fn_enemyReturnToBase.sqf
@@ -44,13 +44,12 @@ if (_vehicle != leader _group) exitWith
     // Ignore captured marker, find nearest suitable base to return to
     if (_vehicle isKindOf "Air") then {
         _marker = [_group, airportsX + ["CSAT_carrier", "NATO_carrier"]] call _fnc_nearestBase;
-    };
-    if (_vehicle isKindOf "Ship") then {
-        _marker = _vehicle getVariable "A3A_shipSpawnPos";      // not a marker, but fixed later
     } else {
+        if (_vehicle isKindOf "Ship") exitWith {
+            _marker = _vehicle getVariable "A3A_shipSpawnPos";      // not a marker, but fixed later
+        };
         _marker = [_group, airportsX + outposts] call _fnc_nearestBase;
     };
-
     if (isNil "_marker") exitWith {};       // just carry on
 
     private _returnPos = if (_marker isEqualType "") then { markerPos _marker } else { _marker };

--- a/A3A/addons/core/functions/Base/fn_citySupportChange.sqf
+++ b/A3A/addons/core/functions/Base/fn_citySupportChange.sqf
@@ -6,6 +6,8 @@ FIX_LINE_NUMBERS()
 
 if (!isServer) exitWith {Error("Server-only function miscalled")};
 
+Trace_1("Params: %1", _this);
+
 params [["_change",""], ["_pos",""], ["_scaled", true]]; // nil protection
 if !(_change isEqualType 0) exitWith {Error("The first parameter, the support change, must be a number");};
 if !(_city isEqualType "") exitWith {Error("The second parameter, the position, must be a string (city name) or array (coordinates)");};
@@ -20,12 +22,17 @@ if (_scaled) then {
 	_change = 10 * _change / sqrt _numCiv;			// normalized to 1 = 1% at size 100
 };
 
-private _antenna = A3A_antennaMap get _city;
-if (alive _antenna and _change > 0) then {
-	private _antSide = sidesX getVariable (A3A_antennaMap get netId _antenna);
-	private _antScale = [0.6, 1.5] select (_antSide == teamPlayer);
-	_change = _change * _antScale;
+if (_change > 0) then {
+	private _antenna = A3A_antennaMap get _city;
+	if (!alive _antenna) then { _change = _change * 1.5 } else {
+		private _antSide = sidesX getVariable (A3A_antennaMap get netId _antenna);
+		_change = _change * ([1, 2] select (_antSide == teamPlayer));
+	};
+	private _stationPos = A3A_garrison get _site getOrDefault ["policeStation", false];
+	if (_stationPos isEqualTo []) then { _change = _change * 1.5 };
 };
+
+Trace_2("City %1 change %2", _city, _change);
 
 // Cap rebel support to 0-100. Changes below 0 reduce accumHR
 _supportReb = (_supportReb + _change) min 100;

--- a/A3A/addons/core/functions/Base/fn_moveHQ.sqf
+++ b/A3A/addons/core/functions/Base/fn_moveHQ.sqf
@@ -27,14 +27,14 @@ if !(_possible#0) exitWith {
 
 A3A_petrosMoving = true; publicVariable "A3A_petrosMoving";
 
-private _groupPetros = group petros;
-[petros] join theBoss;
-deleteGroup _groupPetros;
-
 // The enableAI commands will only affect localhost
 petros setBehaviour "AWARE";
 petros enableAI "MOVE";
 petros enableAI "AUTOTARGET";
+
+private _groupPetros = group petros;
+[petros] join theBoss;
+deleteGroup _groupPetros;
 
 fireX inflame false;
 

--- a/A3A/addons/core/functions/CREATE/fn_patrolReinf.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_patrolReinf.sqf
@@ -66,10 +66,10 @@ if (_isLand) then {
 	private _startPos = getPosATL _vehicle;
 	sleep 10;
 	if (_startPos distance2d _vehicle < 10) then {
-        Error_2("Vehicle %1 failed to clear spawn at %2", _vehicle, _marker);
+        Error_2("Vehicle %1 failed to clear spawn at %2", _vehicle, _mrkOrigin);
         // teleport to first waypoint
         // arguably should just return empty array...
-        private _wayPos = waypoints _crewGroup # 0;
+        private _wayPos = waypointPosition (waypoints _crewGroup # 0);
         _vehicle setVehiclePosition [_wayPos, [], 10, "NONE"];
         _crewGroup setCurrentWaypoint 1;
 	};

--- a/A3A/addons/core/functions/CREATE/fn_reinforceSide.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_reinforceSide.sqf
@@ -19,7 +19,7 @@ if (gamemode == 3 and _side == Invaders) exitWith {};
 
 private _faction = Faction(_side);
 private _lowAir = _faction getOrDefault ["attributeLowAir", false];
-private _totalReinf = 0.1 * ([A3A_resourcesDefenceOcc, A3A_resourcesDefenceInv] select (_side == Invaders));       // spend 10% of defence resources
+private _totalReinf = 0.2 * ([A3A_resourcesDefenceOcc, A3A_resourcesDefenceInv] select (_side == Invaders));       // spend 20% of defence resources
 Debug_2("%1 has %2 resources available for reinforcements", _side, _totalReinf);
 if (_totalReinf <= 0) then {continue};
 

--- a/A3A/addons/core/functions/GarrisonLocal/fn_spawnGarrisonSquads.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_spawnGarrisonSquads.sqf
@@ -139,7 +139,7 @@ private _fnc_initUnit = [A3A_fnc_NATOinit, A3A_fnc_FIAinitBases] select (_side =
         [_curGroup, "Patrol_Defend", 0, _squadRad, -1, true, _markerPos, false, false] call A3A_fnc_patrolLoop;
 
         // Add UAV if it's a specops roaming group
-        if (_type == "camp" and _faction get "uavsPortable" isNotEqualTo []) then
+        if (_type == "camp" and {_storedTroops#1 > 2.2} and _faction get "uavsPortable" isNotEqualTo []) then
         {
     		private _typeVeh = selectRandom (_faction get "uavsPortable");
 			private _uav = createVehicle [_typeVeh, getPosATL leader _curGroup, [], 0, "FLY"];

--- a/A3A/addons/core/functions/GarrisonServer/fn_showSiteInfo.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_showSiteInfo.sqf
@@ -41,7 +41,7 @@ private _text = call {
 
         (A3A_cityData getVariable _marker) params ["_numCiv", "_suppReb"];
         private _text = format [localize "STR_A3A_fn_init_cityinfo_overview_2",
-            _marker, _numCiv, 100-_suppReb, _suppReb, "%", FactionGet(occ,"name"), FactionGet(reb,"name")];
+            _marker, _numCiv, 100-_suppReb toFixed 0, _suppReb toFixed 0, "%", FactionGet(occ,"name"), FactionGet(reb,"name")];
 
         private _power = call {
             private _antenna = A3A_antennaMap get _marker;

--- a/A3A/addons/core/functions/Missions/fn_CON_PoliceStation.sqf
+++ b/A3A/addons/core/functions/Missions/fn_CON_PoliceStation.sqf
@@ -20,13 +20,14 @@ private _taskId = "SUPP" + str A3A_taskCount;
 [[teamPlayer,civilian],_taskId,[_textX,_taskName],_taskPos,false,0,true,"Target",true] call BIS_fnc_taskCreate;
 [_taskId, "SUPP", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
+private _startTime = time;
 private _timeout = time + 90*60;
 waitUntil {sleep 1; (time > _timeout) or (sidesX getVariable _marker == teamPlayer) or (!alive _policeStation)};
 
 if (time > _timeout) then
 {
 	[_taskId, "SUPP", "FAILED"] call A3A_fnc_taskSetState;
-    [-200, _markerSide] remoteExec ["A3A_fnc_timingCA",2];
+    //[-200, _markerSide] remoteExec ["A3A_fnc_timingCA",2];
     [-10,theBoss] call A3A_fnc_playerScoreAdd;
 }
 else
@@ -39,4 +40,5 @@ else
     [10,theBoss] call A3A_fnc_playerScoreAdd;
 };
 
-[_taskId, "SUPP", 1200] spawn A3A_fnc_taskDelete;
+private _delay = 0 min (_startTime + 1200 - time);
+[_taskId, "SUPP", _delay] spawn A3A_fnc_taskDelete;

--- a/A3A/addons/core/functions/Missions/fn_missionRequest.sqf
+++ b/A3A/addons/core/functions/Missions/fn_missionRequest.sqf
@@ -165,7 +165,7 @@ switch (_type) do {
             Debug_1("City weights: %1", _weightedMarkers);
 			private _site = selectRandomWeighted _weightedMarkers;
 			private _stationPos = A3A_garrison get _site getOrDefault ["policeStation", false];
-			if (_stationPos isEqualType [] and sidesX getVariable _site == Occupants) exitWith {
+			if (random 1 < 0.5 and _stationPos isEqualType [] and sidesX getVariable _site == Occupants) exitWith {
 				[_site, nearestBuilding _stationPos] spawn A3A_fnc_CON_PoliceStation;
 			};
 			[A3A_tasks_fnc_LOG_Supplies, [_site]] spawn A3A_tasks_fnc_runTask;

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -196,6 +196,10 @@ player addEventHandler ["GetOutMan", {
     if (!isNull _handle) then { terminate _handle };
 }];
 
+player addEventHandler ["Killed", {
+    [-1, 0] remoteExecCall ["A3A_fnc_resourcesFIA", 2];
+}];
+
 // Prevent players getting shot by their own AIs. EH is respawn-persistent
 player addEventHandler ["HandleRating", {0}];
 

--- a/A3A/addons/core/functions/init/fn_installClientEH.sqf
+++ b/A3A/addons/core/functions/init/fn_installClientEH.sqf
@@ -114,7 +114,3 @@ player addEventHandler ["WeaponDisassembled", {
         [_veh] remoteExecCall ["A3A_fnc_garrisonServer_remVehicle", 2];
     };
 }];
-
-player addEventHandler ["Killed", {
-    [-1, 0] remoteExecCall ["A3A_fnc_resourcesFIA", 2];
-}];

--- a/A3A/addons/core/functions/init/fn_resourcecheck.sqf
+++ b/A3A/addons/core/functions/init/fn_resourcecheck.sqf
@@ -12,8 +12,8 @@ while {true} do
 	waitUntil {sleep 15; time >= nextTick};
     waitUntil {sleep 10; A3A_activePlayerCount > 0};
 
-	private _resAdd = 25;//0
-	private _hrAdd = 2 / A3A_balancePlayerScaleBase;
+	private _resAdd = 50;//0
+	private _hrAdd = 3; // A3A_balancePlayerScaleBase;
 
 	private _suppBoost = 0.5 * (1+ ({sidesX getVariable [_x,sideUnknown] == teamPlayer} count seaports));
 	private _resBoost = 1 + (0.25*({(sidesX getVariable [_x,sideUnknown] == teamPlayer) and !(_x in destroyedSites)} count factories));

--- a/A3A/addons/tasks/Params/fn_city_hostage_p.sqf
+++ b/A3A/addons/tasks/Params/fn_city_hostage_p.sqf
@@ -5,12 +5,14 @@ params ["_marker"];
 
 // Find building with places that's not too close to enemies or players
 private _markerPos = markerPos _marker;
-private _blockers = (units Occupants + units teamPlayer) inAreaArray [_markerPos, 250, 250];
+private _eblockers = units Occupants inAreaArray [_markerPos, 250, 250];
+private _rblockers = units teamPlayer inAreaArray [_markerPos, 250, 250];
 private _house = objNull;
 for "_i" from 1 to 10 do {
     private _rpos = _markerPos getPos [200 * sqrt random 1, random 360];
     private _testHouse = nearestBuilding _rpos;         // should guarantee places?
-    if (_blockers inAreaArray [getPosATL _testHouse, 20, 20] isNotEqualTo []) then { continue };
+    if (_eblockers inAreaArray [getPosATL _testHouse, 20, 20] isNotEqualTo []) then { continue };
+    if (_rblockers inAreaArray [getPosATL _testHouse, 50, 50] isNotEqualTo []) then { continue };
     if (count (_testHouse buildingPos -1) >= 4) exitWith { _house = _testHouse };
 };
 if (isNull _house) exitWith {

--- a/A3A/addons/tasks/Tasks/fn_LOG_Supplies.sqf
+++ b/A3A/addons/tasks/Tasks/fn_LOG_Supplies.sqf
@@ -47,13 +47,16 @@ if (isNil "_checkpoint") then {
 	_params params ["_marker"];
 
 	// Specify larger object to leave space around box
-	private _boxPos = (getMarkerPos respawnTeamPlayer) findEmptyPosition [1,50,"C_Van_01_box_F"];
+	private _hqpos = getMarkerPos respawnTeamPlayer;
+	private _boxPos = _hqPos findEmptyPosition [1,75,"C_Van_01_box_F"];
+	if (_boxPos isEqualTo []) then { _boxPos = _hqPos findEmptyPosition [1,75,"Land_FoodSacks_01_cargo_brown_F"] };
+	if (_boxPos isEqualTo []) then { _boxPos = _hqPos getPos [75 * sqrt random 1, random 360] };
 	[_boxPos] call _fnc_createBox;
 
 	// Determine end time and description
-	private _difficulty = [1, 2] select (random 10 < tierWar);
+	private _difficulty = 1; //[1, 2] select (random 10 < tierWar);
 	if (sidesX getVariable _marker == teamPlayer) then { _difficulty = 1 };
-
+	
 	_task set ["_marker", _marker];
 	_task set ["_difficulty", _difficulty];
 	_task set ["_endTime", time + 60 * (15 + 30*_difficulty)];
@@ -69,6 +72,8 @@ else {
 	_task set ["_endTime", time + _remTime];
 	_task call _fnc_createTask;
 };
+
+A3A_activeTasks pushBack "SUPP";			// backwards compat with missionRequest
 
 _task set ["checkpoint", "c_started"];
 _task set ["state", "s_waitForPlace"];
@@ -105,6 +110,7 @@ _task set ["s_waitForPlace",
 	// Ok, now we go into the placed state
 	_this set ["state", "s_boxPlaced"];
 	_this set ["_countdown", 120 * (_this get "_difficulty")];			// maybe shouldn't reset?
+	_this set ["_blockTime", time];
 
 	// Remove captive from friendlies
 	{
@@ -131,12 +137,10 @@ _task set ["s_boxPlaced",
 	private _marker = _this get "_marker";
 	if !(call (_this get "_fnc_placedCondition")) exitWith { _this set ["state", "s_waitForPlace"]; false };
 
-	private _blockTime = _this getOrDefault ["_blockTime", -1000];
-
 	// Check that there are friendlies nearby and enemies not nearby
 	if ({_x call A3A_fnc_canFight} count (units Occupants inAreaArray [getPosATL _box, 50, 50]) > 0
 		or {_x call A3A_fnc_canFight} count (units teamPlayer inAreaArray [getPosATL _box, 50, 50]) == 0) exitWith {
-		if (time - _blockTime > 30) then {
+		if (time - (_this getOrDefault ["_blockTime", -30]) > 30) then {
 			[_this get "_hintTitle", localize "STR_A3A_Tasks_LOG_Supplies_condition", getPosATL _box, 50] call FUNC(hintNear);
 			_this set ["_blockTime", time];
 		};
@@ -161,7 +165,7 @@ _task set ["s_boxPlaced",
 	};
 
 	// Show the countdown if blocked on last check
-	if (_blockTime >= 0) then {
+	if ("_blockTime" in _this) then {
 		private _nearPlayers = playableUnits inAreaArray [getPosATL _box, 300, 300];
 		private _endTime = serverTime + _countdown;
 		[_this get "_hintTitle", localize "STR_A3A_Tasks_LOG_Supplies_countdown", _endTime, _box, 50] remoteExec ["A3A_fnc_customHintCountdown", _nearPlayers];
@@ -170,18 +174,17 @@ _task set ["s_boxPlaced",
 	false;
 }];
 
-
 _task set ["s_succeeded", {
 	private _bonus = _this get "_difficulty";
 	private _marker = _this get "_marker";
 
 	// TODO: pull this shit out
 	private _playersInRange = (allPlayers - (entities "HeadlessClient_F")) inAreaArray [markerPos _marker, 250, 250];
-	{[10*_bonus * tierWar, _x] call A3A_fnc_playerScoreAdd} forEach _playersInRange;
-	[5*_bonus * tierWar, theBoss] call A3A_fnc_playerScoreAdd;
+	{[5*_bonus, _x] call A3A_fnc_playerScoreAdd} forEach _playersInRange;
+	[5*_bonus, theBoss] call A3A_fnc_playerScoreAdd;
 
 	[15 * _bonus, _marker] remoteExecCall ["A3A_fnc_citySupportChange", 2];
-	[0, 200 * _bonus * tierWar] remoteExec ["A3A_fnc_resourcesFIA", 2];
+	[0, 200 * _bonus] remoteExec ["A3A_fnc_resourcesFIA", 2];
 
 	[_this get "_taskId", "SUCCEEDED"] call BIS_fnc_taskSetState;
 	_this set ["state", "s_cleanup"]; false;
@@ -207,6 +210,16 @@ _task set ["s_cleanup", {
 	// TODO: task deletion, rate throttling?
 	// maybe we should restrict tasks based on request time not completion/failure time?
 	// so then throttling moves to the request management
+
+	// reverse-engineer task start time
+	private _startTime = (_this get "_endTime") - 60 * (15 + 30*(_this get "_difficulty"));
+	private _clearTime = 0 max ((_startTime + 1200) - time);
+	Trace_3("Start time %1; time %2; clearTime %3", _startTime, time, _clearTime);
+	_clearTime spawn {
+		sleep _this;
+		A3A_activeTasks deleteAt (A3A_activeTasks find "SUPP");
+		publicVariable "A3A_activeTasks";
+	};
 
 	(_this get "_taskId") spawn {
 		sleep 120;

--- a/A3A/addons/tasks/Tasks/fn_cityBattle.sqf
+++ b/A3A/addons/tasks/Tasks/fn_cityBattle.sqf
@@ -237,7 +237,7 @@ _task set ["s_waitForStart",
 
     // Perf saving condition: If all troops reached the city but it's not spawned then disable sim
     if (spawner getVariable _marker != 0 and {count (_troops inAreaArray [_pos, 500, 500]) == count _troops}) exitWith {
-        { _x enableSimulationGlobal false; _x hideObjectGlobal true } forEach (_this get "_vehicles");
+        { _x enableSimulationGlobal false; _x hideObjectGlobal true } forEach (_this get "_vehicles" select { _x isKindOf "Land" });
         { _x enableSimulationGlobal false; _x hideObjectGlobal true } forEach _troops;
         _this set ["state", "s_troopsPaused"]; false;
     };
@@ -255,7 +255,7 @@ _task set ["s_troopsPaused",
     };
 
     if (spawner getVariable _marker == 0) exitWith {
-        { _x enableSimulationGlobal true; _x hideObjectGlobal false } forEach (_this get "_vehicles");
+        { _x enableSimulationGlobal true; _x hideObjectGlobal false } forEach (_this get "_vehicles" select { _x isKindOf "Land" });
         { _x enableSimulationGlobal true; _x hideObjectGlobal false } forEach (_this get "_troops");
         _this set ["state", "s_waitForStart"]; false;
     };
@@ -292,8 +292,8 @@ _task set ["s_victory",
 
     // TODO: scale with city size
 	private _playersInRange = (allPlayers - entities "HeadlessClient_F") inAreaArray [markerPos _marker, 500, 500];
-	{[100, _x] call A3A_fnc_playerScoreAdd} forEach _playersInRange;
-	[50, theBoss] call A3A_fnc_playerScoreAdd;
+	{[10, _x] call A3A_fnc_playerScoreAdd} forEach _playersInRange;
+	[10, theBoss] call A3A_fnc_playerScoreAdd;
 
 	[_this get "_taskId", "SUCCEEDED"] call BIS_fnc_taskSetState;
     _this set ["state", "s_cleanup"]; false;
@@ -305,7 +305,7 @@ _task set ["s_defeat",
     private _marker = _this get "_marker";
     [-50, _marker, false] remoteExecCall ["A3A_fnc_citySupportChange", 2];
 
-	[-20, theBoss] call A3A_fnc_playerScoreAdd;
+	[-10, theBoss] call A3A_fnc_playerScoreAdd;
 
 	[_this get "_taskId", "FAILED"] call BIS_fnc_taskSetState;
     _this set ["state", "s_cleanup"]; false;

--- a/A3A/addons/tasks/Tasks/fn_city_killcop.sqf
+++ b/A3A/addons/tasks/Tasks/fn_city_killcop.sqf
@@ -31,7 +31,7 @@ _task set ["s_waitForKill", {
     private _target = _this get "_target";
     if (isNull _target) exitWith {
         // Despawned. Delete the mission and exit.
-   		[_this, true, true] call BIS_fnc_deleteTask;
+   		[_this get "_taskId", true, true] call BIS_fnc_deleteTask;
     	true;		                                    // delete the task
     };
 

--- a/A3A/addons/tasks/Tasks/fn_city_repair.sqf
+++ b/A3A/addons/tasks/Tasks/fn_city_repair.sqf
@@ -164,7 +164,7 @@ _task set ["s_success", {
 	{[10, _x] call A3A_fnc_playerScoreAdd} forEach _playersInRange;
 	[5, theBoss] call A3A_fnc_playerScoreAdd;
 
-	[5, _this get "_marker"] remoteExecCall ["A3A_fnc_citySupportChange", 2];
+	[8, _this get "_marker"] remoteExecCall ["A3A_fnc_citySupportChange", 2];
 	[0, 100] spawn A3A_fnc_resourcesFIA;
 
 	[_this get "_taskId", "SUCCEEDED"] call BIS_fnc_taskSetState;


### PR DESCRIPTION
Balance changes:
- Buffed speed of city support changes, reduced antenna importance a bit.
- Towns with police station destroyed now have *1.5 city support change multiplier.
- Doubled enemy spend on reinforcements.
- Prevented camp squads spawning UAVs unless they're actually specops or near.
- Reduced block time for police station & city supply missions.
- Increased city supply missions relative to police station missions.
- Increased base HR income for large player counts.
- Reduced money income of some missions.

Fixes:
- Fixed bug where HR loss on player death would stack with death count.
- Fixed city supply mission countdown not showing in some cases.
- Fixed air vehicles returning to outposts.
- Attempted fix of hostage/passenger getting back into vehicle.
- Fix bug in kill cop despawn case.
- Fix spawn failure logic in patrolReinf.
- Attempted fix of petros not moving for some commanders.
- Fixed excessive display precision of city support.
- Moved hostage missions further away from players.
- Prevented sim disable of air vehicles at city battle missions.

## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
