### PR TITLE
Fix garrisons spawning underwater if building is on pier

### DIFF
--- a/A3A/addons/patcom/functions/Patcom/fn_patrolGetBuildingPlaces.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolGetBuildingPlaces.sqf
@@ -9,7 +9,7 @@
         <Number> Maximum number of positions to return
 
     Return Value:
-        <Array> Array of [positionATL, dir] for building places
+        <Array> Array of [positionAGL, dir] for building places (AGL, ew)
 
     Scope: Any
     Environment: Any

--- a/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolGroupGarrison.sqf
@@ -39,7 +39,7 @@ _group lockWP true;         // hmm
     _x params ["_placePos", "_placeDir"];
 
     private _unit = _units deleteAt 0;
-    _unit setPosATL _placePos;
+    _unit setPosASL AGLtoASL _placePos;
     _unit setdir _placeDir;
     _unit setUnitPos "UP";
     _unit setVariable ["A3A_forcedStance", "UP"];


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
If garrison units were spawned in a building placed on a pier, they could spawn underwater due to an AGL/ATL mismatch.

Was not very easy to test. Arma seems to do a bit of surface-rounding so units need to be placed well underwater before it breaks. I did eventually hit the case in the Kavala seaport where it puts the guys in the lighthouse building. The seaport north of Paros is probably easier, as the piers there run well out to sea and all seem to have building positions on them. Should probably blacklist those.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
