### PR TITLE
Add custom flag position option to map marker spec

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -393,6 +393,7 @@ class CfgFunctions
             class checkCampaignEnd {};
             class clientIdleChecker {};
             class credits {};
+            class getMarkerPrefix {};
             class initACE {};
             class initACEUnconsciousHandler {};
             class initBases {};

--- a/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_spawn.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_spawn.sqf
@@ -62,10 +62,17 @@ if !(_garrisonType == "hq") then {
 };
 
 
+// If a flag marker is provided, use that for flag & ammobox
+private _flagPos = _markerPos;
+if (_garrisonType in A3A_markerPrefixHM) then {
+    private _flagMarker = (_marker call A3A_fnc_getMarkerPrefix) + "flag";
+    if (markerShape _flagMarker != "") then { _flagPos = markerPos _flagMarker };
+};
+
 // Spawn flagpole
 if !(_garrisonType in ["hq", "city", "roadblock", "camp", "rebpost"]) then
 {
-    private _flag = createVehicle [_faction get "flag", _markerPos, [], 0, "NONE"];
+    private _flag = createVehicle [_faction get "flag", _flagPos, [], 0, "NONE"];
     _flag setFlagTexture (_faction get "flagTexture");
     _flag allowDamage false;
     _garrison set ["flag", _flag];
@@ -111,7 +118,7 @@ if (_side != teamPlayer and _garrisonType in ["airport", "outpost", "seaport"]) 
 
     // Spawn loot crate if it's off cooldown
     if (_garrison getOrDefault ["lootCD", 0] > 0) exitWith {};
-	private _ammoBox = [_faction get "ammobox", _markerPos, 15, 5, true] call A3A_fnc_safeVehicleSpawn;
+	private _ammoBox = [_faction get "ammobox", _flagPos, 10, 5, true] call A3A_fnc_safeVehicleSpawn;
     [_ammoBox, true, _garrison, _marker] call A3A_fnc_setupLootCrate;
 };
 

--- a/A3A/addons/core/functions/init/fn_getMarkerPrefix.sqf
+++ b/A3A/addons/core/functions/init/fn_getMarkerPrefix.sqf
@@ -1,0 +1,9 @@
+
+// Should only be called for types that exist in A3A_markerPrefixHM, airport/outpost/resource/factory/seaport
+
+params ["_marker"];
+
+private _markerSplit = _marker splitString "_";
+private _markerPrefix = A3A_markerPrefixHM get (_markerSplit select 0);
+if (count _markerSplit == 1) exitWith { _markerPrefix };
+format ["%1%2_", _markerPrefix, _markerSplit select 1];

--- a/A3A/addons/core/functions/init/fn_initSpawnPlaces.sqf
+++ b/A3A/addons/core/functions/init/fn_initSpawnPlaces.sqf
@@ -10,20 +10,7 @@ private _hangarMarker = [];
 private _mortarMarker = [];
 private _planeMarker = [];
 
-//Calculating marker prefix
-private _markerSplit = _marker splitString "_";
-private _markerPrefix = switch (_markerSplit select 0) do
-{
-    case ("airport"): {"airp_"};
-    case ("outpost"): {"outp_"};
-    case ("resource"): {"reso_"};
-    case ("factory"): {"fact_"};
-    case ("seaport"): {"seap_"};
-};
-if (count _markerSplit > 1) then
-{
-    _markerPrefix = format ["%1%2_", _markerPrefix, _markerSplit select 1];
-};
+private _markerPrefix = _marker call A3A_fnc_getMarkerPrefix;
 
 //Sort markers
 private _markerPos = getMarkerPos _marker;
@@ -41,6 +28,7 @@ private _markerPos = getMarkerPos _marker;
         case ("hangar"): {_hangarMarker pushBack _fullName;};
         case ("plane"): {_planeMarker pushBack _fullName;};
         case ("mortar"): {_mortarMarker pushBack _fullName;};
+        // "flag" also exists but we ignore it here aside from setting the marker alpha
     };
     _fullName setMarkerAlpha 0;
 } forEach _placementMarker;
@@ -157,7 +145,7 @@ private _mortarSpawns = [];
 private _spawnPlaces = [];
 
 // Vehicle slot special cases
-if (_markerSplit#0 == "airport" and _vehicleSpawns isNotEqualTo []) then {
+if ("airport" in _marker and _vehicleSpawns isNotEqualTo []) then {
     private _aaPlace = _vehicleSpawns deleteAt 0;
     _spawnPlaces pushBack ["vehicleAA", _aaPlace#0, _aaPlace#1];
 };

--- a/A3A/addons/core/functions/init/fn_initVarCommon.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarCommon.sqf
@@ -298,4 +298,11 @@ A3A_strongUniformsHM = _strongUniforms createHashMapFromArray [];		// fills with
 medicAnims = ["AinvPknlMstpSnonWnonDnon_medic_1","AinvPknlMstpSnonWnonDnon_medic0","AinvPknlMstpSnonWnonDnon_medic1","AinvPknlMstpSnonWnonDnon_medic2"];
 
 
+////////////////////////////////////
+//      OTHER LOOKUP TABLES      ///
+////////////////////////////////////
+
+A3A_markerPrefixHM = createHashMapFromArray [["airport", "airp_"], ["outpost", "outp_"], ["resource", "reso_"], ["factory", "fact_"], ["seaport", "seap_"]];
+
+
 Info("initVarCommon completed");

--- a/A3A/addons/maps/Antistasi_isladuala3.isladuala3/mission.sqm
+++ b/A3A/addons/maps/Antistasi_isladuala3.isladuala3/mission.sqm
@@ -8,15 +8,15 @@ class EditorData
 	toggles=1537;
 	class ItemIDProvider
 	{
-		nextID=5604;
+		nextID=5606;
 	};
 	class MarkerIDProvider
 	{
-		nextID=12;
+		nextID=14;
 	};
 	class LayerIndexProvider
 	{
-		nextID=5994;
+		nextID=6105;
 	};
 	class Camera
 	{
@@ -6506,7 +6506,7 @@ class Mission
 					name="airport_5";
 					class Entities
 					{
-						items=55;
+						items=56;
 						class Item0
 						{
 							dataType="Marker";
@@ -7354,9 +7354,17 @@ class Mission
 							angle=179.31004;
 							id=4916;
 						};
+						class Item55
+						{
+							dataType="Marker";
+							position[]={4332.2002,15.25,2219.073};
+							name="airp_5_flag";
+							type="mil_flag";
+							id=5604;
+						};
 					};
 					id=265;
-					atlOffset=0.21574593;
+					atlOffset=0.10787296;
 				};
 				class Item5
 				{


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Add the option to specify a custom flag position to markers in the SQM. Format is prefix + "flag", for example `"airp_1_flag"`. Useful because having to put the flag in the marker center is very annoying for some markers.

Refactored a few things to avoid copying a chunk of init code and replaced a switch with a hashmap lookup. Used the mid-south airport on Isla Duala as an example because it had the flag in the middle of a taxiway junction.

### Please specify which Issue this PR Resolves.
closes #3484

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

