### PR TITLE
Switch hostage & taxi to use follow function

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -6,6 +6,7 @@ class CfgFunctions
         class AI {
             file = QPATHTOFOLDER(functions\AI);
             class AIdrag {};
+            class AIfollow {};
             class airbomb {};
             class AIreactOnKill {};
             class artySupport {};

--- a/A3A/addons/core/functions/AI/fn_AIfollow.sqf
+++ b/A3A/addons/core/functions/AI/fn_AIfollow.sqf
@@ -1,0 +1,74 @@
+// Spawned script to cause "civilian" AI to follow player, including into vehicles
+
+params ["_unit", "_target"];
+
+// Can be used to switch to following a different unit
+private _AIScriptHandle = _unit getVariable "A3A_AIScriptHandle";
+if (!isNil "_AIScriptHandle") then { terminate _AIScriptHandle };
+_unit setVariable ["A3A_AIScriptHandle", _thisScript];
+
+_unit enableAI "PATH";
+doStop _unit;
+
+private _state = "FOLLOW";          //states: "MOUNT", "RIDE", "DISMOUNT", "FOLLOW"
+private _timeout = 0;
+private _lastPos = getPosATL _unit;
+private _curVehicle = objNull;              // assume we didn't start in vehicle...
+
+while {alive _target} do {
+    sleep 1;
+    if (_target getVariable ["incapacitated", false]) then { continue };
+
+    switch (_state) do {
+        case "FOLLOW": {
+            // If target boarded a vehicle with cargo spaces, attempt to board it
+            if (vehicle _target emptyPositions "cargo" > 0) exitWith {
+                _curVehicle = vehicle _target;
+                _unit assignAsCargo _curVehicle;
+                [_unit] orderGetIn true;
+                _timeout = time + 20;
+                _state = "MOUNT";
+            };
+
+            // Otherwise follow on foot
+            private _formDist = [2, 5] select (vehicle _target != _target);
+            private _formPos = _target getPos [_formDist, _target getDir _unit];
+            if (_formPos distance2d _unit > 8 and _lastPos distance2d _unit < 0.05) then { _unit setPosATL _formPos };      // stuck fix
+            _unit doMove _formPos;
+            _lastPos = getPosATL _unit;
+        };
+        case "RIDE": {
+            // If target left our vehicle, join them
+            if (vehicle _target != _curVehicle) exitWith {
+                _curVehicle = objNull;
+                unassignVehicle _unit;
+                _timeout = time + 5;
+                _state = "DISMOUNT";
+            };
+        };
+        case "MOUNT": {
+            if (vehicle _unit == _curVehicle) exitWith {
+                _state = "RIDE";
+            };
+            if (vehicle _target != _curVehicle or _curVehicle emptyPositions "cargo" == 0) exitWith {
+                unassignVehicle _unit;
+                _state = "FOLLOW";
+            };
+            if (time > _timeout) then {
+                // force into vehicle if close (cargo should be free from above check)
+                if (_curVehicle distance2d _unit < 10) exitWith { _unit moveInCargo _curVehicle };
+                unassignVehicle _unit;
+                _state = "FOLLOW";
+            };
+        };
+        case "DISMOUNT": {
+            if (vehicle _unit == _unit) exitWith {
+                _state = "FOLLOW";
+            };
+            if (time > _timeout) exitWith {
+                moveOut _unit;
+                _state = "FOLLOW";
+            };
+        };
+    };
+};

--- a/A3A/addons/tasks/Helpers/fn_hintNear.sqf
+++ b/A3A/addons/tasks/Helpers/fn_hintNear.sqf
@@ -10,4 +10,5 @@ FIX_LINE_NUMBERS()
 params ["_title", "_bodyText", "_center", "_radius"];
 
 private _nearPlayers = playableUnits inAreaArray [_center, _radius, _radius];
+if (_nearPlayers isEqualTo []) exitWith {};
 [_title, _bodyText] remoteExecCall ["A3A_fnc_customHint", _nearPlayers];

--- a/A3A/addons/tasks/Helpers/fn_taskNotifyNear.sqf
+++ b/A3A/addons/tasks/Helpers/fn_taskNotifyNear.sqf
@@ -7,4 +7,5 @@ private _typeTexture = [[_taskId] call BIS_fnc_taskType] call BIS_fnc_taskTypeIc
 private _title = [_taskId] call BIS_fnc_taskDescription select 1 select 0;      // For some reason this is an array of arrays of strings...
 
 private _nearPlayers = playableUnits inAreaArray [_center, _radius, _radius];
+if (_nearPlayers isEqualTo []) exitWith {};
 [_notifyType, [_typeTexture, _title]] remoteExecCall ["BIS_fnc_showNotification", _nearPlayers];

--- a/A3A/addons/tasks/Tasks/fn_city_hostage.sqf
+++ b/A3A/addons/tasks/Tasks/fn_city_hostage.sqf
@@ -20,15 +20,19 @@ private _hostagePos = _positions deleteAt (floor random count _positions);
 private _hostage = [createGroup [civilian, true], FactionGet(civ, "unitMan"), _hostagePos, [], 0, "NONE"] call A3A_fnc_createUnit;
 _hostage setDir (_house getRelDir _hostagePos);
 _hostage disableAI "PATH";
+_hostage disableAI "FSM";      // attempt to prevent occasional case of jumping out and running off
+_hostage disableAI "AUTOCOMBAT";
+group _hostage setBehaviourStrong "SAFE";
 _task set ["_hostage", _hostage];
 
 // Add global action
 private _addActionCode = {
     params ["_unit"];
-    private _condition = toString { (isPlayer _this) and (lifeState _target == "HEALTHY") and (_target isNil "A3A_taxiDriver") };
+    private _condition = toString { (isPlayer _this) and (alive _target) and (_target getVariable ["A3A_taxiDriver", objNull] != _this) };
     _unit addAction [localize "STR_A3A_Tasks_taxi_leave", {
         params ["_target", "_caller"];
         _target setVariable ["A3A_taxiDriver", _caller, true];
+        [_target, _caller] remoteExec ["A3A_fnc_AIfollow", _target];
     },nil,0,false,true,"",_condition, 4];
 };
 [_hostage, _addActionCode] remoteExec ["call", 0, _hostage];
@@ -54,9 +58,9 @@ _task set ["_taskId", _taskId];
 // Function to be run passenger-local on completion
 _task set ["_fnc_getOut", {
     params ["_passenger", "_destPos"];
+    terminate (_unit getVariable ["A3A_AIScriptHandle", scriptNull]);
     unassignVehicle _passenger;
     moveOut _passenger;
-    [_passenger] joinSilent createGroup [civilian, true];
     _passenger doMove _destPos;
 }];
 
@@ -68,22 +72,14 @@ Trace_1("Initial data: %1" _task);
 _task set ["s_waitForPickup", {
     private _hostage = _this get "_hostage";
     if !(_hostage isNil "A3A_taxiDriver") exitWith {
-
-        private _taxiGroup = group (_hostage getVariable "A3A_taxiDriver");
-        _this set ["_taxiGroup", _taxiGroup];
-        _this set ["_endTime", (_this get "_endTime") + 30*60];
-
         // Play start message & set description
         // I'm glad you're here. Get me to any rebel location and I'll figure it out from there.
-        [_this get "_hintTitle", localize "STR_A3A_Tasks_hostage_start"] remoteExecCall ["A3A_fnc_customHint", units _taxiGroup];
+        [_this get "_hintTitle", localize "STR_A3A_Tasks_hostage_start", getPosATL _hostage, 50] call FUNC(hintNear);
 
+        _this set ["_endTime", (_this get "_endTime") + 30*60];
 	    private _displayTime = [((_this get "_endTime") - time) / 60] call FUNC(minutesFromNow);
         private _taskDesc = format [localize "STR_A3A_Tasks_hostage_startDesc", _displayTime];
         [_this get "_taskId", [_taskDesc, _this get "_hintTitle", ""]] call BIS_fnc_taskSetDescription;
-
-        // Join group
-        _hostage enableAI "PATH";
-        [_hostage] joinSilent _taxiGroup;
 
         _this set ["state", "s_transit"]; false;
     };
@@ -117,8 +113,7 @@ _task set ["s_transit", {
     if (time > _this get "_endTime" and _vehSpeed < 2) exitWith {
 
         // Are you even trying to get anywhere? I'll find my own way out.
-        private _nearPlayers = units (_this get "_taxiGroup") inAreaArray [getPosATL _hostage, 50, 50];
-        [_this get "_hintTitle", localize "STR_A3A_Tasks_hostage_angry"] remoteExecCall ["A3A_fnc_customHint", _nearPlayers];
+        [_this get "_hintTitle", localize "STR_A3A_Tasks_hostage_angry", getPosATL _hostage, 50] call FUNC(hintNear);
 
         private _destPos = getPosATL _hostage getPos [1000, random 360];
         [[_hostage, _destPos], _this get "_fnc_getOut"] remoteExec ["call", _hostage];
@@ -129,11 +124,12 @@ _task set ["s_transit", {
 }];
 
 _task set ["s_success", {
-	private _playersInRange = units (_this get "_taxiGroup") inAreaArray [getPosATL (_this get "_hostage"), 250, 250];
-	{[10, _x] call A3A_fnc_playerScoreAdd} forEach _playersInRange;
-	[5, theBoss] call A3A_fnc_playerScoreAdd;
+	private _playersInRange = playableUnits inAreaArray [_this get "_hostage", 100, 100];
+	{[10 / count _playersInRange, _x] call A3A_fnc_playerScoreAdd} forEach _playersInRange;
+	[2, theBoss] call A3A_fnc_playerScoreAdd;
 
 	[10, _this get "_marker"] remoteExecCall ["A3A_fnc_citySupportChange", 2];
+    [2, 0] remoteExec ["A3A_fnc_resourcesFIA", 2];        // direct HR reward
 
     [_this get "_taskId", "SUCCEEDED", getPosATL (_this get "_hostage"), 100] call FUNC(taskNotifyNear);
     [_this get "_taskId", "SUCCEEDED", false] call BIS_fnc_taskSetState;

--- a/A3A/addons/tasks/Tasks/fn_city_taxi.sqf
+++ b/A3A/addons/tasks/Tasks/fn_city_taxi.sqf
@@ -19,15 +19,19 @@ _task set ["_endTime", time + 15*60];
 private _passenger = [createGroup [civilian, true], FactionGet(civ, "unitMan"), _startPos, [], 0, "NONE"] call A3A_fnc_createUnit;
 _passenger setDir _startDir;
 _passenger disableAI "PATH";
+_hostage disableAI "FSM";      // attempt to prevent occasional case of jumping out and running off
+_hostage disableAI "AUTOCOMBAT";
+group _hostage setBehaviourStrong "SAFE";
 _task set ["_passenger", _passenger];
 
 // Add global action
 private _addActionCode = {
     params ["_unit"];
-    private _condition = toString { (isPlayer _this) and (lifeState _target == "HEALTHY") and (_target isNil "A3A_taxiDriver") };
+    private _condition = toString { (isPlayer _this) and (alive _target) and (_target getVariable ["A3A_taxiDriver", objNull] != _this) };
     _unit addAction [localize "STR_A3A_Tasks_taxi_leave", {
         params ["_target", "_caller"];
         _target setVariable ["A3A_taxiDriver", _caller, true];
+        [_target, _caller] remoteExec ["A3A_fnc_AIfollow", _target];
     },nil,0,false,true,"",_condition, 4];
 };
 [_passenger, _addActionCode] remoteExec ["call", 0, _passenger];
@@ -51,6 +55,7 @@ _task set ["_destRad", _compRad];
 // Function to be run passenger-local on completion
 _task set ["_fnc_getOut", {
     params ["_passenger", "_destPos"];
+    terminate (_unit getVariable ["A3A_AIScriptHandle", scriptNull]);       // turn off the follow logic
     unassignVehicle _passenger;
     moveOut _passenger;
     [_passenger] joinSilent createGroup [civilian, true];
@@ -70,22 +75,15 @@ _task set ["s_waitForPickup", {
     private _passenger = _this get "_passenger";
     if !(_passenger isNil "A3A_taxiDriver") exitWith {
 
-        private _taxiGroup = group (_passenger getVariable "A3A_taxiDriver");
-        _this set ["_taxiGroup", _taxiGroup];
-        _this set ["_endTime", (_this get "_endTime") + 45*60];
-
         // Play start message & set description
         private _hintStr = format [localize "STR_A3A_Tasks_taxi_start", _this get "_destMrk"];
-        [_this get "_hintTitle", _hintStr] remoteExecCall ["A3A_fnc_customHint", units _taxiGroup];
+        [_this get "_hintTitle", _hintStr, getPosATL _passenger, 50] call FUNC(hintNear);
 
+        _this set ["_endTime", (_this get "_endTime") + 45*60];
 	    private _displayTime = [((_this get "_endTime") - time) / 60] call FUNC(minutesFromNow);
         private _taskDesc = format [localize "STR_A3A_Tasks_taxi_startDesc", _this get "_destMrk", _displayTime];
         [_this get "_taskId", [_taskDesc, _this get "_hintTitle", ""]] call BIS_fnc_taskSetDescription;
         [_this get "_taskId", _this get "_destPos"] call BIS_fnc_taskSetDestination;         // reposition to destination
-
-        // Join group
-        _passenger enableAI "PATH";
-        [_passenger] joinSilent _taxiGroup;
 
         _this set ["state", "s_transit"]; false;
     };
@@ -121,8 +119,7 @@ _task set ["s_transit", {
     if (time > _this get "_endTime" and _vehSpeed < 2) exitWith {
 
         // Are you just driving me around in circles? I'm outta here.
-        private _nearPlayers = units (_this get "_taxiGroup") inAreaArray [getPosATL _passenger, 50, 50];
-        [_this get "_hintTitle", localize "STR_A3A_Tasks_taxi_angry"] remoteExecCall ["A3A_fnc_customHint", _nearPlayers];
+        [_this get "_hintTitle", localize "STR_A3A_Tasks_taxi_angry", getPosATL _passenger, 50] call FUNC(hintNear);
 
         [[_passenger, _this get "_destPos"], _this get "_fnc_getOut"] remoteExec ["call", _passenger];
         _this set ["state", "s_failure"]; false;
@@ -132,14 +129,14 @@ _task set ["s_transit", {
 
 _task set ["s_success", {
     // TODO: Reward should probably be based on distance
-	private _playersInRange = units (_this get "_taxiGroup") inAreaArray [getPosATL (_this get "_passenger"), 250, 250];
+	private _playersInRange = playableUnits inAreaArray [_this get "_passenger", 100, 100];
 	{[10 / count _playersInRange, _x] call A3A_fnc_playerScoreAdd} forEach _playersInRange;
 	[2, theBoss] call A3A_fnc_playerScoreAdd;
 
     // TODO: Maybe both ends?
     private _distance = markerPos (_this get "_marker") distance2d (_this get "_destPos");
 	[5 + _distance/400, _this get "_marker"] remoteExecCall ["A3A_fnc_citySupportChange", 2];
-	[0, 200] remoteExec ["A3A_fnc_resourcesFIA", 2];
+	[0, 200] remoteExec ["A3A_fnc_resourcesFIA", 2];            // some faction cash
 
     [_this get "_taskId", "SUCCEEDED", getPosATL (_this get "_passenger"), 100] call FUNC(taskNotifyNear);
 	[_this get "_taskId", "SUCCEEDED", false] call BIS_fnc_taskSetState;

--- a/A3A/addons/tasks/stringtable.xml
+++ b/A3A/addons/tasks/stringtable.xml
@@ -147,7 +147,7 @@
         <Original>A rebel agent in %1 needs an escort for important business. He'll make it worth our trouble if we help him. Pick him up before %2. Make sure you bring a vehicle.</Original>
       </Key>
       <Key ID="STR_A3A_Tasks_taxi_leave">
-        <Original>Tell him you're ready to leave</Original>
+        <Original>Tell him to follow you</Original>
       </Key>
       <Key ID="STR_A3A_Tasks_taxi_start">
         <Original>The rebel agent has joined your squad. Take him to his destination in %1.</Original>


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Wrote a function to enable AIs to automatically follow a player without having to join their group. This allows the hostage & taxi missions to be used by players who aren't currently the squad leader. Also includes unstick logic, so AIs stuck in buildings or on scenery will automatically teleport towards the player after a short time. 

Tested moderately including on DS, didn't find a way to break it yet. In theory it also allows other players to order the guy to follow them instead, but that was too much of a pain to test. Probably works. If not then it's not terrible.

Also threw in a fix for Arma complaining about 0-target remoteExecs in the near notify functions and tweaked those two missions a bit.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
