### PR TITLE
Fix bank mission distance check for tall bank buildings

### DIFF
--- a/A3A/addons/core/functions/Missions/fn_LOG_Bank.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Bank.sqf
@@ -72,7 +72,7 @@ for "_i" from 1 to 4 do
 private _bb = flatten boundingBoxReal _banco apply { abs _x };
 private _bankDistMax = selectMin _bb + 10;
 
-waitUntil {sleep 1; (dateToNumber date > _dateLimitNum) or (!alive _truckX) or (_truckX distance _banco < _bankDistMax)};
+waitUntil {sleep 1; (dateToNumber date > _dateLimitNum) or (!alive _truckX) or (_truckX distance2d _banco < _bankDistMax)};
 _bonus = if (_difficultX) then {2} else {1};
 if ((dateToNumber date > _dateLimitNum) or (!alive _truckX)) then
 	{
@@ -94,9 +94,9 @@ else
 		};
 	} forEach ([distanceSPWN,0,_positionX,teamPlayer] call A3A_fnc_distanceUnits);
 	_exit = false;
-	while {(_countX > 0) or (_truckX distance _banco < _bankDistMax) and (alive _truckX) and (dateToNumber date < _dateLimitNum)} do
+	while {(_countX > 0) or (_truckX distance2d _banco < _bankDistMax) and (alive _truckX) and (dateToNumber date < _dateLimitNum)} do
 		{
-		while {(_countX > 0) and (_truckX distance _banco < _bankDistMax) and (alive _truckX)} do
+		while {(_countX > 0) and (_truckX distance2d _banco < _bankDistMax) and (alive _truckX)} do
 			{
 			_formatX = format ["%1", _countX];
 			{if (isPlayer _x) then {[petros,"countdown",_formatX] remoteExec ["A3A_fnc_commsMP",_x]}} forEach ([80,0,_truckX,teamPlayer] call A3A_fnc_distanceUnits);
@@ -106,8 +106,8 @@ else
 		if (_countX > 0) then
 			{
 			_countX = 120*_bonus;//120
-			if (_truckX distance _banco > _bankDistMax-1) then {{[petros,"hint",localize "STR_A3A_fn_mission_log_bank_hint_text2", localize "STR_A3A_fn_mission_log_bank_hint_title1"] remoteExec ["A3A_fnc_commsMP",_x]} forEach ([200,0,_truckX,teamPlayer] call A3A_fnc_distanceUnits)};
-			waitUntil {sleep 1; (!alive _truckX) or (_truckX distance _banco < _bankDistMax) or (dateToNumber date < _dateLimitNum)};
+			if (_truckX distance2d _banco > _bankDistMax-1) then {{[petros,"hint",localize "STR_A3A_fn_mission_log_bank_hint_text2", localize "STR_A3A_fn_mission_log_bank_hint_title1"] remoteExec ["A3A_fnc_commsMP",_x]} forEach ([200,0,_truckX,teamPlayer] call A3A_fnc_distanceUnits)};
+			waitUntil {sleep 1; (!alive _truckX) or (_truckX distance2d _banco < _bankDistMax) or (dateToNumber date < _dateLimitNum)};
 			}
 		else
 			{
@@ -116,7 +116,7 @@ else
 				{if (isPlayer _x) then {[petros,"hint",localize "STR_A3A_fn_mission_log_bank_hint_text3", localize "STR_A3A_fn_mission_log_bank_hint_title1"] remoteExec ["A3A_fnc_commsMP",_x]}} forEach ([80,0,_truckX,teamPlayer] call A3A_fnc_distanceUnits);
 				_exit = true;
 				};
-			//waitUntil {sleep 1; (!alive _truckX) or (_truckX distance _banco > _bankDistMax) or (dateToNumber date < _dateLimitNum)};
+			//waitUntil {sleep 1; (!alive _truckX) or (_truckX distance2d _banco > _bankDistMax) or (dateToNumber date < _dateLimitNum)};
 			};
 		if (_exit) exitWith {};
 		};


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Apparently when `distance` is used with an object as input, it uses the bounding center of the object, not the ATL/ASL/whatever position. This breaks the bank to truck distance checks if the bank building is especially tall. There are a couple of examples on Mehland apparently.

Easy enough to replace with distance2d.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
