### PR TITLE
Fix RHS high command mortars stopping after one shot

### DIFF
--- a/A3A/addons/core/functions/AI/fn_artySupportFire.sqf
+++ b/A3A/addons/core/functions/AI/fn_artySupportFire.sqf
@@ -35,9 +35,14 @@ private _ang = if (_strikeType == "barrage") then {_startPos getDir _detail} els
 {
 	[_x, _roundsPerUnit, _typeAmmunition, _strikeType, _startPos, _interval, _ang, _detail] spawn {
 		params ["_piece", "_rounds", "_ammo", "_strikeType", "_startPos", "_interval", "_ang", "_radius"];
+
+		private _eh = _piece addEventHandler ["Fired", { _this#0 setVariable ["A3A_artyFired", true] }];
+
 		private _pos = [_startPos,random 10,random 360] call BIS_fnc_relPos; // close by target position, they're not 100% accurate;
 		for "_r" from 1 to _rounds do
 		{
+			Trace_1("Firing round %1", _r);
+			_piece setVariable ["A3A_artyFired", nil];
 			_piece commandArtilleryFire [_pos,_ammo,1];
 			if (_strikeType == "barrage") then
 			{
@@ -47,8 +52,21 @@ private _ang = if (_strikeType == "barrage") then {_startPos getDir _detail} els
 			{
 				_pos = [_startPos, _radius * sqrt random 1, random 360] call BIS_fnc_relPos;
 			};
+
+			private _timeout = time + 20;
 			sleep _interval;
-			waitUntil {sleep 0.1; _piece weaponReloadingTime [gunner _piece, currentWeapon _piece] == 0};
+			waitUntil { sleep 0.1; !(_piece isNil "A3A_artyFired") or time > _timeout };
+			if (_piece isNil "A3A_artyFired") exitWith {
+				private _weaponState = weaponState [_piece, [0]];
+				Error_2("Arty failed to fire round #%1; order %2; state %3", _r, _this, _weaponState);
+			};
+			waitUntil {
+				sleep 0.1;
+				weaponState [_piece, [0]] params ["", "", "", "", "", "_reloadPhase", "_magPhase"];
+				_reloadPhase max _magPhase == 0;
+			};
 		};
+		_piece removeEventHandler ["Fired", _eh];
+		_piece setVariable ["A3A_artyInUse", nil, true];
 	};
-} forEach _units; // all mortar gunners	
+} forEach _units; // all mortar gunners	 JJ: Lies, this is mortar vehicles

--- a/A3A/addons/gui/Stringtable.xml
+++ b/A3A/addons/gui/Stringtable.xml
@@ -1402,6 +1402,9 @@
       <Key ID="STR_antistasi_dialogs_main_convertToSquad_button">
         <Original>Convert To HC Squad</Original>
       </Key>
+      <Key ID="STR_antistasi_dialogs_main_artilleryInUse">
+        <Original>One or more selected artillery pieces is already firing. Wait for it to finish.</Original>
+      </Key>
       <Key ID="STR_antistasi_dialogs_main_commanderOnly">
         <Original>Only Player Commander has access to this function.</Original>
       </Key>

--- a/A3A/addons/gui/functions/GUI/fn_commanderTab.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_commanderTab.sqf
@@ -503,23 +503,18 @@ switch (_mode) do
         private _artyDictionary = createHashMap;
         {
             private _veh = vehicle _x;
-            if ((_veh != _x) and (not(_veh in _mortarObjs))) then
+            if (_veh == _x or _veh in _mortarObjs) then {continue};
+            if !("Artillery" in getArray (configfile >> "CfgVehicles" >> typeOf _veh >> "availableForSupportTypes")) then {continue};
+            if !(canFire _veh) then {continue};
             {
-                if (( "Artillery" in (getArray (configfile >> "CfgVehicles" >> typeOf _veh >> "availableForSupportTypes")))) then
-                {
-                    if ((canFire _veh) and (alive _veh)) then
-                    {
-                        {
-                            _x params ["_type","_currentCount"];
-                            private _existingCount = _shellCounts getOrDefault [_type,0];
-                            _shellCounts set [_type, _currentCount + _existingCount];
-                        } forEach magazinesAmmo _veh;
-                        private _dict = [typeOf _veh] call A3A_fnc_getMortarMags;
-                        {_artyDictionary set [_x,_y];} forEach _dict; // automatically covers repeats
-                        _mortarObjs pushBackUnique _veh;
-                    }; // [["8Rnd_82mm_Mo_shells",8],["8Rnd_82mm_Mo_shells",8],["8Rnd_82mm_Mo_shells",8],["8Rnd_82mm_Mo_shells",8],["8Rnd_82mm_Mo_Flare_white",8],["8Rnd_82mm_Mo_Smoke_white",8]]
-                };
-            };
+                _x params ["_type","_currentCount"];
+                private _existingCount = _shellCounts getOrDefault [_type,0];
+                _shellCounts set [_type, _currentCount + _existingCount];
+            } forEach magazinesAmmo _veh;
+            private _dict = [typeOf _veh] call A3A_fnc_getMortarMags;
+            {_artyDictionary set [_x,_y];} forEach _dict; // automatically covers repeats
+            _mortarObjs pushBackUnique _veh;
+            // [["8Rnd_82mm_Mo_shells",8],["8Rnd_82mm_Mo_shells",8],["8Rnd_82mm_Mo_shells",8],["8Rnd_82mm_Mo_shells",8],["8Rnd_82mm_Mo_Flare_white",8],["8Rnd_82mm_Mo_Smoke_white",8]]
         } forEach _units;
         _fireMissionControlsGroup setVariable ["mortarObjs", _mortarObjs];
         _fireMissionControlsGroup setVariable ["shellCounts", _shellCounts];
@@ -1047,6 +1042,10 @@ switch (_mode) do
         private _shellType = _shellTypeBox lbData _index;
         private _vics = _fireMissionControlsGroup getVariable ["mortarObjs", []];
         private _units = _vics select {((magazinesAmmo _x) findIf {(_x#0 == _shellType)}) > -1};
+        if (_units findIf {_x getVariable ["A3A_artyInUse", false]} != -1) exitWith {
+            ["Artillery menu", localize "STR_antistasi_dialogs_main_artilleryInUse"] call A3A_fnc_customHint;
+        };
+
         private _artyDictionary = _fireMissionControlsGroup getVariable ["artyDictionary", createHashMap];
         private _shellDict = _artyDictionary get _shellType;
         private _shortName = _shellDict#2;
@@ -1064,6 +1063,7 @@ switch (_mode) do
             default {0};
         };
 
+        { _x setVariable ["A3A_artyInUse", true, true] } forEach _units;
         [_units,_shellType,_shortName,_strikeType,_roundsNumber,_startPos,_detail] spawn A3A_fnc_artySupportFire;
     };
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The artySupportFire code that was supposed to wait between shots didn't work correctly because it didn't wait for a shot to be fired before checking weaponReloadingTime, and just spammed out the fire orders. For some reason this breaks RHS mortars but not vanilla mortars.

Rewrote the logic to wait for firing (or a timeout, in case it doesn't fire for a good reason). Also needed to use weaponState instead of weaponReloadingTime because weaponReloadingTime is 0 during a magazine reload.

Also added a lockout to prevent giving mortars an order when they're already firing, as that would really fuck up this code. I de-nested some additional code in commanderTab, because I was going to put the lockout there and decided it was a bad idea. Maybe it wasn't a bad idea...

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Should probably test more mortars. I only did the M252 and the vanilla thing.
