### PR TITLE
S.O.G Template Rework + NS Updated Compat

### DIFF
--- a/A3A/addons/core/Templates/AircraftLoadouts/VN/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/VN/config.cpp
@@ -28,7 +28,7 @@ class A3A {
             };
             
             class vn_b_air_f100d_at : baseCAS {
-                loadout[] = {"vn_rocket_ffar_f4_lau59_m229_he_x21","vn_rocket_ffar_f4_lau59_m229_he_x21","vn_fuel_f100_335_camo_01_mag","vn_missile_agm12c_mag_01_x1","vn_missile_agm12c_mag_01_x1"};
+                loadout[] = {"vn_rocket_ffar_f4_lau59_m229_he_x21","vn_rocket_ffar_f4_lau59_m229_he_x21","vn_fuel_f100_335_camo_01_mag","vn_fuel_f100_335_camo_01_mag","vn_missile_agm12c_mag_01_x1","vn_missile_agm12c_mag_01_x1"};
                 mainGun[] = {"vn_m39a1_v_quad"};
                 rocketLauncher[] = {"vn_rocket_ffar_275in_launcher_m229"};
                 missileLauncher[] = {"vn_missile_agm12c_launcher"};

--- a/A3A/addons/core/Templates/AircraftLoadouts/VN/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/VN/config.cpp
@@ -22,16 +22,16 @@ class A3A {
         {
             class baseCAS;
             class vn_b_air_f4c_at : baseCAS {
-                loadout[] = {"vn_missile_f4_out_agm45_mag_x1","vn_missile_f4_out_agm45_mag_x1","vn_rocket_ffar_f4_lau3_m229_he_x57","vn_rocket_ffar_f4_lau3_m229_he_x57","vn_bomb_f4_out_750_blu1b_fb_mag_x3","vn_missile_f4_lau7_aim9e_mag_x2","vn_missile_f4_lau7_aim9e_mag_x2","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1"};
+                loadout[] = {"vn_missile_f4_out_agm12c_mag_x1","vn_missile_f4_out_agm12c_mag_x1","vn_rocket_ffar_f4_lau3_m229_he_x57","vn_rocket_ffar_f4_lau3_m229_he_x57","vn_bomb_f4_out_750_blu1b_fb_mag_x3","vn_missile_f4_lau7_aim9e_mag_x2","vn_missile_f4_lau7_aim9e_mag_x2","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1"};
                 rocketLauncher[] = {"vn_rocket_ffar_275in_launcher_m229"};
-                missileLauncher[] = {"vn_missile_agm45_launcher"};
+                missileLauncher[] = {"vn_missile_agm12c_launcher"};
             };
             
             class vn_b_air_f100d_at : baseCAS {
-                loadout[] = {"vn_rocket_ffar_f4_lau59_m229_he_x21","vn_rocket_ffar_f4_lau59_m229_he_x21","vn_fuel_f100_335_camo_01_mag","vn_fuel_f100_335_camo_01_mag","vn_missile_agm45_03_mag_x1","vn_missile_agm45_03_mag_x1"};
+                loadout[] = {"vn_rocket_ffar_f4_lau59_m229_he_x21","vn_rocket_ffar_f4_lau59_m229_he_x21","vn_fuel_f100_335_camo_01_mag","vn_missile_agm12c_mag_01_x1","vn_missile_agm12c_mag_01_x1"};
                 mainGun[] = {"vn_m39a1_v_quad"};
                 rocketLauncher[] = {"vn_rocket_ffar_275in_launcher_m229"};
-                missileLauncher[] = {"vn_missile_agm45_launcher"};
+                missileLauncher[] = {"vn_missile_agm12c_launcher"};
             };
             
             class vn_o_air_mig19_at : baseCAS {

--- a/A3A/addons/core/Templates/AircraftLoadouts/VNX/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/VNX/config.cpp
@@ -21,11 +21,29 @@ class A3A {
         class CASPlane
         {
             class baseCAS;
-            class vnx_b_air_ov10a_usmc_mr : baseCAS {
+            class vnx_b_air_ov10a_mr : baseCAS {
                 loadout[] = {"vnx_gunpod_m60_v_500_mag","vnx_gunpod_m60_v_500_mag","vnx_gunpod_m60_v_500_mag","vnx_gunpod_m60_v_500_mag","vnx_rocket_ffar_lau59_m229_he_x7_01","vnx_rocket_ffar_lau59_m229_he_x7_01","vnx_rocket_ffar_lau10_mk32_atap_x4","vnx_rocket_ffar_lau10_mk32_atap_x4","vnx_gunpod_mk4_02_v_750_mag","vnx_rocket_ffar_ov10_lau10_mk63_he_01_x2","vnx_rocket_ffar_ov10_lau10_mk63_he_01_x2"};
                 mainGun[] = {"vnx_gunpod_mk4_twin"};
                 rocketLauncher[] = {"vnx_rocket_ffar_275in_launcher_m229","vnx_rocket_ffar_5in_atap_launcher","vnx_rocket_ffar_5in_hefrag_launcher"};
             };
+            class vnx_b_air_ov10a_usmc_mr : vnx_b_air_ov10a_mr {};
+            class vnx_b_air_ov10a_aus_covey : vnx_b_air_ov10a_mr {};
+            class vnx_b_air_a4e_usmc_cas : baseCAS {
+                loadout[] = {"vnx_gunpod_mk12_100_mag","vnx_gunpod_mk12_100_mag","vnx_rocket_ffar_lau3_m151_he_x19_02","vnx_rocket_ffar_lau3_m151_he_x19_02","vnx_missile_agm12c_mag_01_x1","vnx_missile_agm12c_mag_01_x1","vnx_rocket_ffar_a4_lau3_m151_he_x57_02"};
+                mainGun[] = {"vnx_gunpod_mk12"};
+                rocketLauncher[] = {"vnx_rocket_ffar_275in_launcher_m151"};
+                missileLauncher[] = {"vnx_missile_agm12c_launcher"};
+            };
+            class vnx_b_air_a4e_ran_cas : vnx_b_air_a4e_usmc_cas {};
+            class vnx_b_air_a4e_rnzaf_cas : vnx_b_air_a4e_usmc_cas {};
+        };
+        class CAPPlane
+        {
+            class baseCAP;
+            class vnx_b_air_a4e_ran_cap : baseCAP {
+                loadout[] = {"vnx_gunpod_mk12_100_mag","vnx_gunpod_mk12_100_mag","vnx_missile_lau7_aim9b_03_mag_x1","vnx_missile_lau7_aim9b_03_mag_x1","vnx_missile_lau7_aim9b_03_mag_x1","vnx_missile_lau7_aim9b_03_mag_x1","vnx_fuel_a4_300_02_mag"};
+            };
+            class vnx_b_air_a4e_rnzaf_cap : vnx_b_air_a4e_ran_cap {};
         };
     };
 };

--- a/A3A/addons/core/Templates/Templates.hpp
+++ b/A3A/addons/core/Templates/Templates.hpp
@@ -318,6 +318,24 @@ class Templates
         forceDLC[] = {"vn"};
     };
 
+    class VN_USMC : VN_Base
+    {
+        side = "Inv";
+        flagTexture = "vn\objects_f_vietnam\flags\data\vn_flag_01_usmc_co.paa";
+        name = "VN USMC";
+        file = "VN_AI_USMC";
+        shortName = "USMC";
+    };
+
+    class VN_ANZAC : VN_Base
+    {
+        side = "Inv";
+        flagTexture = "vn\objects_f_vietnam\flags\data\vn_flag_01_aus_co.paa";
+        name = "VN ANZAC";
+        file = "VN_AI_ANZAC";
+        shortName = "ANZAC";
+    };
+
     class VN_MACV : VN_Base
     {
         side = "Inv";

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_ANZAC.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_ANZAC.sqf
@@ -2,12 +2,12 @@
 //   Side Information   //
 //////////////////////////
 
-["name", "US Army"] call _fnc_saveToTemplate;
-["spawnMarkerName", "US Army Support Corridor"] call _fnc_saveToTemplate;
+["name", "ANZAC"] call _fnc_saveToTemplate;
+["spawnMarkerName", "ANZAC Support Corridor"] call _fnc_saveToTemplate;
 
-["flag", "vn_flag_usa"] call _fnc_saveToTemplate;
-["flagTexture", "vn\objects_f_vietnam\flags\data\vn_flag_01_usa_co.paa"] call _fnc_saveToTemplate;
-["flagMarkerType", "vn_flag_usa"] call _fnc_saveToTemplate;
+["flag", "vn_flag_aus"] call _fnc_saveToTemplate;
+["flagTexture", "\vn\objects_f_vietnam\flags\data\vn_flag_01_aus_co.paa"] call _fnc_saveToTemplate;
+["flagMarkerType", "vn_flag_aus"] call _fnc_saveToTemplate;
 
 //////////////////////////
 //  Mission/HQ Objects  //
@@ -29,74 +29,68 @@
 //       Vehicles       //
 //////////////////////////
 
-["vehiclesBasic", ["vn_b_wheeled_m151_01"]] call _fnc_saveToTemplate;
-["vehiclesLightUnarmed", ["vn_b_wheeled_m151_01", "vn_b_wheeled_m151_02", "vn_b_wheeled_m274_01_01"]] call _fnc_saveToTemplate;
-private _vehiclesLightArmed = ["vn_b_wheeled_m151_mg_02", "vn_b_wheeled_m151_mg_03", "vn_b_wheeled_m151_mg_04", "vn_b_wheeled_m151_mg_05", "vn_b_wheeled_m54_mg_02", "vn_b_wheeled_m274_mg_01_01"];
-
-["vehiclesTrucks", ["vn_b_wheeled_m54_01", "vn_b_wheeled_m54_02"]] call _fnc_saveToTemplate;
+["vehiclesBasic", ["vn_b_wheeled_m151_01_aus_army"]] call _fnc_saveToTemplate;
+["vehiclesLightUnarmed", ["vn_b_wheeled_m151_01_aus_army", "vn_b_wheeled_m151_02_aus_army"]] call _fnc_saveToTemplate;
+["vehiclesLightArmed" , ["vn_b_wheeled_m151_mg_02_aus_army", "vn_b_wheeled_m151_mg_03_aus_army", "vn_b_wheeled_m151_mg_06_aus_army", "vn_b_wheeled_lr2a_mg_01_aus_army", "vn_b_wheeled_lr2a_mg_02_aus_army", "vn_b_wheeled_lr2a_mg_03_aus_army"]] call _fnc_saveToTemplate;
+["vehiclesTrucks", ["vn_b_wheeled_m54_01_aus_army", "vn_b_wheeled_m54_02_aus_army", "vn_b_wheeled_lr2a_01_aus_army", "vn_b_wheeled_lr2a_02_aus_army"]] call _fnc_saveToTemplate;
 ["vehiclesCargoTrucks", []] call _fnc_saveToTemplate;
-["vehiclesAmmoTrucks", ["vn_b_wheeled_m54_ammo"]] call _fnc_saveToTemplate;
-["vehiclesRepairTrucks", ["vn_b_wheeled_m54_repair"]] call _fnc_saveToTemplate;
-["vehiclesFuelTrucks", ["vn_b_wheeled_m54_fuel"]] call _fnc_saveToTemplate;
-["vehiclesMedical", ["vn_b_armor_m577_02"]] call _fnc_saveToTemplate;
-["vehiclesLightAPCs", ["vn_b_wheeled_m54_mg_03", "vn_b_wheeled_m54_mg_01", "vn_b_armor_m113_01"]] call _fnc_saveToTemplate;
-["vehiclesAPCs", ["vn_b_armor_m113_acav_04", "vn_b_armor_m113_acav_02", "vn_b_armor_m113_acav_01", "vn_b_armor_m113_acav_06", "vn_b_armor_m113_acav_03", "vn_b_armor_m113_acav_05"]] call _fnc_saveToTemplate;
+["vehiclesAmmoTrucks", ["vn_b_wheeled_m54_ammo_aus_army"]] call _fnc_saveToTemplate;
+["vehiclesRepairTrucks", ["vn_b_wheeled_m54_repair_aus_army"]] call _fnc_saveToTemplate;
+["vehiclesFuelTrucks", ["vn_b_wheeled_m54_fuel_aus_army"]] call _fnc_saveToTemplate;
+["vehiclesMedical", ["vn_b_wheeled_lr2a_03_aus_army"]] call _fnc_saveToTemplate;
+["vehiclesLightAPCs", []] call _fnc_saveToTemplate;
+["vehiclesAPCs", ["vn_b_armor_m113_01_aus_army"]] call _fnc_saveToTemplate;
 ["vehiclesIFVs", ["vn_b_armor_m67_01_01"]] call _fnc_saveToTemplate;
-["vehiclesLightTanks", ["vn_b_armor_m41_01_01"]] call _fnc_saveToTemplate;
 ["vehiclesTanks", ["vn_b_armor_m48_01_01"]] call _fnc_saveToTemplate;
-private _vehiclesAA = ["vn_b_wheeled_m54_mg_02"];
+["vehiclesAA", ["vn_b_wheeled_m54_mg_02"]] call _fnc_saveToTemplate;
 
 ["vehiclesTransportBoats", ["vn_o_boat_02_01", "vn_b_boat_10_01", "vn_b_boat_09_01"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["vn_b_boat_13_02", "vn_b_boat_06_02", "vn_b_boat_05_02", "vn_b_boat_12_02"]] call _fnc_saveToTemplate;
-["vehiclesAmphibious", ["vn_b_armor_m113_01", "vn_b_armor_m113_acav_04", "vn_b_armor_m113_acav_02", "vn_b_armor_m113_acav_01", "vn_b_armor_m113_acav_06", "vn_b_armor_m113_acav_03", "vn_b_armor_m113_acav_05"]] call _fnc_saveToTemplate;
+["vehiclesAmphibious", ["vn_b_armor_m113_01_aus_army"]] call _fnc_saveToTemplate;
 
-private _vehiclesPlanesCAS = ["vn_b_air_f4c_at", "vn_b_air_f100d_at", "vn_b_air_f100d_at", "vn_b_air_f100d_at"];
-["vehiclesPlanesAA", ["vn_b_air_f4c_cap", "vn_b_air_f100d_cap"]] call _fnc_saveToTemplate;
-private _vehiclesPlanesTransport = [];
-private _vehiclesAirPatrol = ["vn_b_air_oh6a_07", "vn_b_air_uh1d_02_01"];
+private _vehiclesPlanesCAS = ["vn_b_air_f100d_at"];
+private _vehiclesPlanesAA = ["vn_b_air_f4c_cap"];
+["vehiclesPlanesTransport", []] call _fnc_saveToTemplate;
+private _vehiclesAirPatrol = ["vn_b_air_uh1d_02_01"];
 
-["vehiclesHelisLight", ["vn_b_air_uh1c_07_01"]] call _fnc_saveToTemplate; // this is a uh-1b
-["vehiclesHelisTransport", ["vn_b_air_ch47_04_01", "vn_b_air_ch47_04_01", "vn_b_air_ch47_01_02", "vn_b_air_uh1d_02_01", "vn_b_air_uh1d_02_01", "vn_b_air_uh1d_02_01", "vn_b_air_uh1d_02_01", "vn_b_air_uh1d_02_01", "vn_b_air_uh1d_02_01", "vn_b_air_uh1d_02_01", "vn_b_air_uh1d_02_01", "vn_b_air_uh1c_07_01", "vn_b_air_uh1c_07_01"]] call _fnc_saveToTemplate;
-["vehiclesHelisLightAttack", ["vn_b_air_oh6a_06", "vn_b_air_ach47_04_01", "vn_b_air_uh1c_01_01", "vn_b_air_uh1c_01_01", "vn_b_air_uh1c_01_01", "vn_b_air_uh1c_02_01", "vn_b_air_uh1c_02_01"]] call _fnc_saveToTemplate;
-["vehiclesHelisAttack", ["vn_b_air_ach47_04_01", "vn_b_air_ach47_03_01", "vn_b_air_ah1g_01", "vn_b_air_ah1g_01", "vn_b_air_ah1g_01", "vn_b_air_ah1g_03", "vn_b_air_ah1g_03"]] call _fnc_saveToTemplate;
+if (isClass (configFile >> "vnx_credits")) then {
+	_vehiclesPlanesCAS = ["vnx_b_air_a4e_ran_cas", "vnx_b_air_a4e_ran_cas", "vnx_b_air_a4e_rnzaf_cas", "vnx_b_air_ov10a_aus_covey"];
+	_vehiclesPlanesAA = ["vnx_b_air_a4e_ran_cap", "vnx_b_air_a4e_ran_cap", "vnx_b_air_a4e_rnzaf_cap"];
+	_vehiclesAirPatrol append ["vnx_b_air_ov10a_aus_covey"];
+};
 
-["vehiclesArtillery", ["vn_b_army_static_m101_02"]] call _fnc_saveToTemplate;
+["vehiclesAirPatrol", _vehiclesAirPatrol] call _fnc_saveToTemplate;
+["vehiclesPlanesCAS", _vehiclesPlanesCAS] call _fnc_saveToTemplate;
+["vehiclesPlanesAA", _vehiclesPlanesAA] call _fnc_saveToTemplate;
+
+["vehiclesHelisLight", ["vn_b_air_uh1c_07_06"]] call _fnc_saveToTemplate;
+["vehiclesHelisTransport", ["vn_b_air_uh1d_02_06"]] call _fnc_saveToTemplate;
+["vehiclesHelisLightAttack", ["vn_b_air_uh1d_03_06"]] call _fnc_saveToTemplate;
+["vehiclesHelisAttack", []] call _fnc_saveToTemplate;
+
+["vehiclesArtillery", ["vn_b_nz_army_static_m101_02"]] call _fnc_saveToTemplate;
 ["magazines", createHashMapFromArray [
-["vn_b_army_static_m101_02", ["vn_cannon_m101_mag_he_x8", "vn_cannon_m101_mag_ab_x8", "vn_cannon_m101_mag_wp_x8"]]
+["vn_b_nz_army_static_m101_02", ["vn_cannon_m101_mag_he_x8", "vn_cannon_m101_mag_ab_x8", "vn_cannon_m101_mag_wp_x8"]]
 ]] call _fnc_saveToTemplate;
 
-["uavsAttack", ["vn_b_air_oh6a_01"]] call _fnc_saveToTemplate;				// scout helis are fine for this
+["uavsAttack", ["vnx_b_air_ov10a_aus_covey"]] call _fnc_saveToTemplate;
 ["uavsPortable", []] call _fnc_saveToTemplate;
 
 //Config special vehicles
-["vehiclesMilitiaLightArmed", ["vn_i_wheeled_m151_mg_01_mp"]] call _fnc_saveToTemplate;
-["vehiclesMilitiaTrucks", ["vn_b_wheeled_m54_02_sog"]] call _fnc_saveToTemplate;
-["vehiclesMilitiaCars", ["vn_i_wheeled_m151_01_mp"]] call _fnc_saveToTemplate;
+["vehiclesMilitiaLightArmed", ["vn_b_wheeled_m151_mg_02_nz_army", "vn_b_wheeled_lr2a_mg_01_nz_army"]] call _fnc_saveToTemplate;
+["vehiclesMilitiaTrucks", ["vn_b_wheeled_lr2a_01_nz_army", "vn_b_wheeled_m54_01_nz_army"]] call _fnc_saveToTemplate;
+["vehiclesMilitiaCars", ["vn_b_wheeled_m151_01_nz_army"]] call _fnc_saveToTemplate;
 
 ["vehiclesPolice", ["vn_b_wheeled_m151_02_mp"]] call _fnc_saveToTemplate;
 
-["staticMGs", ["vn_b_army_static_m60_high", "vn_b_army_static_m1919a4_high", "vn_b_army_static_m2_high"]] call _fnc_saveToTemplate;
-["staticAT", ["vn_b_army_static_m40a1rr", "vn_b_army_static_tow"]] call _fnc_saveToTemplate;
+["staticMGs", ["vn_b_aus_army_static_m60_high", "vn_b_aus_army_static_m2_high"]] call _fnc_saveToTemplate;
+["staticAT", ["vn_b_aus_army_static_m40a1rr"]] call _fnc_saveToTemplate;
 ["staticAA", ["vn_b_army_static_m45"]] call _fnc_saveToTemplate;
 ["staticMortars", ["a3a_vn_b_static_mortar_m2"]] call _fnc_saveToTemplate;
 
 ["mortarMagazineHE", "vn_mortar_m2_mag_he_x8"] call _fnc_saveToTemplate;
 ["mortarMagazineSmoke", "vn_mortar_m2_mag_wp_x8"] call _fnc_saveToTemplate;
 ["mortarMagazineFlare", "vn_mortar_m2_mag_lume_x8"] call _fnc_saveToTemplate;
-
-if (isClass (configFile >> "vnx_credits")) then {
-	_vehiclesLightArmed append ["vn_b_wheeled_m151_mg_02", "vn_b_wheeled_m151_mg_03", "vn_b_wheeled_m151_mg_04", "vn_b_wheeled_m151_mg_05", "vnx_b_armor_m50_01", "vnx_b_armor_m50a1_01"];
-	_vehiclesAA append ["vnx_b_armor_m163_01"];
-	_vehiclesAirPatrol append ["vn_b_air_oh6a_07", "vn_b_air_uh1d_02_01", "vnx_b_air_ov10a_covey", "vnx_b_air_hh1h_01_01", "vnx_b_air_hh1h_02_01"];
-	_vehiclesPlanesCAS append ["vnx_b_air_ov10a_mr"];
-	_vehiclesPlanesTransport append ["vnx_b_air_ac119_02_01"];
-};
-
-["vehiclesLightArmed", _vehiclesLightArmed] call _fnc_saveToTemplate;
-["vehiclesAA", _vehiclesAA] call _fnc_saveToTemplate;
-["vehiclesAirPatrol", _vehiclesAirPatrol] call _fnc_saveToTemplate;
-["vehiclesPlanesCAS", _vehiclesPlanesCAS] call _fnc_saveToTemplate;
-["vehiclesPlanesTransport", _vehiclesPlanesTransport] call _fnc_saveToTemplate;
 
 //Minefield definition
 //CFGVehicles variant of Mines are needed "ATMine", "APERSTripMine", "APERSMine"
@@ -116,17 +110,6 @@ if (isClass (configFile >> "vnx_credits")) then {
 "WhiteHead_13", "WhiteHead_15", "WhiteHead_16", "WhiteHead_17", "WhiteHead_18",
 "WhiteHead_20", "WhiteHead_21"]] call _fnc_saveToTemplate;
 ["voices", ["Male01ENG", "Male02ENG", "Male03ENG", "Male04ENG", "Male05ENG", "Male06ENG", "Male07ENG", "Male08ENG", "Male09ENG", "Male10ENG", "Male11ENG", "Male12ENG"]] call _fnc_saveToTemplate;
-["sfFaces", ["GreekHead_A3_09", "Sturrock", "vn_b_AsianHead_A3_01_02", "vn_b_AsianHead_A3_01_04",
-"vn_b_AsianHead_A3_01_07", "vn_b_AsianHead_A3_01_08", "vn_b_AsianHead_A3_01_10", "vn_b_AsianHead_A3_02_01",
-"vn_b_AsianHead_A3_02_03", "vn_b_AsianHead_A3_02_04", "vn_b_AsianHead_A3_02_05", "vn_b_AsianHead_A3_02_09",
-"vn_b_AsianHead_A3_03_05", "vn_b_AsianHead_A3_03_07", "vn_b_AsianHead_A3_03_09", "vn_b_AsianHead_A3_03_11",
-"vn_b_AsianHead_A3_04_05", "vn_b_AsianHead_A3_04_09", "vn_b_AsianHead_A3_04_11", "vn_b_AsianHead_A3_05_02",
-"vn_b_AsianHead_A3_05_04", "vn_b_AsianHead_A3_05_05", "vn_b_AsianHead_A3_05_07", "vn_b_AsianHead_A3_05_08",
-"vn_b_AsianHead_A3_05_10", "vn_b_AsianHead_A3_06_04", "vn_b_AsianHead_A3_06_06", "vn_b_AsianHead_A3_06_09",
-"vn_b_AsianHead_A3_07_03", "vn_b_AsianHead_A3_07_05", "vn_b_AsianHead_A3_07_07", "vn_b_AsianHead_A3_07_11",
-"vn_b_GreekHead_A3_11_11", "vn_b_GreekHead_A3_12_11", "vn_b_LivonianHead_10_09", "vn_b_LivonianHead_2_04",
-"vn_b_TanoanHead_A3_06_11", "vn_b_TanoanHead_A3_07_10", "vn_b_WhiteHead_19_08", "vn_b_WhiteHead_26_02",
-"vn_b_WhiteHead_27_01", "WhiteHead_08", "WhiteHead_10", "WhiteHead_11", "WhiteHead_12"]] call _fnc_saveToTemplate;
 "NATOMen" call _fnc_saveNames;
 
 //////////////////////////
@@ -134,7 +117,6 @@ if (isClass (configFile >> "vnx_credits")) then {
 //////////////////////////
 private _loadoutData = call _fnc_createLoadoutData;
 _loadoutData set ["rifles", []];
-_loadoutData set ["carbines", []];
 _loadoutData set ["grenadeLaunchers", []];
 _loadoutData set ["SMGs", []];
 _loadoutData set ["machineGuns", []];
@@ -219,149 +201,115 @@ _loadoutData set ["items_unarmed_extras", []];
 ///////////////////////////////////////
 
 private _sfLoadoutData = _loadoutData call _fnc_copyLoadoutData;
-_sfLoadoutData set ["uniforms", ["vn_b_uniform_sog_02_02", "vn_b_uniform_sog_02_05", "vn_b_uniform_macv_06_02", "vn_b_uniform_macv_04_02"]];
-_sfLoadoutData set ["vests", ["vn_b_vest_sog_04"]];
-_sfLoadoutData set ["medVests", ["vn_b_vest_sog_02"]];
-_sfLoadoutData set ["engVests", ["vn_b_vest_sog_03"]];
-_sfLoadoutData set ["mgVests", ["vn_b_vest_sog_05"]];
-_sfLoadoutData set ["slVests", ["vn_b_vest_sog_06"]];
-_sfLoadoutData set ["backpacks", ["vn_b_pack_trp_02", "vn_b_pack_lw_03"]];
-_sfLoadoutData set ["slBackpacks", ["vn_b_pack_trp_04", "vn_b_pack_trp_04_02", "vn_b_pack_prc77_01", "vn_b_pack_lw_06"]];
-_sfLoadoutData set ["MGbackpacks", ["vn_b_pack_trp_01", "vn_b_pack_trp_01_02"]];
-_sfLoadoutData set ["medBackpacks", ["vn_b_pack_lw_07", "vn_b_pack_m5_01"]];
-_sfLoadoutData set ["engBackpacks", ["vn_b_pack_lw_04", "vn_b_pack_trp_03_02"]];
-_sfLoadoutData set ["helmets", ["vn_b_boonie_02_02", "vn_b_boonie_02_01", "vn_b_beret_01_01", "vn_b_beret_01_06", "vn_b_bandana_02"]];
+_sfLoadoutData set ["uniforms", ["vn_b_uniform_sas_01_06","vn_b_uniform_sas_02_06","vn_b_uniform_sas_03_06"]];
+_sfLoadoutData set ["vests", ["vn_b_vest_sas_01"]];
+_sfLoadoutData set ["mgVests", ["vn_b_vest_sas_03"]];
+_sfLoadoutData set ["glVests", ["vn_b_vest_sas_02"]];
+_sfLoadoutData set ["slVests", ["vn_b_vest_sas_04"]];
+_sfLoadoutData set ["backpacks", ["vn_b_pack_p44_01", "vn_b_pack_p44_02"]];
+_sfLoadoutData set ["engBackpacks", ["vn_b_pack_p08_02"]];
+_sfLoadoutData set ["helmets", [["vn_b_headband_01","vn_b_bandana_08","vn_b_boonie_06_01","vn_b_boonie_08_01","vn_b_boonie_02_08", "", "", ""]]];
 _sfLoadoutData set ["binoculars", ["vn_anpvs2_binoc"]];
 
 _sfLoadoutData set ["rifles", [
 ["vn_m16_camo", "vn_s_m16", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], [], ""],
 ["vn_m16_camo", "vn_s_m16", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], [], ""],
-["vn_m63a", "", "", "", ["vn_m63a_30_mag", "vn_m63a_30_mag", "vn_m63a_30_t_mag"], [], ""],
-["vn_type56", "", "vn_b_type56", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], [], ""]
+["vn_l1a1_03", "", "", "", ["vn_l1a1_30_mag", "vn_l1a1_30_mag", "vn_l1a1_30_t_mag"], [], ""],
+["vn_l1a1_03_camo", "", "", "", ["vn_l1a1_30_02_mag", "vn_l1a1_30_02_mag", "vn_l1a1_30_02_t_mag"], [], ""],
+["vn_l1a1_03_camo", "", "", "", ["vn_l1a1_30_mag", "vn_l1a1_30_mag", "vn_l1a1_30_t_mag"], [], ""]
 ]];
 _sfLoadoutData set ["slRifles", [
 ["vn_m16_camo", "vn_s_m16", "", "vn_o_4x_m16", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], [], ""],
-["vn_xm177_fg", "", "", "vn_o_4x_m16", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], [], ""],
-["vn_m16_camo", "vn_s_m16", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], [], ""],
-["vn_xm177_fg", "", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], [], ""],
-["vn_m63a", "", "", "", ["vn_m63a_30_mag", "vn_m63a_30_mag", "vn_m63a_30_t_mag"], [], ""],
+["vn_m14a1_shorty", "", "", "vn_o_m14_front", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], ""],
 ["vn_type56", "", "vn_b_type56", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], [], ""]
 ]];
