### PR TITLE
Fix units getting stuck in unconscious animation after fast revive

### DIFF
--- a/A3A/addons/core/functions/Revive/fn_unconscious.sqf
+++ b/A3A/addons/core/functions/Revive/fn_unconscious.sqf
@@ -146,7 +146,7 @@ if (alive _unit) then
 {
 	_unit setUnconscious false;
 	//_unit playMoveNow "AmovPpneMstpSnonWnonDnon_healed";
-	_unit playMoveNow "unconsciousoutprone";
+	//_unit playMoveNow "unconsciousoutprone";
 	_unit setBleedingremaining 0;
 
 	// Temp invulnerability on revive

--- a/A3A/addons/core/functions/Revive/fn_unconsciousAAF.sqf
+++ b/A3A/addons/core/functions/Revive/fn_unconsciousAAF.sqf
@@ -57,7 +57,7 @@ if (time >= _bleedOutTime) exitWith
 if (alive _unit) then
 {
 	_unit setUnconscious false;
-	_unit playMoveNow "unconsciousoutprone";
+	//_unit playMoveNow "unconsciousoutprone";
 	_unit setVariable ["A3A_downedBy", nil];
 
 	if (_unit getVariable ["surrendering", false]) exitWith {


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
It was possible to get stuck in the unconscious animation by pressing the self-revive key within ~5 seconds of being downed. This PR fixes it.

I'm not sure what the playMoveNow was for originally. I remember the older one was extremely slow and I switched it to the one that matched the normal setUnconscious false behaviour. But I haven't seen any reason to use it at all. Maybe there was an old bug with setUnconscious that was fixed at some point.

Dropped the playMoveNow for enemies as well, even though it's pretty much impossible for them to be revived within five seconds. Doesn't seem to hurt.

### Please specify which Issue this PR Resolves.
closes #3786

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)
