### PR TITLE
Better mod blacklisting

### DIFF
--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -16675,5 +16675,19 @@
         <Original>Rebel</Original>
       </Key>
     </Container>
+    <Container name="mod_blacklist">
+      <Key ID="STR_A3A_mod_blacklist_title">
+        <Original>Mod Blacklist</Original>
+      </Key>
+      <Key ID="STR_A3A_mod_blacklist_serverHint">
+        <Original>The following mods present on the server are known to be broken with Antistasi:&lt;br/&gt;%1&lt;br/&gt;Removing these mods is highly recommended.</Original>
+      </Key>
+      <Key ID="STR_A3A_mod_blacklist_warningTitle">
+        <Original>Blacklisted Mod Detected!</Original>
+      </Key>
+      <Key ID="STR_A3A_mod_blacklist_warningText">
+        <Original>Antistasi has detected a blacklisted mod on your client:&lt;br/&gt;&lt;br/&gt;%1&lt;br/&gt;&lt;br/&gt;It is highly recommended that you remove this mod; it may break the gamemode in unpredictable ways.<br/><br/>Dev comment: %2</Original>
+      </Key>
+    </Container>
   </Package>
 </Project>

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -16686,7 +16686,7 @@
         <Original>Blacklisted Mod Detected!</Original>
       </Key>
       <Key ID="STR_A3A_mod_blacklist_warningText">
-        <Original>Antistasi has detected a blacklisted mod on your client:&lt;br/&gt;&lt;br/&gt;%1&lt;br/&gt;&lt;br/&gt;It is highly recommended that you remove this mod; it may break the gamemode in unpredictable ways.<br/><br/>Dev comment: %2</Original>
+        <Original>Antistasi has detected a blacklisted mod on your client:&lt;br/&gt;&lt;br/&gt;%1&lt;br/&gt;&lt;br/&gt;It is highly recommended that you remove this mod; it may break the gamemode in unpredictable ways.&lt;br/&gt;&lt;br/&gt;Dev comment: %2</Original>
       </Key>
     </Container>
   </Package>

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -16677,16 +16677,16 @@
     </Container>
     <Container name="mod_blacklist">
       <Key ID="STR_A3A_mod_blacklist_title">
-        <Original>Mod Blacklist</Original>
-      </Key>
-      <Key ID="STR_A3A_mod_blacklist_serverHint">
-        <Original>The following mods present on the server are known to be broken with Antistasi:&lt;br/&gt;%1&lt;br/&gt;Removing these mods is highly recommended.</Original>
-      </Key>
-      <Key ID="STR_A3A_mod_blacklist_warningTitle">
         <Original>Blacklisted Mod Detected!</Original>
       </Key>
-      <Key ID="STR_A3A_mod_blacklist_warningText">
+      <Key ID="STR_A3A_mod_blacklist_titleServer">
+        <Original>Blacklisted Mod On Server!</Original>
+      </Key>
+      <Key ID="STR_A3A_mod_blacklist_text">
         <Original>Antistasi has detected a blacklisted mod on your client:&lt;br/&gt;&lt;br/&gt;%1&lt;br/&gt;&lt;br/&gt;It is highly recommended that you remove this mod; it may break the gamemode in unpredictable ways.&lt;br/&gt;&lt;br/&gt;Dev comment: %2</Original>
+      </Key>
+      <Key ID="STR_A3A_mod_blacklist_textServer">
+        <Original>Antistasi has detected a blacklisted mod on your server:&lt;br/&gt;&lt;br/&gt;%1&lt;br/&gt;&lt;br/&gt;It is highly recommended that you remove this mod; it may break the gamemode in unpredictable ways.&lt;br/&gt;&lt;br/&gt;Dev comment: %2</Original>
       </Key>
     </Container>
   </Package>

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -15797,7 +15797,7 @@
         <Chinesesimp>服务器加载完毕</Chinesesimp>
       </Key>
       <Key ID="STR_A3A_feedback_serverinfo_mismatch">
