### PR TITLE
Fix garrison unit types not importing correctly from old saves

### DIFF
--- a/A3A/addons/core/functions/Save/fn_convertSavedGarrisons.sqf
+++ b/A3A/addons/core/functions/Save/fn_convertSavedGarrisons.sqf
@@ -17,7 +17,8 @@ private _translateMarker = {
 A3A_garrison = createHashMap;
 
 // Rebels simply get replaced if they're not a recognised loadout
-private _rebLoadouts = A3A_faction_reb get "loadouts";
+// "loadouts" hashmap only contains the "militia_Rifleman" part
+private _rebLoadouts = keys (A3A_faction_reb get "loadouts") apply { "loadouts_reb_" + _x } createHashMapFromArray [];
 private _rebReplacements = A3A_faction_reb get "groupSquad";
 
 private _validMarkers = (markersX + outpostsFIA) createHashMapFromArray [];


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The code that translated the garrisons for old saves to 3.10 was losing the unit types. Fixed. Too late for anyone who already continued their save, but probably worth fixing anyway.

### Please specify which Issue this PR Resolves.
closes #3766

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
