### PR TITLE
Allow towns to be invader side at campaign start

### DIFF
--- a/A3A/addons/core/functions/init/fn_initBases.sqf
+++ b/A3A/addons/core/functions/init/fn_initBases.sqf
@@ -26,7 +26,6 @@ private _fnc_initMarkerList =
 
         // arguable whether this should be done here? could be delayed until game start
         sidesX setVariable [_x, [Occupants, Invaders] select _isInvader, true];
-        garrison setVariable [_x, [], true];
 		if (_useSideName) then {             // in this case it's an airport or outpost
 			killZones setVariable [_x, [], true];
 			server setVariable [_x, 0, true];           // TODO: check if these two need to be global
@@ -44,5 +43,15 @@ getArray (_mapInfoRoot/"A3A"/"mapInfo"/toLower worldName/"garrison") params ["",
 [_mrkCSAT, factories, "u_installation", localize "STR_A3A_fn_init_initBases_factory"] call _fnc_initMarkerList;
 [_mrkCSAT, outposts, "loc_bunker", localize "STR_A3A_fn_init_initBases_outpost", true] call _fnc_initMarkerList;
 [_mrkCSAT, seaports, "b_naval", localize "STR_A3A_fn_init_initBases_seaPort"] call _fnc_initMarkerList;
+
+// Cities can now start as invader, so move the city dummy marker init here
+{
+    private _isInvader = _x in _mrkCSAT;
+    sidesX setVariable [_x, [Occupants, Invaders] select _isInvader, true];
+   	private _mrkD = createMarkerLocal [format ["Dum%1", _x], markerPos _x];
+	_mrkD setMarkerShapeLocal "ICON";
+	_mrkD setMarkerTypeLocal "loc_Ruin";
+	_mrkD setMarkerColor ([colorOccupants, colorInvaders] select _isInvader);
+} forEach citiesX;
 
 Info("InitBases completed");

--- a/A3A/addons/core/functions/init/fn_initZones.sqf
+++ b/A3A/addons/core/functions/init/fn_initZones.sqf
@@ -35,9 +35,6 @@ sidesX setVariable ["Synd_HQ", teamPlayer, true];
 sidesX setVariable ["NATO_carrier", Occupants, true];
 sidesX setVariable ["CSAT_carrier", Invaders, true];
 
-// Set up dummy markers
-call A3A_fnc_initBases;
-
 
 Info("Setting up towns");
 
@@ -94,21 +91,13 @@ configClasses (configfile >> "CfgWorlds" >> worldName >> "Names") apply {
 
 	_mrk = createmarkerLocal [format ["%1", _nameX], _pos];
 	_mrk setMarkerSizeLocal [_size, _size];
-	_mrk setMarkerShapeLocal "RECTANGLE";
+	_mrk setMarkerShapeLocal "ELLIPSE";
 	_mrk setMarkerBrushLocal "SOLID";
-	_mrk setMarkerColorLocal colorOccupants;
 	_mrk setMarkerTextLocal _nameX;
 	_mrk setMarkerAlpha 0;
 	citiesX pushBack _nameX;
 	spawner setVariable [_nameX, 2, true];
 	spawner setVariable [_nameX + "_civ", 2, true];		// civ part of spawning
-
-	_dmrk = createMarkerLocal [format ["Dum%1", _nameX], _pos];
-	_dmrk setMarkerShapeLocal "ICON";
-	_dmrk setMarkerTypeLocal "loc_Ruin";
-	_dmrk setMarkerColor colorOccupants;
-
-	sidesX setVariable [_mrk, Occupants, true];
 
 	// ok, how much bulk HR? based on pop or sqrt pop? latter is safer...
 	private _info = [_numCiv, 0, sqrt _numCiv];				// initial full pop, 0% rebel support, 10 HR for 100 pop (multiplied by map factor on award)
@@ -137,6 +126,10 @@ A3A_garrisonSize = createHashMap;
 
 // And now set up the max/par/index values per type (needs troop counts)
 [markersX - ["Synd_HQ"]] call A3A_fnc_initSpawnPlaceStats;
+
+
+// Set up dummy markers and starting sides
+call A3A_fnc_initBases;
 
 
 Info("Setting up banks");

--- a/A3A/addons/core/functions/init/fn_initZones.sqf
+++ b/A3A/addons/core/functions/init/fn_initZones.sqf
@@ -58,38 +58,46 @@ A3A_cityPop = createHashMap;							// city -> base pop, won't change
 !((configName _x) in _disabledTowns)"
 configClasses (configfile >> "CfgWorlds" >> worldName >> "Names") apply {
 
-	_nameX = getText (_x >> "Name");
-	_sizeX = getNumber (_x >> "radiusA");
-	_sizeY = getNumber (_x >> "radiusB");
-	_size = [_sizeY, _sizeX] select (_sizeX > _sizeY);
-	_pos = getArray (_x >> "position");
-	_size = [_size, 400] select (_size < 400);
-	_numCiv = 0;
+	private _nameX = getText (_x >> "Name");
+	private _pos = getArray (_x >> "position");
 
+	// Recenter to nearest road
+	private _roads = nearestTerrainObjects [_pos, ["MAIN ROAD", "ROAD", "TRACK"], 300, true, true];
+	if (count _roads > 0) then {
+		_pos = _roads select 0;
+	};
+
+	// Automatically find suitable size for city marker
+	// Calculates an approximate base density for town center and then searches for radius where relative density has fallen below threshold
+	private _lastCiv = count nearestObjects [_pos, ["house","ruins"], 150];
+	private _baseCiv = 0.08 * (8 max _lastCiv^0.7);
+	private _size = 150;
+	while {_size < 500} do {
+		private _testSize = _size + 50;
+		private _testCiv = count nearestObjects [_pos, ["house","ruins"], _testSize];
+		private _ratio = (_testCiv - _lastCiv) / (_baseCiv * _testSize^0.7);
+		if (_ratio < 0.33) exitWith { _size = _size + 150*_ratio };
+		_size = _size + 50;
+		_lastCiv = _testCiv;
+	};
+
+	// Search hardcoded pop data for city, or just count houses if missing
+	private _numCiv = 0;
 	if (_hardCodedPop) then
 	{
 		_numCiv = _townPop getOrDefault [_nameX, _townPop get (configName _x)]; //backwards compat to config name based pop defines
 		if (isNil "_numCiv" || {!(_numCiv isEqualType 0)}) then
 		{
             Error_1("Bad population count data for %1", _nameX);
-			_numCiv = (count (nearestObjects [_pos, ["house"], _size]));
+			_numCiv = count nearestObjects [_pos, ["house"], _size];
 		};
 	}
 	else {
-		_numCiv = (count (nearestObjects [_pos, ["house"], _size]));
+		_numCiv = count nearestObjects [_pos, ["house"], _size];
 	};
-
-	// This can be used without hardcoded population
 	_numCiv = ceil (_numCiv * _popMult);
 
-	_roads = nearestTerrainObjects [_pos, ["MAIN ROAD", "ROAD", "TRACK"], _size, true, true];
-	if (count _roads > 0) then {
-		// Move marker position to the nearest road, if any
-		_pos = _roads select 0;
-	};
-	_numVeh = (count _roads) min (_numCiv / 3);
-
-	_mrk = createmarkerLocal [format ["%1", _nameX], _pos];
+	private _mrk = createmarkerLocal [format ["%1", _nameX], _pos];
 	_mrk setMarkerSizeLocal [_size, _size];
 	_mrk setMarkerShapeLocal "ELLIPSE";
 	_mrk setMarkerBrushLocal "SOLID";
@@ -104,7 +112,7 @@ configClasses (configfile >> "CfgWorlds" >> worldName >> "Names") apply {
 	A3A_cityData setVariable [_nameX, _info, true];
 	A3A_cityPop set [_nameX, _numCiv];
 
-};	//find in congigs faster then find location in 25000 radius
+};
 
 markersX = markersX + citiesX;
 


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Allow towns to be set as invader-sided at campaign start. This is useful for Stubbhult as there are ~5 towns within the invader control area. Also moving the city dummy markers & side setting to initBases makes more sense because that's where it's done for every other marker.

Odd thing I noticed here is that the underlying town markers are created as axis-aligned rectangles, which is almost never correct. Switched to ellipse.

Might add some code in this PR to automatically determine the city marker size, as it'll probably collide.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)