-        <Original>Version mismatch error:&lt;br/&gt;&lt;br/&gt;Server: %1&lt;br/&gt;Client: %2</Original>
+        <Original>Error: Version mismatch on client and server:&lt;br/&gt;&lt;br/&gt;Server: %1&lt;br/&gt;&lt;br/&gt;Client: %2&lt;br/&gt;&lt;br/&gt;Ensure you are running the most recent version of Antistasi - The Mod on the server and your computer.</Original>
         <Italian>Errore, versione non corrispondente:&lt;br/&gt;&lt;br/&gt;Server: %1&lt;br/&gt;Client: %2</Italian>
         <Spanish>Error de discordancia de versión:&lt;br&gt;&lt;br/&gt;Servidor: %1&lt;br/&gt;Cliente: %2</Spanish>
         <French>Erreur d'incohérence de version :&lt;br/&gt;&lt;br/&gt;Serveur : %1&lt;br/&gt;Client : %2</French>

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -26,7 +26,7 @@ if (!isNil "serverInitDone" and !isNil "A3A_utilityItemHM") then {
 };
 
 if (!requiredVersion QUOTE(REQUIRED_VERSION)) exitWith { Error("Arma version is out of date") };
-if (call A3A_fnc_modBlacklist) exitWith {};
+[] spawn A3A_fnc_modBlacklist;
 
 //Disables rabbits and snakes, because they cause the log to be filled with "20:06:39 Ref to nonnetwork object Agent 0xf3b4a0c0"
 //Can re-enable them if we find the source of the bug.
@@ -63,15 +63,6 @@ if !(isServer) then {
         0 spawn A3A_fnc_garrisonOpLoop;
     };
 
-    if ((isClass (configfile >> "CBA_Extended_EventHandlers")) && (
-        isClass (configfile >> "CfgPatches" >> "lambs_danger"))) then {
-        // disable lambs danger fsm entrypoint
-        ["CAManBase", "InitPost", {
-            params ["_unit"];
-            (group _unit) setVariable ["lambs_danger_disableGroupAI", true];
-            _unit setVariable ["lambs_danger_disableAI", true];
-        }] call CBA_fnc_addClassEventHandler;
-    };
 };
 
 // Server/client version check

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -65,12 +65,19 @@ if !(isServer) then {
 };
 
 // Server/client version check
-waitUntil { sleep 0.1; !isNil "initZonesDone" };
+waitUntil { sleep 0.1; getClientState == "BRIEFING READ" and !isNil "initZonesDone" };
 if (isNil "A3A_serverVersion") then { A3A_serverVersion = "pre-3.3" };
-if (A3A_clientVersion != A3A_serverVersion) exitWith {
+if (A3A_clientVersion != A3A_serverVersion) then {
     private _errorStr = format [localize "STR_A3A_feedback_serverinfo_mismatch", A3A_serverVersion, A3A_clientVersion];
+    Error_2("Version mismatch: Server %1, client %2", A3A_serverVersion, A3A_clientVersion);
     localize "STR_A3A_feedback_serverinfo" hintC parseText _errorStr;
+    waitUntil {sleep 0.01; isNull findDisplay 72};
+    hintSilent "";
 };
+
+// Should be called after server sends A3A_serverBadMods
+// Blocks until the hintCs are done if it's a real client
+[] call A3A_fnc_modBlacklist;
 
 // Show server startup state hints
 if (isNil "A3A_startupState") then { A3A_startupState = "waitserver" };
@@ -88,7 +95,6 @@ while {true} do {
 Info("Server started, continuing with client init");
 
 //call A3A_fnc_installSchrodingersBuildingFix;
-[] spawn A3A_fnc_modBlacklist;
 
 if (!isServer) then {
     // get server to send us the current destroyedBuildings list, hide them locally
@@ -103,7 +109,7 @@ if (!isServer) then {
 
 // Headless clients register with server and bail out at this point
 if (!isServer and !hasInterface) exitWith {
-
+    if (A3A_clientVersion != A3A_serverVersion) exitWith {};            // Do not use HCs that have a version mismatch
     player setPosATL (markerPos respawnTeamPlayer vectorAdd [-100, -100, 0]);
     [clientOwner] remoteExecCall ["A3A_fnc_addHC",2];
 };

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -26,7 +26,6 @@ if (!isNil "serverInitDone" and !isNil "A3A_utilityItemHM") then {
 };
 
 if (!requiredVersion QUOTE(REQUIRED_VERSION)) exitWith { Error("Arma version is out of date") };
-[] spawn A3A_fnc_modBlacklist;
 
 //Disables rabbits and snakes, because they cause the log to be filled with "20:06:39 Ref to nonnetwork object Agent 0xf3b4a0c0"
 //Can re-enable them if we find the source of the bug.
@@ -70,7 +69,7 @@ waitUntil { sleep 0.1; !isNil "initZonesDone" };
 if (isNil "A3A_serverVersion") then { A3A_serverVersion = "pre-3.3" };
 if (A3A_clientVersion != A3A_serverVersion) exitWith {
     private _errorStr = format [localize "STR_A3A_feedback_serverinfo_mismatch", A3A_serverVersion, A3A_clientVersion];
-    [localize "STR_A3A_feedback_serverinfo", _errorStr] call A3A_fnc_customHint;
+    localize "STR_A3A_feedback_serverinfo" hintC parseText _errorStr;
 };
 
 // Show server startup state hints
@@ -89,6 +88,7 @@ while {true} do {
 Info("Server started, continuing with client init");
 
 //call A3A_fnc_installSchrodingersBuildingFix;
+[] spawn A3A_fnc_modBlacklist;
 
 if (!isServer) then {
     // get server to send us the current destroyedBuildings list, hide them locally

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -77,6 +77,9 @@ A3A_backgroundInitDone = true;
 Info("Server Initialising PATCOM Variables");
 [] call A3A_fnc_patrolInit;
 
+Info("Checking for blacklisted mods on server");
+[] spawn A3A_fnc_modBlacklist;
+
 // **************** Starting game, param-dependent init *******************************
 
 // Wait until we have selected/created save data
@@ -309,16 +312,6 @@ addMissionEventHandler ["EntityKilled", {
         ["", _object] call A3A_fnc_garrisonServer_addVehicle;
     }] call CBA_fnc_addEventHandler;
 };*/
-
-if ((isClass (configfile >> "CBA_Extended_EventHandlers")) && (
-    isClass (configfile >> "CfgPatches" >> "lambs_danger"))) then {
-    // disable lambs danger fsm entrypoint
-    ["CAManBase", "InitPost", {
-        params ["_unit"];
-        (group _unit) setVariable ["lambs_danger_disableGroupAI", true];
-        _unit setVariable ["lambs_danger_disableAI", true];
-    }] call CBA_fnc_addClassEventHandler;
-};
 
 // Could replace these with entityCreated handler instead...
 if(A3A_hasZen) then {

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -13,7 +13,6 @@ Info_1("Server version: %1", QUOTE(VERSION_FULL));
 
 if (isClass (missionConfigFile/"CfgFunctions"/"A3A")) exitWith {};          // Pre-mod mission will break. Messaging handled in initPreJIP
 if (!requiredVersion QUOTE(REQUIRED_VERSION)) exitWith { Error("Arma version is out of date") };
-if (call A3A_fnc_modBlacklist) exitWith {};
 
 // hide all the HQ objects
 {

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -76,8 +76,11 @@ A3A_backgroundInitDone = true;
 Info("Server Initialising PATCOM Variables");
 [] call A3A_fnc_patrolInit;
 
-Info("Checking for blacklisted mods on server");
-[] spawn A3A_fnc_modBlacklist;
+if !(hasInterface) then { // already runs client side
+    Info("Checking for blacklisted mods on server");
+    [] spawn A3A_fnc_modBlacklist;
+};
+
 
 // **************** Starting game, param-dependent init *******************************
 

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -39,6 +39,11 @@ if (isClass (configFile/"CfgVehicles"/"vn_module_dynamicradiomusic_disable")) th
     A3A_VN_MusicModule = (createGroup sideLogic) createUnit ["vn_module_dynamicradiomusic_disable", [worldSize, worldSize,0], [],0,"NONE"];
 };
 
+if !(hasInterface) then {       // Only needs client call on localhost
+    Info("Checking for blacklisted mods on server");
+    [] call A3A_fnc_modBlacklist;
+};
+
 // Shouldn't be anything with dependencies in here
 call A3A_fnc_initVarCommon;
 call A3A_fnc_initZones;					// needed here because new-game setup needs to know where the markers are
@@ -75,11 +80,6 @@ A3A_backgroundInitDone = true;
 
 Info("Server Initialising PATCOM Variables");
 [] call A3A_fnc_patrolInit;
-
-if !(hasInterface) then { // already runs client side
-    Info("Checking for blacklisted mods on server");
-    [] spawn A3A_fnc_modBlacklist;
-};
 
 
 // **************** Starting game, param-dependent init *******************************

--- a/A3A/addons/core/functions/init/fn_modBlacklist.sqf
+++ b/A3A/addons/core/functions/init/fn_modBlacklist.sqf
@@ -1,23 +1,54 @@
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
-_bad = false;
+if !(canSuspend) exitWith {};
 
-if (missionNamespace getVariable ["MCC_isMode",false]) then {_bad = true};
-if (isClass (configfile >> "CfgVehicles" >> "ALiVE_require")) then {_bad = true};
-if ("asr_ai3_main" in activatedAddons) then {_bad = true};
-if (_bad) then
+private _blacklistedHM = createHashMapFromArray [ // ["Mod Name As Seen On Steam", [{condition}, "Dev Comment"],
+	// All of these strings dont need to be localized
+	["LAMBS_Danger", [{isClass (configfile >> "CfgPatches" >> "lambs_danger")}, "Causes AI to walk away from garrisons and ignore tasks assigned by Antistasi"]],
+	["Vcom", [{isClass (configfile >> "CfgPatches" >> "VCOM_AI")}, "Breaks Antistasi AI and also causes AI to attempt to steal random vehicles"]],
+	["ALiVE", [{isClass (configfile >> "CfgVehicles" >> "ALiVE_require")}, "Antistasi has its own save system and AI command system"]],
+	["MCC Sandbox 4", [{missionNamespace getVariable ["MCC_isMode",false]}, ""]], // blocked from a while ago, could find no solid info
+	["ASR AI3", [{"asr_ai3_main" in activatedAddons}, ""]], // blocked from a while ago, could find no solid info
+	["Project Injury Reaction (PiR)", [{isClass (configfile >> "CfgPatches" >> "PiR")}, "Breaks the death / unconscious states for Antistasi medical. May work fine with ACE Medical."]],
+	["Zulu Headless Client (ZHC)", [{isClass (configfile >> "CfgPatches" >> "zhc_main")}, "Antistasi is reliant on its own scripts for using headless clients"]],
+	["Werthles' Headless Module", [{isClass (configfile >> "CfgPatches" >> "Werthles_WHK")}, "Antistasi is reliant on its own scripts for using headless clients"]],
+	["Advanced Rappelling", [{isClass (configfile >> "CfgPatches" >> "AR_AdvancedRappelling") && (isServer && (productVersion # 6) isEqualTo "Linux")}, "Breaks AI movement on Linux servers"]],
+	["Advanced Urban Rappelling", [{isClass (configfile >> "CfgPatches" >> "AUR_AdvancedUrbanRappelling") && (isServer && (productVersion # 6) isEqualTo "Linux")}, "Breaks AI movement on Linux servers"]]
+];
+
+private _badMods = [];
+
 {
-	if (isServer) then
-	{
-		["modUnautorized",false,1,false,false] remoteExec ["BIS_fnc_endMission"];
-        Error("Blacklisted mod detected on SP or MP Server. Ending Mission");
-	}
-	else
-	{
-		["modUnautorized",false,1,false,false] call BIS_fnc_endMission;
-        Error("Blacklisted mod detected on client. Ending Mission");
+	if (call (_y#0)) then {_badMods pushBack _x};
+} forEach _blacklistedHM;
 
-	};
+if (count _badMods == 0) exitWith {};
+private _formattedBadMods = _badMods joinString ", ";
+
+Error_1("Blacklisted mods detected: %1. Removing these mods is recommended.", _formattedBadMods)
+
+// this can be a single case for right now
+if ("LAMBS_Danger" in _badMods) then {
+	// disable lambs danger fsm entrypoint
+	// lambs also has cba dependency
+	["CAManBase", "InitPost", {
+		params ["_unit"];
+		(group _unit) setVariable ["lambs_danger_disableGroupAI", true];
+		_unit setVariable ["lambs_danger_disableAI", true];
+	}] call CBA_fnc_addClassEventHandler;
 };
 
-_bad;
+if !(hasInterface) exitWith {
+	waitUntil {sleep 0.5; count playableUnits > 0};
+	[localize "STR_A3A_mod_blacklist_title", format [localize "STR_A3A_mod_blacklist_serverHint", _badMods joinString "<br/>"]] call A3A_fnc_customHint;
+};
+
+{
+	private _mod = _x;
+	private _devComment = (_blacklistedHM get _mod)#1;
+	if (_devComment isEqualTo "") then {_devComment = "None"};
+	sleep 0.1;
+	localize "STR_A3A_mod_blacklist_warningTitle" hintC parseText format [localize "STR_A3A_mod_blacklist_warningText", _mod, _devComment];
+	waitUntil {sleep 0.1; isNull findDisplay 72};
+	hintSilent "";
+} forEach _badMods;

--- a/A3A/addons/core/functions/init/fn_modBlacklist.sqf
+++ b/A3A/addons/core/functions/init/fn_modBlacklist.sqf
@@ -13,7 +13,8 @@ private _blacklistedHM = createHashMapFromArray [ // ["Mod Name As Seen On Steam
 	["Zulu Headless Client (ZHC)", [{isClass (configfile >> "CfgPatches" >> "zhc_main")}, "Antistasi is reliant on its own scripts for using headless clients"]],
 	["Werthles' Headless Module", [{isClass (configfile >> "CfgPatches" >> "Werthles_WHK")}, "Antistasi is reliant on its own scripts for using headless clients"]],
 	["Advanced Rappelling", [{isClass (configfile >> "CfgPatches" >> "AR_AdvancedRappelling") && (isServer && (productVersion # 6) isEqualTo "Linux")}, "Breaks AI movement on Linux servers"]],
-	["Advanced Urban Rappelling", [{isClass (configfile >> "CfgPatches" >> "AUR_AdvancedUrbanRappelling") && (isServer && (productVersion # 6) isEqualTo "Linux")}, "Breaks AI movement on Linux servers"]]
+	["Advanced Urban Rappelling", [{isClass (configfile >> "CfgPatches" >> "AUR_AdvancedUrbanRappelling") && (isServer && (productVersion # 6) isEqualTo "Linux")}, "Breaks AI movement on Linux servers"]],
+	["ACE Medical", [{isClass (configFile >> "CfgSounds" >> "ACE_heartbeat_fast_3") && {!isMultiplayer}}, "Breaks respawning in singleplayer. Download the ACE No Medical mod to get the rest of the ACE features without the broken Medical"]], // broken only in real sp
 ];
 
 private _badMods = [];

--- a/A3A/addons/core/functions/init/fn_modBlacklist.sqf
+++ b/A3A/addons/core/functions/init/fn_modBlacklist.sqf
@@ -1,13 +1,12 @@
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
 if !(canSuspend) exitWith {};
-if !(isNil "A3A_modsChecked") exitWith {};
 
 private _blacklistedHM = createHashMapFromArray [ // ["Mod Name As Seen On Steam", [{condition}, "Dev Comment"],
 	// All of these strings dont need to be localized
 	["LAMBS_Danger", [{isClass (configfile >> "CfgPatches" >> "lambs_danger")}, "Causes AI to walk away from garrisons and ignore tasks assigned by Antistasi"]],
 	["Vcom", [{isClass (configfile >> "CfgPatches" >> "VCOM_AI")}, "Breaks Antistasi AI and also causes AI to attempt to steal random vehicles"]],
-	["ALiVE", [{isClass (configfile >> "CfgVehicles" >> "ALiVE_require")}, "Antistasi has its own save system and AI command system"]],
+	["ALiVE", [{isClass (configfile >> "CfgVehicles" >> "ALiVE_require")}, "Antistasi has its own save system and AI command system, stops game from starting entirely"]], // also hard breaks game start LOL
 	["MCC Sandbox 4", [{missionNamespace getVariable ["MCC_isMode",false]}, ""]], // blocked from a while ago, could find no solid info
 	["ASR AI3", [{"asr_ai3_main" in activatedAddons}, ""]], // blocked from a while ago, could find no solid info
 	["Project Injury Reaction (PiR)", [{isClass (configfile >> "CfgPatches" >> "PiR")}, "Breaks the death / unconscious states for Antistasi medical. May work fine with ACE Medical."]],
@@ -29,8 +28,6 @@ private _formattedBadMods = _badMods joinString ", ";
 
 Error_1("Blacklisted mods detected: %1. Removing these mods is recommended.", _formattedBadMods)
 
-A3A_modsChecked = true;
-
 // this can be a single case for right now
 if ("LAMBS_Danger" in _badMods) then {
 	// disable lambs danger fsm entrypoint
@@ -44,15 +41,15 @@ if ("LAMBS_Danger" in _badMods) then {
 
 if !(hasInterface) exitWith {
 	waitUntil {sleep 0.5; count playableUnits > 0};
-	[localize "STR_A3A_mod_blacklist_title", format [localize "STR_A3A_mod_blacklist_serverHint", _badMods joinString "<br/>"]] call A3A_fnc_customHint;
+	[localize "STR_A3A_mod_blacklist_title", format [localize "STR_A3A_mod_blacklist_serverHint", _badMods joinString "<br/>"]] remoteExec [A3A_fnc_customHint, playableUnits#0];
 };
 
 {
 	private _mod = _x;
 	private _devComment = (_blacklistedHM get _mod)#1;
 	if (_devComment isEqualTo "") then {_devComment = "None"};
-	sleep 0.1;
-	localize "STR_A3A_mod_blacklist_warningTitle" hintC parseText format [localize "STR_A3A_mod_blacklist_warningText", _mod, _devComment];
 	waitUntil {sleep 0.1; isNull findDisplay 72};
 	hintSilent "";
+	localize "STR_A3A_mod_blacklist_warningTitle" hintC parseText format [localize "STR_A3A_mod_blacklist_warningText", _mod, _devComment];
 } forEach _badMods;
+hintSilent "";

--- a/A3A/addons/core/functions/init/fn_modBlacklist.sqf
+++ b/A3A/addons/core/functions/init/fn_modBlacklist.sqf
@@ -1,26 +1,40 @@
+// Uses hintC on clients & blocks until acknowledged
+// Returns immediately on server/HC, server publishes A3A_serverBadMods
+
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
-if !(canSuspend) exitWith {};
 
 private _blacklistedHM = createHashMapFromArray [ // ["Mod Name As Seen On Steam", [{condition}, "Dev Comment"],
-	// All of these strings dont need to be localized
-	["LAMBS_Danger", [{isClass (configfile >> "CfgPatches" >> "lambs_danger")}, "Causes AI to walk away from garrisons and ignore tasks assigned by Antistasi"]],
-	["Vcom", [{isClass (configfile >> "CfgPatches" >> "VCOM_AI")}, "Breaks Antistasi AI and also causes AI to attempt to steal random vehicles"]],
-	["ALiVE", [{isClass (configfile >> "CfgVehicles" >> "ALiVE_require")}, "Antistasi has its own save system and AI command system, stops game from starting entirely"]], // also hard breaks game start LOL
-	["MCC Sandbox 4", [{missionNamespace getVariable ["MCC_isMode",false]}, ""]], // blocked from a while ago, could find no solid info
-	["ASR AI3", [{"asr_ai3_main" in activatedAddons}, ""]], // blocked from a while ago, could find no solid info
-	["Project Injury Reaction (PiR)", [{isClass (configfile >> "CfgPatches" >> "PiR")}, "Breaks the death / unconscious states for Antistasi medical. May work fine with ACE Medical."]],
-	["Zulu Headless Client (ZHC)", [{isClass (configfile >> "CfgPatches" >> "zhc_main")}, "Antistasi is reliant on its own scripts for using headless clients"]],
-	["Werthles' Headless Module", [{isClass (configfile >> "CfgPatches" >> "Werthles_WHK")}, "Antistasi is reliant on its own scripts for using headless clients"]],
-	["Advanced Rappelling", [{isClass (configfile >> "CfgPatches" >> "AR_AdvancedRappelling") && (isServer && (productVersion # 6) isEqualTo "Linux")}, "Breaks AI movement on Linux servers"]],
-	["Advanced Urban Rappelling", [{isClass (configfile >> "CfgPatches" >> "AUR_AdvancedUrbanRappelling") && (isServer && (productVersion # 6) isEqualTo "Linux")}, "Breaks AI movement on Linux servers"]],
-	["ACE Medical", [{isClass (configFile >> "CfgSounds" >> "ACE_heartbeat_fast_3") && {!isMultiplayer}}, "Breaks respawning in singleplayer. Download the ACE No Medical mod to get the rest of the ACE features without the broken medical"]] // broken only in real sp
+    // All of these strings dont need to be localized
+    ["LAMBS_Danger", [{isClass (configfile >> "CfgPatches" >> "lambs_danger")}, "Causes AI to walk away from garrisons and ignore tasks assigned by Antistasi"]],
+    ["Vcom", [{isClass (configfile >> "CfgPatches" >> "VCOM_AI")}, "Breaks Antistasi AI and also causes AI to attempt to steal random vehicles"]],
+    ["ALiVE", [{isClass (configfile >> "CfgVehicles" >> "ALiVE_require")}, "Antistasi has its own save system and AI command system, stops game from starting entirely"]], // also hard breaks game start LOL
+    ["MCC Sandbox 4", [{missionNamespace getVariable ["MCC_isMode",false]}, ""]], // blocked from a while ago, could find no solid info
+    ["ASR AI3", [{"asr_ai3_main" in activatedAddons}, ""]], // blocked from a while ago, could find no solid info
+    ["Project Injury Reaction (PiR)", [{isClass (configfile >> "CfgPatches" >> "PiR")}, "Breaks the death / unconscious states for Antistasi medical. May work fine with ACE Medical."]],
+    ["Zulu Headless Client (ZHC)", [{isClass (configfile >> "CfgPatches" >> "zhc_main")}, "Antistasi is reliant on its own scripts for using headless clients"]],
+    ["Werthles' Headless Module", [{isClass (configfile >> "CfgPatches" >> "Werthles_WHK")}, "Antistasi is reliant on its own scripts for using headless clients"]],
+    ["Advanced Rappelling", [{isClass (configfile >> "CfgPatches" >> "AR_AdvancedRappelling") && (isServer && (productVersion # 6) isEqualTo "Linux")}, "Breaks AI movement on Linux servers"]],
+    ["Advanced Urban Rappelling", [{isClass (configfile >> "CfgPatches" >> "AUR_AdvancedUrbanRappelling") && (isServer && (productVersion # 6) isEqualTo "Linux")}, "Breaks AI movement on Linux servers"]],
+    ["ACE Medical", [{isClass (configFile >> "CfgSounds" >> "ACE_heartbeat_fast_3") && {!isMultiplayer}}, "Breaks respawning in singleplayer. Download the ACE No Medical mod to get the rest of the ACE features without the broken medical"]] // broken only in real sp
 ];
+
+// First show bad mods running on server, if there are any
+if (hasInterface and !isServer and !isNil "A3A_serverBadMods") then {
+    {
+        private _mod = _x;
+        private _devComment = (_blacklistedHM get _mod)#1;
+        if (_devComment isEqualTo "") then {_devComment = "None"};
+        localize "STR_A3A_mod_blacklist_titleServer" hintC parseText format [localize "STR_A3A_mod_blacklist_textServer", _mod, _devComment];
+        waitUntil {sleep 0.01; isNull findDisplay 72};
+        hintSilent "";
+    } forEach A3A_serverBadMods;
+};
 
 private _badMods = [];
 
 {
-	if (call (_y#0)) then {_badMods pushBack _x};
+    if (call (_y#0)) then {_badMods pushBack _x};
 } forEach _blacklistedHM;
 
 if (count _badMods == 0) exitWith {};
@@ -30,26 +44,26 @@ Error_1("Blacklisted mods detected: %1. Removing these mods is recommended.", _f
 
 // this can be a single case for right now
 if ("LAMBS_Danger" in _badMods) then {
-	// disable lambs danger fsm entrypoint
-	// lambs also has cba dependency
-	["CAManBase", "InitPost", {
-		params ["_unit"];
-		(group _unit) setVariable ["lambs_danger_disableGroupAI", true];
-		_unit setVariable ["lambs_danger_disableAI", true];
-	}] call CBA_fnc_addClassEventHandler;
+    // disable lambs danger fsm entrypoint
+    // lambs also has cba dependency
+    ["CAManBase", "InitPost", {
+        params ["_unit"];
+        (group _unit) setVariable ["lambs_danger_disableGroupAI", true];
+        _unit setVariable ["lambs_danger_disableAI", true];
+    }] call CBA_fnc_addClassEventHandler;
 };
 
 if !(hasInterface) exitWith {
-	waitUntil {sleep 0.5; count playableUnits > 0};
-	[localize "STR_A3A_mod_blacklist_title", format [localize "STR_A3A_mod_blacklist_serverHint", _badMods joinString "<br/>"]] remoteExec [A3A_fnc_customHint, playableUnits#0];
+    if !(isServer) exitWith {};         // Don't show UI stuff for HCs. Should probably end the mission but whatever.
+    A3A_serverBadMods = _badMods;
+    publicVariable "A3A_serverBadMods";
 };
 
 {
-	private _mod = _x;
-	private _devComment = (_blacklistedHM get _mod)#1;
-	if (_devComment isEqualTo "") then {_devComment = "None"};
-	waitUntil {sleep 0.1; isNull findDisplay 72};
-	hintSilent "";
-	localize "STR_A3A_mod_blacklist_warningTitle" hintC parseText format [localize "STR_A3A_mod_blacklist_warningText", _mod, _devComment];
+    private _mod = _x;
+    private _devComment = (_blacklistedHM get _mod)#1;
+    if (_devComment isEqualTo "") then {_devComment = "None"};
+    localize "STR_A3A_mod_blacklist_title" hintC parseText format [localize "STR_A3A_mod_blacklist_text", _mod, _devComment];
+    waitUntil {sleep 0.01; isNull findDisplay 72};
+    hintSilent "";
 } forEach _badMods;
-hintSilent "";

--- a/A3A/addons/core/functions/init/fn_modBlacklist.sqf
+++ b/A3A/addons/core/functions/init/fn_modBlacklist.sqf
@@ -1,6 +1,7 @@
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
 if !(canSuspend) exitWith {};
+if !(isNil "A3A_modsChecked") exitWith {};
 
 private _blacklistedHM = createHashMapFromArray [ // ["Mod Name As Seen On Steam", [{condition}, "Dev Comment"],
 	// All of these strings dont need to be localized
@@ -14,7 +15,7 @@ private _blacklistedHM = createHashMapFromArray [ // ["Mod Name As Seen On Steam
 	["Werthles' Headless Module", [{isClass (configfile >> "CfgPatches" >> "Werthles_WHK")}, "Antistasi is reliant on its own scripts for using headless clients"]],
 	["Advanced Rappelling", [{isClass (configfile >> "CfgPatches" >> "AR_AdvancedRappelling") && (isServer && (productVersion # 6) isEqualTo "Linux")}, "Breaks AI movement on Linux servers"]],
 	["Advanced Urban Rappelling", [{isClass (configfile >> "CfgPatches" >> "AUR_AdvancedUrbanRappelling") && (isServer && (productVersion # 6) isEqualTo "Linux")}, "Breaks AI movement on Linux servers"]],
-	["ACE Medical", [{isClass (configFile >> "CfgSounds" >> "ACE_heartbeat_fast_3") && {!isMultiplayer}}, "Breaks respawning in singleplayer. Download the ACE No Medical mod to get the rest of the ACE features without the broken Medical"]], // broken only in real sp
+	["ACE Medical", [{isClass (configFile >> "CfgSounds" >> "ACE_heartbeat_fast_3") && {!isMultiplayer}}, "Breaks respawning in singleplayer. Download the ACE No Medical mod to get the rest of the ACE features without the broken medical"]] // broken only in real sp
 ];
 
 private _badMods = [];
@@ -27,6 +28,8 @@ if (count _badMods == 0) exitWith {};
 private _formattedBadMods = _badMods joinString ", ";
 
 Error_1("Blacklisted mods detected: %1. Removing these mods is recommended.", _formattedBadMods)
+
+A3A_modsChecked = true;
 
 // this can be a single case for right now
 if ("LAMBS_Danger" in _badMods) then {


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Provides a better blacklisting system for mods
Each banned mod will put a hintC on screen that needs to be dismissed.
Put entries for each banned mod in the guide. Also banned ACE Medical in SP

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: Could throw it on dedicated and make sure the server side detection works, which isnt a too-too critical feature because hopefully either the server is a player who gets the errors or its a dedicated which is enforcing signatures, but it's still useful to have

********************************************************
Notes:
