### PR TITLE
Fix bad Mehland map name stringtable

### DIFF
--- a/A3A/addons/maps/Stringtable.xml
+++ b/A3A/addons/maps/Stringtable.xml
@@ -738,7 +738,7 @@
       <Key ID="STR_antistasi_mission_info_Mehland_blurb_text">
         <Original>Scandinavian Sight Seeing </Original>
       </Key>
-      <Key ID="STR_antistasi_mission_info_Mehland_mapname_text;">
+      <Key ID="STR_antistasi_mission_info_Mehland_mapname_text">
         <Original>Antistasi - Liberation of Mehland</Original>
       </Key>
       <Key ID="STR_antistasi_mission_info_Mehland_description_text">


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Stringtable entry had a rogue semicolon. Not sure what it does except throw some RPT warnings, but whatever.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
