### PR TITLE
City battle tweaks

### DIFF
--- a/A3A/addons/core/functions/Base/fn_citySupportChange.sqf
+++ b/A3A/addons/core/functions/Base/fn_citySupportChange.sqf
@@ -55,10 +55,14 @@ A3A_cityData setVariable [_city, [_numCiv, _supportReb, _accumHR, _taskDelay]];
 private _citySide = sidesX getVariable _city;
 if (_supportReb > 80 and _citySide != teamPlayer) then
 {
-	// Run cityBattle task if it's a significant town
 	if (_city in A3A_activeCityBattles) exitWith {};			// might be possible?
 	if (count keys A3A_activeCityBattles > 0) exitWith {};		// don't allow multiple simultaneous city battles for now
-	if (_numCiv >= 70) exitWith {
+
+	// Run cityBattle task if it's a significant town
+	// Avoid generating city battles in smaller cities if defence resources are low
+	private _minPop = A3A_minCityBattlePop * linearConversion [0, 1000, A3A_resourcesDefenceOcc, 1.4, 1.0, true];
+	Trace_3("City %1 numCiv %2, city battle minPop %3", _city, sqrt _numCiv, _minPop);
+	if (sqrt _numCiv >= _minPop) exitWith {
 		A3A_activeCityBattles set [_city, true];
 		[A3A_tasks_fnc_cityBattle, [_city]] spawn A3A_tasks_fnc_runTask;
 	};

--- a/A3A/addons/core/functions/CREATE/fn_createAttackForceMixed.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAttackForceMixed.sqf
@@ -53,8 +53,6 @@ if (_boatCount > 0 && _target isEqualType "" && (_faction get "vehiclesGunBoats"
         _maxSpeed = _speed max _maxSpeed;
     } forEach (_faction get "vehiclesGunBoats");
     _seaTime = 3600 * 2 / _maxSpeed; // speed in km/h, 2km to travel, convert to seconds
-
-    _vehCount = 0 max (_vehCount - _boatCount);
 };
 
 
@@ -88,7 +86,7 @@ private _landRatio = if ("airboost" in _modifiers) then {     // punishment, HQ 
     };
 };
 ServerDebug_4("Land ratio %1 out of vehicle count %2 due to lowAir %3 and modifiers %4", _landRatio, _vehCount, _lowAir, _modifiers);
-private _landCount = round (_landRatio * _vehCount);
+private _landCount = round (_landRatio * (_vehCount - count _vehicles));
 
 if (_landCount > 0) then
 {

--- a/A3A/addons/core/functions/init/fn_initZones.sqf
+++ b/A3A/addons/core/functions/init/fn_initZones.sqf
@@ -274,6 +274,11 @@ A3A_rebelHRTickMult = 10 / _sumPop;
 // Goal for lump sum is to fill garrisons
 A3A_rebelHRLumpMult = _reqGarrison / _sumPop;
 
+// Set typical number of city battles equal to number of outposts
+private _allPops = citiesX apply { sqrt (A3A_cityPop get _x) };
+_allPops sort false;		// largest first
+A3A_minCityBattlePop = if (count outposts < count citiesX) then { _allPops select count outposts } else { _allPops select -1 };
+A3A_minCityBattlePop = A3A_minCityBattlePop max 9;			// Set a floor for now, fixes a couple of weird maps
 
 publicVariable "blackListDest";
 publicVariable "markersX";

--- a/A3A/addons/tasks/Tasks/fn_cityBattle.sqf
+++ b/A3A/addons/tasks/Tasks/fn_cityBattle.sqf
@@ -124,7 +124,7 @@ if (isNil "_checkpoint") then {
 	_task set ["_endTime", time + 1800];
 
     private _numCiv = (A3A_cityData getVariable _marker) select 0;
-    _numCiv = 30 min (round sqrt _numCiv);
+    _numCiv = 30 min (3 + round sqrt _numCiv);
     _task set ["_numCiv", _numCiv];
 
     _task call _fnc_spawnLeader;
@@ -163,7 +163,7 @@ _task set ["s_spawnEnemies",
     // Create the enemy force
     // Not executed at init because it's fairly slow
     private _marker = _this get "_marker";
-    private _vehCount = round (1 + random 1 + 0.13 * sqrt (A3A_cityPop get _marker) + 1.2 * A3A_balancePlayerScale);
+    private _vehCount = round (0.7 + random 0.5 + 0.13 * sqrt (A3A_cityPop get _marker) + 1.3 * A3A_balancePlayerScale);
 
     private _airbase = [Occupants, markerPos _marker] call A3A_fnc_availableBasesAir;
 
@@ -205,7 +205,7 @@ _task set ["s_waitForStart",
     {
          // Set timers
         _this set ["_endTime", time + 1200];        // 20 minutes maximum to take the city
-        _this set ["_minLossTime", time + 300];     // 5 minutes minimum before checking for loss condition
+        _this set ["_minLossTime", time + 600];     // 10 minutes minimum before checking for loss condition
 
         // Set mission description to current state
         private _nameDest = [_marker] call A3A_fnc_localizar;
@@ -276,7 +276,7 @@ _task set ["s_battleStarted",
     private _civProp = ({_x call A3A_fnc_canFight} count _civilians) / count _civilians;
     private _enemyProp = ({_x call A3A_fnc_canFight} count _troops) / count _troops;
 
-    if ((time > _this get "_endTime" and _civProp >= 0.5) or _enemyProp < 0.25) exitWith {
+    if ((time > _this get "_endTime" and _civProp >= 0.5) or _enemyProp < 0.3) exitWith {
         private _taskDesc = format [localize "STR_A3A_Tasks_cityBattle_victoryDesc", _marker];
         [_this get "_taskId", [_taskDesc, _this get "_hintTitle", ""]] call BIS_fnc_taskSetDescription;
         _this set ["state", "s_victory"]; false;
@@ -334,8 +334,11 @@ _task set ["s_cleanup",
         {deleteGroup _x} forEach _civGroups;
     };
 
-    // Remove from active city battles (added on call)
-    A3A_activeCityBattles deleteAt (_this get "_marker");
+    // Remove from active city battles after 10min (added on call)
+    (_this get "_marker") spawn {
+        sleep 600;
+        A3A_activeCityBattles deleteAt _this;
+    };
 
 	(_this get "_taskId") spawn {
 		sleep 1200;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Don't really have any evidence on "why":
- Increased minimum pop for city battle missions on some maps.
- Increased minimum pop for city battles if occupant defence resources are low.
- Added 10min minimum spacing between city battles.
- Reduced number of enemy vehicles a bit for low player counts.
- Increased minimum loss time and decreased kills required for victory.
- Increased number of civ defenders.
- Fixed bug where boats would be double-counted in createAttackForceMixed.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
