### PR TITLE
Increase vanilla Titan static traverse angles

### DIFF
--- a/A3A/addons/config_fixes/Vanilla/CfgVehicles.hpp
+++ b/A3A/addons/config_fixes/Vanilla/CfgVehicles.hpp
@@ -14,5 +14,6 @@ class CfgVehicles
 #include "ifv.hpp"
 #include "sea.hpp"
 #include "soft.hpp"
+#include "static.hpp"
 #include "houses.hpp"
 };

--- a/A3A/addons/config_fixes/Vanilla/static.hpp
+++ b/A3A/addons/config_fixes/Vanilla/static.hpp
@@ -1,0 +1,29 @@
+// Vanilla - static.hpp
+
+// Increase traverse arc of vanilla Titan launchers
+// Changing turret config parameters sucks
+class LandVehicle;
+class StaticWeapon : LandVehicle {
+    class Turrets;
+};
+class StaticMGWeapon : StaticWeapon {
+    class Turrets : Turrets {
+        class MainTurret;
+    };
+};
+class AT_01_base_F : StaticMGWeapon {
+    class Turrets : Turrets {
+        class MainTurret : MainTurret {
+            maxTurn = 75;
+            minTurn = -75;
+        };
+    };
+};
+class AA_01_base_F : StaticMGWeapon {
+    class Turrets : Turrets {
+        class MainTurret : MainTurret {
+            maxTurn = 75;
+            minTurn = -75;
+        };
+    };
+};


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Increased vanilla Titan traverse arcs from -/+40 to +/-75 degrees. Doesn't look any weirder than usual, and 75 degrees means we can keep the thing at 2 logistics size units without players hanging off the sides of vehicles.

Should probably have had a bit more left than right traverse due to the gunner position, but it'll do for now.

### Please specify which Issue this PR Resolves.
closes #3705

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
