### PR TITLE
Fix how-to-save hint for 3.10

### DIFF
--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -2896,9 +2896,7 @@
         <Chinesesimp>清除树林</Chinesesimp>
       </Key>
       <Key ID="STR_A3A_fn_dialogs_createDialog_SLPS_line1">
-        <Original>Antistasi has a custom save system similar to other CTIs.&lt;br/&gt;&lt;br/&gt;To Save: Your commander needs to go to the &lt;t color='#f0d498'&gt;Map Board&lt;/t&gt;, scroll-select &lt;t color='#f0d498'&gt;""Game Options""&lt;/t&gt; and click on the &lt;t color='#f0d498'&gt;""Persistent Save""&lt;/t&gt; button.</Original>
-        <Korean>안티스타시에는 다른 CTI 모드와 유사한 사용자 정의 저장 시스템이 있습니다.&lt;br/&gt;&lt;br/&gt;저장 방법: 지휘관은 &lt;t color='#f0d498'&gt;지도 화이트보드&lt;/t&gt;로 이동하여 스크롤 선택으로&lt;t color='#f0d498'&gt;""게임 설정""&lt;/t&gt;을 선택하고 &lt;t color='#f0d498'&gt;""영구 저장""&lt;/t&gt; 버튼을 누르십시오.</Korean>
-        <Russian>В Antistasi есть собственная система сохранения, похожая на другие CTI.&lt;br/&gt;&lt;br/&gt; Чтобы сохранить: Ваш командир должен подойти к &lt;t color='#f0d498'&gt;Карте&lt;/t&gt;, открыть &lt;t color='#f0d498'&gt;""Параметры""&lt;/t&gt; и нажать на кнопку &lt;t color='#f0d498'&gt;""Сохранение""&lt;/t&gt;.</Russian>
+        <Original>Antistasi has a custom save system similar to other CTIs.&lt;br/&gt;&lt;br/&gt;To Save: Go to the &lt;t color='#f0d498'&gt;Battle Menu (%1)&lt;/t&gt;, select the Commander or Admin tab and then click the &lt;t color='#f0d498'&gt;"Persistent Save"&lt;/t&gt; button.</Original>
       </Key>
       <Key ID="STR_A3A_fn_dialogs_createDialog_SLPS_line2">
         <Original>Current parameters are configured to auto-save every %1 minutes.</Original>

--- a/A3A/addons/core/functions/Dialogs/fn_createDialog_shouldLoadPersonalSave.sqf
+++ b/A3A/addons/core/functions/Dialogs/fn_createDialog_shouldLoadPersonalSave.sqf
@@ -2,7 +2,7 @@
 private _autoSaveInterval = [false,(autoSaveInterval/60)] select autoSave;
 _autoSaveInterval = "<t color='#f0d498'>" + str _autoSaveInterval + "</t>";
 
-private _saveString = (localize "STR_A3A_fn_dialogs_createDialog_SLPS_line1") + "<br/><br/>";
+private _saveString = format [localize "STR_A3A_fn_dialogs_createDialog_SLPS_line1", actionKeysNames "A3A_core_battleMenu"] + "<br/><br/>";
 _saveString = if (autoSave) then { [_saveString,format[localize "STR_A3A_fn_dialogs_createDialog_SLPS_line2", _autoSaveInterval]] joinString "" }
     else { [_saveString,localize "STR_A3A_fn_dialogs_createDialog_SLPS_line3"] joinString "" };
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The how-to-save startup hint describes a method that no longer exists in 3.10. I fixed it:

![20B910~1](https://github.com/user-attachments/assets/7e7330d6-ab95-44d4-a144-57b3e50cd6cb)

### Please specify which Issue this PR Resolves.
closes #3763

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
