### PR TITLE
Fix some attachment garaging bugs

### DIFF
--- a/A3A/addons/core/functions/EventHandler/fn_addVehAttachDetachEH.sqf
+++ b/A3A/addons/core/functions/EventHandler/fn_addVehAttachDetachEH.sqf
@@ -26,6 +26,7 @@ _veh addEventHandler ["Detached", {
         // Wait for the thing to settle
         waitUntil { sleep 1; vectorMagnitude velocity _veh < 0.01 };
 
+        if (isNull _veh) exitWith {};                       // might have been deleted immediately after detaching
         if (getNumber (configOf _veh >> "hasDriver") != 0 and !(_veh inArea "Synd_HQ")) exitWith {};      // quadbikes shouldn't be auto-added
         if (!isNull attachedTo _veh) exitWith {};           // might be attached again
         isNil { ["", _veh] call A3A_fnc_garrisonServer_addVehicle };

--- a/A3A/addons/garage/Stringtable.xml
+++ b/A3A/addons/garage/Stringtable.xml
@@ -44,6 +44,9 @@
         <Turkish>%1'e ait bir Havaalanının yakınında değilken bir uçağı garaja alamazsınız. Garajı kullanabilmek için lütfen uçağınızı kontrolünüz altındaki bir Havaalanına götürün</Turkish>
         <Chinesesimp>你不能在不属于 1% 的机场附近存放飞行器，移动到附近的友军机场来存取它</Chinesesimp>
       </Key>
+      <Key ID="STR_HR_GRG_Feedback_addVehicle_Attached">
+        <Original>You can't garage an object that's attached to another vehicle</Original>
+      </Key>
       <Key ID="STR_HR_GRG_Feedback_addVehicle_badLocation">
         <Original>You and the vehicle need to be in a %1 garrisons surroundings in order to garage a it</Original>
         <German>Du musst dich mit dem Fahrzeug in der Nähe eines 1% Standorts befinden um es in einer Garage zu parken.</German>


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed some bugs:
- Utility items in ACE cargo would be lost (well, underground) on garaging.
- Garaging a vehicle with a quadbike on it could ignore garage caps and lose the quadbike's items.
- It was possible to garage an object while loaded into a vehicle, causing desync of cargo slots.

May have added an issue where blacklisted attachments are left in place rather than deleted. I don't know of an example case to test.

Utility items in logistics cargo still floats in mid-air until another physX object moves nearby. It's probably for the best.

### Please specify which Issue this PR Resolves.
closes #3636

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
