### PR TITLE
Make QRF/attack air vehicles spawn facing towards the destination

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_createAttackVehicle.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAttackVehicle.sqf
@@ -31,7 +31,7 @@ private _vehicle = if (_vehicleType isKindOf "Ship") then {
     _veh setDir (_seaPath#-1 getDir _seaPath#1);
     _veh;
 } else {
-    [_markerOrigin, _vehicleType] call A3A_fnc_spawnVehicleAtMarker;
+    [_markerOrigin, _vehicleType, _posDestination] call A3A_fnc_spawnVehicleAtMarker;
 };
 if(isNull _vehicle) exitWith {objNull};
 

--- a/A3A/addons/core/functions/CREATE/fn_spawnVehicleAtMarker.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_spawnVehicleAtMarker.sqf
@@ -1,7 +1,8 @@
 params
 [
     ["_marker", "", [""]],
-    ["_vehicle", "", [""]]
+    ["_vehicle", "", [""]],
+    "_posDest"
 ];
 
 /*  Spawns the given vehicle at the given marker, only works if the marker as spawn places defined, not recommended for planes
@@ -13,6 +14,7 @@ params
     Params:
         _marker : STRING : The name of the marker, where the vehicle should be spawned in
         _vehicle : STRING : The configname of the vehicle, which should be spawned in
+        _posDest : ARRAY : Optional approximate target position, for determining spawn heading of aircraft
 
     Returns:
         OBJECT : The vehicle object, objNull if spawn wasnt possible
@@ -31,6 +33,11 @@ private _vehicleObj = objNull;
 if ((_vehicle isKindOf "Air") || (_vehicle isKindOf "Ship")) exitWith
 {
     _vehicleObj = [_vehicle, getMarkerPos _marker, 100, 5, true] call A3A_fnc_safeVehicleSpawn;
+    if !(isNil "_posDest") then {
+        private _rVel = velocityModelSpace _vehicleObj;
+        _vehicleObj setDir (_vehicleObj getDir _posDest);
+        _vehicleObj setVelocityModelSpace _rVel;
+    };
     _vehicleObj;
 };
 


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Air vehicles spawned by QRFs and attacks always spawn facing north. This PR changes them to spawn facing their destination. Improves response speed of transport aircraft significantly, because they often struggle to make the turn.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