-_sfLoadoutData set ["slSidearms", [
-["vn_m79_p", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ["vn_40mm_m576_buck_mag"], ""],
-["vn_m79_p", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ["vn_40mm_m576_buck_mag"], ""]
-]];
-_sfLoadoutData set ["carbines", [
-["vn_xm177_short", "", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], [], ""],
-["vn_xm177_short", "", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], [], ""],
-["vn_gau5a", "", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], [], ""],
-["vn_gau5a", "", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], [], ""]
+_sfLoadoutData set ["SMGs", [
+["vn_l34a1", "", "", "", ["vn_f1_smg_mag", "vn_f1_smg_mag", "vn_f1_smg_t_mag"], [], ""]
 ]];
 _sfLoadoutData set ["grenadeLaunchers", [
-["vn_m16_xm148", "", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ""],
-["vn_m16_xm148", "", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""],
-["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ["vn_40mm_m576_buck_mag"], ""],
-["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ["vn_40mm_m576_buck_mag"], ""],
-["vn_m16_m203_camo", "", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ""],
-["vn_m16_m203_camo", "", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""]
+["vn_l34a1_xm148", "", "", "", ["vn_f1_smg_mag", "vn_f1_smg_mag", "vn_f1_smg_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ""],
+["vn_l1a1_xm148_camo", "", "", "", ["vn_l1a1_30_mag", "vn_l1a1_30_mag", "vn_l1a1_30_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ""]
 ]];
 _sfLoadoutData set ["machineGuns", [
-["vn_m60", "", "", "", [], [], ""],
 ["vn_m60_shorty_camo", "", "", "", [], [], ""],
 ["vn_rpd", "", "", "", [], [], ""],
-["vn_m63a_cdo", "", "", "", ["vn_m63a_150_mag", "vn_m63a_150_mag", "vn_m63a_150_t_mag"], [], ""],
-["vn_m63a_lmg", "", "", "", ["vn_m63a_100_mag", "vn_m63a_100_mag", "vn_m63a_100_t_mag"], [], ""]
+["vn_l2a1_01", "", "", "", ["vn_l1a1_30_mag", "vn_l1a1_30_mag", "vn_l1a1_30_t_mag"], [], ""]
 ]];
 _sfLoadoutData set ["marksmanRifles", [
-["vn_m16_camo", "vn_s_m16", "", "vn_o_9x_m16", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], [], ""],
 ["vn_m16_camo", "vn_s_m16", "", "vn_o_4x_m16", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], [], ""],
 ["vn_m14_camo", "vn_s_m14", "", "vn_o_9x_m14", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], "vn_b_camo_m14"],
-["vn_m14_camo", "vn_s_m14", "", "vn_o_9x_m14", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], "vn_b_camo_m14"],
 ["vn_m14a1", "vn_s_m14", "", "vn_o_9x_m14", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], "vn_b_camo_m14a1"],
-["vn_m14a1", "vn_s_m14", "", "vn_o_9x_m14", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], "vn_b_camo_m14a1"]
+["vn_l1a1_01", "", "", "vn_o_3x_l1a1", ["vn_l1a1_30_mag", "vn_l1a1_30_mag", "vn_l1a1_30_t_mag"], [], ""]
 ]];
 _sfLoadoutData set ["sniperRifles", [
-["vn_m40a1_camo", "vn_s_m14", "", "vn_o_9x_m40a1", ["vn_m40a1_mag", "vn_m40a1_mag", "vn_m40a1_t_mag"], [], "vn_b_camo_m40a1"],
+["vn_l1a1_01", "", "", "vn_o_3x_l1a1", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], [], ""],
 ["vn_m40a1_camo", "vn_s_m14", "", "vn_o_9x_m40a1", ["vn_m40a1_mag", "vn_m40a1_mag", "vn_m40a1_t_mag"], [], ""]
 ]];
 _sfLoadoutData set ["sidearms", [
-["vn_mx991_m1911", "vn_s_m1911", "", "", [], [], ""],
-["vn_mk22", "vn_s_mk22", "", "", [], [], ""]
+["vn_mx991_m1911", "vn_s_m1911", "", "", [], [], ""]
 ]];
