### PR TITLE
increased Civilian loadout count

### DIFF
--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_ADC.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_ADC.sqf
@@ -181,8 +181,8 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate],
-    ["Man", _manTemplate]
+    ["Worker", _workerTemplate, nil, 10],
+    ["Man", _manTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_CHC.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_CHC.sqf
@@ -191,8 +191,8 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate],
-    ["Man", _manTemplate]
+    ["Worker", _workerTemplate, nil, 10],
+    ["Man", _manTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_MEC.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_MEC.sqf
@@ -164,8 +164,8 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate],
-    ["Man", _manTemplate]
+    ["Worker", _workerTemplate, nil, 10],
+    ["Man", _manTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_MEC.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_MEC.sqf
@@ -164,7 +164,7 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate, nil, 10],
+    ["Worker", _workerTemplate],
     ["Man", _manTemplate, nil, 10]
 ];
 

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_TKC.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_TKC.sqf
@@ -163,8 +163,8 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate],
-    ["Man", _manTemplate]
+    ["Worker", _workerTemplate, nil, 10],
+    ["Man", _manTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_TKC.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_TKC.sqf
@@ -163,7 +163,7 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate, nil, 10],
+    ["Worker", _workerTemplate],
     ["Man", _manTemplate, nil, 10]
 ];
 

--- a/A3A/addons/core/Templates/Templates/Aegis/Aegis_Civ.sqf
+++ b/A3A/addons/core/Templates/Templates/Aegis/Aegis_Civ.sqf
@@ -265,8 +265,8 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate],
-    ["Man", _manTemplate]
+    ["Worker", _workerTemplate, nil, 10],
+    ["Man", _manTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/Aegis/Aegis_Civ.sqf
+++ b/A3A/addons/core/Templates/Templates/Aegis/Aegis_Civ.sqf
@@ -265,8 +265,8 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate, nil, 10],
-    ["Man", _manTemplate, nil, 10]
+    ["Worker", _workerTemplate],
+    ["Man", _manTemplate, nil, 15]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/CSLA/CSLA_Civ_TC.sqf
+++ b/A3A/addons/core/Templates/Templates/CSLA/CSLA_Civ_TC.sqf
@@ -138,8 +138,8 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate],
-    ["Man", _manTemplate]
+    ["Worker", _workerTemplate, nil, 10],
+    ["Man", _manTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/CSLA/CSLA_Civ_TC.sqf
+++ b/A3A/addons/core/Templates/Templates/CSLA/CSLA_Civ_TC.sqf
@@ -138,7 +138,7 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate, nil, 10],
+    ["Worker", _workerTemplate],
     ["Man", _manTemplate, nil, 10]
 ];
 

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_Civ_CHC.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_Civ_CHC.sqf
@@ -171,8 +171,8 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate],
-    ["Man", _manTemplate]
+    ["Worker", _workerTemplate, nil, 10],
+    ["Man", _manTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_Civ_CHC.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_Civ_CHC.sqf
@@ -171,7 +171,7 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate, nil, 10],
+    ["Worker", _workerTemplate],
     ["Man", _manTemplate, nil, 10]
 ];
 

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_Civ_TKC.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_Civ_TKC.sqf
@@ -177,8 +177,8 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate],
-    ["Man", _manTemplate]
+    ["Worker", _workerTemplate, nil, 10],
+    ["Man", _manTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/CWR/CWR_Civ_CHC.sqf
+++ b/A3A/addons/core/Templates/Templates/CWR/CWR_Civ_CHC.sqf
@@ -161,8 +161,8 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate],
-    ["Man", _manTemplate]
+    ["Worker", _workerTemplate, nil, 10],
+    ["Man", _manTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/CWR/CWR_Civ_CHC.sqf
+++ b/A3A/addons/core/Templates/Templates/CWR/CWR_Civ_CHC.sqf
@@ -161,7 +161,7 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate, nil, 10],
+    ["Worker", _workerTemplate],
     ["Man", _manTemplate, nil, 10]
 ];
 

--- a/A3A/addons/core/Templates/Templates/GM/GM_Civ.sqf
+++ b/A3A/addons/core/Templates/Templates/GM/GM_Civ.sqf
@@ -143,8 +143,8 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate],
-    ["Man", _manTemplate]
+    ["Worker", _workerTemplate, nil, 10],
+    ["Man", _manTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/GM/GM_Civ.sqf
+++ b/A3A/addons/core/Templates/Templates/GM/GM_Civ.sqf
@@ -143,8 +143,8 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate, nil, 10],
-    ["Man", _manTemplate, nil, 10]
+    ["Worker", _workerTemplate],
+    ["Man", _manTemplate]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/IFA/IFA_CIV_FR.sqf
+++ b/A3A/addons/core/Templates/Templates/IFA/IFA_CIV_FR.sqf
@@ -86,8 +86,8 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate],
-    ["Man", _manTemplate]
+    ["Worker", _workerTemplate, nil, 10],
+    ["Man", _manTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/IFA/IFA_CIV_FR.sqf
+++ b/A3A/addons/core/Templates/Templates/IFA/IFA_CIV_FR.sqf
@@ -86,7 +86,7 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate, nil, 10],
+    ["Worker", _workerTemplate],
     ["Man", _manTemplate, nil, 10]
 ];
 

--- a/A3A/addons/core/Templates/Templates/IFA/IFA_CIV_PL.sqf
+++ b/A3A/addons/core/Templates/Templates/IFA/IFA_CIV_PL.sqf
@@ -74,8 +74,8 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate],
-    ["Man", _manTemplate]
+    ["Worker", _workerTemplate, nil, 10],
+    ["Man", _manTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/IFA/IFA_CIV_PL.sqf
+++ b/A3A/addons/core/Templates/Templates/IFA/IFA_CIV_PL.sqf
@@ -74,7 +74,7 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate, nil, 10],
+    ["Worker", _workerTemplate],
     ["Man", _manTemplate, nil, 10]
 ];
 

--- a/A3A/addons/core/Templates/Templates/RHS/RHS_Civ.sqf
+++ b/A3A/addons/core/Templates/Templates/RHS/RHS_Civ.sqf
@@ -194,8 +194,8 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate],
-    ["Man", _manTemplate]
+    ["Worker", _workerTemplate, nil, 10],
+    ["Man", _manTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/RHS/RHS_Civ.sqf
+++ b/A3A/addons/core/Templates/Templates/RHS/RHS_Civ.sqf
@@ -194,7 +194,7 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate, nil, 10],
+    ["Worker", _workerTemplate],
     ["Man", _manTemplate, nil, 10]
 ];
 

--- a/A3A/addons/core/Templates/Templates/SPE/SPE_CIV.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE/SPE_CIV.sqf
@@ -155,8 +155,8 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate],
-    ["Man", _manTemplate]
+    ["Worker", _workerTemplate, nil, 10],
+    ["Man", _manTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_CIV.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_CIV.sqf
@@ -161,8 +161,8 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate],
-    ["Man", _manTemplate]
+    ["Worker", _workerTemplate, nil, 10],
+    ["Man", _manTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/UNS/UNS_Civ.sqf
+++ b/A3A/addons/core/Templates/Templates/UNS/UNS_Civ.sqf
@@ -109,7 +109,7 @@ private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
     ["Worker", _workerTemplate],
-    ["Man", _manTemplate]
+    ["Man", _manTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/VN/VN_CIV.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_CIV.sqf
@@ -145,7 +145,7 @@ private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
     ["Worker", _workerTemplate],
-    ["Man", _manTemplate]
+    ["Man", _manTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Civ.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Civ.sqf
@@ -252,8 +252,8 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate],
-    ["Man", _manTemplate]
+    ["Worker", _workerTemplate, nil, 10],
+    ["Man", _manTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Civ.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Civ.sqf
@@ -252,7 +252,7 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate, nil, 10],
+    ["Worker", _workerTemplate],
     ["Man", _manTemplate, nil, 10]
 ];
 

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Civ_LIV.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Civ_LIV.sqf
@@ -259,8 +259,8 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate],
-    ["Man", _manTemplate]
+    ["Worker", _workerTemplate, nil, 10],
+    ["Man", _manTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Civ_LIV.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Civ_LIV.sqf
@@ -259,7 +259,7 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate, nil, 10],
+    ["Worker", _workerTemplate],
     ["Man", _manTemplate, nil, 10]
 ];
 

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Civ_TNA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Civ_TNA.sqf
@@ -258,8 +258,8 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate],
-    ["Man", _manTemplate]
+    ["Worker", _workerTemplate, nil, 10],
+    ["Man", _manTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Civ_TNA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Civ_TNA.sqf
@@ -258,7 +258,7 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate, nil, 10],
+    ["Worker", _workerTemplate],
     ["Man", _manTemplate, nil, 10]
 ];
 

--- a/A3A/addons/core/Templates/Templates/WS/WS_Civ.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_Civ.sqf
@@ -248,8 +248,8 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate],
-    ["Man", _manTemplate]
+    ["Worker", _workerTemplate, nil, 10],
+    ["Man", _manTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Doubles the number of loadouts generated for civilians to increase the visual diversity - lots of civ gear will still go unused though.
Some were omitted due to having too few assets to actually see a difference - see VN for example.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
