### PR TITLE
More static places for Livonia/Stubbhult military buildings

### DIFF
--- a/A3A/addons/core/functions/init/fn_initSpawnPlaces.sqf
+++ b/A3A/addons/core/functions/init/fn_initSpawnPlaces.sqf
@@ -117,6 +117,8 @@ private _vehicleSpawns = [];
     };
 } forEach _vehicleMarker;
 
+reverse _vehicleSpawns;         // so that first spot is used for attack vehicles and last is used for parking
+
 private _heliSpawns = [];
 {
     private _pos = getPosATL _x;

--- a/A3A/addons/core/functions/init/fn_initStaticPlaces.sqf
+++ b/A3A/addons/core/functions/init/fn_initStaticPlaces.sqf
@@ -25,11 +25,11 @@ _veh setDir (180 + getDir _building);
 
 // Data collection. Place statics on building, then run this while looking at building:
 _building = cursorObject;
-_statics = [];
+_statics = [[typeof _building]];
 {
 	_pos = _building worldToModel (getPosATL _x);
 	_dir = getDir _x - getDir _building;
-	_statics pushBack ["staticMG", _pos, _dir];
+	_statics pushBack ["MG", _pos, _dir];
 } forEach vehicles;
 _statics;
 */
@@ -60,6 +60,29 @@ private _buildingData = [
         ["MG", [-4.435,-4.998,4.973], -180]
     ],
 
+    // Livonia control/guard tower
+    [["Land_ControlTower_01_F"],
+        ["MG", [2.269,-1.918,1.769], 90],
+        ["MG",[-0.589,-2.299,1.769], 270],
+        ["MG",[0.627,-2.290,-1.331], 180]
+    ],
+
+    // Livonia control tower
+    [["Land_ControlTower_02_F"],
+        ["MG", [7.363,1.998,2.801], 45],
+        ["MG", [1.940,-2.295,2.799], -135]
+    ],
+
+    // Tall Livonia MG platform
+    [["Land_Sawmill_01_illuminati_tower_F"],
+        ["MG", [-0.213,-0.213,10.321], 180]
+    ],
+
+    // Livonia castle bastion
+    [["Land_CastleRuins_01_bastion_F"],
+        ["MG", [2.271,1.360,2.949], 90]
+    ],
+
     // Ground-level vanilla sandbag bunkers. Offset for some reason?
     [["Land_BagBunker_Small_F", "Land_BagBunker_01_small_green_F", "Land_vn_bagbunker_01_small_green_f", "Land_vn_bagbunker_small_f", "Land_vn_bunker_small_01"], 
         ["MG", [-0.998,-0.249,-0.946], 180]
@@ -75,9 +98,11 @@ private _buildingData = [
         ["MG", [-0.243,-0.100,-0.951], 180]
     ],
 
-    // Some sort of military building with open roof. Tanoa? VN not tested
+    // Some sort of military building with open roof. Common on Stubbhult. VN version not tested.
     [["Land_Radar_01_HQ_F", "Land_vn_radar_01_hq_f"],
-        ["AA", [-0.016,-0.031,3.841], 0]
+        ["AA", [-0.016,-0.031,3.841], 0],
+        ["MG", [-9.538,3.258,3.841], -45],
+        ["MG", [4.977,-10.323,3.841], 135]
     ],
 
     // Camouflaged wooden tower


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Added more MG places to suitable Livonia buildings (used heavily by Stubbhult) as they were very thin. As 3.10 restricts the number of statics placed according to the garrison population, there is no risk of spamming. Stubbhult's still a bit thin in places even with these, but that can be fixed by adding a few buildings.

Also reversed the vehicle places order, so that the first vehicle place is the one used by attack vehicles and the last is parked (or AA tank for airfields). Before 3.10, places were used in order, so attack vehicles would spawn in the first vehicle place(s) if the location wasn't spawned.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
