### PR TITLE
Fix rebuildAssets eating money for live radio towers

### DIFF
--- a/A3A/addons/core/functions/Base/fn_rebuildAssets.sqf
+++ b/A3A/addons/core/functions/Base/fn_rebuildAssets.sqf
@@ -41,7 +41,7 @@ if (_siteX in _destroyedSites) exitWith {
     [0,-5000] remoteExec ["A3A_fnc_resourcesFIA",2];
 };
 
-if (_siteX in A3A_antennaMap and !(_siteX in citiesX)) exitWith {
+if (_siteX in A3A_antennaMap and !(_siteX in citiesX) and {!alive (A3A_antennaMap get _siteX)}) exitWith {
     [_titleStr, localize "STR_A3A_fn_base_rebasset_done_2"] call A3A_fnc_customHint;
     [A3A_antennaMap get _siteX] remoteExec ["A3A_fnc_rebuildRadioTower", 2];
     [0,-5000] remoteExec ["A3A_fnc_resourcesFIA",2];


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed rebuildAssets taking your money when the radio tower is alive.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
