### PR TITLE
Improve performance of mapDrawUserMarkersEH

### DIFF
--- a/A3A/addons/gui/functions/GUI/fn_mapDrawUserMarkersEH.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_mapDrawUserMarkersEH.sqf
@@ -41,8 +41,8 @@ params ["_map"];
     _markerColor = (configFile >> "CfgmarkerColors" >> getmarkerColor _x >> "color") call BIS_fnc_colorConfigToRGBA;
 
     // Check for line markers
-    private _markerPolyline = markerPolyline _x;
-    if (_markerPolyline isEqualto []) then
+    private _polyline = markerPolyline _x;
+    if (_polyline isEqualto []) then
     {
         // not a line marker
         // Get marker data
@@ -63,18 +63,11 @@ params ["_map"];
         ];
     } else {
         // Marker is a line marker
-
-        // Convert polyLine array to coordinates
-        _lineCoords = [];
-        for [{ _i = 0 }, { _i < ((count _markerPolyline) - 1)}, { _i = _i + 2 }] do
-        {
-            _lineCoords pushBack [_markerPolyline # _i, _markerPolyline # (_i + 1)];
-        };
-
-        // Draw line Segments
-        for [{ _i = 0 }, { _i < ((count _lineCoords) - 2)}, { _i = _i + 1 }] do
-        {
-            _map drawLine [_lineCoords # _i, _lineCoords # (_i + 1), _markerColor];
+        private _lastPoint = [_polyLine#0, _polyLine#1];
+        for "_i" from 2 to (count _polyline - 2 min 200) step 2 do {
+            private _newPoint = [_polyLine#_i, _polyLine#(_i+1)];
+            _map drawLine [_lastPoint, _newPoint, _markerColor];
+            _lastPoint = _newPoint;
         };
     };
 } forEach allMapMarkers;


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement
4. [X] Performance

### What have you changed and why?
Improved the performance of mapDrawUserMarkersEH when drawing polylines. Also capped each marker to 200 line segments drawn, which seems like a reasonable maximum unless people are drawing for the fun of it.

There doesn't seem to be a *good* way to draw a polyline marker onto a map control. drawPolygon doesn't work because it completes the loop. This algorithm (without the cap) is maybe twice as fast as the previous code but perf can still get pretty bad compared to the original marker rendering. Can't do anything about that without Arma changes though.

### Please specify which Issue this PR Resolves.
closes #3610

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
