### PR TITLE
Fix garbage cleaning wrecks of large fuel tank etc.

### DIFF
--- a/A3A/addons/core/functions/Base/fn_HQGarbageClean.sqf
+++ b/A3A/addons/core/functions/Base/fn_HQGarbageClean.sqf
@@ -33,7 +33,8 @@ Debug("Moving dead solders out of vehicles at HQ...")
 Debug("Finished moving soldiers out of vehicles at HQ; executing garbage clean.")
 sleep 0.5;
 
-[allDead, true] call _fnc_objNearHQ;
+[allDeadMen, true] call _fnc_objNearHQ;
+[vehicles select {!alive _x}, true] call _fnc_objNearHQ;				// allDead doesn't include 0-crew vehicles like the large fuel tank
 [allMissionObjects "WeaponHolder", true] call _fnc_objNearHQ;
 [allMissionObjects "WeaponHolderSimulated", true] call _fnc_objNearHQ;
 

--- a/A3A/addons/core/functions/Base/fn_garbageCleaner.sqf
+++ b/A3A/addons/core/functions/Base/fn_garbageCleaner.sqf
@@ -20,7 +20,8 @@ Debug("Moving dead solders out of vehicles...")
 Debug("Finished moving soldiers out of vehicles; executing garbage clean.")
 sleep 0.5;
 
-{ deleteVehicle _x } forEach allDead;
+{ deleteVehicle _x } forEach allDeadMen;
+{ deleteVehicle _x } forEach (vehicles select {!alive _x});				// allDead doesn't include 0-crew vehicles like the large fuel tank
 { deleteVehicle _x } forEach (allMissionObjects "WeaponHolder");
 { deleteVehicle _x } forEach (allMissionObjects "WeaponHolderSimulated");
 { if (isNull attachedTo _x) then { [_x, 500] call _fnc_distCheck } } forEach (allMissionObjects FactionGet(reb,"surrenderCrate"));// Surrender boxes


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement
4. [X] Arma

### What have you changed and why?
Unlike the wiki suggests, `allDead` does not include wrecks of crewless vehicles such as the large fuel tank or repair station. I have changed the garbage cleaners to use allDeadMen + dead vehicles instead. Seems to work correctly.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
