### PR TITLE
Garrison support fixes

### DIFF
--- a/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_enemyInfo.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_enemyInfo.sqf
@@ -74,15 +74,8 @@ if (abs _threat > 0.01) then {
     _threat = _threat - ((time - _threatTime) / 60) * _threat / abs _threat;
 };
 _threat = (_threat max 0) + ([1, 3] select (_type == "mortar"));
-_garrison set ["threatTime", time];
-_garrison set ["threat", _threat];
 
 Trace_2("%1 current threat %2", _marker, _threat);
-
-//if (_defenders isEqualTo [] and _mortars isEqualTo []) exitWith {
-//    ServerDebug_1("No defensive units available at %1", _marker);
-//};
-
 
 if (_threat > random 3) then
 {
@@ -102,7 +95,7 @@ if (_threat > random 3) then
         private _side = _garrison get "side";
         if (_type == "detect" or _side == teamPlayer) exitWith {};             // Do not call cheap supports vs spotted targets
         [_side, _enemy, markerPos _marker, _knowsAbout, 0.7] remoteExec ["A3A_fnc_requestSupport", 2];
-        _threat = _threat - 3;                  // don't spam
+        _threat = 0;                  // don't spam support calls
     };
 
     private _precisionOff = random (60 - (_knowsAbout / 4) * 50);
@@ -122,4 +115,5 @@ if (_threat > random 3) then
     };
 };
 
+_garrison set ["threatTime", time];
 _garrison set ["threat", _threat];


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
- Fix support passthrough not triggering once all groups have been used.
- Fix garrisons sending infantry groups after enemy aircraft.
- Fix passthrough spamming requestSupport.

Main effect is the first one. Support passthrough wasn't working if the garrison had no functioning mortars and all the mobile patrols had already been sent. It's probably a relatively mild effect because groups could still call supports themselves, but if that didn't happen then it would have been possible to capture a site with any response.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