+
 /////////////////////////////////
 //    Military Loadout Data    //
 /////////////////////////////////
 
 private _militaryLoadoutData = _loadoutData call _fnc_copyLoadoutData;
-_militaryLoadoutData set ["uniforms", ["vn_b_uniform_macv_02_01", "vn_b_uniform_macv_02_07", "vn_b_uniform_macv_01_01", "vn_b_uniform_macv_06_01", "vn_b_uniform_macv_04_01"]];
-_militaryLoadoutData set ["vests", ["vn_b_vest_usarmy_02", "vn_b_vest_usarmy_03"]];
-_militaryLoadoutData set ["glVests", ["vn_b_vest_usarmy_05"]];
-_militaryLoadoutData set ["sniVests", ["vn_b_vest_usarmy_08"]];
-_militaryLoadoutData set ["medVests", ["vn_o_vest_06", "vn_b_vest_usarmy_12"]];
+_militaryLoadoutData set ["uniforms", ["vn_b_uniform_aus_05_01","vn_b_uniform_aus_06_01","vn_b_uniform_aus_03_01","vn_b_uniform_aus_04_01"	,"vn_b_uniform_aus_08_01","vn_b_uniform_aus_07_01","vn_b_uniform_aus_09_01"]];
+_militaryLoadoutData set ["vests", ["vn_b_vest_anzac_01","vn_b_vest_anzac_02","vn_b_vest_anzac_03"]];
+_militaryLoadoutData set ["glVests", ["vn_b_vest_anzac_04"]];
+_militaryLoadoutData set ["medVests", ["vn_b_vest_anzac_06"]];
 _militaryLoadoutData set ["engVests", ["vn_b_vest_usarmy_12", "vn_b_vest_usarmy_11"]];
-_militaryLoadoutData set ["mgVests", ["vn_b_vest_usarmy_06"]];
-_militaryLoadoutData set ["slVests", ["vn_b_vest_usarmy_09", "vn_b_vest_usarmy_11"]];
-_militaryLoadoutData set ["backpacks", ["vn_b_pack_lw_01", "vn_b_pack_lw_03"]];
-_militaryLoadoutData set ["slBackpacks", ["vn_b_pack_trp_04_02", "vn_b_pack_prc77_01", "vn_b_pack_lw_06"]];
-_militaryLoadoutData set ["MGbackpacks", ["vn_b_pack_lw_02", "vn_b_pack_lw_05", "vn_b_pack_trp_01_02"]];
-_militaryLoadoutData set ["medBackpacks", ["vn_b_pack_lw_07", "vn_b_pack_m5_01"]];
-_militaryLoadoutData set ["engBackpacks", ["vn_b_pack_lw_04", "vn_b_pack_trp_03_02"]];
-_militaryLoadoutData set ["helmets", ["vn_b_helmet_m1_02_01", "vn_b_helmet_m1_03_01", "vn_b_helmet_m1_05_01", "vn_b_helmet_m1_06_01", "vn_b_helmet_m1_07_01"]];
-_militaryLoadoutData set ["GLhelmets", ["vn_b_helmet_m1_04_02"]];
-_militaryLoadoutData set ["MGhelmets", ["vn_b_helmet_m1_08_01"]];
-_militaryLoadoutData set ["binoculars", ["vn_anpvs2_binoc"]];
+_militaryLoadoutData set ["mgVests", ["vn_b_vest_anzac_05"]];
+_militaryLoadoutData set ["slVests", ["vn_b_vest_anzac_07"]];
+_militaryLoadoutData set ["backpacks", ["vn_b_pack_p08_01", "vn_b_pack_p44_01", "vn_b_pack_p44_02"]];
+_militaryLoadoutData set ["engBackpacks", ["vn_b_pack_p08_02", "vn_b_pack_p44_03"]];
+_militaryLoadoutData set ["helmets", ["vn_b_boonie_06_02","vn_b_headband_01","vn_b_boonie_08_02","vn_b_boonie_07_02"]];
+_militaryLoadoutData set ["binoculars", ["vn_mk21_binocs"]];
 
 _militaryLoadoutData set ["rifles", [
 ["vn_m16", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
-["vn_m16", "", "vn_b_m16", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""]
+["vn_m16_camo", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
+["vn_l1a1_01", "", "vn_b_l1a1", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], [], ""],
+["vn_l1a1_01", "", "vn_b_l1a1", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], [], ""],
+["vn_l1a1_01_camo", "", "vn_b_l1a1", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], [], ""],
+["vn_l1a1_01_camo", "", "vn_b_l1a1", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], [], ""]
 ]];
 _militaryLoadoutData set ["slRifles", [
 ["vn_m16", "", "", "vn_o_4x_m16", ["vn_m16_30_mag", "vn_m16_30_mag", "vn_m16_30_t_mag"], [], ""],
-["vn_xm177", "", "", "vn_o_4x_m16", ["vn_m16_30_mag", "vn_m16_30_mag", "vn_m16_30_t_mag"], [], ""],
-["vn_m16", "", "", "", ["vn_m16_30_mag", "vn_m16_30_mag", "vn_m16_30_t_mag"], [], ""],
-["vn_xm177", "", "", "", ["vn_m16_30_mag", "vn_m16_30_mag", "vn_m16_30_t_mag"], [], ""],
-["vn_m63a", "", "", "", ["vn_m63a_30_mag", "vn_m63a_30_mag", "vn_m63a_30_t_mag"], [], ""]
-]];
-_militaryLoadoutData set ["slSidearms", [
-"vn_mx991_m1911",
-["vn_m79_p", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ["vn_40mm_m576_buck_mag"], ""],
-["vn_m79_p", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ["vn_40mm_m576_buck_mag"], ""]
-]];
-_militaryLoadoutData set ["carbines", [
-["vn_m1carbine", "", "vn_b_carbine", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""],
-["vn_m1carbine", "", "", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""],
-["vn_m2carbine", "", "vn_b_carbine", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""],
-["vn_m2carbine", "", "", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""],
-["vn_m1carbine", "", "vn_b_carbine", "", ["vn_carbine_30_mag", "vn_carbine_30_mag", "vn_carbine_30_t_mag"], [], ""],
-["vn_m1carbine", "", "", "", ["vn_carbine_30_mag", "vn_carbine_30_mag", "vn_carbine_30_t_mag"], [], ""],
-["vn_m2carbine", "", "vn_b_carbine", "", ["vn_carbine_30_mag", "vn_carbine_30_mag", "vn_carbine_30_t_mag"], [], ""],
-["vn_m2carbine", "", "", "", ["vn_carbine_30_mag", "vn_carbine_30_mag", "vn_carbine_30_t_mag"], [], ""]
-]];
-_militaryLoadoutData set ["grenadeLaunchers", [
-["vn_m16_xm148", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ""],
-["vn_m16_xm148", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""],
-["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ["vn_40mm_m576_buck_mag"], ""],
-["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ["vn_40mm_m576_buck_mag"], ""]
+["vn_m16_camo", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
+["vn_m16_camo", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
+["vn_l34a1", "", "", "", ["vn_f1_smg_mag", "vn_f1_smg_mag", "vn_f1_smg_t_mag"], [], ""],
+["vn_l1a1_03", "", "", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], [], ""]
 ]];
 _militaryLoadoutData set ["SMGs", [
-["vn_m3a1", "", "", "", ["vn_m3a1_mag", "vn_m3a1_mag", "vn_m3a1_t_mag"], [], ""]
+["vn_f1_smg", "", "", "", ["vn_f1_smg_mag", "vn_f1_smg_mag", "vn_f1_smg_t_mag"], [], ""],
+["vn_l2a3", "", "", "", ["vn_f1_smg_mag", "vn_f1_smg_mag", "vn_f1_smg_t_mag"], [], ""],
+["vn_l2a3", "", "", "", ["vn_f1_smg_mag", "vn_f1_smg_mag", "vn_f1_smg_t_mag"], [], ""],
+["vn_l2a3", "", "", "", ["vn_f1_smg_mag", "vn_f1_smg_mag", "vn_f1_smg_t_mag"], [], ""]
+]];
+_militaryLoadoutData set ["grenadeLaunchers", [
+["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ["vn_40mm_m576_buck_mag"], ""],
+["vn_l1a1_01_gl", "", "", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], ["vn_22mm_m61_frag_mag", "vn_22mm_m61_frag_mag", "vn_22mm_n94_heat_mag"], ""],
+["vn_l1a1_01_gl", "", "", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], ["vn_22mm_m61_frag_mag", "vn_22mm_m61_frag_mag", "vn_22mm_n94_heat_mag"], ""],
+["vn_l1a1_01_gl", "", "", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], ["vn_22mm_m61_frag_mag", "vn_22mm_m61_frag_mag", "vn_22mm_n94_heat_mag"], ""],
+["vn_l1a1_xm148", "", "", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""]
 ]];
 _militaryLoadoutData set ["machineGuns", [
+["vn_l2a1_01", "", "", "", ["vn_l1a1_30_02_mag", "vn_l1a1_30_02_mag", "vn_l1a1_30_02_t_mag"], [], ""],
+"vn_l4",
 ["vn_m60", "", "", "", [], [], ""]
 ]];
 _militaryLoadoutData set ["marksmanRifles", [
-["vn_m16", "", "", "vn_o_9x_m16", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
-["vn_m16", "", "", "vn_o_4x_m16", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
+["vn_l1a1_01", "", "", "vn_o_3x_l1a1", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], [], ""],
 ["vn_m14_camo", "", "", "vn_o_9x_m14", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], "vn_b_camo_m14"],
-["vn_m14_camo", "", "", "vn_o_9x_m14", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], "vn_b_camo_m14"]
+["vn_m14_camo", "", "", "vn_o_9x_m14", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], ""]
 ]];
 _militaryLoadoutData set ["sniperRifles", [
-["vn_m40a1_camo", "", "", "vn_o_9x_m40a1", ["vn_m40a1_mag", "vn_m40a1_mag", "vn_m40a1_t_mag"], [], "vn_b_camo_m40a1"],
+["vn_l1a1_01", "", "", "vn_o_3x_l1a1", ["vn_l1a1_10_mag", "vn_l1a1_10_mag", "vn_l1a1_10_t_mag"], [], ""],
 ["vn_m40a1_camo", "", "", "vn_o_9x_m40a1", ["vn_m40a1_mag", "vn_m40a1_mag", "vn_m40a1_t_mag"], [], ""]
 ]];
 _militaryLoadoutData set ["sidearms", [
-"vn_m1911",
-"vn_mx991_m1911"
+"vn_hp"
 ]];
 
 ///////////////////////////////
