### PR TITLE
Fix various rebel vehicle garrison consistency bugs 

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -584,6 +584,7 @@ class CfgFunctions
         class REINF {
             file = QPATHTOFOLDER(functions\REINF);
             class addBombRun {};
+            class addBombRunServer {};
             class addFIAsquadHC {};
             class addFIAveh {};
             class addSquadVeh {};

--- a/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_despawn.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_despawn.sqf
@@ -36,7 +36,7 @@ if (_side != teamPlayer) then {
     [_marker, false, false] call A3A_fnc_garrisonServer_cleanup;
 } else {
     // If it's a rebel marker then update vehicle fuel/ammo state
-    _marker call A3A_garrisonServer_updateVehData;
+    _marker call A3A_fnc_garrisonServer_updateVehData;
 };
 
 ["despawn", [_marker]] call A3A_fnc_garrisonOp;

--- a/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_updateVehData.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_updateVehData.sqf
@@ -29,7 +29,8 @@ private _garrison = A3A_garrison get _marker;
 
 private _usedVehicles = [];
 {
-    private _veh = nearestObject [_x#1, _x#0];          // position, type
+    if (_x#1 isEqualType 0) then { continue };                     // don't bother dealing with placed vehicles for now
+    private _veh = nearestObject [ASLtoATL (_x#1), _x#0];          // position, type
     // sanity checks?
     private _reason = call {
         if (isNull _veh) exitWith { "missing" };
@@ -41,6 +42,8 @@ private _usedVehicles = [];
         Error_3("Vehicle type %1 not found in %2, reason: %3", _x#0, _marker, _reason);
         continue;
     };
-    if !(_veh isKindOf "StaticWeapon") then { _x set [4, _veh call HR_GRG_getVehState] };
+    // Update pos/dir, in case it got nudged
+    _x set [1, getPosWorld _veh]; _x set [2, vectorDir _veh]; _x set [3, vectorUp _veh];
+    if !(_veh isKindOf "StaticWeapon") then { _x set [4, _veh call HR_GRG_fnc_getState] };
     _usedVehicles pushBack _veh;
 } forEach (_garrison get "vehicles");

--- a/A3A/addons/core/functions/GarrisonServer/fn_rebelVehPlacedWorker.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_rebelVehPlacedWorker.sqf
@@ -17,7 +17,7 @@ params ["_veh"];
 // Wait for the thing to settle
 waitUntil { sleep 0.1; vectorMagnitude velocity _veh < 0.01 };
 
-if (isNull _veh) exitWith {};                       // might have been deleted immediately after detaching
+if (!alive _veh) exitWith {};                       // might have been deleted immediately after detaching
 if (!isNull attachedTo _veh) exitWith {};           // might be attached again
 if !(_veh isNil "markerX") exitWith {};             // Already added to a marker apparently
 

--- a/A3A/addons/core/functions/GarrisonServer/fn_rebelVehPlacedWorker.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_rebelVehPlacedWorker.sqf
@@ -17,20 +17,21 @@ params ["_veh"];
 // Wait for the thing to settle
 waitUntil { sleep 0.1; vectorMagnitude velocity _veh < 0.01 };
 
-if (!alive _veh) exitWith {};                       // might have been deleted immediately after detaching
-if (!isNull attachedTo _veh) exitWith {};           // might be attached again
-if !(_veh isNil "markerX") exitWith {};             // Already added to a marker apparently
-
-if (getNumber (configOf _veh >> "hasDriver") == 0) exitWith {
-    // Statics get added to any marker regardless of crew
-    isNil { ["", _veh] call A3A_fnc_garrisonServer_addVehicle };
-};
-
-// Mobile vehicles are only added if they're in the rebel HQ and not crewed
-if (crew _veh isNotEqualTo []) exitWith {};         // someone could have boarded it immediately
-if (A3A_petrosMoving or !(_veh inArea "Synd_HQ")) exitWith {};
-
+// Unscheduled to ensure checks are still valid when garrisoned
 isNil {
+    if (!alive _veh) exitWith {};                       // might have been deleted immediately after detaching
+    if (!isNull attachedTo _veh) exitWith {};           // might be attached again
+    if !(_veh isNil "markerX") exitWith {};             // Already added to a marker apparently
+
+    if (getNumber (configOf _veh >> "hasDriver") == 0) exitWith {
+        // Statics get added to any marker regardless of crew
+        ["", _veh] call A3A_fnc_garrisonServer_addVehicle;
+    };
+
+    // Mobile vehicles are only added if they're in the rebel HQ and not crewed
+    if (crew _veh isNotEqualTo []) exitWith {};         // someone could have boarded it immediately
+    if (A3A_petrosMoving or !(_veh inArea "Synd_HQ")) exitWith {};
+
     _veh setVariable ["lockedForAI", true, true];
     ["Synd_HQ", _veh] call A3A_fnc_garrisonServer_addVehicle;
 };

--- a/A3A/addons/core/functions/REINF/fn_addBombRun.sqf
+++ b/A3A/addons/core/functions/REINF/fn_addBombRun.sqf
@@ -1,6 +1,10 @@
-_veh = cursortarget;
+// Client-side, used by both old & new UI. New UI calls with vehicle as parameter.
+
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
+
+params [["_veh", cursorTarget]];			// cursorTarget is kinda sus but whatever
+
 #define OccAndInv(VEH) (FactionGet(occ, VEH) + FactionGet(inv, VEH))
 private _titleStr = localize "STR_A3A_fn_reinf_bombrun_title";
 private _owner = _veh getVariable "ownerX";
@@ -54,8 +58,6 @@ if ((floor bombRuns + _pointsX) > _strikeCap) exitWith {
     false;
 };
 
-deleteVehicle _veh;
 [_titleStr, format [localize "STR_A3A_fn_reinf_bombrun_increased",_pointsX]] call A3A_fnc_customHint;
-bombRuns = bombRuns + _pointsX;
-publicVariable "bombRuns";
-[] remoteExec ["A3A_fnc_statistics",theBoss];
+
+[_veh, _pointsX] remoteExecCall ["A3A_fnc_addBombRunServer", 2];

--- a/A3A/addons/core/functions/REINF/fn_addBombRunServer.sqf
+++ b/A3A/addons/core/functions/REINF/fn_addBombRunServer.sqf
@@ -1,0 +1,11 @@
+// Server-side unscheduled code to convert a vehicle into bomb runs
+
+params ["_vehicle", "_pointsX"];
+
+if !(_vehicle isNil "markerX") then { [_vehicle] call A3A_fnc_garrisonServer_remVehicle };     // must be done before deletion
+
+deleteVehicle _vehicle;
+bombRuns = bombRuns + _pointsX;
+publicVariable "bombRuns";
+
+[] remoteExec ["A3A_fnc_statistics",theBoss];

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -131,9 +131,9 @@ private _cityDataHM = createHashMap;
 
 ["cityData", _cityDataHM] call A3A_fnc_setStatVariable;
 
-// Update rebel garrison vehicle states. Can do this on active data because it doesn't change anything
+// Update rebel garrison vehicle states for spawned garrisons. Can do this on active data because it doesn't change anything
 private _rebMarkers = (markersX select { sidesX getVariable _x == teamPlayer }) + outpostsFIA;
-{ _x call A3A_fnc_garrisonServer_updateVehData } forEach _rebMarker;
+{ _x call A3A_fnc_garrisonServer_updateVehData } forEach (_rebMarkers select { spawner getVariable _x != 2 });
 
 // Cull garrison data to what we want to save
 private _saveGarrison = +A3A_garrison;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
- Fixed addBombRun not removing vehicles from garrison. Could be exploited to gain unlimited airstrike points.
- Fixed vehicles being added to garrisons when destroyed on a marker while crewed.
- Fixed vehicle states (fuel/ammo/etc) not being stored, either when a garrison despawned or on save.

Also fixed minor issue where the new UI vehicle context wasn't being used by addBombRun.

Note that the changes to rebelVehPlacedWorker are mostly bumping the code into unscheduled. The only logic change is isNull -> !alive.

### Please specify which Issue this PR Resolves.
closes #3770

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

