### PR TITLE
Show arsenal quantity and unlock quantity in gunshop

### DIFF
--- a/A3A/addons/gui/Stringtable.xml
+++ b/A3A/addons/gui/Stringtable.xml
@@ -4896,6 +4896,21 @@
       <Key ID="STR_antistasi_gun_shop_total_cost_text">
         <Original>Total:</Original>
       </Key>
+      <Key ID="STR_antistasi_gun_shop_stock_gs">
+        <Original>%1 in stock</Original>
+      </Key>
+      <Key ID="STR_antistasi_gun_shop_stock_arsenal">
+        <Original>%1 in arsenal</Original>
+      </Key>
+      <Key ID="STR_antistasi_gun_shop_unlock_amount">
+        <Original>%1 to unlock</Original>
+      </Key>
+      <Key ID="STR_antistasi_gun_shop_unlocks_disabled">
+        <Original>Unlocks disabled</Original>
+      </Key>
+      <Key ID="STR_antistasi_gun_shop_unlocks_disabled_specific">
+        <Original>Unlocks disabled for this equipment type</Original>
+      </Key>
     </Container>
     <Container name="map_selector">
       <Key ID="STR_antistasi_mapSelector_onload_text">

--- a/A3A/addons/gui/functions/gunShop/fn_createGunShopTab.sqf
+++ b/A3A/addons/gui/functions/gunShop/fn_createGunShopTab.sqf
@@ -119,7 +119,7 @@ private _createdCtrls = [];
 
 {
     private _className = _x;
-    _y params ["_itemPrice", "_stock"];
+    _y params ["_itemPrice", "_stockGS", "_stockArsenal"];
 
     private _configClass = _config >> _className;
     private _displayName = getText (_configClass >> "displayName");
@@ -162,7 +162,7 @@ private _createdCtrls = [];
 
     private _displayStock = _display ctrlCreate ["A3A_StructuredText", -1, _itemControlsGroup];
     _displayStock ctrlSetPosition _stockBox;
-    private _stockStr = str _stock + " in stock";           // TODO: stringtable
+    private _stockStr = str _stockGS + " in stock; " + ([str _stockArsenal, _stockArsenal] select (_stockArsenal isEqualType "")) + " in arsenal; " + str minWeaps + " to unlock";           // TODO: stringtable, make this control bigger
     _displayStock ctrlSetStructuredText parseText (format ["<t size='0.65' align='left' valign='middle' color='#63DDFF' shadow='2'>%1</t>", _stockStr]);
     _displayStock ctrlCommit 0;
 
@@ -184,17 +184,17 @@ private _createdCtrls = [];
     _button setVariable ["className", _className];
     _button setVariable ["selectedTabIDC", _selectedTabIDC];
     _button setVariable ["price", _itemPrice];
-    _button setVariable ["stock", _stock];
+    _button setVariable ["stock", _stockGS];
 
     _button ctrladdeventhandler ["ButtonClick", {
         params ["_control"];
         private _className = _control getVariable ["className", ""];
         private _selectedTabIDC = _control getVariable ["selectedTabIDC", ""];
         private _price = _control getVariable ["price", ""];
-        private _stock = _control getVariable ["stock", 0];
+        private _stockGS = _control getVariable ["stock", 0];
         if(_className isEqualTo "" || _selectedTab isEqualTo "") exitwith {};
 
-        [_className, _price, 1, _stock] call A3A_GUI_fnc_addToCart;
+        [_className, _price, 1, _stockGS] call A3A_GUI_fnc_addToCart;
 
         call A3A_GUI_fnc_updateCartNumber;
 

--- a/A3A/addons/gui/functions/gunShop/fn_createGunShopTab.sqf
+++ b/A3A/addons/gui/functions/gunShop/fn_createGunShopTab.sqf
@@ -47,8 +47,8 @@ switch(_selectedTab) do
 
     _pictureBox = [0, 0, 6, 6];
     _displayBox = [7.5, 0, 55.5, 3];
-    _priceBox = [13, 3, 61, 3];
-    _stockBox = [20, 3, 54, 3];
+    _priceBox = [13, 3, 6, 3];
+    _stockBox = [20, 3, 30, 3];
     _logoBox = [70, 0, 6, 6];
     _addBox = [76, 0, 24, 6];
 
@@ -162,8 +162,17 @@ private _createdCtrls = [];
 
     private _displayStock = _display ctrlCreate ["A3A_StructuredText", -1, _itemControlsGroup];
     _displayStock ctrlSetPosition _stockBox;
-    private _stockStr = str _stockGS + " in stock; " + ([str _stockArsenal, _stockArsenal] select (_stockArsenal isEqualType "")) + " in arsenal; " + str minWeaps + " to unlock";           // TODO: stringtable, make this control bigger
+    private _stockStr = str _stockGS + " in stock"; // TODO: stringtable
+    private _stockArsenalStr = switch true do {
+        case (_stockArsenal isEqualTo -1): { "Unlocked in arsenal" }; // just in case, but unlocked items shouldn't be here
+        case (minWeaps isEqualTo -1): { format ["%1 in arsenal; Unlocks disabled", _stockArsenal] };
+        case (_className in AllMissileLaunchers && {allowGuidedLaunchers isEqualTo 0});
+        case (_className in AllRocketLaunchers && {allowUnguidedLaunchers isEqualTo 0});
+        case (_className in AllExplosives && {allowUnlockedExplosives isEqualTo 0}): { format ["%1 in arsenal; Unlocks disabled for this equipment type", _stockArsenal] };
+        default { format ["%1 in arsenal; %2 to unlock", _stockArsenal, minWeaps] };
+    }; // TODO: stringtable
     _displayStock ctrlSetStructuredText parseText (format ["<t size='0.65' align='left' valign='middle' color='#63DDFF' shadow='2'>%1</t>", _stockStr]);
+    _displayStock ctrlSetTooltip _stockArsenalStr;
     _displayStock ctrlCommit 0;
 
     private _displayPrice = _display ctrlCreate ["A3A_StructuredText", -1, _itemControlsGroup];

--- a/A3A/addons/gui/functions/gunShop/fn_createGunShopTab.sqf
+++ b/A3A/addons/gui/functions/gunShop/fn_createGunShopTab.sqf
@@ -162,15 +162,15 @@ private _createdCtrls = [];
 
     private _displayStock = _display ctrlCreate ["A3A_StructuredText", -1, _itemControlsGroup];
     _displayStock ctrlSetPosition _stockBox;
-    private _stockStr = str _stockGS + " in stock"; // TODO: stringtable
+    private _stockStr = format [localize "STR_antistasi_gun_shop_stock_gs", _stockGS];
     private _stockArsenalStr = switch true do {
-        case (_stockArsenal isEqualTo -1): { "Unlocked in arsenal" }; // just in case, but unlocked items shouldn't be here
-        case (minWeaps isEqualTo -1): { format ["%1 in arsenal; Unlocks disabled", _stockArsenal] };
+        case (_stockArsenal isEqualTo -1): { format [localize "STR_antistasi_gun_shop_stock_arsenal", "Unlocked"] }; // just in case, but unlocked items shouldn't be here
+        case (minWeaps isEqualTo -1): { format [localize "STR_antistasi_gun_shop_stock_arsenal" + "; " + localize "STR_antistasi_gun_shop_unlocks_disabled", _stockArsenal] };
         case (_className in AllMissileLaunchers && {allowGuidedLaunchers isEqualTo 0});
         case (_className in AllRocketLaunchers && {allowUnguidedLaunchers isEqualTo 0});
-        case (_className in AllExplosives && {allowUnlockedExplosives isEqualTo 0}): { format ["%1 in arsenal; Unlocks disabled for this equipment type", _stockArsenal] };
-        default { format ["%1 in arsenal; %2 to unlock", _stockArsenal, minWeaps] };
-    }; // TODO: stringtable
+        case (_className in AllExplosives && {allowUnlockedExplosives isEqualTo 0}): { format [localize "STR_antistasi_gun_shop_stock_arsenal" + "; " + localize "STR_antistasi_gun_shop_unlocks_disabled_specific", _stockArsenal] };
+        default { format [localize "STR_antistasi_gun_shop_stock_arsenal" + "; ", _stockArsenal] + format [localize "STR_antistasi_gun_shop_unlock_amount", minWeaps] };
+    };
     _displayStock ctrlSetStructuredText parseText (format ["<t size='0.65' align='left' valign='middle' color='#63DDFF' shadow='2'>%1</t>", _stockStr]);
     _displayStock ctrlSetTooltip _stockArsenalStr;
     _displayStock ctrlCommit 0;

--- a/A3A/addons/gui/functions/gunShop/fn_gatherGunShopLists.sqf
+++ b/A3A/addons/gui/functions/gunShop/fn_gatherGunShopLists.sqf
@@ -24,8 +24,10 @@ private _fnc_generateList = {
     while {_itemCount > 0 and _allItems isNotEqualTo []} do {
         private _item = _allItems deleteAt floor random count _allItems;
         private _price = [_item, _cfgType] call A3A_GUI_fnc_calculateItemPrice;
-        private _stock = ceil (_maxStock * (0.3 + random 0.7));
-        _itemPriceList set [_item, [_price call _fnc_roundPrice, _stock]];
+        private _stockGS = ceil (_maxStock * (0.3 + random 0.7));
+        private _stockArsenal = [jna_dataList select (_item call jn_fnc_arsenal_itemType), _item] call jn_fnc_arsenal_itemCount;
+        if (_stockArsenal isEqualTo -1) then { _stockArsenal = "unlocked" };
+        _itemPriceList set [_item, [_price call _fnc_roundPrice, _stockGS, _stockArsenal]];
         _itemCount = _itemCount - 1;
     };
     _itemPriceList;
@@ -69,8 +71,12 @@ if (_minCount >= 100) then {
         if !(_mag in allMagazines) then {continue};     // use Antistasi blacklisting? kinda expensive but whatever
 
         private _price = [_mag, "mag"] call A3A_GUI_fnc_calculateItemPrice;
-        private _stock = ceil (15 + random 15);
-        _magsPrices set [_mag, [_price call _fnc_roundPrice, _stock]];
+        private _stockGS = ceil (15 + random 15);
+        // TODO: replace 26 with constant? Will require including "\A3\Ui_f\hpp\defineResinclDesign.inc" and replacing 26 with IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL
+        private _stockArsenal = [jna_dataList select 26, _mag] call jn_fnc_arsenal_itemCount;
+        private _capacity = getNumber (configFile >> "CfgMagazines" >> _mag >> "count");
+        if (_stockArsenal isEqualTo -1) then { _stockArsenal = "unlocked" } else { _stockArsenal = _stockArsenal / _capacity };
+        _magsPrices set [_mag, [_price call _fnc_roundPrice, _stockGS, _stockArsenal]];
     } forEach _weapons;
 
     _gunShopData set [A3A_IDC_GUN_SHOP_MAGAZINES_TAB, _magsPrices];

--- a/A3A/addons/gui/functions/gunShop/fn_gatherGunShopLists.sqf
+++ b/A3A/addons/gui/functions/gunShop/fn_gatherGunShopLists.sqf
@@ -42,21 +42,21 @@ if (isNil "A3A_itemPriceCache") then { A3A_itemPriceCache = createHashMap };
 private _gunShopData = createHashMap;
 
 private _glOnly = allGrenadeLaunchers select { (_x call A3A_fnc_equipmentClassToCategories) # 0 != "Rifles" };
-_gunShopData set [A3A_IDC_GUN_SHOP_PRIMARY_TAB, ["weapon", _minCount*3, 15, allRifles + allSniperRifles + allMachineGuns + allSMGs + allShotguns + _glOnly] call _fnc_generateList];
-_gunShopData set [A3A_IDC_GUN_SHOP_HANDGUN_TAB, ["weapon", _minCount, 15, +allHandguns] call _fnc_generateList];
-_gunShopData set [A3A_IDC_GUN_SHOP_SECONDARY_TAB, ["weapon", _minCount, 8, allMissileLaunchers + allRocketLaunchers] call _fnc_generateList];
+_gunShopData set [A3A_IDC_GUN_SHOP_PRIMARY_TAB, ["weapon", _minCount*3, 15, (allRifles + allSniperRifles + allMachineGuns + allSMGs + allShotguns + _glOnly) - unlockedItems] call _fnc_generateList];
+_gunShopData set [A3A_IDC_GUN_SHOP_HANDGUN_TAB, ["weapon", _minCount, 15, +allHandguns - unlockedItems] call _fnc_generateList];
+_gunShopData set [A3A_IDC_GUN_SHOP_SECONDARY_TAB, ["weapon", _minCount, 8, (allMissileLaunchers + allRocketLaunchers) - unlockedItems] call _fnc_generateList];
 
-_gunShopData set [A3A_IDC_GUN_SHOP_GRENADES_TAB, ["mag", _minCount, 30, +allGrenades] call _fnc_generateList];      // check smoke etc
-_gunShopData set [A3A_IDC_GUN_SHOP_EXPLOSIVES_TAB, ["mag", _minCount, 20, allMine + allMineDirectional + allMineBounding] call _fnc_generateList];
+_gunShopData set [A3A_IDC_GUN_SHOP_GRENADES_TAB, ["mag", _minCount, 30, +allGrenades - unlockedItems] call _fnc_generateList];      // check smoke etc
+_gunShopData set [A3A_IDC_GUN_SHOP_EXPLOSIVES_TAB, ["mag", _minCount, 20, (allMine + allMineDirectional + allMineBounding) - unlockedItems] call _fnc_generateList];
 
-_gunShopData set [A3A_IDC_GUN_SHOP_OPTICS_TAB, ["item", _minCount, 8, +allOptics] call _fnc_generateList];
-_gunShopData set [A3A_IDC_GUN_SHOP_RAILS_TAB, ["item", _minCount, 8, +allPointerAttachments] call _fnc_generateList];
-_gunShopData set [A3A_IDC_GUN_SHOP_MUZZLES_TAB, ["item", _minCount, 8, +allMuzzleAttachments] call _fnc_generateList];
-_gunShopData set [A3A_IDC_GUN_SHOP_BIPODS_TAB, ["item", _minCount, 8, +allBipods] call _fnc_generateList];
+_gunShopData set [A3A_IDC_GUN_SHOP_OPTICS_TAB, ["item", _minCount, 8, +allOptics - unlockedItems] call _fnc_generateList];
+_gunShopData set [A3A_IDC_GUN_SHOP_RAILS_TAB, ["item", _minCount, 8, +allPointerAttachments - unlockedItems] call _fnc_generateList];
+_gunShopData set [A3A_IDC_GUN_SHOP_MUZZLES_TAB, ["item", _minCount, 8, +allMuzzleAttachments - unlockedItems] call _fnc_generateList];
+_gunShopData set [A3A_IDC_GUN_SHOP_BIPODS_TAB, ["item", _minCount, 8, +allBipods - unlockedItems] call _fnc_generateList];
 
 if (_minCount >= 100) then {
     private _allMags = allMagBullet + allMagShotgun + allMagMissile + allMagRocket + allMagShell + allMagSmokeShell + allMagFlare;
-    _gunShopData set [A3A_IDC_GUN_SHOP_MAGAZINES_TAB, ["mag", _minCount, 30, _allMags] call _fnc_generateList];
+    _gunShopData set [A3A_IDC_GUN_SHOP_MAGAZINES_TAB, ["mag", _minCount, 30, _allMags - unlockedItems] call _fnc_generateList];
 } else {
     // Special case for magazines, base on previous weapons
     private _weapons = keys (_gunShopData get A3A_IDC_GUN_SHOP_PRIMARY_TAB);
@@ -75,7 +75,7 @@ if (_minCount >= 100) then {
         // TODO: replace 26 with constant? Will require including "\A3\Ui_f\hpp\defineResinclDesign.inc" and replacing 26 with IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL
         private _stockArsenal = [jna_dataList select 26, _mag] call jn_fnc_arsenal_itemCount;
         private _capacity = getNumber (configFile >> "CfgMagazines" >> _mag >> "count");
-        if (_stockArsenal isEqualTo -1) then { _stockArsenal = "unlocked" } else { _stockArsenal = _stockArsenal / _capacity };
+        if (_stockArsenal isNotEqualTo -1) then { _stockArsenal = _stockArsenal / _capacity };
         _magsPrices set [_mag, [_price call _fnc_roundPrice, _stockGS, _stockArsenal]];
     } forEach _weapons;
 

--- a/A3A/addons/gui/functions/gunShop/fn_gatherGunShopLists.sqf
+++ b/A3A/addons/gui/functions/gunShop/fn_gatherGunShopLists.sqf
@@ -25,7 +25,7 @@ private _fnc_generateList = {
         private _item = _allItems deleteAt floor random count _allItems;
         private _price = [_item, _cfgType] call A3A_GUI_fnc_calculateItemPrice;
         private _stockGS = ceil (_maxStock * (0.3 + random 0.7));
-        private _stockArsenal = [jna_dataList select (_item call jn_fnc_arsenal_itemType), _item] call jn_fnc_arsenal_itemCount;
+        private _stockArsenal = _arsenalCountHM getOrDefault [_item, 0];
         _itemPriceList set [_item, [_price call _fnc_roundPrice, _stockGS, _stockArsenal]];
         _itemCount = _itemCount - 1;
     };
@@ -38,24 +38,28 @@ A3A_gunShopData = createHashMap;
 // Set up the item price cache
 if (isNil "A3A_itemPriceCache") then { A3A_itemPriceCache = createHashMap };
 
+// Build arsenal item quantity lookup table
+private _arsenalCountHM = createHashMap;
+{ _arsenalCountHM insert _x } forEach ((jna_dataList select [0,3]) + (jna_dataList select [18,9]));
+
 private _gunShopData = createHashMap;
 
 private _glOnly = allGrenadeLaunchers select { (_x call A3A_fnc_equipmentClassToCategories) # 0 != "Rifles" };
-_gunShopData set [A3A_IDC_GUN_SHOP_PRIMARY_TAB, ["weapon", _minCount*3, 15, (allRifles + allSniperRifles + allMachineGuns + allSMGs + allShotguns + _glOnly) - unlockedItems] call _fnc_generateList];
-_gunShopData set [A3A_IDC_GUN_SHOP_HANDGUN_TAB, ["weapon", _minCount, 15, +allHandguns - unlockedItems] call _fnc_generateList];
-_gunShopData set [A3A_IDC_GUN_SHOP_SECONDARY_TAB, ["weapon", _minCount, 8, (allMissileLaunchers + allRocketLaunchers) - unlockedItems] call _fnc_generateList];
+_gunShopData set [A3A_IDC_GUN_SHOP_PRIMARY_TAB, ["weapon", _minCount*3, 15, (allRifles + allSniperRifles + allMachineGuns + allSMGs + allShotguns + _glOnly) - unlockedWeapons] call _fnc_generateList];
+_gunShopData set [A3A_IDC_GUN_SHOP_HANDGUN_TAB, ["weapon", _minCount, 15, +allHandguns - unlockedHandguns] call _fnc_generateList];
+_gunShopData set [A3A_IDC_GUN_SHOP_SECONDARY_TAB, ["weapon", _minCount, 8, (allMissileLaunchers + allRocketLaunchers) - unlockedWeapons] call _fnc_generateList];
 
-_gunShopData set [A3A_IDC_GUN_SHOP_GRENADES_TAB, ["mag", _minCount, 30, +allGrenades - unlockedItems] call _fnc_generateList];      // check smoke etc
-_gunShopData set [A3A_IDC_GUN_SHOP_EXPLOSIVES_TAB, ["mag", _minCount, 20, (allMine + allMineDirectional + allMineBounding) - unlockedItems] call _fnc_generateList];
+_gunShopData set [A3A_IDC_GUN_SHOP_GRENADES_TAB, ["mag", _minCount, 30, +allGrenades - unlockedGrenades] call _fnc_generateList];      // check smoke etc
+_gunShopData set [A3A_IDC_GUN_SHOP_EXPLOSIVES_TAB, ["mag", _minCount, 20, (allMine + allMineDirectional + allMineBounding) - unlockedMine] call _fnc_generateList];
 
-_gunShopData set [A3A_IDC_GUN_SHOP_OPTICS_TAB, ["item", _minCount, 8, +allOptics - unlockedItems] call _fnc_generateList];
-_gunShopData set [A3A_IDC_GUN_SHOP_RAILS_TAB, ["item", _minCount, 8, +allPointerAttachments - unlockedItems] call _fnc_generateList];
-_gunShopData set [A3A_IDC_GUN_SHOP_MUZZLES_TAB, ["item", _minCount, 8, +allMuzzleAttachments - unlockedItems] call _fnc_generateList];
-_gunShopData set [A3A_IDC_GUN_SHOP_BIPODS_TAB, ["item", _minCount, 8, +allBipods - unlockedItems] call _fnc_generateList];
+_gunShopData set [A3A_IDC_GUN_SHOP_OPTICS_TAB, ["item", _minCount, 8, +allOptics - unlockedOptics] call _fnc_generateList];
+_gunShopData set [A3A_IDC_GUN_SHOP_RAILS_TAB, ["item", _minCount, 8, +allPointerAttachments - unlockedPointerAttachments] call _fnc_generateList];
+_gunShopData set [A3A_IDC_GUN_SHOP_MUZZLES_TAB, ["item", _minCount, 8, +allMuzzleAttachments - unlockedMuzzleAttachments] call _fnc_generateList];
+_gunShopData set [A3A_IDC_GUN_SHOP_BIPODS_TAB, ["item", _minCount, 8, +allBipods - unlockedBipods] call _fnc_generateList];
 
 if (_minCount >= 100) then {
     private _allMags = allMagBullet + allMagShotgun + allMagMissile + allMagRocket + allMagShell + allMagSmokeShell + allMagFlare;
-    _gunShopData set [A3A_IDC_GUN_SHOP_MAGAZINES_TAB, ["mag", _minCount, 30, _allMags - unlockedItems] call _fnc_generateList];
+    _gunShopData set [A3A_IDC_GUN_SHOP_MAGAZINES_TAB, ["mag", _minCount, 30, _allMags - unlockedMagazines] call _fnc_generateList];
 } else {
     // Special case for magazines, base on previous weapons
     private _weapons = keys (_gunShopData get A3A_IDC_GUN_SHOP_PRIMARY_TAB);
@@ -71,9 +75,8 @@ if (_minCount >= 100) then {
 
         private _price = [_mag, "mag"] call A3A_GUI_fnc_calculateItemPrice;
         private _stockGS = ceil (15 + random 15);
-        // TODO: replace 26 with constant? Will require including "\A3\Ui_f\hpp\defineResinclDesign.inc" and replacing 26 with IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL
-        private _stockArsenal = [jna_dataList select 26, _mag] call jn_fnc_arsenal_itemCount;
-        private _capacity = getNumber (configFile >> "CfgMagazines" >> _mag >> "count");
+        private _stockArsenal = _arsenalCountHM getOrDefault [_mag, 0];
+        private _capacity = getNumber (configFile >> "CfgMagazines" >> _mag >> "count") max 1;
         if (_stockArsenal isNotEqualTo -1) then { _stockArsenal = _stockArsenal / _capacity };
         _magsPrices set [_mag, [_price call _fnc_roundPrice, _stockGS, _stockArsenal]];
     } forEach _weapons;

--- a/A3A/addons/gui/functions/gunShop/fn_gatherGunShopLists.sqf
+++ b/A3A/addons/gui/functions/gunShop/fn_gatherGunShopLists.sqf
@@ -26,7 +26,6 @@ private _fnc_generateList = {
         private _price = [_item, _cfgType] call A3A_GUI_fnc_calculateItemPrice;
         private _stockGS = ceil (_maxStock * (0.3 + random 0.7));
         private _stockArsenal = [jna_dataList select (_item call jn_fnc_arsenal_itemType), _item] call jn_fnc_arsenal_itemCount;
-        if (_stockArsenal isEqualTo -1) then { _stockArsenal = "unlocked" };
         _itemPriceList set [_item, [_price call _fnc_roundPrice, _stockGS, _stockArsenal]];
         _itemCount = _itemCount - 1;
     };


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement

### What have you changed and why?
Information:

Title. See pics.

![gs-tooltip-1](https://github.com/user-attachments/assets/a5ce36ff-5183-4372-b9b1-61e1b4d60330)

![gs-tooltip-2](https://github.com/user-attachments/assets/7e049bf7-0e07-4986-87aa-6ed392d36724)



### Please specify which Issue this PR Resolves.
closes #3717 

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

 - add items (not enough to unlock) to arsenal
 - spawn gunshop mission
 - go to gunshop and look at inventory
 - profit?

********************************************************
Notes:

TODO:
 - ~~when unlocks are disabled, unlock quantity will show as `-1`. Should be changed in a similar way as the `-1` quantity for unlocked items is changed.~~
 - ~~'quantity to unlock' text does not consider that not all item types are unlockable (e.g. *certain* launchers lol)~~
 - ~~structured text control needs to be made bigger for some tabs, or a new control added as the text runs over (still happens even when just showing quantity in arsenal without unlock quantity)~~