### PR TITLE
Fix AIs getting stuck in DOWN state after ducking mortars

### DIFF
--- a/A3A/addons/core/functions/AI/fn_duckMortar.sqf
+++ b/A3A/addons/core/functions/AI/fn_duckMortar.sqf
@@ -1,20 +1,18 @@
 // Function to force AIs to duck temporarily
 // Should be run locally to the unit
+// A3A_forcedStance should be set if a unit has a long-term requirement to be in a specific stance
 
 params ["_unit"];
 
 // Most of this code is to handle the case when mortar rounds land in rapid succession:
 // - Extend lock time with each shell
-// - Prevent AIs being locked down forever because previous stance is overwritten
+// - (obsolete) Prevent AIs being locked down forever because previous stance is overwritten
 
 terminate (_unit getVariable ["A3A_duckHandle", scriptNull]);
 private _handle = _unit spawn {
     sleep random 1.5;
-    private _prevStance = _this getVariable ["A3A_duckPrevStance", unitPos _this];
-    _this setVariable ["A3A_duckPrevStance", _prevStance];
     _this setUnitPos "DOWN";
     sleep (4 + random 6);               // doesn't actually matter much. The FSM holds them down anyway
-    _this setUnitPos _prevStance;
-    _this setVariable ["A3A_duckPrevStance", nil];
+    _this setUnitPos (_this getVariable ["A3A_forcedStance", "AUTO"]);
 };
 _unit setVariable ["A3A_duckHandle", _handle];

--- a/A3A/addons/core/functions/AI/fn_enemyReturnToBase.sqf
+++ b/A3A/addons/core/functions/AI/fn_enemyReturnToBase.sqf
@@ -86,6 +86,7 @@ if (isNil "_marker") exitWith {
     _x disableAI "AUTOCOMBAT";
     _x disableAI "TARGET";
     _x setUnitPos "UP";
+    _x setVariable ["A3A_forcedStance", "UP"];
     _x doFollow leader _group;          // in case they were a building garrison
     _x setVariable ["retreating", true, true];
 } forEach units _group;

--- a/A3A/addons/core/functions/AI/fn_rebelReturnToBase.sqf
+++ b/A3A/addons/core/functions/AI/fn_rebelReturnToBase.sqf
@@ -44,6 +44,7 @@ private _retreatPos = if (_potentials isEqualTo []) then {
     _x disableAI "AUTOCOMBAT";
     _x disableAI "TARGET";
     _x setUnitPos "UP";
+    _x setVariable ["A3A_forcedStance", "UP"];
     _x doFollow leader _group;
 } forEach units _group;
 

--- a/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_cityReinf.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_cityReinf.sqf
@@ -58,6 +58,7 @@ if (alive _station) then {
         _unit setDir (_station getRelDir _x);
         [_unit, _marker] call A3A_fnc_NATOinit;
         _unit setUnitPos "UP";
+        _unit setVariable ["A3A_forcedStance", "UP"];
         dostop _unit;
     } forEach _unitPositions;
     _stationUsed = true;

--- a/A3A/addons/core/functions/GarrisonLocal/fn_spawnPoliceStation.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_spawnPoliceStation.sqf
@@ -108,6 +108,7 @@ for "_i" from 1 to _numUnits do
     _unit setDir (_station getRelDir _placePos);
     [_unit, _marker] call A3A_fnc_NATOinit;
     _unit setUnitPos "UP";
+    _unit setVariable ["A3A_forcedStance", "UP"];
     dostop _unit;
 
     sleep 0.1;

--- a/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
@@ -42,6 +42,7 @@ _group lockWP true;         // hmm
     _unit setPosATL _placePos;
     _unit setdir _placeDir;
     _unit setUnitPos "UP";
+    _unit setVariable ["A3A_forcedStance", "UP"];
     _unit disableAI "TARGET";           // should stop them being ordered to search 300m away...
     dostop _unit;
     if (_units isEqualTo []) exitWith {};       // ran out of units before places


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Turns out `unitPos` doesn't do what I thought it did. Seems to return engine-ordered positions (setUnitPosWeak) not just setUnitPos, which means the mortar duck routine could lock a unit in DOWN or MIDDLE state after completion.

Switched it to use an object variable instead, which is set by routines that need the unit to be in a particular position long term (basically building garrison & retreats).

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Haven't actually tested it yet. Works in theory.