### PR TITLE
Fix potential gun shop divide by zero with bad mods

### DIFF
--- a/A3A/addons/gui/functions/gunShop/fn_calculateItemPrice.sqf
+++ b/A3A/addons/gui/functions/gunShop/fn_calculateItemPrice.sqf
@@ -155,7 +155,7 @@ private _fnc_weaponPriceCalculator = {
             if (_firstMode == "this") exitWith { _modeCfg = _weaponCfg };
             _modeCfg = _weaponCfg >> _firstMode;
         };
-        private _dispersion = getNumber (_modeCfg >> "dispersion");
+        private _dispersion = 0.0001 max getNumber (_modeCfg >> "dispersion");
         _dispMul =  (0.001 / _dispersion) ^ 0.5;
     };
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
calculateItemPrice used by the gun shop has a divide by zero if weapons have a dispersion of 0. That's really not a valid value, but apparently there is a mod somewhere that does it with 3CBF's MG3. 

Fixed by capping to 0.0001 minimum. Vanilla doesn't have any weapons that go that low. Not sure about other mods but it won't hurt if it's close.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
