### PR TITLE
Fix logistics unload breaking when switching weird vehicles in garage 

### DIFF
--- a/A3A/addons/logistics/Private/fn_unload.sqf
+++ b/A3A/addons/logistics/Private/fn_unload.sqf
@@ -23,6 +23,7 @@ params ["_vehicle", ["_instant", false, [true]]];
 private _fileName = "fn_logistics_unload";
 
 private _loaded = _vehicle getVariable ["Cargo", []];
+if (_loaded isEqualTo []) exitWith {};                  // in case this function was called without cargo in the vehicle (happens with garage + bad mods)
 private _lastLoaded = false;
 if ((count _loaded) isEqualTo 1) then {_lastLoaded = true};
 (_loaded#0) params ["_cargo", "_node"];


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Some mod vehicles (eg. `CRO_HMMWV_M1151_W`) use init event handlers which attach objects on creation. The garage currently assumes that all attached objects on the vehicle preview are created by it, so it over-calls logistics_fnc_unload, which has no sanity check for that case.

The garage code is bad but adding this sanity check to logistics_fnc_unload should work around it.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
