### PR TITLE
Fix building placer repair not working on remote clients

### DIFF
--- a/A3A/addons/core/functions/Builder/fn_lockBuilderBox.sqf
+++ b/A3A/addons/core/functions/Builder/fn_lockBuilderBox.sqf
@@ -25,7 +25,7 @@ if (_take) then {
     {
         private _building = _x getVariable ["building", objNull];
         if (isNull _building) then { continue };
-        _ruin setVariable ["building", _x, owner player];
+        _x setVariable ["building", _building, owner _player];
     } forEach _nearRuins;
 
     private _money = _box getVariable ["A3A_itemPrice", 0];


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The building placer repair functionality didn't correctly transmit the ruin->building links to remote clients (again). This PR fixes it (again).

### Please specify which Issue this PR Resolves.
closes #3762

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Blow up a building on a dedicated server. Try to repair it with the building placer.