### PR TITLE
Fix missing A3A_core dependencies in SQMs

### DIFF
--- a/A3A/addons/maps/Antistasi_Altis.Altis/mission.sqm
+++ b/A3A/addons/maps/Antistasi_Altis.Altis/mission.sqm
@@ -57,7 +57,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=11;
+		items=12;
 		class Item0
 		{
 			className="A3_Structures_F_Mil";
@@ -134,6 +134,12 @@ class AddonsMetaData
 			name="Arma 3 Zeus Update - Scripted Modules";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item11
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_Altis.Altis/mission.sqm
+++ b/A3A/addons/maps/Antistasi_Altis.Altis/mission.sqm
@@ -38,6 +38,7 @@ addons[]=
 	"A3_Structures_F_Ind_AirPort",
 	"A3_Structures_F_Exp_Infrastructure_Airports",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Structures_F_Mil_Fortification",
 	"A3_Structures_F_Walls",
 	"A3_Structures_F_Ind_Cargo",

--- a/A3A/addons/maps/Antistasi_Enoch.Enoch/mission.sqm
+++ b/A3A/addons/maps/Antistasi_Enoch.Enoch/mission.sqm
@@ -36,6 +36,7 @@ addons[]=
 	"A3_Ui_F",
 	"A3_Structures_F_Mil_Fortification",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Structures_F_Walls",
 	"A3_Structures_F_Enoch_Military_Barracks",
 	"A3_Structures_F_Enoch_Walls_Concrete",

--- a/A3A/addons/maps/Antistasi_Enoch.Enoch/mission.sqm
+++ b/A3A/addons/maps/Antistasi_Enoch.Enoch/mission.sqm
@@ -75,7 +75,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=17;
+		items=18;
 		class Item0
 		{
 			className="A3_Structures_F_Mil";
@@ -194,6 +194,12 @@ class AddonsMetaData
 			name="Arma 3 Contact Platform - Commercial Buildings";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item17
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_Kunduz.Kunduz/mission.sqm
+++ b/A3A/addons/maps/Antistasi_Kunduz.Kunduz/mission.sqm
@@ -32,6 +32,7 @@ addons[]=
 {
 	"A3_Structures_F_Ind_Cargo",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Weapons_F_Ammoboxes",
 	"A3_Characters_F",
 	"A3_Structures_F_EPC_Civ_InfoBoards",

--- a/A3A/addons/maps/Antistasi_Kunduz.Kunduz/mission.sqm
+++ b/A3A/addons/maps/Antistasi_Kunduz.Kunduz/mission.sqm
@@ -75,7 +75,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=16;
+		items=17;
 		class Item0
 		{
 			className="A3_Structures_F_Ind";
@@ -187,6 +187,12 @@ class AddonsMetaData
 			name="Arma 3 Apex - Buildings and Structures";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item16
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_Malden.Malden/mission.sqm
+++ b/A3A/addons/maps/Antistasi_Malden.Malden/mission.sqm
@@ -35,6 +35,7 @@ addons[]=
 	"A3_Structures_F_Mil_Cargo",
 	"A3_Structures_F_Mil_TentHangar",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Ui_F",
 	"A3_Structures_F_Exp_Military_ContainerBases",
 	"A3_Structures_F_Civ_Lamps",

--- a/A3A/addons/maps/Antistasi_Malden.Malden/mission.sqm
+++ b/A3A/addons/maps/Antistasi_Malden.Malden/mission.sqm
@@ -78,7 +78,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=16;
+		items=17;
 		class Item0
 		{
 			className="A3_Structures_F_Ind";
@@ -190,6 +190,12 @@ class AddonsMetaData
 			name="Arma 3 Zeus Update - Scripted Modules";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item16
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_Napf.Napf/mission.sqm
+++ b/A3A/addons/maps/Antistasi_Napf.Napf/mission.sqm
@@ -83,7 +83,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=28;
+		items=29;
 		class Item0
 		{
 			className="A3_Structures_F_Enoch";
@@ -265,6 +265,12 @@ class AddonsMetaData
 			name="Arma 3 Alpha - Characters and Clothing";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item28
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_Napf.Napf/mission.sqm
+++ b/A3A/addons/maps/Antistasi_Napf.Napf/mission.sqm
@@ -40,6 +40,7 @@ addons[]=
 	"A3_Structures_F_Mil_Cargo",
 	"A3_Structures_F_Exp_Military_Fortifications",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Structures_F_Walls",
 	"A3_Structures_F_Mil_BagFence",
 	"CUP_Misc_e_Config",

--- a/A3A/addons/maps/Antistasi_NapfWinter.NapfWinter/mission.sqm
+++ b/A3A/addons/maps/Antistasi_NapfWinter.NapfWinter/mission.sqm
@@ -83,7 +83,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=28;
+		items=29;
 		class Item0
 		{
 			className="A3_Structures_F_Enoch";
@@ -265,6 +265,12 @@ class AddonsMetaData
 			name="Arma 3 Alpha - Characters and Clothing";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item28
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_NapfWinter.NapfWinter/mission.sqm
+++ b/A3A/addons/maps/Antistasi_NapfWinter.NapfWinter/mission.sqm
@@ -40,6 +40,7 @@ addons[]=
 	"A3_Structures_F_Mil_Cargo",
 	"A3_Structures_F_Exp_Military_Fortifications",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Structures_F_Walls",
 	"A3_Structures_F_Mil_BagFence",
 	"CUP_Misc_e_Config",

--- a/A3A/addons/maps/Antistasi_SPE_Mortain.SPE_Mortain/mission.sqm
+++ b/A3A/addons/maps/Antistasi_SPE_Mortain.SPE_Mortain/mission.sqm
@@ -36,6 +36,7 @@ addons[]=
 	"WW2_SPE_Core_c_EditorPreviews_c",
 	"WW2_SPE_Assets_c_Vehicles_SimpleObjects_c",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Ui_F",
 	"WW2_SPE_Core_c_UI_Gui_c",
 	"WW2_SPE_Assets_c_Vehicles_Planes_c_FW190F8",

--- a/A3A/addons/maps/Antistasi_SPE_Mortain.SPE_Mortain/mission.sqm
+++ b/A3A/addons/maps/Antistasi_SPE_Mortain.SPE_Mortain/mission.sqm
@@ -60,7 +60,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=20;
+		items=21;
 		class Item0
 		{
 			className="A3_Structures_F_Ind";
@@ -182,6 +182,12 @@ class AddonsMetaData
 		{
 			className="WW2_SPE_Structures2_c";
 			name="WW2_SPE_Structures2_c";
+		};
+		class Item20
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_SPE_Normandy.SPE_Normandy/mission.sqm
+++ b/A3A/addons/maps/Antistasi_SPE_Normandy.SPE_Normandy/mission.sqm
@@ -44,6 +44,7 @@ addons[]=
 	"A3_Structures_F_Exp_Walls_Polewalls",
 	"A3_Structures_F_Mil_TentHangar",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Structures_F_Civ_Market",
 	"A3_Props_F_Exp_Commercial_Market",
 	"A3_Structures_F_Enoch_Military_Bunkers",

--- a/A3A/addons/maps/Antistasi_SPE_Normandy.SPE_Normandy/mission.sqm
+++ b/A3A/addons/maps/Antistasi_SPE_Normandy.SPE_Normandy/mission.sqm
@@ -71,7 +71,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=26;
+		items=27;
 		class Item0
 		{
 			className="A3_Ui_F";
@@ -235,6 +235,12 @@ class AddonsMetaData
 			name="Arma 3 Contact Platform - Decorative and Mission Objects";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item26
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_Stratis.Stratis/mission.sqm
+++ b/A3A/addons/maps/Antistasi_Stratis.Stratis/mission.sqm
@@ -55,7 +55,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=11;
+		items=12;
 		class Item0
 		{
 			className="A3_Structures_F_Mil";
@@ -132,6 +132,12 @@ class AddonsMetaData
 			name="Arma 3 Malden - Buildings and Structures";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item11
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_Stratis.Stratis/mission.sqm
+++ b/A3A/addons/maps/Antistasi_Stratis.Stratis/mission.sqm
@@ -34,6 +34,7 @@ addons[]=
 	"A3_Structures_F_Mil_Cargo",
 	"A3_Ui_F",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Structures_F_Mil_Helipads",
 	"A3_Structures_F_Ind_SolarPowerPlant",
 	"A3_Structures_F_Ind_Transmitter_Tower",

--- a/A3A/addons/maps/Antistasi_Takistan.takistan/mission.sqm
+++ b/A3A/addons/maps/Antistasi_Takistan.takistan/mission.sqm
@@ -39,6 +39,7 @@ addons[]=
 	"A3_Props_F_Enoch_Military_Camps",
 	"A3_Structures_F_EPC_Civ_InfoBoards",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Modules_F_Curator_Curator",
 	"A3_Modules_F_Hc",
 	"A3_Structures_F_Mil_BagBunker",

--- a/A3A/addons/maps/Antistasi_Takistan.takistan/mission.sqm
+++ b/A3A/addons/maps/Antistasi_Takistan.takistan/mission.sqm
@@ -67,7 +67,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=18;
+		items=19;
 		class Item0
 		{
 			className="A3_Ui_F";
@@ -181,6 +181,12 @@ class AddonsMetaData
 		{
 			className="CUP_CAMisc";
 			name="CUP_CAMisc";
+		};
+		class Item18
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_Tanoa.Tanoa/mission.sqm
+++ b/A3A/addons/maps/Antistasi_Tanoa.Tanoa/mission.sqm
@@ -54,7 +54,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=11;
+		items=12;
 		class Item0
 		{
 			className="A3_Structures_F_Ind";
@@ -131,6 +131,12 @@ class AddonsMetaData
 			name="Arma 3 Zeus Update - Scripted Modules";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item11
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_Tanoa.Tanoa/mission.sqm
+++ b/A3A/addons/maps/Antistasi_Tanoa.Tanoa/mission.sqm
@@ -37,6 +37,7 @@ addons[]=
 	"A3_Structures_F_Mil_TentHangar",
 	"A3_Structures_F_Exp_Military_ContainerBases",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Structures_F_Ind_Transmitter_Tower",
 	"A3_Structures_F_Enoch_Military_Barracks",
 	"A3_Characters_F",

--- a/A3A/addons/maps/Antistasi_Tembelan.Tembelan/mission.sqm
+++ b/A3A/addons/maps/Antistasi_Tembelan.Tembelan/mission.sqm
@@ -62,7 +62,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=15;
+		items=16;
 		class Item0
 		{
 			className="A3_Ui_F";
@@ -167,6 +167,12 @@ class AddonsMetaData
 			name="Arma 3 Zeus Update - Scripted Modules";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item15
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_Tembelan.Tembelan/mission.sqm
+++ b/A3A/addons/maps/Antistasi_Tembelan.Tembelan/mission.sqm
@@ -32,6 +32,7 @@ addons[]=
 {
 	"A3_Ui_F",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Structures_F_Mil_Cargo",
 	"A3_Structures_F_Exp_Military_Fortifications",
 	"A3_Structures_F_Mil_Helipads",

--- a/A3A/addons/maps/Antistasi_UMB_Colombia.UMB_Colombia/mission.sqm
+++ b/A3A/addons/maps/Antistasi_UMB_Colombia.UMB_Colombia/mission.sqm
@@ -86,7 +86,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=22;
+		items=23;
 		class Item0
 		{
 			className="A3_Modules_F";
@@ -240,6 +240,12 @@ class AddonsMetaData
 			name="Arma 3 Orange - Buildings and Structures";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item22
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_UMB_Colombia.UMB_Colombia/mission.sqm
+++ b/A3A/addons/maps/Antistasi_UMB_Colombia.UMB_Colombia/mission.sqm
@@ -31,6 +31,7 @@ sourceName="Antistasi-Colombia2";
 addons[]=
 {
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Ui_F",
 	"A3_Structures_F_Mil_Cargo",
 	"A3_Structures_F_Mil_Helipads",

--- a/A3A/addons/maps/Antistasi_cam_lao_nam.cam_lao_nam/mission.sqm
+++ b/A3A/addons/maps/Antistasi_cam_lao_nam.cam_lao_nam/mission.sqm
@@ -35,6 +35,7 @@ addons[]=
 	"A3_Weapons_F",
 	"modules_f_vietnam",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Modules_F_Curator_Curator",
 	"A3_Modules_F_Hc",
 	"A3_Structures_F_Exp_Military_Flags",

--- a/A3A/addons/maps/Antistasi_cam_lao_nam.cam_lao_nam/mission.sqm
+++ b/A3A/addons/maps/Antistasi_cam_lao_nam.cam_lao_nam/mission.sqm
@@ -52,7 +52,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=15;
+		items=16;
 		class Item0
 		{
 			className="A3_Ui_F";
@@ -157,6 +157,12 @@ class AddonsMetaData
 			name="Arma 3 Tank - Buildings and Structures";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item15
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_chernarus.chernarus/mission.sqm
+++ b/A3A/addons/maps/Antistasi_chernarus.chernarus/mission.sqm
@@ -37,6 +37,7 @@ addons[]=
 	"A3_Structures_F_Mil_Helipads",
 	"CUP_Misc3_Config",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Structures_F_Enoch_Civilian_Sheds",
 	"CUP_CAStructures_Mil",
 	"CUP_CAMisc_ACR_Sign_Mines",

--- a/A3A/addons/maps/Antistasi_chernarus.chernarus/mission.sqm
+++ b/A3A/addons/maps/Antistasi_chernarus.chernarus/mission.sqm
@@ -63,7 +63,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=20;
+		items=21;
 		class Item0
 		{
 			className="A3_Ui_F";
@@ -187,6 +187,12 @@ class AddonsMetaData
 			name="Arma 3 Zeus Update - Scripted Modules";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item20
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_chernarus_summer.chernarus_summer/mission.sqm
+++ b/A3A/addons/maps/Antistasi_chernarus_summer.chernarus_summer/mission.sqm
@@ -37,6 +37,7 @@ addons[]=
 	"A3_Structures_F_Mil_Helipads",
 	"CUP_Misc3_Config",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Structures_F_Enoch_Civilian_Sheds",
 	"CUP_CAStructures_Mil",
 	"CUP_CAMisc_ACR_Sign_Mines",

--- a/A3A/addons/maps/Antistasi_chernarus_summer.chernarus_summer/mission.sqm
+++ b/A3A/addons/maps/Antistasi_chernarus_summer.chernarus_summer/mission.sqm
@@ -63,7 +63,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=20;
+		items=21;
 		class Item0
 		{
 			className="A3_Ui_F";
@@ -187,6 +187,12 @@ class AddonsMetaData
 			name="Arma 3 Zeus Update - Scripted Modules";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item20
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_chernarus_winter.chernarus_winter/mission.sqm
+++ b/A3A/addons/maps/Antistasi_chernarus_winter.chernarus_winter/mission.sqm
@@ -62,7 +62,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=22;
+		items=23;
 		class Item0
 		{
 			className="A3_Ui_F";
@@ -193,6 +193,12 @@ class AddonsMetaData
 			name="Arma 3 Zeus Update - Scripted Modules";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item22
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_chernarus_winter.chernarus_winter/mission.sqm
+++ b/A3A/addons/maps/Antistasi_chernarus_winter.chernarus_winter/mission.sqm
@@ -37,6 +37,7 @@ addons[]=
 	"CUP_WarfareBuildings",
 	"A3_Structures_F_Mil_Helipads",
 	"A3_Modules_F",
+	"A3A_core",
 	"CUP_Terrains_Winter_Objects",
 	"A3_Structures_F_Enoch_Civilian_Sheds",
 	"CUP_CAStructures_Mil",

--- a/A3A/addons/maps/Antistasi_cup_chernarus_A3.cup_chernarus_A3/mission.sqm
+++ b/A3A/addons/maps/Antistasi_cup_chernarus_A3.cup_chernarus_A3/mission.sqm
@@ -64,7 +64,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=22;
+		items=23;
 		class Item0
 		{
 			className="A3_Ui_F";
@@ -200,6 +200,12 @@ class AddonsMetaData
 			name="Arma 3 Zeus Update - Scripted Modules";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item22
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_cup_chernarus_A3.cup_chernarus_A3/mission.sqm
+++ b/A3A/addons/maps/Antistasi_cup_chernarus_A3.cup_chernarus_A3/mission.sqm
@@ -35,6 +35,7 @@ addons[]=
 	"A3_Structures_F_Exp_Military_Fortifications",
 	"A3_Structures_F_Mil_Cargo",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Structures_F_Mil_Helipads",
 	"CUP_Misc3_Config",
 	"A3_Structures_F_Enoch_Civilian_Sheds",

--- a/A3A/addons/maps/Antistasi_gm_weferlingen_summer.gm_weferlingen_summer/mission.sqm
+++ b/A3A/addons/maps/Antistasi_gm_weferlingen_summer.gm_weferlingen_summer/mission.sqm
@@ -58,7 +58,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=18;
+		items=19;
 		class Item0
 		{
 			className="A3_Modules_F";
@@ -184,6 +184,12 @@ class AddonsMetaData
 			name="Arma 3 Contact Platform - Civilian Buildings";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item18
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_gm_weferlingen_summer.gm_weferlingen_summer/mission.sqm
+++ b/A3A/addons/maps/Antistasi_gm_weferlingen_summer.gm_weferlingen_summer/mission.sqm
@@ -31,6 +31,7 @@ sourceName="Antistasi-Weferlingen";
 addons[]=
 {
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Ui_F",
 	"A3_Structures_F_Enoch_Decals_Horizontal",
 	"A3_Structures_F_Enoch_Infrastructure_Railways",

--- a/A3A/addons/maps/Antistasi_gm_weferlingen_winter.gm_weferlingen_winter/mission.sqm
+++ b/A3A/addons/maps/Antistasi_gm_weferlingen_winter.gm_weferlingen_winter/mission.sqm
@@ -58,7 +58,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=18;
+		items=19;
 		class Item0
 		{
 			className="A3_Modules_F";
@@ -184,6 +184,12 @@ class AddonsMetaData
 			name="Arma 3 Contact Platform - Civilian Buildings";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item18
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_gm_weferlingen_winter.gm_weferlingen_winter/mission.sqm
+++ b/A3A/addons/maps/Antistasi_gm_weferlingen_winter.gm_weferlingen_winter/mission.sqm
@@ -31,6 +31,7 @@ sourceName="Antistasi-Weferlingen";
 addons[]=
 {
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Ui_F",
 	"A3_Structures_F_Enoch_Decals_Horizontal",
 	"A3_Structures_F_Enoch_Infrastructure_Railways",

--- a/A3A/addons/maps/Antistasi_isladuala3.isladuala3/mission.sqm
+++ b/A3A/addons/maps/Antistasi_isladuala3.isladuala3/mission.sqm
@@ -33,6 +33,7 @@ addons[]=
 	"A3_Structures_F_Wrecks",
 	"A3_Structures_F_Enoch_Wrecks",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Structures_F_Mil_Cargo",
 	"CUP_Misc3_Config",
 	"A3_Signs_F",

--- a/A3A/addons/maps/Antistasi_isladuala3.isladuala3/mission.sqm
+++ b/A3A/addons/maps/Antistasi_isladuala3.isladuala3/mission.sqm
@@ -89,7 +89,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=31;
+		items=32;
 		class Item0
 		{
 			className="A3_Structures_F_Wrecks";
@@ -288,6 +288,12 @@ class AddonsMetaData
 		{
 			className="CUP_Editor_A2_Roads_Config";
 			name="CUP_Editor_A2_Roads_Config";
+		};
+		class Item31
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_pulau.pulau/mission.sqm
+++ b/A3A/addons/maps/Antistasi_pulau.pulau/mission.sqm
@@ -37,6 +37,7 @@ addons[]=
 	"A3_Props_F_Enoch_Military_Camps",
 	"A3_Structures_F_EPC_Civ_InfoBoards",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Modules_F_Curator_Curator",
 	"A3_Modules_F_Hc",
 	"A3_Ui_F",

--- a/A3A/addons/maps/Antistasi_pulau.pulau/mission.sqm
+++ b/A3A/addons/maps/Antistasi_pulau.pulau/mission.sqm
@@ -76,7 +76,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=17;
+		items=18;
 		class Item0
 		{
 			className="A3_Characters_F";
@@ -195,6 +195,12 @@ class AddonsMetaData
 			name="Arma 3 Apex - Decorative and Mission Objects";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item17
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_regero.regero/mission.sqm
+++ b/A3A/addons/maps/Antistasi_regero.regero/mission.sqm
@@ -96,7 +96,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=26;
+		items=27;
 		class Item0
 		{
 			className="A3_Structures_F_Ind";
@@ -274,6 +274,12 @@ class AddonsMetaData
 			name="Arma 3 Zeus Update - Scripted Modules";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item26
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_regero.regero/mission.sqm
+++ b/A3A/addons/maps/Antistasi_regero.regero/mission.sqm
@@ -36,6 +36,7 @@ addons[]=
 	"A3_Structures_F_Mil_Cargo",
 	"A3_Structures_F_Mil_TentHangar",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Ui_F",
 	"CUP_Buildings_Config",
 	"A3_Structures_F_Mil_Fortification",

--- a/A3A/addons/maps/Antistasi_sara.sara/mission.sqm
+++ b/A3A/addons/maps/Antistasi_sara.sara/mission.sqm
@@ -131,7 +131,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=64;
+		items=65;
 		class Item0
 		{
 			className="A3_Structures_F";
@@ -500,6 +500,12 @@ class AddonsMetaData
 		{
 			className="CUP_CAStructures_E_Ind_Ind_FuelStation";
 			name="CUP_CAStructures_E_Ind_Ind_FuelStation";
+		};
+		class Item64
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_sara.sara/mission.sqm
+++ b/A3A/addons/maps/Antistasi_sara.sara/mission.sqm
@@ -43,6 +43,7 @@ addons[]=
 	"CUP_StandaloneTerrains_Core_Faction",
 	"A3_Structures_F_Exp_Commercial_Warehouses",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Ui_F",
 	"CUP_CAMisc",
 	"A3_Structures_F_EPA_Mil_Scrapyard",

--- a/A3A/addons/maps/Antistasi_tem_anizay.tem_anizay/mission.sqm
+++ b/A3A/addons/maps/Antistasi_tem_anizay.tem_anizay/mission.sqm
@@ -82,7 +82,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=27;
+		items=28;
 		class Item0
 		{
 			className="A3_Structures_F_Mil";
@@ -247,6 +247,12 @@ class AddonsMetaData
 		{
 			className="CUP_Misc_e_Config";
 			name="CUP_Misc_e_Config";
+		};
+		class Item27
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_tem_anizay.tem_anizay/mission.sqm
+++ b/A3A/addons/maps/Antistasi_tem_anizay.tem_anizay/mission.sqm
@@ -33,6 +33,7 @@ addons[]=
 	"A3_Structures_F_Mil_Helipads",
 	"A3_Structures_F_Mil_Cargo",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Ui_F",
 	"A3_Structures_F_Ind_Transmitter_Tower",
 	"A3_Structures_F_Civ_Lamps",

--- a/A3A/addons/maps/Antistasi_tem_kujari.tem_kujari/mission.sqm
+++ b/A3A/addons/maps/Antistasi_tem_kujari.tem_kujari/mission.sqm
@@ -85,7 +85,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=35;
+		items=36;
 		class Item0
 		{
 			className="A3_Props_F_Decade_Spaceship";
@@ -300,6 +300,12 @@ class AddonsMetaData
 		{
 			className="CUP_CAMisc";
 			name="CUP_CAMisc";
+		};
+		class Item35
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_tem_kujari.tem_kujari/mission.sqm
+++ b/A3A/addons/maps/Antistasi_tem_kujari.tem_kujari/mission.sqm
@@ -44,6 +44,7 @@ addons[]=
 	"A3_Structures_F_Exp_Military_Fortifications",
 	"CUP_CAStructures_E_HouseC",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Structures_F_Ind_AirPort",
 	"A3_Structures_F_Mil_Barracks",
 	"A3_Structures_F_Tank_Military_Fortifications",

--- a/A3A/addons/maps/Antistasi_vn_khe_sanh.vn_khe_sanh/mission.sqm
+++ b/A3A/addons/maps/Antistasi_vn_khe_sanh.vn_khe_sanh/mission.sqm
@@ -33,6 +33,7 @@ addons[]=
 	"A3_Ui_F",
 	"structures_f_vietnam_c",
 	"A3_Modules_F",
+	"A3A_core",
 	"weapons_f_vietnam_c",
 	"A3_Characters_F",
 	"A3_Weapons_F",

--- a/A3A/addons/maps/Antistasi_vn_khe_sanh.vn_khe_sanh/mission.sqm
+++ b/A3A/addons/maps/Antistasi_vn_khe_sanh.vn_khe_sanh/mission.sqm
@@ -51,7 +51,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=14;
+		items=15;
 		class Item0
 		{
 			className="A3_Ui_F";
@@ -147,6 +147,12 @@ class AddonsMetaData
 			name="Arma 3 - Buildings and Structures";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item14
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };

--- a/A3A/addons/maps/Antistasi_vt7.vt7/mission.sqm
+++ b/A3A/addons/maps/Antistasi_vt7.vt7/mission.sqm
@@ -32,6 +32,7 @@ addons[]=
 {
 	"A3_Structures_F_Mil_Cargo",
 	"A3_Modules_F",
+	"A3A_core",
 	"A3_Structures_F_Mil_TentHangar",
 	"A3_Structures_F_Mil_Helipads",
 	"A3_Structures_F_Exp_Military_Fortifications",

--- a/A3A/addons/maps/Antistasi_vt7.vt7/mission.sqm
+++ b/A3A/addons/maps/Antistasi_vt7.vt7/mission.sqm
@@ -81,7 +81,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=20;
+		items=21;
 		class Item0
 		{
 			className="A3_Structures_F_Mil";
@@ -219,6 +219,12 @@ class AddonsMetaData
 			name="Arma 3 Zeus Update - Scripted Modules";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
+		};
+		class Item20
+		{
+			className="A3A_core";
+			name="A3A - core";
+			author="Antistasi Dev Team";
 		};
 	};
 };


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The missing A3A_core dependencies in every SQM other than Mehland prevents some dedicated servers from loading the missions. Not sure why it works on some servers but not others, but whatever.

The order of dependencies doesn't appear to matter. I put it after A3_Modules_F for no good reason.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
