### PR TITLE
Remove RHS armored helmets from start

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_equipmentSort.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_equipmentSort.sqf
@@ -72,7 +72,10 @@ allCosmeticHeadgear = allHeadgear - allArmoredHeadgear;
 	"H_SPE_GER_ST_M40_Pz_cap_Offz_headset",
 	"H_SPE_GER_ST_M40_Pz_cap_Offz_2",
 	"H_SPE_GER_ST_M40_Pz_cap_2",
-	"H_SPE_GER_ST_M40_cap_2"
+	"H_SPE_GER_ST_M40_cap_2",
+	"rhs_fieldcap_helm",
+	"rhs_fieldcap_helm_ml",
+	"rhs_fieldcap_helm_digi"
 ];
 
 //////////////////


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
You can ACE-interact with these field caps on to put on an armor level 2 helmet and because its a field cap you start with them off spawn. Removed them from spawning in the arsenal.

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: load the game with rhsafrf loaded

********************************************************
Notes:
