### PR TITLE
Reduce city reinf log spam

### DIFF
--- a/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_cityReinf.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_cityReinf.sqf
@@ -16,8 +16,6 @@ FIX_LINE_NUMBERS()
 
 params ["_marker", "_troopCount"];
 
-Trace_1("Called with params %1", _this);
-
 // Add to the server garrison data store
 
 private _garrison = A3A_garrison get _marker;
@@ -26,6 +24,7 @@ if (_troops#0 >= A3A_garrisonSize get _marker) exitWith {};         // maxed
 private _reinf = _troopCount + (_garrison getOrDefault ["reinfCount", 0]);
 
 while {_reinf >= 2} do {
+    Trace_1("Reinforcing city %1", _marker);
     _troops set [0, (_troops#0) + 2];
     _reinf = _reinf - 2;
     if (_marker in A3A_garrisonMachine) then {


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
City reinf currently spams once per city per minute in debug mode. Changed to only log when a city is actually reinforced.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
