### PR TITLE
Fix airstrike bombs being spawned above the aircraft when over water

### DIFF
--- a/A3A/addons/core/functions/AI/fn_airbomb.sqf
+++ b/A3A/addons/core/functions/AI/fn_airbomb.sqf
@@ -51,8 +51,8 @@ for "_i" from 1 to _bombCount do
     sleep _timeBetweenBombs;
     if (alive _plane) then
     {
-        private _bombPos = (getPosATL _plane) vectorAdd [0, 0, -5];
-        _bomb = _ammo createvehicle _bombPos;
+        private _bombPos = (ASLtoAGL getPosASL _plane) vectorAdd [0, 0, -5];
+        _bomb = _ammo createvehicle _bombPos;       // Uses AGL. Undocumented
         _bomb setDir (getDir _plane);
         _bomb setVelocity [0,0,-50];
         _bomb setShotParents [_plane, driver _plane];           // server exec, really?


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
If an airstrike plane was over water when it dropped its bombs, it would spawn them above the plane, and typically overshoot the target by some distance. This PR fixes the problem.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Float in the sea and call an airstrike on yourself.