### PR TITLE
Scale HR income by map resources

### DIFF
--- a/A3A/addons/core/functions/Base/fn_citySideChange.sqf
+++ b/A3A/addons/core/functions/Base/fn_citySideChange.sqf
@@ -15,7 +15,7 @@ if (_rebel) then {
 	if (_forceSupport >= 0) then { _cityData set [1, _forceSupport max _cityData#1] };
 	sidesX setVariable [_city, teamPlayer, true];
 	[Occupants, 10, 60] spawn A3A_fnc_addAggression;
-	[_cityData#2 max 0, 0] spawn A3A_fnc_resourcesFIA;
+	[A3A_rebelHRLumpMult * (_cityData#2 max 0), 0] spawn A3A_fnc_resourcesFIA;
 	[_city, teamPlayer] call A3A_fnc_garrisonServer_changeSide;
 	//[_city] call A3A_fnc_deleteNearSites;
 } else {

--- a/A3A/addons/core/functions/init/fn_initZones.sqf
+++ b/A3A/addons/core/functions/init/fn_initZones.sqf
@@ -111,7 +111,7 @@ configClasses (configfile >> "CfgWorlds" >> worldName >> "Names") apply {
 	sidesX setVariable [_mrk, Occupants, true];
 
 	// ok, how much bulk HR? based on pop or sqrt pop? latter is safer...
-	private _info = [_numCiv, 0, 2 * sqrt _numCiv];				// initial full pop, 0% rebel support, 20 HR for 100 pop?
+	private _info = [_numCiv, 0, sqrt _numCiv];				// initial full pop, 0% rebel support, 10 HR for 100 pop (multiplied by map factor on award)
 	A3A_cityData setVariable [_nameX, _info, true];
 	A3A_cityPop set [_nameX, _numCiv];
 
@@ -258,6 +258,22 @@ A3A_fuelStations apply {
 		[_x, 250] call ace_refuel_fnc_setFuel; // only call on fuels that are not blacklisted and first zone init.
 	};
 };
+
+// Generate rebel resource multipliers based on the map
+private _reqGarrison = 0;
+_reqGarrison = _reqGarrison + 30 * count airportsX;
+_reqGarrison = _reqGarrison + 20 * (count outposts + count seaports);
+_reqGarrison = _reqGarrison + 10 * (count factories + count resourcesX);
+
+private _sumPop = 0;
+{ _sumPop = _sumPop + sqrt (A3A_cityPop get _x) } forEach citiesX;
+
+// Goal for incremental income is 5HR at half-map support per 10min tick
+A3A_rebelHRTickMult = 10 / _sumPop;
+
+// Goal for lump sum is to fill garrisons
+A3A_rebelHRLumpMult = _reqGarrison / _sumPop;
+
 
 publicVariable "blackListDest";
 publicVariable "markersX";

--- a/A3A/addons/core/functions/init/fn_resourcecheck.sqf
+++ b/A3A/addons/core/functions/init/fn_resourcecheck.sqf
@@ -27,7 +27,7 @@ while {true} do
 
 		private _ownerMul = [0.5, 1] select (sidesX getVariable _city == teamPlayer);
 		private _resAddCity = _ownerMul * sqrt _numCiv * (_supportReb / 100);
-		private _hrAddCity = _ownerMul * sqrt _numCiv * (_supportReb / 10000);
+		private _hrAddCity = _ownerMul * sqrt _numCiv * (_supportReb / 100) * A3A_rebelHRTickMult;
 
 		_resAdd = _resAdd + _resAddCity;
 		_hrAdd = _hrAdd + _hrAddCity;


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
City tick HR income was probably too low generally and much too low for smaller maps, as it needs to be roughly proportional to enemy income (it's supposed to pay for garrison losses & high command cannon fodder). I've rescaled that so that owning half the map gives you about +5 HR per tick on top of the 2 HR base.

City lump sum HR income could be problematic on maps with low population relative to garrisons (it's supposed to pay for garrisons), so I scaled that accordingly. Doesn't make much difference on Altis. Might do on other maps.

Should do something similar with monetary income but that's potentially a major change at short notice.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