@@ -390,59 +338,54 @@ _policeLoadoutData set ["sidearms", [
 ////////////////////////////////
 
 private _militiaLoadoutData = _loadoutData call _fnc_copyLoadoutData;
-_militiaLoadoutData set ["uniforms", ["vn_b_uniform_macv_02_01", "vn_b_uniform_macv_02_07", "vn_b_uniform_macv_01_01"]];
-_militiaLoadoutData set ["vests", ["vn_b_vest_usarmy_02", "vn_b_vest_usarmy_03"]];
-_militiaLoadoutData set ["glVests", ["vn_b_vest_usarmy_05"]];
-_militiaLoadoutData set ["sniVests", ["vn_b_vest_usarmy_08"]];
-_militiaLoadoutData set ["medVests", ["vn_o_vest_06"]];
-_militiaLoadoutData set ["mgVests", ["vn_b_vest_usarmy_06"]];
-_militiaLoadoutData set ["slVests", ["vn_b_vest_usarmy_09"]];
-_militiaLoadoutData set ["backpacks", ["vn_b_pack_lw_01", "vn_b_pack_lw_03"]];
-_militiaLoadoutData set ["slBackpacks", ["vn_b_pack_trp_04_02", "vn_b_pack_prc77_01", "vn_b_pack_lw_06"]];
-_militiaLoadoutData set ["MGbackpacks", ["vn_b_pack_lw_02", "vn_b_pack_lw_05", "vn_b_pack_trp_01_02"]];
-_militiaLoadoutData set ["medBackpacks", ["vn_b_pack_lw_07", "vn_b_pack_m5_01"]];
-_militiaLoadoutData set ["engBackpacks", ["vn_b_pack_lw_04", "vn_b_pack_trp_03_02"]];
-_militiaLoadoutData set ["helmets", ["vn_b_helmet_m1_01_01", "vn_b_bandana_04", "vn_b_headband_02", "vn_b_helmet_m1_01_01", "vn_b_bandana_06"]];
+_militiaLoadoutData set ["uniforms", ["vn_b_uniform_nz_01_01", "vn_b_uniform_nz_02_01", "vn_b_uniform_nz_03_01", "vn_b_uniform_nz_04_01", "vn_b_uniform_nz_05_01", "vn_b_uniform_nz_06_01"]];
+_militiaLoadoutData set ["vests", ["vn_b_vest_anzac_01", "vn_b_vest_anzac_02"]];
+_militiaLoadoutData set ["glVests", ["vn_b_vest_anzac_04"]];
+_militiaLoadoutData set ["medVests", ["vn_b_vest_anzac_06"]];
+_militiaLoadoutData set ["mgVests", ["vn_b_vest_anzac_05"]];
+_militiaLoadoutData set ["slVests", ["vn_b_vest_anzac_07"]];
+_militiaLoadoutData set ["backpacks", ["vn_b_pack_p08_01"]];
+_militiaLoadoutData set ["engBackpacks", ["vn_b_pack_p08_02"]];
+_militiaLoadoutData set ["helmets", ["vn_b_boonie_06_01","vn_b_headband_01","vn_b_boonie_08_01","vn_b_boonie_07_01"]];
 _militiaLoadoutData set ["binoculars", ["vn_mk21_binocs"]];
 
 _militiaLoadoutData set ["rifles", [
-["vn_m14", "", "", "", ["vn_m14_10_mag", "vn_m14_10_mag", "vn_m14_10_t_mag"], [], ""],
-["vn_m14", "", "vn_b_m14", "", ["vn_m14_10_mag", "vn_m14_10_mag", "vn_m14_10_t_mag"], [], ""],
-["vn_m1_garand", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], [], ""],
-["vn_m1_garand", "", "vn_b_m1_garand", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], [], ""]
+["vn_m16", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
+["vn_l1a1_01", "", "vn_b_l1a1", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], [], ""],
+["vn_l1a1_01", "", "", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], [], ""],
+["vn_f1_smg", "", "", "", ["vn_f1_smg_mag", "vn_f1_smg_mag", "vn_f1_smg_t_mag"], [], ""]
 ]];
 _militiaLoadoutData set ["slRifles", [
-["vn_m14", "", "", "", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], ""],
-["vn_m14", "", "vn_b_m14", "", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], ""]
+["vn_m16", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
+["vn_m16", "", "vn_b_m16", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
+["vn_m16_camo", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
+["vn_m16_camo", "", "vn_b_m16", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""]
 ]];
-_militiaLoadoutData set ["carbines", [
-["vn_m1carbine", "", "vn_b_carbine", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""],
-["vn_m1carbine", "", "", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""],
-["vn_m2carbine", "", "vn_b_carbine", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""],
-["vn_m2carbine", "", "", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""]
+_militiaLoadoutData set ["SMGs", [
+["vn_f1_smg", "", "", "", ["vn_f1_smg_mag", "vn_f1_smg_mag", "vn_f1_smg_t_mag"], [], ""]
 ]];
 _militiaLoadoutData set ["grenadeLaunchers", [
-["vn_m16_xm148", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ""],
-["vn_m16_xm148", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""],
 ["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ["vn_40mm_m576_buck_mag"], ""],
 ["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ["vn_40mm_m576_buck_mag"], ""],
-["vn_m1_garand", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m1a2_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_m19_wp_mag"], ""],
-["vn_m1_garand", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m1a2_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_lume_mag"], ""]
+["vn_l1a1_01_gl", "", "", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], ["vn_22mm_m61_frag_mag", "vn_22mm_m61_frag_mag", "vn_22mm_n94_heat_mag"], ""]
 ]];
 _militiaLoadoutData set ["machineGuns", [
+["vn_l2a1_01", "", "", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], [], ""],
+["vn_l2a1_01", "", "", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], [], ""],
+"vn_l4",
+"vn_l4",
 ["vn_m60", "", "", "", [], [], ""]
 ]];
 _militiaLoadoutData set ["marksmanRifles", [
-["vn_m14", "", "", "vn_o_9x_m14", ["vn_m14_10_mag", "vn_m14_10_mag", "vn_m14_10_t_mag"], [], "vn_b_camo_m14"],
-["vn_m14", "", "vn_b_m14", "vn_o_9x_m14", ["vn_m14_10_mag", "vn_m14_10_mag", "vn_m14_10_t_mag"], [], "vn_b_camo_m14"]
+["vn_l1a1_01", "", "", "vn_o_3x_l1a1", ["vn_l1a1_10_mag", "vn_l1a1_10_mag", "vn_l1a1_10_t_mag"], [], ""]
 ]];
 _militiaLoadoutData set ["sniperRifles", [
-["vn_m40a1_camo", "", "", "vn_o_9x_m40a1", ["vn_m40a1_mag", "vn_m40a1_mag", "vn_m40a1_t_mag"], [], "vn_b_camo_m40a1"],
+["vn_l1a1_01", "", "", "vn_o_3x_l1a1", ["vn_l1a1_10_mag", "vn_l1a1_10_mag", "vn_l1a1_10_t_mag"], [], ""],
 ["vn_m40a1_camo", "", "", "vn_o_9x_m40a1", ["vn_m40a1_mag", "vn_m40a1_mag", "vn_m40a1_t_mag"], [], ""]
 ]];
 _militiaLoadoutData set ["sidearms", [
-"vn_m1911",
-"vn_p38s"
+"vn_mx991",
+"vn_hp"
 ]];
 
 //////////////////////////
@@ -450,30 +393,45 @@ _militiaLoadoutData set ["sidearms", [
 //////////////////////////
 
 private _crewLoadoutData = _militaryLoadoutData call _fnc_copyLoadoutData;
-_crewLoadoutData set ["uniforms", ["vn_b_uniform_macv_01_01"]];
-_crewLoadoutData set ["vests", ["vn_b_vest_usarmy_13"]];
-_crewLoadoutData set ["helmets", ["vn_b_helmet_t56_02_02", "vn_b_helmet_t56_02_01"]];
+_crewLoadoutData set ["uniforms", ["vn_b_uniform_aus_01_01"]];
+_crewLoadoutData set ["vests", ["vn_b_vest_anzac_09"]];
+_crewLoadoutData set ["helmets", ["vn_b_helmet_t56_02_02", "vn_b_helmet_t56_02_01", "vn_b_beret_04_01"]];
 
 private _pilotLoadoutData = _militaryLoadoutData call _fnc_copyLoadoutData;
-_pilotLoadoutData set ["uniforms", ["vn_b_uniform_heli_01_01"]];
-_pilotLoadoutData set ["vests", ["vn_b_vest_aircrew_05"]];
-_pilotLoadoutData set ["helmets", ["vn_b_helmet_svh4_02_06", "vn_b_helmet_svh4_02_03", "vn_b_helmet_svh4_02_04"]];
+_pilotLoadoutData set ["uniforms", ["vn_b_uniform_k2b_03_01", "vn_b_uniform_k2b_03_02"]];
+_pilotLoadoutData set ["vests", ["vn_b_vest_anzac_08"]];
+_pilotLoadoutData set ["helmets", ["vn_b_helmet_svh4_01_04","vn_b_helmet_svh4_02_04"]];
 
 if (isClass (configFile >> "vnx_credits")) then {
 	(_policeLoadoutData get "shotGuns") append [
 	["vnx_m77e", "", "", "", ["vnx_m77e_fl_mag","vnx_m77e_buck_mag"], [], ""],
 	["vnx_m77e_shorty", "", "", "", ["vnx_m77e_fl_mag","vnx_m77e_buck_mag"], [], ""]
 	];
-	(_militaryLoadoutData get "SMGs") append [
-	["vn_m3a1", "", "", "", ["vn_m3a1_mag", "vn_m3a1_mag", "vn_m3a1_t_mag"], [], ""],
-	["vn_m3a1", "", "", "", ["vn_m3a1_mag", "vn_m3a1_mag", "vn_m3a1_t_mag"], [], ""],
-	["vnx_m45_sf", "", "", "", ["vn_m45_t_mag", "vn_m45_mag"], [], ""]
+	(_militiaLoadoutData get "SMGs") append [
+	["vn_f1_smg", "", "", "", ["vn_f1_smg_mag", "vn_f1_smg_mag", "vn_f1_smg_t_mag"], [], ""],
+	["vnx_m50_smg", "", "", "", ["vnx_m50_smg_t_mag", "vnx_m50_smg_mag"], [], ""]
 	];
 	(_sfLoadoutData get "slRifles") append [
 	["vnx_type56_xm148", "", "", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""]
 	];
+	(_sfLoadoutData get "rifles") append [
+	["vnx_l1a1_05", "", "", "", ["vn_l1a1_30_mag", "vn_l1a1_30_mag", "vn_l1a1_30_t_mag"], [], ""],
+	["vnx_l1a1_05_camo", "", "", "", ["vn_l1a1_30_mag", "vn_l1a1_30_mag", "vn_l1a1_30_t_mag"], [], ""]
+	];
+	(_militaryLoadoutData get "rifles") append [
+	["vnx_l1a1_04", "", "", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], [], ""]
+	];
 	(_sfLoadoutData get "grenadeLaunchers") append [
 	["vnx_type56_xm148", "", "", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""]
+	];
+	_militiaLoadoutData set ["sniperRifles", [
+	"vnx_no4_sniper"
+	]];
+	(_militiaLoadoutData get "marksmanRifles") append [
+	"vnx_no4"
+	];
+	(_militaryLoadoutData get "sniperRifles") append [
+	"vnx_no4_sniper"
 	];
 };
 
@@ -500,7 +458,7 @@ private _squadLeaderTemplate = {
 
 	["lightATLaunchers"] call _fnc_setLauncher;
 
-	[["slSidearms", "sidearms"] call _fnc_fallback] call _fnc_setHandgun;
+	["sidearms"] call _fnc_setHandgun;
 	["handgun", 4] call _fnc_addMagazines;
 	["handgun", 4] call _fnc_addAdditionalMuzzleMagazines;
 	["items_medical_standard"] call _fnc_addItemSet;
@@ -525,7 +483,7 @@ private _riflemanTemplate = {
 
 	["lightATLaunchers"] call _fnc_setLauncher;
 
-	[selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+	["rifles"] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 
 	["sidearms"] call _fnc_setHandgun;
@@ -548,7 +506,7 @@ private _medicTemplate = {
 	[["medVests", "vests"] call _fnc_fallback] call _fnc_setVest;
 	["uniforms"] call _fnc_setUniform;
 	[["medBackpacks", "backpacks"] call _fnc_fallback] call _fnc_setBackpack;
-  	["carbines"] call _fnc_setPrimary;
+  	["SMGs"] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 
 	["sidearms"] call _fnc_setHandgun;
@@ -576,7 +534,7 @@ private _grenadierTemplate = {
 	["primary", 8] call _fnc_addMagazines;
 	["primary", 10] call _fnc_addAdditionalMuzzleMagazines;
 
-	[["slSidearms", "sidearms"] call _fnc_fallback] call _fnc_setHandgun;
+	["sidearms"] call _fnc_setHandgun;
 	["handgun", 4] call _fnc_addMagazines;
 	["handgun", 2] call _fnc_addAdditionalMuzzleMagazines;
 
@@ -598,7 +556,7 @@ private _explosivesExpertTemplate = {
 	["uniforms"] call _fnc_setUniform;
 	[["engBackpacks", "backpacks"] call _fnc_fallback] call _fnc_setBackpack;
 
-	[selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+	[selectRandom ["rifles", "SMGs"]] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 
 
@@ -629,7 +587,7 @@ private _engineerTemplate = {
 	["uniforms"] call _fnc_setUniform;
 	[["engBackpacks", "backpacks"] call _fnc_fallback] call _fnc_setBackpack;
 
-	["carbines"] call _fnc_setPrimary;
+	["SMGs"] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 
 	["sidearms"] call _fnc_setHandgun;
@@ -655,7 +613,7 @@ private _latTemplate = {
 	["vests"] call _fnc_setVest;
 	["uniforms"] call _fnc_setUniform;
 
-	[selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+	[selectRandom ["rifles", "SMGs"]] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 
 	["lightATLaunchers"] call _fnc_setLauncher;
@@ -680,7 +638,7 @@ private _atTemplate = {
 	["vests"] call _fnc_setVest;
 	["uniforms"] call _fnc_setUniform;
 
-	[selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+	[selectRandom ["rifles", "SMGs"]] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 
 	["lightATLaunchers"] call _fnc_setLauncher;
@@ -705,7 +663,7 @@ private _aaTemplate = {
 	["vests"] call _fnc_setVest;
 	["uniforms"] call _fnc_setUniform;
 
-	[selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+	[selectRandom ["rifles", "SMGs"]] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 
 	["lightATLaunchers"] call _fnc_setLauncher;

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_ANZAC.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_ANZAC.sqf
@@ -208,7 +208,7 @@ _sfLoadoutData set ["glVests", ["vn_b_vest_sas_02"]];
 _sfLoadoutData set ["slVests", ["vn_b_vest_sas_04"]];
 _sfLoadoutData set ["backpacks", ["vn_b_pack_p44_01", "vn_b_pack_p44_02"]];
 _sfLoadoutData set ["engBackpacks", ["vn_b_pack_p08_02"]];
-_sfLoadoutData set ["helmets", [["vn_b_headband_01","vn_b_bandana_08","vn_b_boonie_06_01","vn_b_boonie_08_01","vn_b_boonie_02_08", "", "", ""]]];
+_sfLoadoutData set ["helmets", ["vn_b_headband_01","vn_b_bandana_08","vn_b_boonie_06_01","vn_b_boonie_08_01","vn_b_boonie_02_08", "", "", ""]];
 _sfLoadoutData set ["binoculars", ["vn_anpvs2_binoc"]];
 
 _sfLoadoutData set ["rifles", [
@@ -458,8 +458,6 @@ private _squadLeaderTemplate = {
 	["primary", 8] call _fnc_addMagazines;
 	["primary", 4] call _fnc_addAdditionalMuzzleMagazines;
 
-	["lightATLaunchers"] call _fnc_setLauncher;
-
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 4] call _fnc_addMagazines;
 	["handgun", 4] call _fnc_addAdditionalMuzzleMagazines;
@@ -482,8 +480,6 @@ private _riflemanTemplate = {
 	["helmets"] call _fnc_setHelmet;
 	["vests"] call _fnc_setVest;
 	["uniforms"] call _fnc_setUniform;
-
-	["lightATLaunchers"] call _fnc_setLauncher;
 
 	["rifles"] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_ANZAC.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_ANZAC.sqf
@@ -110,7 +110,7 @@ if (isClass (configFile >> "vnx_credits")) then {
 "WhiteHead_13", "WhiteHead_15", "WhiteHead_16", "WhiteHead_17", "WhiteHead_18",
 "WhiteHead_20", "WhiteHead_21"]] call _fnc_saveToTemplate;
 ["voices", ["Male01ENG", "Male02ENG", "Male03ENG", "Male04ENG", "Male05ENG", "Male06ENG", "Male07ENG", "Male08ENG", "Male09ENG", "Male10ENG", "Male11ENG", "Male12ENG"]] call _fnc_saveToTemplate;
-"NATOMen" call _fnc_saveNames;
+"EnglishMen" call _fnc_saveNames;
 
 //////////////////////////
 //       Loadouts       //
@@ -322,8 +322,10 @@ _policeLoadoutData set ["uniforms", ["vn_b_uniform_macv_01_03"]];
 _policeLoadoutData set ["vests", ["vn_b_vest_usarmy_13"]];
 _policeLoadoutData set ["helmets", ["vn_b_helmet_m1_01_02"]];
 
-_policeLoadoutData set ["rifles", [
-["vn_m16", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""]
+_policeLoadoutData set ["carbines", [
+["vn_m1carbine", "", "", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""],
+["vn_m1carbine", "", "", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""],
+["vn_m2carbine", "", "", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""]
 ]];
 _policeLoadoutData set ["shotGuns", [
 ["vn_m1897", "", "", "", ["vn_m1897_buck_mag", "vn_m1897_fl_mag"], [], ""]
@@ -760,7 +762,7 @@ private _policeTemplate = {
 	["vests"] call _fnc_setVest;
 	["uniforms"] call _fnc_setUniform;
 
-	[selectRandom ["rifles", "shotGuns"]] call _fnc_setPrimary;
+	[selectRandom ["carbines", "shotGuns"]] call _fnc_setPrimary;
 	["primary", 3] call _fnc_addMagazines;
 
 	["sidearms"] call _fnc_setHandgun;

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_ARVN.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_ARVN.sqf
@@ -1,13 +1,20 @@
+/*
+There are a few french guns that could be used here (mas36, m49/56, vz54?), all WW2/Korean era French bolt/semi-auto rifles
+SOG Nickel Steel also has a few (FM24/29, mas38)
+Overall though the vehicles and weapons don't have enough distinction from ARVN equipment to justify a new template for it
+If anyone wants to pick up here, the vehicles are already setup, just need to work out the infantry kits.
+*/
+
 //////////////////////////
 //   Side Information   //
 //////////////////////////
 
-["name", "US Army"] call _fnc_saveToTemplate;
-["spawnMarkerName", "US Army Support Corridor"] call _fnc_saveToTemplate;
+["name", "ARVN"] call _fnc_saveToTemplate;
+["spawnMarkerName", "ARVN Support Corridor"] call _fnc_saveToTemplate;
 
 ["flag", "vn_flag_usa"] call _fnc_saveToTemplate;
-["flagTexture", "vn\objects_f_vietnam\flags\data\vn_flag_01_usa_co.paa"] call _fnc_saveToTemplate;
-["flagMarkerType", "vn_flag_usa"] call _fnc_saveToTemplate;
+["flagTexture", "vn\objects_f_vietnam\flags\data\vn_flag_01_arvn_co.paa"] call _fnc_saveToTemplate;
+["flagMarkerType", "vn_flag_arvn"] call _fnc_saveToTemplate;
 
 //////////////////////////
 //  Mission/HQ Objects  //
@@ -29,43 +36,42 @@
 //       Vehicles       //
 //////////////////////////
 
-["vehiclesBasic", ["vn_b_wheeled_m151_01"]] call _fnc_saveToTemplate;
-["vehiclesLightUnarmed", ["vn_b_wheeled_m151_01", "vn_b_wheeled_m151_02", "vn_b_wheeled_m274_01_01"]] call _fnc_saveToTemplate;
-private _vehiclesLightArmed = ["vn_b_wheeled_m151_mg_02", "vn_b_wheeled_m151_mg_03", "vn_b_wheeled_m151_mg_04", "vn_b_wheeled_m151_mg_05", "vn_b_wheeled_m54_mg_02", "vn_b_wheeled_m274_mg_01_01"];
-
-["vehiclesTrucks", ["vn_b_wheeled_m54_01", "vn_b_wheeled_m54_02"]] call _fnc_saveToTemplate;
+["vehiclesBasic", ["vn_i_wheeled_m151_01"]] call _fnc_saveToTemplate;
+["vehiclesLightUnarmed", ["vn_i_wheeled_m151_01", "vn_i_wheeled_m151_02"]] call _fnc_saveToTemplate;
+["vehiclesLightArmed" , ["vn_i_wheeled_m151_mg_01", "vn_i_wheeled_m151_mg_01", "vn_i_wheeled_m151_mg_01", "vn_i_wheeled_m151_mg_06"]] call _fnc_saveToTemplate;
+["vehiclesTrucks", ["vn_i_wheeled_m54_01", "vn_i_wheeled_m54_02"]] call _fnc_saveToTemplate;
 ["vehiclesCargoTrucks", []] call _fnc_saveToTemplate;
-["vehiclesAmmoTrucks", ["vn_b_wheeled_m54_ammo"]] call _fnc_saveToTemplate;
-["vehiclesRepairTrucks", ["vn_b_wheeled_m54_repair"]] call _fnc_saveToTemplate;
-["vehiclesFuelTrucks", ["vn_b_wheeled_m54_fuel"]] call _fnc_saveToTemplate;
-["vehiclesMedical", ["vn_b_armor_m577_02"]] call _fnc_saveToTemplate;
-["vehiclesLightAPCs", ["vn_b_wheeled_m54_mg_03", "vn_b_wheeled_m54_mg_01", "vn_b_armor_m113_01"]] call _fnc_saveToTemplate;
-["vehiclesAPCs", ["vn_b_armor_m113_acav_04", "vn_b_armor_m113_acav_02", "vn_b_armor_m113_acav_01", "vn_b_armor_m113_acav_06", "vn_b_armor_m113_acav_03", "vn_b_armor_m113_acav_05"]] call _fnc_saveToTemplate;
-["vehiclesIFVs", ["vn_b_armor_m67_01_01"]] call _fnc_saveToTemplate;
-["vehiclesLightTanks", ["vn_b_armor_m41_01_01"]] call _fnc_saveToTemplate;
-["vehiclesTanks", ["vn_b_armor_m48_01_01"]] call _fnc_saveToTemplate;
+["vehiclesAmmoTrucks", ["vn_i_wheeled_m54_ammo"]] call _fnc_saveToTemplate;
+["vehiclesRepairTrucks", ["vn_i_wheeled_m54_repair"]] call _fnc_saveToTemplate;
+["vehiclesFuelTrucks", ["vn_i_wheeled_m54_fuel"]] call _fnc_saveToTemplate;
+["vehiclesMedical", ["vn_i_armor_m577_02"]] call _fnc_saveToTemplate;
+["vehiclesLightAPCs", ["vn_b_wheeled_m54_mg_03", "vn_b_wheeled_m54_mg_01", "vn_i_armor_m113_01"]] call _fnc_saveToTemplate;
+["vehiclesAPCs", ["vn_i_armor_m113_acav_04", "vn_i_armor_m113_acav_02", "vn_i_armor_m113_acav_01", "vn_i_armor_m113_acav_06", "vn_i_armor_m113_acav_03", "vn_i_armor_m113_acav_05"]] call _fnc_saveToTemplate;
+["vehiclesIFVs", ["vn_i_armor_m67_01_01", "vn_i_armor_type63_01"]] call _fnc_saveToTemplate;
+["vehiclesLightTanks", ["vn_i_armor_m41_01"]] call _fnc_saveToTemplate;
+["vehiclesTanks", ["vn_i_armor_m48_01_01", "vn_i_armor_type63_01"]] call _fnc_saveToTemplate;
 private _vehiclesAA = ["vn_b_wheeled_m54_mg_02"];
 
 ["vehiclesTransportBoats", ["vn_o_boat_02_01", "vn_b_boat_10_01", "vn_b_boat_09_01"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["vn_b_boat_13_02", "vn_b_boat_06_02", "vn_b_boat_05_02", "vn_b_boat_12_02"]] call _fnc_saveToTemplate;
-["vehiclesAmphibious", ["vn_b_armor_m113_01", "vn_b_armor_m113_acav_04", "vn_b_armor_m113_acav_02", "vn_b_armor_m113_acav_01", "vn_b_armor_m113_acav_06", "vn_b_armor_m113_acav_03", "vn_b_armor_m113_acav_05"]] call _fnc_saveToTemplate;
+["vehiclesAPCs", ["vn_i_armor_m113_acav_04", "vn_i_armor_m113_acav_02", "vn_i_armor_m113_acav_01", "vn_i_armor_m113_acav_06", "vn_i_armor_m113_acav_03", "vn_i_armor_m113_acav_05"]] call _fnc_saveToTemplate;
 
 private _vehiclesPlanesCAS = ["vn_b_air_f4c_at", "vn_b_air_f100d_at", "vn_b_air_f100d_at", "vn_b_air_f100d_at"];
-["vehiclesPlanesAA", ["vn_b_air_f4c_cap", "vn_b_air_f100d_cap"]] call _fnc_saveToTemplate;
+["vehiclesPlanesAA", ["vn_b_air_f4c_cap", "vn_b_air_f100d_cap", "vn_b_air_f100d_cap"]] call _fnc_saveToTemplate;
 private _vehiclesPlanesTransport = [];
-private _vehiclesAirPatrol = ["vn_b_air_oh6a_07", "vn_b_air_uh1d_02_01"];
+private _vehiclesAirPatrol = ["vn_i_air_uh1d_02_01"];
 
 ["vehiclesHelisLight", ["vn_b_air_uh1c_07_01"]] call _fnc_saveToTemplate; // this is a uh-1b
-["vehiclesHelisTransport", ["vn_b_air_ch47_04_01", "vn_b_air_ch47_04_01", "vn_b_air_ch47_01_02", "vn_b_air_uh1d_02_01", "vn_b_air_uh1d_02_01", "vn_b_air_uh1d_02_01", "vn_b_air_uh1d_02_01", "vn_b_air_uh1d_02_01", "vn_b_air_uh1d_02_01", "vn_b_air_uh1d_02_01", "vn_b_air_uh1d_02_01", "vn_b_air_uh1c_07_01", "vn_b_air_uh1c_07_01"]] call _fnc_saveToTemplate;
-["vehiclesHelisLightAttack", ["vn_b_air_oh6a_06", "vn_b_air_ach47_04_01", "vn_b_air_uh1c_01_01", "vn_b_air_uh1c_01_01", "vn_b_air_uh1c_01_01", "vn_b_air_uh1c_02_01", "vn_b_air_uh1c_02_01"]] call _fnc_saveToTemplate;
-["vehiclesHelisAttack", ["vn_b_air_ach47_04_01", "vn_b_air_ach47_03_01", "vn_b_air_ah1g_01", "vn_b_air_ah1g_01", "vn_b_air_ah1g_01", "vn_b_air_ah1g_03", "vn_b_air_ah1g_03"]] call _fnc_saveToTemplate;
+["vehiclesHelisTransport", ["vn_i_air_ch47_01_01", "vn_i_air_ch47_04_01", "vn_i_air_ch34_02_01", "vn_i_air_ch34_01_02", "vn_i_air_uh1d_02_01", "vn_i_air_uh1d_02_01", "vn_i_air_uh1d_02_01", "vn_i_air_uh1d_02_01"]] call _fnc_saveToTemplate; // "real" ratio is about 1:3:5
+["vehiclesHelisLightAttack", ["vn_i_air_uh1c_01_01", "vn_i_air_uh1c_02_01"]] call _fnc_saveToTemplate;
+["vehiclesHelisAttack", []] call _fnc_saveToTemplate;
 
-["vehiclesArtillery", ["vn_b_army_static_m101_02"]] call _fnc_saveToTemplate;
+["vehiclesArtillery", ["vn_i_static_m101_02"]] call _fnc_saveToTemplate;
 ["magazines", createHashMapFromArray [
-["vn_b_army_static_m101_02", ["vn_cannon_m101_mag_he_x8", "vn_cannon_m101_mag_ab_x8", "vn_cannon_m101_mag_wp_x8"]]
+["vn_i_static_m101_02", ["vn_cannon_m101_mag_he_x8", "vn_cannon_m101_mag_ab_x8", "vn_cannon_m101_mag_wp_x8"]]
 ]] call _fnc_saveToTemplate;
 
-["uavsAttack", ["vn_b_air_oh6a_01"]] call _fnc_saveToTemplate;				// scout helis are fine for this
+["uavsAttack", ["vn_i_air_uh1c_07_01"]] call _fnc_saaveToTemplate;				// scout helis are fine for this
 ["uavsPortable", []] call _fnc_saveToTemplate;
 
 //Config special vehicles
@@ -75,9 +81,9 @@ private _vehiclesAirPatrol = ["vn_b_air_oh6a_07", "vn_b_air_uh1d_02_01"];
 
 ["vehiclesPolice", ["vn_b_wheeled_m151_02_mp"]] call _fnc_saveToTemplate;
 
-["staticMGs", ["vn_b_army_static_m60_high", "vn_b_army_static_m1919a4_high", "vn_b_army_static_m2_high"]] call _fnc_saveToTemplate;
-["staticAT", ["vn_b_army_static_m40a1rr", "vn_b_army_static_tow"]] call _fnc_saveToTemplate;
-["staticAA", ["vn_b_army_static_m45"]] call _fnc_saveToTemplate;
+["staticMGs", ["vn_i_static_m1919a4_high", "vn_i_static_m60_high"]] call _fnc_saveToTemplate;
+["staticAT", ["vn_b_army_static_m40a1rr"]] call _fnc_saveToTemplate;
+["staticAA", ["vn_i_static_m45"]] call _fnc_saveToTemplate;
 ["staticMortars", ["a3a_vn_b_static_mortar_m2"]] call _fnc_saveToTemplate;
 
 ["mortarMagazineHE", "vn_mortar_m2_mag_he_x8"] call _fnc_saveToTemplate;
@@ -85,14 +91,11 @@ private _vehiclesAirPatrol = ["vn_b_air_oh6a_07", "vn_b_air_uh1d_02_01"];
 ["mortarMagazineFlare", "vn_mortar_m2_mag_lume_x8"] call _fnc_saveToTemplate;
 
 if (isClass (configFile >> "vnx_credits")) then {
-	_vehiclesLightArmed append ["vn_b_wheeled_m151_mg_02", "vn_b_wheeled_m151_mg_03", "vn_b_wheeled_m151_mg_04", "vn_b_wheeled_m151_mg_05", "vnx_b_armor_m50_01", "vnx_b_armor_m50a1_01"];
 	_vehiclesAA append ["vnx_b_armor_m163_01"];
-	_vehiclesAirPatrol append ["vn_b_air_oh6a_07", "vn_b_air_uh1d_02_01", "vnx_b_air_ov10a_covey", "vnx_b_air_hh1h_01_01", "vnx_b_air_hh1h_02_01"];
-	_vehiclesPlanesCAS append ["vnx_b_air_ov10a_mr"];
-	_vehiclesPlanesTransport append ["vnx_b_air_ac119_02_01"];
+	_vehiclesPlanesTransport append ["vnx_i_air_ac119_02_01"];
+	_vehiclesAirPatrol append ["vn_i_air_uh1d_02_01", "vnx_b_air_ov10a_covey"];
 };
 
-["vehiclesLightArmed", _vehiclesLightArmed] call _fnc_saveToTemplate;
 ["vehiclesAA", _vehiclesAA] call _fnc_saveToTemplate;
 ["vehiclesAirPatrol", _vehiclesAirPatrol] call _fnc_saveToTemplate;
 ["vehiclesPlanesCAS", _vehiclesPlanesCAS] call _fnc_saveToTemplate;
@@ -173,8 +176,6 @@ _loadoutData set ["mgVests", []];
 _loadoutData set ["slVests", []];
 _loadoutData set ["backpacks", []];
 _loadoutData set ["slBackpacks", []];
-_loadoutData set ["MGbackpacks", []];
-_loadoutData set ["medBackpacks", []];
 _loadoutData set ["engBackpacks", []];
 _loadoutData set ["helmets", []];
 _loadoutData set ["GLhelmets", []];
@@ -227,8 +228,6 @@ _sfLoadoutData set ["mgVests", ["vn_b_vest_sog_05"]];
 _sfLoadoutData set ["slVests", ["vn_b_vest_sog_06"]];
 _sfLoadoutData set ["backpacks", ["vn_b_pack_trp_02", "vn_b_pack_lw_03"]];
 _sfLoadoutData set ["slBackpacks", ["vn_b_pack_trp_04", "vn_b_pack_trp_04_02", "vn_b_pack_prc77_01", "vn_b_pack_lw_06"]];
-_sfLoadoutData set ["MGbackpacks", ["vn_b_pack_trp_01", "vn_b_pack_trp_01_02"]];
-_sfLoadoutData set ["medBackpacks", ["vn_b_pack_lw_07", "vn_b_pack_m5_01"]];
 _sfLoadoutData set ["engBackpacks", ["vn_b_pack_lw_04", "vn_b_pack_trp_03_02"]];
 _sfLoadoutData set ["helmets", ["vn_b_boonie_02_02", "vn_b_boonie_02_01", "vn_b_beret_01_01", "vn_b_beret_01_06", "vn_b_bandana_02"]];
 _sfLoadoutData set ["binoculars", ["vn_anpvs2_binoc"]];
@@ -293,23 +292,20 @@ _sfLoadoutData set ["sidearms", [
 /////////////////////////////////
 
 private _militaryLoadoutData = _loadoutData call _fnc_copyLoadoutData;
-_militaryLoadoutData set ["uniforms", ["vn_b_uniform_macv_02_01", "vn_b_uniform_macv_02_07", "vn_b_uniform_macv_01_01", "vn_b_uniform_macv_06_01", "vn_b_uniform_macv_04_01"]];
+_militaryLoadoutData set ["uniforms", ["vn_b_uniform_macv_04_01","vn_b_uniform_macv_01_07","vn_b_uniform_macv_05_07","vn_b_uniform_macv_04_07","vn_b_uniform_macv_06_07","vn_b_uniform_macv_02_07","vn_b_uniform_macv_03_07"]];
 _militaryLoadoutData set ["vests", ["vn_b_vest_usarmy_02", "vn_b_vest_usarmy_03"]];
 _militaryLoadoutData set ["glVests", ["vn_b_vest_usarmy_05"]];
 _militaryLoadoutData set ["sniVests", ["vn_b_vest_usarmy_08"]];
-_militaryLoadoutData set ["medVests", ["vn_o_vest_06", "vn_b_vest_usarmy_12"]];
 _militaryLoadoutData set ["engVests", ["vn_b_vest_usarmy_12", "vn_b_vest_usarmy_11"]];
 _militaryLoadoutData set ["mgVests", ["vn_b_vest_usarmy_06"]];
 _militaryLoadoutData set ["slVests", ["vn_b_vest_usarmy_09", "vn_b_vest_usarmy_11"]];
-_militaryLoadoutData set ["backpacks", ["vn_b_pack_lw_01", "vn_b_pack_lw_03"]];
+_militaryLoadoutData set ["backpacks", ["vn_b_pack_arvn_01", "vn_b_pack_arvn_02", "vn_b_pack_arvn_04"]];
 _militaryLoadoutData set ["slBackpacks", ["vn_b_pack_trp_04_02", "vn_b_pack_prc77_01", "vn_b_pack_lw_06"]];
-_militaryLoadoutData set ["MGbackpacks", ["vn_b_pack_lw_02", "vn_b_pack_lw_05", "vn_b_pack_trp_01_02"]];
-_militaryLoadoutData set ["medBackpacks", ["vn_b_pack_lw_07", "vn_b_pack_m5_01"]];
-_militaryLoadoutData set ["engBackpacks", ["vn_b_pack_lw_04", "vn_b_pack_trp_03_02"]];
+_militaryLoadoutData set ["engBackpacks", ["vn_b_pack_arvn_03"]];
 _militaryLoadoutData set ["helmets", ["vn_b_helmet_m1_02_01", "vn_b_helmet_m1_03_01", "vn_b_helmet_m1_05_01", "vn_b_helmet_m1_06_01", "vn_b_helmet_m1_07_01"]];
 _militaryLoadoutData set ["GLhelmets", ["vn_b_helmet_m1_04_02"]];
 _militaryLoadoutData set ["MGhelmets", ["vn_b_helmet_m1_08_01"]];
-_militaryLoadoutData set ["binoculars", ["vn_anpvs2_binoc"]];
+_militaryLoadoutData set ["binoculars", ["vn_mk21_binocs"]];
 
 _militaryLoadoutData set ["rifles", [
 ["vn_m16", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
@@ -361,7 +357,11 @@ _militaryLoadoutData set ["sniperRifles", [
 ]];
 _militaryLoadoutData set ["sidearms", [
 "vn_m1911",
-"vn_mx991_m1911"
+"vn_m1911",
+"vn_m1911",
+"vn_mx991_m1911",
+"vn_p38",
+"vn_m10"
 ]];
 
 ///////////////////////////////
@@ -394,13 +394,10 @@ _militiaLoadoutData set ["uniforms", ["vn_b_uniform_macv_02_01", "vn_b_uniform_m
 _militiaLoadoutData set ["vests", ["vn_b_vest_usarmy_02", "vn_b_vest_usarmy_03"]];
 _militiaLoadoutData set ["glVests", ["vn_b_vest_usarmy_05"]];
 _militiaLoadoutData set ["sniVests", ["vn_b_vest_usarmy_08"]];
-_militiaLoadoutData set ["medVests", ["vn_o_vest_06"]];
 _militiaLoadoutData set ["mgVests", ["vn_b_vest_usarmy_06"]];
 _militiaLoadoutData set ["slVests", ["vn_b_vest_usarmy_09"]];
 _militiaLoadoutData set ["backpacks", ["vn_b_pack_lw_01", "vn_b_pack_lw_03"]];
 _militiaLoadoutData set ["slBackpacks", ["vn_b_pack_trp_04_02", "vn_b_pack_prc77_01", "vn_b_pack_lw_06"]];
-_militiaLoadoutData set ["MGbackpacks", ["vn_b_pack_lw_02", "vn_b_pack_lw_05", "vn_b_pack_trp_01_02"]];
-_militiaLoadoutData set ["medBackpacks", ["vn_b_pack_lw_07", "vn_b_pack_m5_01"]];
 _militiaLoadoutData set ["engBackpacks", ["vn_b_pack_lw_04", "vn_b_pack_trp_03_02"]];
 _militiaLoadoutData set ["helmets", ["vn_b_helmet_m1_01_01", "vn_b_bandana_04", "vn_b_headband_02", "vn_b_helmet_m1_01_01", "vn_b_bandana_06"]];
 _militiaLoadoutData set ["binoculars", ["vn_mk21_binocs"]];
@@ -547,7 +544,7 @@ private _medicTemplate = {
 	["helmets"] call _fnc_setHelmet;
 	[["medVests", "vests"] call _fnc_fallback] call _fnc_setVest;
 	["uniforms"] call _fnc_setUniform;
-	[["medBackpacks", "backpacks"] call _fnc_fallback] call _fnc_setBackpack;
+	["medBackpacks"] call _fnc_setBackpack;
   	["carbines"] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 
@@ -729,7 +726,7 @@ private _machineGunnerTemplate = {
 	["helmets"] call _fnc_setHelmet;
 	[["mgVests", "vests"] call _fnc_fallback] call _fnc_setVest;
 	["uniforms"] call _fnc_setUniform;
-	[["MGbackpacks", "backpacks"] call _fnc_fallback] call _fnc_setBackpack;
+	["backpacks"] call _fnc_setBackpack;
 
 	["machineGuns"] call _fnc_setPrimary;
 	["primary", 6] call _fnc_addMagazines;

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_ARVN.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_ARVN.sqf
@@ -423,8 +423,8 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 ["vn_m16_xm148", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""],
 ["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ["vn_40mm_m576_buck_mag"], ""],
 ["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ["vn_40mm_m576_buck_mag"], ""],
-["vn_m1_garand", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m1a2_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_m19_wp_mag"], ""],
-["vn_m1_garand", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m1a2_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_lume_mag"], ""]
+["vn_m1_garand_gl", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m1a2_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_m19_wp_mag"], ""],
+["vn_m1_garand_gl", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m1a2_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_lume_mag"], ""]
 ]];
 _militiaLoadoutData set ["machineGuns", [
 ["vn_m60", "", "", "", [], [], ""]

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_MACV.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_MACV.sqf
@@ -2,8 +2,8 @@
 //   Side Information   //
 //////////////////////////
 
-["name", "US Army"] call _fnc_saveToTemplate;
-["spawnMarkerName", "US Army Support Corridor"] call _fnc_saveToTemplate;
+["name", "MACV"] call _fnc_saveToTemplate;
+["spawnMarkerName", "MACV Support Corridor"] call _fnc_saveToTemplate;
 
 ["flag", "vn_flag_usa"] call _fnc_saveToTemplate;
 ["flagTexture", "vn\objects_f_vietnam\flags\data\vn_flag_01_usa_co.paa"] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_MACV.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_MACV.sqf
@@ -426,8 +426,8 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 ["vn_m16_xm148", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""],
 ["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ["vn_40mm_m576_buck_mag"], ""],
 ["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ["vn_40mm_m576_buck_mag"], ""],
-["vn_m1_garand", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m1a2_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_m19_wp_mag"], ""],
-["vn_m1_garand", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m1a2_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_lume_mag"], ""]
+["vn_m1_garand_gl", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m1a2_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_m19_wp_mag"], ""],
+["vn_m1_garand_gl", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m1a2_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_lume_mag"], ""]
 ]];
 _militiaLoadoutData set ["machineGuns", [
 ["vn_m60", "", "", "", [], [], ""]
@@ -498,8 +498,6 @@ private _squadLeaderTemplate = {
 	["primary", 8] call _fnc_addMagazines;
 	["primary", 4] call _fnc_addAdditionalMuzzleMagazines;
 
-	["lightATLaunchers"] call _fnc_setLauncher;
-
 	[["slSidearms", "sidearms"] call _fnc_fallback] call _fnc_setHandgun;
 	["handgun", 4] call _fnc_addMagazines;
 	["handgun", 4] call _fnc_addAdditionalMuzzleMagazines;
@@ -522,8 +520,6 @@ private _riflemanTemplate = {
 	["helmets"] call _fnc_setHelmet;
 	["vests"] call _fnc_setVest;
 	["uniforms"] call _fnc_setUniform;
-
-	["lightATLaunchers"] call _fnc_setLauncher;
 
 	[selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_PAVN.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_PAVN.sqf
@@ -390,7 +390,7 @@ if (isClass (configFile >> "vnx_credits")) then {
     "vnx_c96"
     ];
     (_militaryLoadoutData get "sidearms") append [
-    "vnx_c96"
+    "vnx_c96", "vnx_p08"
     ];
     (_sfLoadoutData get "sidearms") append [
     "vnx_c96"
@@ -426,6 +426,17 @@ if (isClass (configFile >> "vnx_credits")) then {
     ];
     (_militaryLoadoutData get "sniperRifles") append [
     "vnx_no4_sniper"
+    ];
+    _militiaLoadoutData set ["machineGuns",[
+    ["vnx_tul1", "", "", "", [], ["vn_type56_t_mag", "vn_type56_mag", "vn_type56_mag"], ""]
+    ]];
+    (_militaryLoadoutData get "machineGuns") append [
+    ["vnx_tul1", "", "", "", [], ["vnx_rpk_40_t_mag", "vn_type56_t_mag", "vn_type56_mag"], ""],
+    ["vnx_tul1", "", "", "", [], ["vnx_rpk_75_mag", "vn_type56_vnx_rpk_40_mag", "vn_type56_mag"], ""]
+    ];
+    (_sfLoadoutData get "machineGuns") append [
+    ["vnx_tul1", "", "", "", [], ["vnx_rpk_75_t_mag", "vnx_rpk_75_mag", "vnx_rpk_40_t_mag"], ""],
+    ["vnx_tul1", "", "", "", [], ["vnx_rpk_75_mag", "vnx_rpk_75_t_mag", "vnx_rpk_40_mag"], ""]
     ];
 };
 

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_PAVN.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_PAVN.sqf
@@ -19,7 +19,7 @@
 
 // All fo bellow are optional overrides
 ["firstAidKits", ["vn_o_item_firstaidkit"]] call _fnc_saveToTemplate;
-["mediKits", ["vn_o_item_medikit_01"]] call _fnc_saveToTemplate;
+["mediKits", ["vn_b_item_medikit_01"]] call _fnc_saveToTemplate;
 
 ["placeIntel_desk", ["Land_vn_us_common_table_01",0]] call _fnc_saveToTemplate;
 ["placeIntel_itemMedium", ["Land_vn_file1_f",-25,false]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_USMC.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_USMC.sqf
@@ -243,7 +243,8 @@ _sfLoadoutData set ["rifles", [
 ["vn_m16_camo", "vn_s_m16", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], [], ""],
 ["vn_m16_camo", "vn_s_m16", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], [], ""],
 ["vn_m63a", "", "", "", ["vn_m63a_30_mag", "vn_m63a_30_mag", "vn_m63a_30_t_mag"], [], ""],
-["vn_type56", "", "vn_b_type56", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], [], ""]
+["vn_type56", "", "vn_b_type56", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], [], ""],
+["vn_m14a1_shorty", "", "", "", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], ""]
 ]];
 _sfLoadoutData set ["slRifles", [
 ["vn_m16_camo", "vn_s_m16", "", "vn_o_4x_m16", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], [], ""],
@@ -276,7 +277,8 @@ _sfLoadoutData set ["machineGuns", [
 ["vn_m60_shorty_camo", "", "", "", [], [], ""],
 ["vn_rpd", "", "", "", [], [], ""],
 ["vn_m63a_cdo", "", "", "", ["vn_m63a_150_mag", "vn_m63a_150_mag", "vn_m63a_150_t_mag"], [], ""],
-["vn_m63a_lmg", "", "", "", ["vn_m63a_100_mag", "vn_m63a_100_mag", "vn_m63a_100_t_mag"], [], ""]
+["vn_m63a_lmg", "", "", "", ["vn_m63a_100_mag", "vn_m63a_100_mag", "vn_m63a_100_t_mag"], [], ""],
+["vn_m14a1", "", "", "", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], "vn_bipod_m14"]
 ]];
 _sfLoadoutData set ["marksmanRifles", [
 ["vn_m16_camo", "vn_s_m16", "", "vn_o_9x_m16", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], [], ""],
@@ -312,14 +314,16 @@ _militaryLoadoutData set ["binoculars", ["vn_anpvs2_binoc"]];
 
 _militaryLoadoutData set ["rifles", [
 ["vn_m16", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
-["vn_m16", "", "vn_b_m16", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""]
+["vn_m16", "", "vn_b_m16", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
+["vn_m14", "", "vn_b_m14", "", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], ""],
+["vn_m14_camo", "", "vn_b_m14", "", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], ""]
 ]];
 _militaryLoadoutData set ["slRifles", [
 ["vn_m16", "", "", "vn_o_4x_m16", ["vn_m16_30_mag", "vn_m16_30_mag", "vn_m16_30_t_mag"], [], ""],
 ["vn_xm177", "", "", "vn_o_4x_m16", ["vn_m16_30_mag", "vn_m16_30_mag", "vn_m16_30_t_mag"], [], ""],
-["vn_m16", "", "", "", ["vn_m16_30_mag", "vn_m16_30_mag", "vn_m16_30_t_mag"], [], ""],
 ["vn_xm177", "", "", "", ["vn_m16_30_mag", "vn_m16_30_mag", "vn_m16_30_t_mag"], [], ""],
-["vn_m63a", "", "", "", ["vn_m63a_30_mag", "vn_m63a_30_mag", "vn_m63a_30_t_mag"], [], ""]
+["vn_m63a", "", "", "", ["vn_m63a_30_mag", "vn_m63a_30_mag", "vn_m63a_30_t_mag"], [], ""],
+["vn_m14a1_shorty", "", "", "vn_o_m14_front", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], ""]
 ]];
 _militaryLoadoutData set ["slSidearms", [
 "vn_mx991_m1911",
@@ -346,13 +350,15 @@ _militaryLoadoutData set ["SMGs", [
 ["vn_m3a1", "", "", "", ["vn_m3a1_mag", "vn_m3a1_mag", "vn_m3a1_t_mag"], [], ""]
 ]];
 _militaryLoadoutData set ["machineGuns", [
-["vn_m60", "", "", "", [], [], ""]
+["vn_m60", "", "", "", [], [], ""],
+["vn_m60", "", "", "", [], [], ""],
+["vn_m14a1", "", "", "", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], "vn_bipod_m14"]
 ]];
 _militaryLoadoutData set ["marksmanRifles", [
 ["vn_m16", "", "", "vn_o_9x_m16", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
 ["vn_m16", "", "", "vn_o_4x_m16", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
 ["vn_m14_camo", "", "", "vn_o_9x_m14", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], "vn_b_camo_m14"],
-["vn_m14_camo", "", "", "vn_o_9x_m14", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], "vn_b_camo_m14"]
+["vn_m14", "", "", "vn_o_9x_m14", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], "vn_bipod_m14"]
 ]];
 _militaryLoadoutData set ["sniperRifles", [
 ["vn_m40a1_camo", "", "", "vn_o_9x_m40a1", ["vn_m40a1_mag", "vn_m40a1_mag", "vn_m40a1_t_mag"], [], "vn_b_camo_m40a1"],

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_USMC.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_USMC.sqf
@@ -2,11 +2,11 @@
 //   Side Information   //
 //////////////////////////
 
-["name", "US Army"] call _fnc_saveToTemplate;
-["spawnMarkerName", "US Army Support Corridor"] call _fnc_saveToTemplate;
+["name", "USMC"] call _fnc_saveToTemplate;
+["spawnMarkerName", "USMC Support Corridor"] call _fnc_saveToTemplate;
 
 ["flag", "vn_flag_usa"] call _fnc_saveToTemplate;
-["flagTexture", "vn\objects_f_vietnam\flags\data\vn_flag_01_usa_co.paa"] call _fnc_saveToTemplate;
+["flagTexture", "vn\objects_f_vietnam\flags\data\vn_flag_01_usmc_co.paa"] call _fnc_saveToTemplate;
 ["flagMarkerType", "vn_flag_usa"] call _fnc_saveToTemplate;
 
 //////////////////////////
@@ -29,36 +29,36 @@
 //       Vehicles       //
 //////////////////////////
 
-["vehiclesBasic", ["vn_b_wheeled_m151_01"]] call _fnc_saveToTemplate;
-["vehiclesLightUnarmed", ["vn_b_wheeled_m151_01", "vn_b_wheeled_m151_02", "vn_b_wheeled_m274_01_01"]] call _fnc_saveToTemplate;
+["vehiclesBasic", ["vn_b_wheeled_m151_01_usmc"]] call _fnc_saveToTemplate;
+["vehiclesLightUnarmed", ["vn_b_wheeled_m151_01_usmc", "vn_b_wheeled_m151_02_usmc", "vn_b_wheeled_m274_01_02"]] call _fnc_saveToTemplate;
 private _vehiclesLightArmed = ["vn_b_wheeled_m151_mg_02", "vn_b_wheeled_m151_mg_03", "vn_b_wheeled_m151_mg_04", "vn_b_wheeled_m151_mg_05", "vn_b_wheeled_m54_mg_02", "vn_b_wheeled_m274_mg_01_01"];
 
 ["vehiclesTrucks", ["vn_b_wheeled_m54_01", "vn_b_wheeled_m54_02"]] call _fnc_saveToTemplate;
 ["vehiclesCargoTrucks", []] call _fnc_saveToTemplate;
 ["vehiclesAmmoTrucks", ["vn_b_wheeled_m54_ammo"]] call _fnc_saveToTemplate;
-["vehiclesRepairTrucks", ["vn_b_wheeled_m54_repair"]] call _fnc_saveToTemplate;
+private _vehiclesRepairTrucks = ["vn_b_wheeled_m54_repair"];
 ["vehiclesFuelTrucks", ["vn_b_wheeled_m54_fuel"]] call _fnc_saveToTemplate;
 ["vehiclesMedical", ["vn_b_armor_m577_02"]] call _fnc_saveToTemplate;
-["vehiclesLightAPCs", ["vn_b_wheeled_m54_mg_03", "vn_b_wheeled_m54_mg_01", "vn_b_armor_m113_01"]] call _fnc_saveToTemplate;
-["vehiclesAPCs", ["vn_b_armor_m113_acav_04", "vn_b_armor_m113_acav_02", "vn_b_armor_m113_acav_01", "vn_b_armor_m113_acav_06", "vn_b_armor_m113_acav_03", "vn_b_armor_m113_acav_05"]] call _fnc_saveToTemplate;
-["vehiclesIFVs", ["vn_b_armor_m67_01_01"]] call _fnc_saveToTemplate;
-["vehiclesLightTanks", ["vn_b_armor_m41_01_01"]] call _fnc_saveToTemplate;
-["vehiclesTanks", ["vn_b_armor_m48_01_01"]] call _fnc_saveToTemplate;
+private _vehiclesLightAPCs = ["vn_b_wheeled_m54_mg_03", "vn_b_wheeled_m54_mg_01"];
+private _vehiclesAPCs = ["vn_b_armor_m113_acav_01", "vn_b_armor_m113_acav_03", "vn_b_armor_m113_acav_06"];
+["vehiclesIFVs", ["vn_b_armor_m67_01_02"]] call _fnc_saveToTemplate;
+["vehiclesLightTanks", ["vn_b_armor_m41_01_02"]] call _fnc_saveToTemplate;
+["vehiclesTanks", ["vn_b_armor_m48_01_02"]] call _fnc_saveToTemplate;
 private _vehiclesAA = ["vn_b_wheeled_m54_mg_02"];
 
 ["vehiclesTransportBoats", ["vn_o_boat_02_01", "vn_b_boat_10_01", "vn_b_boat_09_01"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["vn_b_boat_13_02", "vn_b_boat_06_02", "vn_b_boat_05_02", "vn_b_boat_12_02"]] call _fnc_saveToTemplate;
-["vehiclesAmphibious", ["vn_b_armor_m113_01", "vn_b_armor_m113_acav_04", "vn_b_armor_m113_acav_02", "vn_b_armor_m113_acav_01", "vn_b_armor_m113_acav_06", "vn_b_armor_m113_acav_03", "vn_b_armor_m113_acav_05"]] call _fnc_saveToTemplate;
+private _vehiclesAmphibious = ["vn_b_armor_m113_acav_01", "vn_b_armor_m113_acav_03", "vn_b_armor_m113_acav_06"];
 
-private _vehiclesPlanesCAS = ["vn_b_air_f4c_at", "vn_b_air_f100d_at", "vn_b_air_f100d_at", "vn_b_air_f100d_at"];
-["vehiclesPlanesAA", ["vn_b_air_f4c_cap", "vn_b_air_f100d_cap"]] call _fnc_saveToTemplate;
+private _vehiclesPlanesCAS = ["vn_b_air_f4c_at"];
+["vehiclesPlanesAA", ["vn_b_air_f4c_cap"]] call _fnc_saveToTemplate;
 private _vehiclesPlanesTransport = [];
-private _vehiclesAirPatrol = ["vn_b_air_oh6a_07", "vn_b_air_uh1d_02_01"];
+private _vehiclesAirPatrol = ["vn_b_air_uh1c_07_05", "vn_b_air_uh1b_01_04"];
 
-["vehiclesHelisLight", ["vn_b_air_uh1c_07_01"]] call _fnc_saveToTemplate; // this is a uh-1b
-["vehiclesHelisTransport", ["vn_b_air_ch47_04_01", "vn_b_air_ch47_04_01", "vn_b_air_ch47_01_02", "vn_b_air_uh1d_02_01", "vn_b_air_uh1d_02_01", "vn_b_air_uh1d_02_01", "vn_b_air_uh1d_02_01", "vn_b_air_uh1d_02_01", "vn_b_air_uh1d_02_01", "vn_b_air_uh1d_02_01", "vn_b_air_uh1d_02_01", "vn_b_air_uh1c_07_01", "vn_b_air_uh1c_07_01"]] call _fnc_saveToTemplate;
-["vehiclesHelisLightAttack", ["vn_b_air_oh6a_06", "vn_b_air_ach47_04_01", "vn_b_air_uh1c_01_01", "vn_b_air_uh1c_01_01", "vn_b_air_uh1c_01_01", "vn_b_air_uh1c_02_01", "vn_b_air_uh1c_02_01"]] call _fnc_saveToTemplate;
-["vehiclesHelisAttack", ["vn_b_air_ach47_04_01", "vn_b_air_ach47_03_01", "vn_b_air_ah1g_01", "vn_b_air_ah1g_01", "vn_b_air_ah1g_01", "vn_b_air_ah1g_03", "vn_b_air_ah1g_03"]] call _fnc_saveToTemplate;
+["vehiclesHelisLight", ["vn_b_air_uh1c_07_05"]] call _fnc_saveToTemplate;
+["vehiclesHelisTransport", ["vn_b_air_ch34_01_01", "vn_b_air_ch34_03_01", "vn_b_air_uh1d_02_04", "vn_b_air_uh1d_02_04", "vn_b_air_uh1e_03_04"]] call _fnc_saveToTemplate;
+["vehiclesHelisLightAttack", ["vn_b_air_ch34_04_01", "vn_b_air_ch34_04_02", "vn_b_air_uh1b_02_05", "vn_b_air_uh1e_01_04", "vn_b_air_uh1e_02_04"]] call _fnc_saveToTemplate;
+["vehiclesHelisAttack", ["vn_b_air_ah1g_01_usmc", "vn_b_air_ah1g_03_usmc"]] call _fnc_saveToTemplate;
 
 ["vehiclesArtillery", ["vn_b_army_static_m101_02"]] call _fnc_saveToTemplate;
 ["magazines", createHashMapFromArray [
@@ -75,9 +75,9 @@ private _vehiclesAirPatrol = ["vn_b_air_oh6a_07", "vn_b_air_uh1d_02_01"];
 
 ["vehiclesPolice", ["vn_b_wheeled_m151_02_mp"]] call _fnc_saveToTemplate;
 
-["staticMGs", ["vn_b_army_static_m60_high", "vn_b_army_static_m1919a4_high", "vn_b_army_static_m2_high"]] call _fnc_saveToTemplate;
-["staticAT", ["vn_b_army_static_m40a1rr", "vn_b_army_static_tow"]] call _fnc_saveToTemplate;
-["staticAA", ["vn_b_army_static_m45"]] call _fnc_saveToTemplate;
+["staticMGs", ["vn_b_army_static_m60_high", "vn_b_army_static_m2_high"]] call _fnc_saveToTemplate;
+["staticAT", ["vn_b_army_static_m40a1rr"]] call _fnc_saveToTemplate;
+["staticAA", ["vn_b_navy_static_l70mk2", "vn_b_navy_static_l60mk3"]] call _fnc_saveToTemplate;
 ["staticMortars", ["a3a_vn_b_static_mortar_m2"]] call _fnc_saveToTemplate;
 
 ["mortarMagazineHE", "vn_mortar_m2_mag_he_x8"] call _fnc_saveToTemplate;
@@ -85,18 +85,26 @@ private _vehiclesAirPatrol = ["vn_b_air_oh6a_07", "vn_b_air_uh1d_02_01"];
 ["mortarMagazineFlare", "vn_mortar_m2_mag_lume_x8"] call _fnc_saveToTemplate;
 
 if (isClass (configFile >> "vnx_credits")) then {
-	_vehiclesLightArmed append ["vn_b_wheeled_m151_mg_02", "vn_b_wheeled_m151_mg_03", "vn_b_wheeled_m151_mg_04", "vn_b_wheeled_m151_mg_05", "vnx_b_armor_m50_01", "vnx_b_armor_m50a1_01"];
+    _vehiclesRepairTrucks append ["vnx_b_armor_lvtr1_01_usmc", "vnx_b_armor_lvtr1_01_usmc"];
+	_vehiclesLightArmed append ["vn_b_wheeled_m151_mg_02", "vn_b_wheeled_m151_mg_03", "vn_b_wheeled_m151_mg_04", "vn_b_wheeled_m151_mg_05", "vnx_b_armor_m50_01_usmc", "vnx_b_armor_m50a1_01_usmc"];
+    _vehiclesLightAPCs append ["vnx_b_armor_lvtp5c_01_usmc", "vnx_b_armor_lvtp5c_01_usmc"];
+	_vehiclesAPCs append ["vnx_b_armor_lvtp5_01", "vnx_b_armor_lvtp5_01", "vnx_b_armor_lvtp5_01", "vnx_b_armor_lvtp5_01", "vnx_b_armor_lvtp5_01", "vnx_b_armor_lvtp5c_01_usmc", "vnx_b_armor_lvtp5c_01_usmc"];
 	_vehiclesAA append ["vnx_b_armor_m163_01"];
-	_vehiclesAirPatrol append ["vn_b_air_oh6a_07", "vn_b_air_uh1d_02_01", "vnx_b_air_ov10a_covey", "vnx_b_air_hh1h_01_01", "vnx_b_air_hh1h_02_01"];
-	_vehiclesPlanesCAS append ["vnx_b_air_ov10a_mr"];
+    _vehiclesAmphibious append ["vnx_b_armor_lvtp5_01", "vnx_b_armor_lvtp5_01", "vnx_b_armor_lvtp5_01", "vnx_b_armor_lvtp5_01", "vnx_b_armor_lvtp5_01"];
+	_vehiclesPlanesCAS append ["vnx_b_air_a4e_usmc_cas", "vnx_b_air_a4e_usmc_cas", "vnx_b_air_a4e_usmc_cas", "vnx_b_air_ov10a_mr"];
 	_vehiclesPlanesTransport append ["vnx_b_air_ac119_02_01"];
+	_vehiclesAirPatrol append ["vnx_b_air_ov10a_covey"];
 };
 
 ["vehiclesLightArmed", _vehiclesLightArmed] call _fnc_saveToTemplate;
+["vehiclesRepairTrucks", _vehiclesRepairTrucks] call _fnc_saveToTemplate;
+["vehiclesAPCs", _vehiclesAPCs] call _fnc_saveToTemplate;
 ["vehiclesAA", _vehiclesAA] call _fnc_saveToTemplate;
+["vehiclesAmphibious", _vehiclesAmphibious] call _fnc_saveToTemplate;
 ["vehiclesAirPatrol", _vehiclesAirPatrol] call _fnc_saveToTemplate;
 ["vehiclesPlanesCAS", _vehiclesPlanesCAS] call _fnc_saveToTemplate;
 ["vehiclesPlanesTransport", _vehiclesPlanesTransport] call _fnc_saveToTemplate;
+["vehiclesLightAPCs", _vehiclesLightAPCs] call _fnc_saveToTemplate;
 
 //Minefield definition
 //CFGVehicles variant of Mines are needed "ATMine", "APERSTripMine", "APERSMine"
@@ -219,18 +227,16 @@ _loadoutData set ["items_unarmed_extras", []];
 ///////////////////////////////////////
 
 private _sfLoadoutData = _loadoutData call _fnc_copyLoadoutData;
-_sfLoadoutData set ["uniforms", ["vn_b_uniform_sog_02_02", "vn_b_uniform_sog_02_05", "vn_b_uniform_macv_06_02", "vn_b_uniform_macv_04_02"]];
-_sfLoadoutData set ["vests", ["vn_b_vest_sog_04"]];
-_sfLoadoutData set ["medVests", ["vn_b_vest_sog_02"]];
-_sfLoadoutData set ["engVests", ["vn_b_vest_sog_03"]];
-_sfLoadoutData set ["mgVests", ["vn_b_vest_sog_05"]];
-_sfLoadoutData set ["slVests", ["vn_b_vest_sog_06"]];
+_sfLoadoutData set ["uniforms", ["vn_b_uniform_macv_02_15","vn_b_uniform_macv_04_15","vn_b_uniform_macv_03_15","vn_b_uniform_macv_06_15","vn_b_uniform_macv_05_15"]];
+_sfLoadoutData set ["vests", ["vn_b_vest_usmc_07"]];
+_sfLoadoutData set ["glVests", ["vn_b_vest_usmc_09"]];
+_sfLoadoutData set ["mgVests", ["vn_b_vest_usmc_08"]];
 _sfLoadoutData set ["backpacks", ["vn_b_pack_trp_02", "vn_b_pack_lw_03"]];
 _sfLoadoutData set ["slBackpacks", ["vn_b_pack_trp_04", "vn_b_pack_trp_04_02", "vn_b_pack_prc77_01", "vn_b_pack_lw_06"]];
 _sfLoadoutData set ["MGbackpacks", ["vn_b_pack_trp_01", "vn_b_pack_trp_01_02"]];
 _sfLoadoutData set ["medBackpacks", ["vn_b_pack_lw_07", "vn_b_pack_m5_01"]];
 _sfLoadoutData set ["engBackpacks", ["vn_b_pack_lw_04", "vn_b_pack_trp_03_02"]];
-_sfLoadoutData set ["helmets", ["vn_b_boonie_02_02", "vn_b_boonie_02_01", "vn_b_beret_01_01", "vn_b_beret_01_06", "vn_b_bandana_02"]];
+_sfLoadoutData set ["helmets", ["vn_b_boonie_02_01","vn_b_boonie_05_08","vn_b_boonie_04_08","vn_b_boonie_03_08","vn_b_headband_01","vn_b_boonie_02_08","vn_b_boonie_01_01","vn_b_boonie_04_01"]];
 _sfLoadoutData set ["binoculars", ["vn_anpvs2_binoc"]];
 
 _sfLoadoutData set ["rifles", [
@@ -293,22 +299,15 @@ _sfLoadoutData set ["sidearms", [
 /////////////////////////////////
 
 private _militaryLoadoutData = _loadoutData call _fnc_copyLoadoutData;
-_militaryLoadoutData set ["uniforms", ["vn_b_uniform_macv_02_01", "vn_b_uniform_macv_02_07", "vn_b_uniform_macv_01_01", "vn_b_uniform_macv_06_01", "vn_b_uniform_macv_04_01"]];
-_militaryLoadoutData set ["vests", ["vn_b_vest_usarmy_02", "vn_b_vest_usarmy_03"]];
-_militaryLoadoutData set ["glVests", ["vn_b_vest_usarmy_05"]];
-_militaryLoadoutData set ["sniVests", ["vn_b_vest_usarmy_08"]];
-_militaryLoadoutData set ["medVests", ["vn_o_vest_06", "vn_b_vest_usarmy_12"]];
-_militaryLoadoutData set ["engVests", ["vn_b_vest_usarmy_12", "vn_b_vest_usarmy_11"]];
-_militaryLoadoutData set ["mgVests", ["vn_b_vest_usarmy_06"]];
-_militaryLoadoutData set ["slVests", ["vn_b_vest_usarmy_09", "vn_b_vest_usarmy_11"]];
-_militaryLoadoutData set ["backpacks", ["vn_b_pack_lw_01", "vn_b_pack_lw_03"]];
-_militaryLoadoutData set ["slBackpacks", ["vn_b_pack_trp_04_02", "vn_b_pack_prc77_01", "vn_b_pack_lw_06"]];
-_militaryLoadoutData set ["MGbackpacks", ["vn_b_pack_lw_02", "vn_b_pack_lw_05", "vn_b_pack_trp_01_02"]];
-_militaryLoadoutData set ["medBackpacks", ["vn_b_pack_lw_07", "vn_b_pack_m5_01"]];
-_militaryLoadoutData set ["engBackpacks", ["vn_b_pack_lw_04", "vn_b_pack_trp_03_02"]];
-_militaryLoadoutData set ["helmets", ["vn_b_helmet_m1_02_01", "vn_b_helmet_m1_03_01", "vn_b_helmet_m1_05_01", "vn_b_helmet_m1_06_01", "vn_b_helmet_m1_07_01"]];
-_militaryLoadoutData set ["GLhelmets", ["vn_b_helmet_m1_04_02"]];
-_militaryLoadoutData set ["MGhelmets", ["vn_b_helmet_m1_08_01"]];
+_militaryLoadoutData set ["uniforms", ["vn_b_uniform_macv_02_15","vn_b_uniform_macv_03_15","vn_b_uniform_macv_04_15","vn_b_uniform_macv_05_15","vn_b_uniform_macv_06_15"]];
+_militaryLoadoutData set ["vests", ["vn_b_vest_usmc_01","vn_b_vest_usmc_02"]];
+_militaryLoadoutData set ["glVests", ["vn_b_vest_usmc_04"]];
+_militaryLoadoutData set ["medVests", ["vn_b_vest_usmc_05"]];
+_militaryLoadoutData set ["mgVests", ["vn_b_vest_usmc_03"]];
+_militaryLoadoutData set ["slVests", ["vn_b_vest_usmc_06"]];
+_militaryLoadoutData set ["backpacks", ["vn_b_pack_m41_01","vn_b_pack_m41_02","vn_b_pack_m41_03","vn_b_pack_m41_04"]];
+_militaryLoadoutData set ["slBackpacks", ["vn_b_pack_m41_05"]];
+_militaryLoadoutData set ["helmets", ["vn_b_helmet_m1_02_01", "vn_b_helmet_m1_02_01", "vn_b_helmet_m1_14_01", "vn_b_helmet_m1_14_01", "vn_b_bandana_04"]];
 _militaryLoadoutData set ["binoculars", ["vn_anpvs2_binoc"]];
 
 _militaryLoadoutData set ["rifles", [
@@ -390,19 +389,15 @@ _policeLoadoutData set ["sidearms", [
 ////////////////////////////////
 
 private _militiaLoadoutData = _loadoutData call _fnc_copyLoadoutData;
-_militiaLoadoutData set ["uniforms", ["vn_b_uniform_macv_02_01", "vn_b_uniform_macv_02_07", "vn_b_uniform_macv_01_01"]];
-_militiaLoadoutData set ["vests", ["vn_b_vest_usarmy_02", "vn_b_vest_usarmy_03"]];
-_militiaLoadoutData set ["glVests", ["vn_b_vest_usarmy_05"]];
-_militiaLoadoutData set ["sniVests", ["vn_b_vest_usarmy_08"]];
-_militiaLoadoutData set ["medVests", ["vn_o_vest_06"]];
-_militiaLoadoutData set ["mgVests", ["vn_b_vest_usarmy_06"]];
-_militiaLoadoutData set ["slVests", ["vn_b_vest_usarmy_09"]];
-_militiaLoadoutData set ["backpacks", ["vn_b_pack_lw_01", "vn_b_pack_lw_03"]];
-_militiaLoadoutData set ["slBackpacks", ["vn_b_pack_trp_04_02", "vn_b_pack_prc77_01", "vn_b_pack_lw_06"]];
-_militiaLoadoutData set ["MGbackpacks", ["vn_b_pack_lw_02", "vn_b_pack_lw_05", "vn_b_pack_trp_01_02"]];
-_militiaLoadoutData set ["medBackpacks", ["vn_b_pack_lw_07", "vn_b_pack_m5_01"]];
-_militiaLoadoutData set ["engBackpacks", ["vn_b_pack_lw_04", "vn_b_pack_trp_03_02"]];
-_militiaLoadoutData set ["helmets", ["vn_b_helmet_m1_01_01", "vn_b_bandana_04", "vn_b_headband_02", "vn_b_helmet_m1_01_01", "vn_b_bandana_06"]];
+_militiaLoadoutData set ["uniforms", ["vn_b_uniform_macv_02_01","vn_b_uniform_macv_05_01","vn_b_uniform_macv_04_01","vn_b_uniform_macv_06_01","vn_b_uniform_macv_03_01"]];
+_militiaLoadoutData set ["vests", ["vn_b_vest_usmc_01","vn_b_vest_usmc_02"]];
+_militiaLoadoutData set ["glVests", ["vn_b_vest_usmc_04"]];
+_militiaLoadoutData set ["medVests", ["vn_b_vest_usmc_05"]];
+_militiaLoadoutData set ["mgVests", ["vn_b_vest_usmc_03"]];
+_militiaLoadoutData set ["slVests", ["vn_b_vest_usmc_06"]];
+_militiaLoadoutData set ["backpacks", ["vn_b_pack_m41_01"]]; // "vn_b_pack_m41_02","vn_b_pack_m41_03","vn_b_pack_m41_04"
+_militiaLoadoutData set ["slBackpacks", ["vn_b_pack_m41_05"]];
+_militiaLoadoutData set ["helmets", ["vn_b_helmet_m1_02_01", "vn_b_bandana_04", "vn_b_headband_02", "vn_b_helmet_m1_14_01", "vn_b_bandana_06"]];
 _militiaLoadoutData set ["binoculars", ["vn_mk21_binocs"]];
 
 _militiaLoadoutData set ["rifles", [
@@ -422,7 +417,6 @@ _militiaLoadoutData set ["carbines", [
 ["vn_m2carbine", "", "", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""]
 ]];
 _militiaLoadoutData set ["grenadeLaunchers", [
-["vn_m16_xm148", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ""],
 ["vn_m16_xm148", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""],
 ["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ["vn_40mm_m576_buck_mag"], ""],
 ["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ["vn_40mm_m576_buck_mag"], ""],
@@ -441,8 +435,7 @@ _militiaLoadoutData set ["sniperRifles", [
 ["vn_m40a1_camo", "", "", "vn_o_9x_m40a1", ["vn_m40a1_mag", "vn_m40a1_mag", "vn_m40a1_t_mag"], [], ""]
 ]];
 _militiaLoadoutData set ["sidearms", [
-"vn_m1911",
-"vn_p38s"
+"vn_m1911"
 ]];
 
 //////////////////////////
@@ -465,10 +458,14 @@ if (isClass (configFile >> "vnx_credits")) then {
 	["vnx_m77e_shorty", "", "", "", ["vnx_m77e_fl_mag","vnx_m77e_buck_mag"], [], ""]
 	];
 	(_militaryLoadoutData get "SMGs") append [
-	["vn_m3a1", "", "", "", ["vn_m3a1_mag", "vn_m3a1_mag", "vn_m3a1_t_mag"], [], ""],
-	["vn_m3a1", "", "", "", ["vn_m3a1_mag", "vn_m3a1_mag", "vn_m3a1_t_mag"], [], ""],
+	["vnx_m50_smg", "", "", "", ["vnx_m50_smg_t_mag", "vnx_m50_smg_mag"], [], ""],
+	["vnx_m50_smg", "", "", "", ["vnx_m50_smg_t_mag", "vnx_m50_smg_mag"], [], ""],
+	["vnx_m12_smg", "", "", "", ["vnx_m12_smg_32_t_mag", "vnx_m12_smg_32_mag", "vnx_m12_smg_20_mag"], [], ""],
 	["vnx_m45_sf", "", "", "", ["vn_m45_t_mag", "vn_m45_mag"], [], ""]
 	];
+	_militiaLoadoutData set ["SMGs", [
+	["vnx_m50_smg", "", "", "", ["vnx_m50_smg_t_mag", "vnx_m50_smg_mag"], [], ""]
+	]];
 	(_sfLoadoutData get "slRifles") append [
 	["vnx_type56_xm148", "", "", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""]
 	];

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_USMC.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_USMC.sqf
@@ -358,7 +358,7 @@ _militaryLoadoutData set ["marksmanRifles", [
 ["vn_m16", "", "", "vn_o_9x_m16", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
 ["vn_m16", "", "", "vn_o_4x_m16", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
 ["vn_m14_camo", "", "", "vn_o_9x_m14", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], "vn_b_camo_m14"],
-["vn_m14", "", "", "vn_o_9x_m14", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], "vn_bipod_m14"]
+["vn_m14", "", "", "vn_o_9x_m14", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], ""]
 ]];
 _militaryLoadoutData set ["sniperRifles", [
 ["vn_m40a1_camo", "", "", "vn_o_9x_m40a1", ["vn_m40a1_mag", "vn_m40a1_mag", "vn_m40a1_t_mag"], [], "vn_b_camo_m40a1"],
@@ -426,8 +426,8 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 ["vn_m16_xm148", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""],
 ["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ["vn_40mm_m576_buck_mag"], ""],
 ["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ["vn_40mm_m576_buck_mag"], ""],
-["vn_m1_garand", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m1a2_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_m19_wp_mag"], ""],
-["vn_m1_garand", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m1a2_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_lume_mag"], ""]
+["vn_m1_garand_gl", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m1a2_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_m19_wp_mag"], ""],
+["vn_m1_garand_gl", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m1a2_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_lume_mag"], ""]
 ]];
 _militiaLoadoutData set ["machineGuns", [
 ["vn_m60", "", "", "", [], [], ""]
@@ -501,8 +501,6 @@ private _squadLeaderTemplate = {
 	["primary", 8] call _fnc_addMagazines;
 	["primary", 4] call _fnc_addAdditionalMuzzleMagazines;
 
-	["lightATLaunchers"] call _fnc_setLauncher;
-
 	[["slSidearms", "sidearms"] call _fnc_fallback] call _fnc_setHandgun;
 	["handgun", 4] call _fnc_addMagazines;
 	["handgun", 4] call _fnc_addAdditionalMuzzleMagazines;
@@ -525,8 +523,6 @@ private _riflemanTemplate = {
 	["helmets"] call _fnc_setHelmet;
 	["vests"] call _fnc_setVest;
 	["uniforms"] call _fnc_setUniform;
-
-	["lightATLaunchers"] call _fnc_setLauncher;
 
 	[selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;

--- a/A3A/addons/core/Templates/Templates/VN/VN_CIV.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_CIV.sqf
@@ -4,7 +4,7 @@
 
 // All of bellow are optional overrides.
 ["firstAidKits", ["vn_o_item_firstaidkit"]] call _fnc_saveToTemplate;  // Relies on autodetection. However, item is tested for for help and reviving.
-["mediKits", ["vn_o_item_medikit_01"]] call _fnc_saveToTemplate;  // Relies on autodetection. However, item is tested for for help and reviving.
+["mediKits", ["vn_b_item_medikit_01"]] call _fnc_saveToTemplate;  // Relies on autodetection. However, item is tested for for help and reviving.
 
 //////////////////////////
 //       Vehicles       //

--- a/A3A/addons/core/Templates/Templates/VN/VN_Reb_POF.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_Reb_POF.sqf
@@ -14,7 +14,7 @@
 
 // All of bellow are optional overrides.
 ["firstAidKits", ["vn_b_item_firstaidkit", "vn_o_item_firstaidkit"]] call _fnc_saveToTemplate;  // Relies on autodetection. However, item is tested for for help and reviving.
-["mediKits", ["vn_b_item_medikit_01", "vn_o_item_medikit_01"]] call _fnc_saveToTemplate;  // Relies on autodetection. However, item is tested for for help and reviving.
+["mediKits", ["vn_b_item_medikit_01"]] call _fnc_saveToTemplate;  // Relies on autodetection. However, item is tested for for help and reviving.
 ["toolKits", ["vn_b_item_toolkit"]] call _fnc_saveToTemplate;  // Relies on autodetection.
 ["itemMaps", ["vn_b_item_map"]] call _fnc_saveToTemplate;  // Relies on autodetection.
 

--- a/A3A/addons/core/Templates/Templates/VN/VN_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_Vehicle_Attributes.sqf
@@ -16,10 +16,22 @@
     // These are probably not super effective
     ["vn_o_air_mig19_at", ["cost", 150]],
     ["vn_o_air_mig19_cap", ["cost", 200]],
-    ["vn_b_air_f100d_at", ["cost", 150]],
+    ["vn_b_air_f100d_at", ["cost", 210]],
     ["vn_b_air_f100d_cap", ["cost", 200]],
     
     // PT76 with slightly better armor and gunner
-    ["vn_o_armor_type63_01", ["cost", 180]]
+    ["vn_o_armor_type63_01", ["cost", 180]],
+
+    // skyhawks, worse across the board than either of the real planes + restricted to aim9ds
+    ["vnx_b_air_a4e_usmc_cas", ["cost", 180]],
+    ["vnx_b_air_a4e_ran_cas", ["cost", 180]],
+    ["vnx_b_air_a4e_rnzaf_cas", ["cost", 180]],
+    ["vnx_b_air_a4e_ran_cap", ["cost", 200]],
+    ["vnx_b_air_a4e_rnzaf_cap", ["cost", 200]],
+
+    // silly COIN plane with MMG main guns, no guided munitions
+    ["vnx_b_air_ov10a_mr", ["cost", 140]],
+    ["vnx_b_air_ov10a_usmc_mr", ["cost", 140]],
+    ["vnx_b_air_ov10a_aus_covey", ["cost", 140]]
 
 ]] call _fnc_saveToTemplate;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
A bit of a rework to the SOG factions available in the mod.

- Aircraft loadouts:
  - Updated CAS planes to use real A2G missiles instead of the Shrike they were equipped with for whatever reason
  - Added additional OV-10 variants to aircraft loadouts
  - Gave the NS Skyhawks loadouts
- New faction ANZAC:
  - Coalition between Australia and New Zealand during Vietnam
  - Militia are New Zealand forces, military is Australian, SF is a mix of both country's SAS
- ARVN:
  - Scrapped for now, partially complete, packaging in case someone sees and wants to finish it later. See comment at top of file
- MACV updates
  - Added ambulance APC
  - Added amphibious vehicles
  - Added Loach to air patrol category
  - Rework to helicopter categorization
  - Tiny loadout changes after some of my research turned out to be inaccurate
- New faction USMC:
  - Pretty similar to MACV across the board, most striking differences are visible only with NS loaded
- Resource values updated for new planes and CAS f100
    
### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes: Definitely needs some test server game time, but the changes from the MACV faction arent massive and both templates validate fine.
