### PR TITLE
New ammo price algorithm to cover vehicle weapons

### DIFF
--- a/A3A/addons/gui/functions/gunShop/fn_calculateItemPrice.sqf
+++ b/A3A/addons/gui/functions/gunShop/fn_calculateItemPrice.sqf
@@ -23,9 +23,9 @@ private _fnc_payloadValue = {
         _hit = _hit min _penetration*1.5;  // hack to workaround RHS AT weirdness
 
         private _indirPayload = _indirHit*_indirRange;
-        _indirPayload = if (_simType in _mineSims) then { _indirPayload^0.7 } else { 0.8*_indirPayload^0.9 };
+        _indirPayload = if (_simType in _mineSims) then { _indirPayload^0.7 } else { 0.6*_indirPayload^0.9 };
 
-        private _fuseCost = 2.5*_indirPayload^0.4;		// use to buff cost of small HE rounds
+        private _fuseCost = 2.4*_indirPayload^0.4;		// use to buff cost of small HE rounds
         if (_isHEAT or getNumber (_cfgAmmo >> "explosive") > 0) then { _fuseCost = _fuseCost + _penetration^0.6 };		// add on HEAT rounds
 
         private _guidanceMod = [0, 50] select (getNumber (_cfgAmmo >> "weaponLockSystem") != 0);
@@ -131,7 +131,7 @@ private _fnc_ammoPriceCalculator = {
     // hit & indirHit for final projectile (assuming original doesn't matter for subProjectile)
     [_cfgAmmo, _probablyHEAT, _log] call _fnc_payloadValue params ["_varPayload", "_fixedPayload"];
     private _varTotal = _varPayload * _subCount^0.8 + _guidanceMod;
-    private _varCost = 0.00019 * (500 + _velocity + _totThrust) * _varTotal;
+    private _varCost = 0.000175 * (600 + _velocity + _totThrust) * _varTotal;
 
     // guidance applies twice, once as payload weight and then as direct expense
     private _price = _varCost + (_fixedPayload * _subCount^0.8) + _guidanceMod;

--- a/A3A/addons/gui/functions/gunShop/fn_calculateItemPrice.sqf
+++ b/A3A/addons/gui/functions/gunShop/fn_calculateItemPrice.sqf
@@ -7,77 +7,128 @@ params ["_className", "_itemCfgCat"];
 private _cacheVal = A3A_itemPriceCache get (_itemCfgCat + ":" + _classname);
 if (!isNil "_cacheVal") exitWith { _cacheVal };
 
+// _simType and _subVelocity also passed in
+private _fnc_payloadValue = {
+	params ["_cfgAmmo", "_log"];
+	
+	if !(_simType in _utilSims) exitWith {
+		private _hit = getNumber (_cfgAmmo >> "hit");
+		private _indirHit = getNumber (_cfgAmmo >> "indirectHit");
+		private _indirRange = getNumber (_cfgAmmo >> "indirectHitRange");
+		if (_simType in _mineSims and getNumber (_cfgAmmo >> "directionalExplosion") != 0) then {
+			_indirHit = _indirHit * getNumber (_cfgAmmo >> "explosionAngle") / 180;
+		};
+		private _caliber = getNumber(_cfgAmmo >> "caliber");
+		private _penetration = (15/1000) * _caliber * _subVelocity;		// should be mm of RHS steel
+		
+		private _indirPayload = _indirHit*_indirRange;
+		_indirPayload = if (_simType in _mineSims) then { _indirPayload^0.7 } else { 0.4*_indirPayload^1 };
+		if (_indirHit > 0) then {_indirPayload = _indirPayload + 10*_indirPayload^0.5};		// "trigger cost"
 
-// still need old-style shotgun adjustment
+		private _guidanceMod = [0, 300] select (getNumber (_cfgAmmo >> "weaponLockSystem") != 0);
+		//if (_log) then {diag_log format ["Hit %1, indir %2, indirRange %3, caliber %4, pen %5, guidance %6", _hit, _indirHit, _indirRange, _caliber, _penetration, _guidanceMod]};
+		
+		_hit = _hit min _penetration*1.5;		// hack to workaround RHS AT weirdness
+		0.1*(_hit + _penetration)^1.2 + _indirPayload + _guidanceMod;
+	};
+	if (_simType == "shotilluminating") exitWith {
+		private _intensity = getNumber (_cfgAmmo >> "intensity");
+		private _brightness = 2500 * getNumber (_cfgAmmo >> "brightness") ^ 2;
+		private _timeToLive = getNumber (_cfgAmmo >> "timeToLive");
+		//if (_log) then {diag_log format ["Intensity %1, brightness %2, ttl %3", _intensity, _brightness, _timeToLive]};
+		_timeToLive * (_intensity max _brightness) / 8000;
+	};
+	60;		// Smokes are all the same?
+};
 
+// Normalized for 50cal at approx 10
 private _fnc_ammoPriceCalculator = {
-    params ["_className"];
+	params ["_className", ["_log", false]];
 
-    private _cfgAmmo = configFile >> "CfgAmmo" >> _className;
-    if (!isClass _cfgAmmo) exitWith { Error_1("Ammo %1 does not exist", _className); 10000 };
-    if (isNumber (_cfgAmmo >> "A3A_price")) exitWith { getNumber (_cfgAmmo >> "A3A_price") };
+    // No way to get reasonable initSpeed from CfgAmmo, need to read from CfgMagazines
+    if (isNil "A3A_ammoInitSpeed") then {
+        A3A_ammoInitSpeed = createHashMap;
+        {
+            private _ammo = getText (_x >> "ammo");
+            A3A_ammoInitSpeed set [_ammo, getNumber (_x >> "initSpeed")];
+        } forEach ("true" configClasses (configFile >> "CfgMagazines"));
+    };
+
+	private _cfgAmmo = configFile >> "CfgAmmo" >> _className;
+	if (!isClass _cfgAmmo) exitWith { Error_1("Ammo %1 does not exist", _className); 10000 };
+	if (isNumber (_cfgAmmo >> "A3A_price")) exitWith { getNumber (_cfgAmmo >> "A3A_price") };
 
     private _rocketSims = ["shotrocket", "shotmissile"];
     private _utilSims = ["shotsmoke", "shotsmokex", "shotilluminating", "shotnvgmarker"];
     private _mineSims = ["shotmine", "shotdirectionalbomb", "shotboundingmine", "shotgrenade"];
 
-    private _simType = tolower getText(_cfgAmmo >> "simulation");
-    if (_simType in _utilSims) exitWith { 40 };
+	private _simType = tolower getText(_cfgAmmo >> "simulation");
+	//if (_log) then {diag_log format ["Data for ammo %1:", _className]};
 
-    // maxSpeed better for rockets, usually zero elsewhere. Mines have random crap.
-    private _velocity = getNumber (_cfgAmmo >> (["typicalSpeed", "maxSpeed"] select (_simType in _rocketSims)));
-    if (_simType in _mineSims) then { _velocity = 0 };
-    private _maxRange = getNumber (_cfgAmmo >> "missileLockMaxDistance") max getNumber (_cfgAmmo >> "maxControlRange");
-    private _rangeMod = _velocity max _maxRange;
+	private _guidanceMod = call {
+		if (getNumber (_cfgAmmo >> "weaponLockSystem") != 0) exitWith { getNumber (_cfgAmmo >> "missileLockMaxDistance") / 40 };
+		if (getNumber (_cfgAmmo >> "manualControl") != 0) exitWith { getNumber (_cfgAmmo >> "maxControlRange") / 40 };
+		0;
+	};
 
-    // any non-zero gets a multiplicative bump? airLock double+?
-    private _guidance = getNumber (_cfgAmmo >> "irLock") + 2*getNumber (_cfgAmmo >> "manualControl") + getNumber (_cfgAmmo >> "laserLock");
-    private _airLock = getNumber (_cfgAmmo >> "airLock");
-    if (_airLock == 1) then { _airLock = 0 };
+    // Add in thrust for rockets and maneuvrability for guided missiles (iron bombs are missile sim, so need to check guidance)
+	private _velocity = A3A_ammoInitSpeed getOrDefault [_className, 0];
+	private _totThrust = 0;
+	if (_simType in _rocketSims) then {
+		_totThrust = getNumber (_cfgAmmo >> "thrust") * getNumber (_cfgAmmo >> "thrustTime");
+        if (_guidanceMod > 0) then {
+            private _maneuvrability = getNumber (_cfgAmmo >> "maxSpeed")^2 * getNumber (_cfgAmmo >> "maneuvrability") / 1500;
+            _maneuvrability = _maneuvrability max (getNumber (_cfgAmmo >> "maxSpeed") * getNumber (_cfgAmmo >> "maneuvrability") / 5);
+            //if (_log) then {diag_log format ["thrust %1, maxSpeed %2, maneuvrability %3, guidanceMod %4", _totThrust, getNumber (_cfgAmmo >> "maxSpeed"), getNumber (_cfgAmmo >> "maneuvrability"), _guidanceMod]};
+    		_totThrust = _totThrust + _maneuvrability;
+        };
+	};
+	//if (_log) then {diag_log format ["Sim %1, velocity %2, thrust %3, guidanceMod %4", _simType, _velocity, _totThrust, _guidanceMod]};
+	
+	// submunitionAmmo can be either [type, prob, type2, prob2] array or just type string
+	private _subAmmoType = getText (_cfgAmmo >> "submunitionAmmo");
+	if (isArray (_cfgAmmo >> "submunitionAmmo")) then { _subAmmoType = getArray (_cfgAmmo >> "submunitionAmmo") # 0 };
 
-    // hit & indirHit for original projectile
-    private _hit = getNumber(_cfgAmmo >> "hit");
-    private _indirHit = getNumber(_cfgAmmo >> "indirectHit") * getNumber(_cfgAmmo >> "indirectHitRange");
-    if (_simType in _mineSims and getNumber (_cfgAmmo >> "directionalExplosion") != 0) then {
-        _indirHit = _indirHit * getNumber (_cfgAmmo >> "explosionAngle") / 180;
-    };
-    
-    // submunitionAmmo can be either [type, prob, type2, prob2] array or just type string
-    private _subAmmoType = getText (_cfgAmmo >> "submunitionAmmo");
-    if (isArray (_cfgAmmo >> "submunitionAmmo")) then { _subAmmoType = getArray (_cfgAmmo >> "submunitionAmmo") # 0 };
-
-    private _subVelocity = _velocity;
-    if (_subAmmoType != "") then {
-        _subVelocity = getNumber (_cfgAmmo >> "initSpeed");
-        _cfgAmmo = configFile >> "CfgAmmo" >> _subAmmoType;
-        if (_subVelocity == 0) then { _subVelocity = getNumber (_cfgAmmo >> "typicalSpeed") };
-
-        // If there's a submunition cone type then get the submunition count from that
-        private _subCount = 1;
-        private _subConeType = getArray (_cfgAmmo >> "submunitionConeType");
-        if (_subConeType isNotEqualTo []) then {
-            _subCount = if (_subConeType#1 isEqualType 0) then { _subConeType#1 } else { count (_subConeType#1) };
+	private _subVelocity = _velocity;       // used for payload value later
+	private _subCount = 1;
+	while {_subAmmoType != ""} do
+	{
+		private _subConeType = getArray (_cfgAmmo >> "submunitionConeType");
+		if (count _subConeType >= 2) then {
+			private _thisSubCount = if (_subConeType#1 isEqualType 0) then { _subConeType#1 } else { count (_subConeType#1) };
+			_subCount = _subCount * _thisSubCount;
+		};
+		if (getNumber (_cfgAmmo >> "submunitionInitSpeed") > 0) then {                // _simType != "shotdeploy" ? Not sure which is correct
+            _subVelocity = getNumber (_cfgAmmo >> "submunitionInitSpeed");
+    		_totThrust = _totThrust + (_subVelocity - _velocity);
         };
 
-        _hit = _hit + _subCount * getNumber(_cfgAmmo >> "hit");
-        _indirHit = _indirHit + (_subCount * getNumber(_cfgAmmo >> "indirectHit") * getNumber(_cfgAmmo >> "indirectHitRange"));
-    };
+        // Submunitions can have thrust/guidance/maneuver too. Add that in.
+		_cfgAmmo = configFile >> "CfgAmmo" >> _subAmmoType;			// replace main ammo
+		_simType = tolower getText (_cfgAmmo >> "simulation");
+		if (_simType in _rocketSims) then {
+			_subVelocity = _subVelocity + getNumber (_cfgAmmo >> "thrust") * getNumber (_cfgAmmo >> "thrustTime");
+            if (getNumber (_cfgAmmo >> "weaponLockSystem") != 0) then {
+                private _maneuvrability = getNumber (_cfgAmmo >> "maxSpeed")^2 * getNumber (_cfgAmmo >> "maneuvrability") / 1500;
+                //if (_log) then {diag_log format ["thrust %1, maxSpeed %2, maneuvrability %3", _totThrust, getNumber (_cfgAmmo >> "maxSpeed"), getNumber (_cfgAmmo >> "maneuvrability")]};
+                _totThrust = _totThrust + _maneuvrability;
+            };
+		};
+		//if (_log) then {diag_log format ["SubammoType %1, subVelocity %2, subCount %3", _subAmmoType, _subVelocity, _subCount]};
 
-    // Penetration comes from subammo config, if it exists.
-    private _caliber = getNumber(_cfgAmmo >> "caliber");
-    //private _explosive = getNumber(_cfgAmmo >> "explosive");		// 1 to 0 range for proportion of kinetic vs explosive damage
-    private _penetration = (15/1000) * _caliber  * _subVelocity;		// should be mm of RHS steel
+		// iteration, in case of chained submunitions
+		_subAmmoType = getText (_cfgAmmo >> "submunitionAmmo");
+		if (isArray (_cfgAmmo >> "submunitionAmmo")) then { _subAmmoType = getArray (_cfgAmmo >> "submunitionAmmo") # 0 };
+	};
 
-    _hit = _hit min _penetration*1.5;        // hack to workaround RHS AT weirdness
-    private _payload = 0.5*_hit + 0.5*_penetration + _indirHit;
-    private _costPerRound = if (_simType in _mineSims) then {
-        0.5 * _payload^0.7;
-    } else {
-        0.02 * (1 + _rangeMod / 600) * _payload^1.4 * (1 + _guidance * _airLock);
-    };
+	// hit & indirHit for final projectile (assuming original doesn't matter for subProjectile)
+	private _payload = [_cfgAmmo, _log] call _fnc_payloadValue;
+	private _totPayload = _payload * _subCount + _guidanceMod;
 
-    A3A_itemPriceCache set ["ammo:" + _classname, _costPerRound];
-    _costPerRound;
+    // Normalized to 5.56/6.5mm ~= 1
+	private _price = 0.0002 * (450 + _velocity + _totThrust) * _totPayload;
+	//if (_log) then {diag_log format ["Payload %1, vMul %2, Price %3, end", _totPayload, 450 + _velocity + _totThrust, _price]};
+	_price;
 };
 
 private _fnc_ammoPriceCalculatorCache = {

--- a/A3A/addons/gui/functions/gunShop/fn_calculateItemPrice.sqf
+++ b/A3A/addons/gui/functions/gunShop/fn_calculateItemPrice.sqf
@@ -23,10 +23,11 @@ private _fnc_payloadValue = {
         _hit = _hit min _penetration*1.5;  // hack to workaround RHS AT weirdness
 
         private _indirPayload = _indirHit*_indirRange;
-        _indirPayload = if (_simType in _mineSims) then { _indirPayload^0.7 } else { 1.6*_indirPayload^0.8 };
+        _indirPayload = if (_simType in _mineSims) then { _indirPayload^0.7 } else { 0.8*_indirPayload^0.9 };
 
-        private _fuseCost = 3*_indirPayload^0.4;		// use to buff cost of small HE rounds
+        private _fuseCost = 2.5*_indirPayload^0.4;		// use to buff cost of small HE rounds
         if (_isHEAT or getNumber (_cfgAmmo >> "explosive") > 0) then { _fuseCost = _fuseCost + _penetration^0.6 };		// add on HEAT rounds
+
         private _guidanceMod = [0, 50] select (getNumber (_cfgAmmo >> "weaponLockSystem") != 0);
         //if (_log) then {diag_log format ["Hit %1, indir %2, indirRange %3, caliber %4, pen %5, guidance %6", _hit, _indirHit, _indirRange, _caliber, _penetration, _guidanceMod]};
 
@@ -38,10 +39,10 @@ private _fnc_payloadValue = {
         private _brightness = 2500 * getNumber (_cfgAmmo >> "brightness") ^ 2;
         private _timeToLive = getNumber (_cfgAmmo >> "timeToLive");
         //if (_log) then {diag_log format ["Intensity %1, brightness %2, ttl %3", _intensity, _brightness, _timeToLive]};
-        [_timeToLive * (_intensity max _brightness) / 8000, 0];
+        [_timeToLive * (_intensity max _brightness) / 80000, 0];
     };
-    if (_simType == "shotcm") exitWith { [20, 0] };
-    [60, 0];		// Smokes are all the same?
+    if (_simType == "shotcm") exitWith { [100, 0] };
+    [120, 0];		// Smokes are all the same?
 };
 
 // Normalized for 50cal at approx 4
@@ -58,7 +59,7 @@ private _fnc_ammoPriceCalculator = {
     };
 
     private _cfgAmmo = configFile >> "CfgAmmo" >> _className;
-    if (!isClass _cfgAmmo) exitWith { Error_1("Ammo %1 does not exist", _className); 10000 };
+    //if (!isClass _cfgAmmo) exitWith { Error_1("Ammo %1 does not exist", _className); 10000 };
     if (isNumber (_cfgAmmo >> "A3A_price")) exitWith { getNumber (_cfgAmmo >> "A3A_price") };
 
     private _rocketSims = ["shotrocket", "shotmissile"];
@@ -69,8 +70,8 @@ private _fnc_ammoPriceCalculator = {
     //if (_log) then {diag_log format ["Data for ammo %1:", _className]};
 
     private _guidanceMod = call {
-        if (getNumber (_cfgAmmo >> "weaponLockSystem") != 0) exitWith { getNumber (_cfgAmmo >> "missileLockMaxDistance") / 40 };
-        if (getNumber (_cfgAmmo >> "manualControl") != 0) exitWith { getNumber (_cfgAmmo >> "maxControlRange") / 40 };
+        if (getNumber (_cfgAmmo >> "weaponLockSystem") != 0) exitWith { getNumber (_cfgAmmo >> "missileLockMaxDistance") / 30 };
+        if (getNumber (_cfgAmmo >> "manualControl") != 0) exitWith { getNumber (_cfgAmmo >> "maxControlRange") / 30 };
         0;
     };
 
@@ -80,8 +81,8 @@ private _fnc_ammoPriceCalculator = {
     if (_simType in _rocketSims) then {
         _totThrust = getNumber (_cfgAmmo >> "thrust") * getNumber (_cfgAmmo >> "thrustTime");
         if (_guidanceMod > 0) then {
-            private _manHigh = getNumber (_cfgAmmo >> "maxSpeed")^1.8 * getNumber (_cfgAmmo >> "maneuvrability") / 200;
-            private _manLow = getNumber (_cfgAmmo >> "maxSpeed") * getNumber (_cfgAmmo >> "maneuvrability") / 3;
+            private _manHigh = getNumber (_cfgAmmo >> "maxSpeed")^1.8 * getNumber (_cfgAmmo >> "maneuvrability") / 175;
+            private _manLow = getNumber (_cfgAmmo >> "maxSpeed") * getNumber (_cfgAmmo >> "maneuvrability") / 2;
             //if (_log) then {diag_log format ["thrust %1, maxSpeed %2, manuver %3, manHigh %4, manLow %5, guidanceMod %6", _totThrust, getNumber (_cfgAmmo >> "maxSpeed"), getNumber (_cfgAmmo >> "maneuvrability"), _manHigh, _manLow, _guidanceMod]};
             _totThrust = _totThrust + (_manHigh max _manLow);
         };
@@ -92,7 +93,7 @@ private _fnc_ammoPriceCalculator = {
     private _subAmmoType = getText (_cfgAmmo >> "submunitionAmmo");
     if (isArray (_cfgAmmo >> "submunitionAmmo")) then { _subAmmoType = getArray (_cfgAmmo >> "submunitionAmmo") # 0 };
 
-    private _subVelocity = _velocity;           // used for payload value later
+    private _subVelocity = _velocity;	   // used for payload value later
     private _subCount = 1;
     private _probablyHEAT = false;
     while {_subAmmoType != ""} do
@@ -114,7 +115,7 @@ private _fnc_ammoPriceCalculator = {
         if (_simType in _rocketSims) then {
             _subVelocity = _subVelocity + getNumber (_cfgAmmo >> "thrust") * getNumber (_cfgAmmo >> "thrustTime");
             if (getNumber (_cfgAmmo >> "weaponLockSystem") != 0) then {
-                private _maneuvrability = getNumber (_cfgAmmo >> "maxSpeed")^1.8 * getNumber (_cfgAmmo >> "maneuvrability") / 200;
+                private _maneuvrability = getNumber (_cfgAmmo >> "maxSpeed")^1.8 * getNumber (_cfgAmmo >> "maneuvrability") / 175;
                 //if (_log) then {diag_log format ["thrust %1, maxSpeed %2, maneuvrability %3", _totThrust, getNumber (_cfgAmmo >> "maxSpeed"), getNumber (_cfgAmmo >> "maneuvrability")]};
                 _totThrust = _totThrust + _maneuvrability;
             };
@@ -124,6 +125,7 @@ private _fnc_ammoPriceCalculator = {
         // iteration, in case of chained submunitions
         _subAmmoType = getText (_cfgAmmo >> "submunitionAmmo");
         if (isArray (_cfgAmmo >> "submunitionAmmo")) then { _subAmmoType = getArray (_cfgAmmo >> "submunitionAmmo") # 0 };
+        if (_subAmmoType == "rhs_ammo_spall") then {break};			// fake shit
     };
 
     // hit & indirHit for final projectile (assuming original doesn't matter for subProjectile)

--- a/A3A/addons/gui/functions/gunShop/fn_calculateItemPrice.sqf
+++ b/A3A/addons/gui/functions/gunShop/fn_calculateItemPrice.sqf
@@ -9,7 +9,7 @@ if (!isNil "_cacheVal") exitWith { _cacheVal };
 
 // _simType and _subVelocity also passed in
 private _fnc_payloadValue = {
-    params ["_cfgAmmo", "_log"];
+    params ["_cfgAmmo", "_isHEAT", "_log"];
 
     if !(_simType in _utilSims) exitWith {
         private _hit = getNumber (_cfgAmmo >> "hit");
@@ -20,27 +20,31 @@ private _fnc_payloadValue = {
         };
         private _caliber = getNumber(_cfgAmmo >> "caliber");
         private _penetration = (15/1000) * _caliber * _subVelocity;		// should be mm of RHS steel
+        _hit = _hit min _penetration*1.5;  // hack to workaround RHS AT weirdness
 
         private _indirPayload = _indirHit*_indirRange;
-        _indirPayload = if (_simType in _mineSims) then { _indirPayload^0.7 } else { 0.4*_indirPayload^1 };
-        if (_indirHit > 0) then {_indirPayload = _indirPayload + 10*_indirPayload^0.5};		// "trigger cost"
+        _indirPayload = if (_simType in _mineSims) then { _indirPayload^0.7 } else { 1.6*_indirPayload^0.8 };
 
-        private _guidanceMod = [0, 300] select (getNumber (_cfgAmmo >> "weaponLockSystem") != 0);
+        private _fuseCost = 3*_indirPayload^0.4;		// use to buff cost of small HE rounds
+        if (_isHEAT or getNumber (_cfgAmmo >> "explosive") > 0) then { _fuseCost = _fuseCost + _penetration^0.6 };		// add on HEAT rounds
+        private _guidanceMod = [0, 50] select (getNumber (_cfgAmmo >> "weaponLockSystem") != 0);
         //if (_log) then {diag_log format ["Hit %1, indir %2, indirRange %3, caliber %4, pen %5, guidance %6", _hit, _indirHit, _indirRange, _caliber, _penetration, _guidanceMod]};
 
-        _hit = _hit min _penetration*1.5;		// hack to workaround RHS AT weirdness
-        0.1*(_hit + _penetration)^1.2 + _indirPayload + _guidanceMod;
+        private _payloadVal = 0.1*(_hit + _penetration)^1.2 + _indirPayload + _fuseCost/2 + _guidanceMod/2;
+        [_payloadVal, _fuseCost + _guidanceMod];
     };
     if (_simType == "shotilluminating") exitWith {
         private _intensity = getNumber (_cfgAmmo >> "intensity");
         private _brightness = 2500 * getNumber (_cfgAmmo >> "brightness") ^ 2;
         private _timeToLive = getNumber (_cfgAmmo >> "timeToLive");
         //if (_log) then {diag_log format ["Intensity %1, brightness %2, ttl %3", _intensity, _brightness, _timeToLive]};
-        _timeToLive * (_intensity max _brightness) / 8000;
+        [_timeToLive * (_intensity max _brightness) / 8000, 0];
     };
-    60;		// Smokes are all the same?
+    if (_simType == "shotcm") exitWith { [20, 0] };
+    [60, 0];		// Smokes are all the same?
 };
 
+// Normalized for 50cal at approx 4
 private _fnc_ammoPriceCalculator = {
     params ["_className", ["_log", false]];
 
@@ -58,7 +62,7 @@ private _fnc_ammoPriceCalculator = {
     if (isNumber (_cfgAmmo >> "A3A_price")) exitWith { getNumber (_cfgAmmo >> "A3A_price") };
 
     private _rocketSims = ["shotrocket", "shotmissile"];
-    private _utilSims = ["shotsmoke", "shotsmokex", "shotilluminating", "shotnvgmarker"];
+    private _utilSims = ["shotsmoke", "shotsmokex", "shotilluminating", "shotnvgmarker", "shotcm"];
     private _mineSims = ["shotmine", "shotdirectionalbomb", "shotboundingmine", "shotgrenade"];
 
     private _simType = tolower getText(_cfgAmmo >> "simulation");
@@ -76,10 +80,10 @@ private _fnc_ammoPriceCalculator = {
     if (_simType in _rocketSims) then {
         _totThrust = getNumber (_cfgAmmo >> "thrust") * getNumber (_cfgAmmo >> "thrustTime");
         if (_guidanceMod > 0) then {
-            private _maneuvrability = getNumber (_cfgAmmo >> "maxSpeed")^2 * getNumber (_cfgAmmo >> "maneuvrability") / 1500;
-            _maneuvrability = _maneuvrability max (getNumber (_cfgAmmo >> "maxSpeed") * getNumber (_cfgAmmo >> "maneuvrability") / 5);
-            //if (_log) then {diag_log format ["thrust %1, maxSpeed %2, maneuvrability %3, guidanceMod %4", _totThrust, getNumber (_cfgAmmo >> "maxSpeed"), getNumber (_cfgAmmo >> "maneuvrability"), _guidanceMod]};
-            _totThrust = _totThrust + _maneuvrability;
+            private _manHigh = getNumber (_cfgAmmo >> "maxSpeed")^1.8 * getNumber (_cfgAmmo >> "maneuvrability") / 200;
+            private _manLow = getNumber (_cfgAmmo >> "maxSpeed") * getNumber (_cfgAmmo >> "maneuvrability") / 3;
+            //if (_log) then {diag_log format ["thrust %1, maxSpeed %2, manuver %3, manHigh %4, manLow %5, guidanceMod %6", _totThrust, getNumber (_cfgAmmo >> "maxSpeed"), getNumber (_cfgAmmo >> "maneuvrability"), _manHigh, _manLow, _guidanceMod]};
+            _totThrust = _totThrust + (_manHigh max _manLow);
         };
     };
     //if (_log) then {diag_log format ["Sim %1, velocity %2, thrust %3, guidanceMod %4", _simType, _velocity, _totThrust, _guidanceMod]};
@@ -88,8 +92,9 @@ private _fnc_ammoPriceCalculator = {
     private _subAmmoType = getText (_cfgAmmo >> "submunitionAmmo");
     if (isArray (_cfgAmmo >> "submunitionAmmo")) then { _subAmmoType = getArray (_cfgAmmo >> "submunitionAmmo") # 0 };
 
-    private _subVelocity = _velocity;       // used for payload value later
+    private _subVelocity = _velocity;           // used for payload value later
     private _subCount = 1;
+    private _probablyHEAT = false;
     while {_subAmmoType != ""} do
     {
         private _subConeType = getArray (_cfgAmmo >> "submunitionConeType");
@@ -97,7 +102,8 @@ private _fnc_ammoPriceCalculator = {
             private _thisSubCount = if (_subConeType#1 isEqualType 0) then { _subConeType#1 } else { count (_subConeType#1) };
             _subCount = _subCount * _thisSubCount;
         };
-        if (getNumber (_cfgAmmo >> "submunitionInitSpeed") > 0) then {                // _simType != "shotdeploy" ? Not sure which is correct
+        _probablyHEAT = count _subConeType < 2;										// single projectile so treat as HEAT warhead later
+        if (getNumber (_cfgAmmo >> "submunitionInitSpeed") > 0) then {				// _simType != "shotdeploy" ? Not sure which is correct
             _subVelocity = getNumber (_cfgAmmo >> "submunitionInitSpeed");
             _totThrust = _totThrust + (_subVelocity - _velocity);
         };
@@ -108,7 +114,7 @@ private _fnc_ammoPriceCalculator = {
         if (_simType in _rocketSims) then {
             _subVelocity = _subVelocity + getNumber (_cfgAmmo >> "thrust") * getNumber (_cfgAmmo >> "thrustTime");
             if (getNumber (_cfgAmmo >> "weaponLockSystem") != 0) then {
-                private _maneuvrability = getNumber (_cfgAmmo >> "maxSpeed")^2 * getNumber (_cfgAmmo >> "maneuvrability") / 1500;
+                private _maneuvrability = getNumber (_cfgAmmo >> "maxSpeed")^1.8 * getNumber (_cfgAmmo >> "maneuvrability") / 200;
                 //if (_log) then {diag_log format ["thrust %1, maxSpeed %2, maneuvrability %3", _totThrust, getNumber (_cfgAmmo >> "maxSpeed"), getNumber (_cfgAmmo >> "maneuvrability")]};
                 _totThrust = _totThrust + _maneuvrability;
             };
@@ -121,12 +127,13 @@ private _fnc_ammoPriceCalculator = {
     };
 
     // hit & indirHit for final projectile (assuming original doesn't matter for subProjectile)
-    private _payload = [_cfgAmmo, _log] call _fnc_payloadValue;
-    private _totPayload = _payload * _subCount + _guidanceMod;
+    [_cfgAmmo, _probablyHEAT, _log] call _fnc_payloadValue params ["_varPayload", "_fixedPayload"];
+    private _varTotal = _varPayload * _subCount^0.8 + _guidanceMod;
+    private _varCost = 0.00019 * (500 + _velocity + _totThrust) * _varTotal;
 
-    // Normalized to 5.56/6.5mm ~= 1
-    private _price = 0.0002 * (450 + _velocity + _totThrust) * _totPayload;
-    //if (_log) then {diag_log format ["Payload %1, vMul %2, Price %3, end", _totPayload, 450 + _velocity + _totThrust, _price]};
+    // guidance applies twice, once as payload weight and then as direct expense
+    private _price = _varCost + (_fixedPayload * _subCount^0.8) + _guidanceMod;
+    //if (_log) then {diag_log format ["VCost %1, FCost %2, Vmul %3, Price %4, end", _varCost, _fixedPayload*_subCount^0.8, 1 + (_velocity + _totThrust) / 500, _price]};
     _price;
 };
 

--- a/A3A/addons/gui/functions/gunShop/fn_calculateItemPrice.sqf
+++ b/A3A/addons/gui/functions/gunShop/fn_calculateItemPrice.sqf
@@ -9,41 +9,40 @@ if (!isNil "_cacheVal") exitWith { _cacheVal };
 
 // _simType and _subVelocity also passed in
 private _fnc_payloadValue = {
-	params ["_cfgAmmo", "_log"];
-	
-	if !(_simType in _utilSims) exitWith {
-		private _hit = getNumber (_cfgAmmo >> "hit");
-		private _indirHit = getNumber (_cfgAmmo >> "indirectHit");
-		private _indirRange = getNumber (_cfgAmmo >> "indirectHitRange");
-		if (_simType in _mineSims and getNumber (_cfgAmmo >> "directionalExplosion") != 0) then {
-			_indirHit = _indirHit * getNumber (_cfgAmmo >> "explosionAngle") / 180;
-		};
-		private _caliber = getNumber(_cfgAmmo >> "caliber");
-		private _penetration = (15/1000) * _caliber * _subVelocity;		// should be mm of RHS steel
-		
-		private _indirPayload = _indirHit*_indirRange;
-		_indirPayload = if (_simType in _mineSims) then { _indirPayload^0.7 } else { 0.4*_indirPayload^1 };
-		if (_indirHit > 0) then {_indirPayload = _indirPayload + 10*_indirPayload^0.5};		// "trigger cost"
+    params ["_cfgAmmo", "_log"];
 
-		private _guidanceMod = [0, 300] select (getNumber (_cfgAmmo >> "weaponLockSystem") != 0);
-		//if (_log) then {diag_log format ["Hit %1, indir %2, indirRange %3, caliber %4, pen %5, guidance %6", _hit, _indirHit, _indirRange, _caliber, _penetration, _guidanceMod]};
-		
-		_hit = _hit min _penetration*1.5;		// hack to workaround RHS AT weirdness
-		0.1*(_hit + _penetration)^1.2 + _indirPayload + _guidanceMod;
-	};
-	if (_simType == "shotilluminating") exitWith {
-		private _intensity = getNumber (_cfgAmmo >> "intensity");
-		private _brightness = 2500 * getNumber (_cfgAmmo >> "brightness") ^ 2;
-		private _timeToLive = getNumber (_cfgAmmo >> "timeToLive");
-		//if (_log) then {diag_log format ["Intensity %1, brightness %2, ttl %3", _intensity, _brightness, _timeToLive]};
-		_timeToLive * (_intensity max _brightness) / 8000;
-	};
-	60;		// Smokes are all the same?
+    if !(_simType in _utilSims) exitWith {
+        private _hit = getNumber (_cfgAmmo >> "hit");
+        private _indirHit = getNumber (_cfgAmmo >> "indirectHit");
+        private _indirRange = getNumber (_cfgAmmo >> "indirectHitRange");
+        if (_simType in _mineSims and getNumber (_cfgAmmo >> "directionalExplosion") != 0) then {
+            _indirHit = _indirHit * getNumber (_cfgAmmo >> "explosionAngle") / 180;
+        };
+        private _caliber = getNumber(_cfgAmmo >> "caliber");
+        private _penetration = (15/1000) * _caliber * _subVelocity;		// should be mm of RHS steel
+
+        private _indirPayload = _indirHit*_indirRange;
+        _indirPayload = if (_simType in _mineSims) then { _indirPayload^0.7 } else { 0.4*_indirPayload^1 };
+        if (_indirHit > 0) then {_indirPayload = _indirPayload + 10*_indirPayload^0.5};		// "trigger cost"
+
+        private _guidanceMod = [0, 300] select (getNumber (_cfgAmmo >> "weaponLockSystem") != 0);
+        //if (_log) then {diag_log format ["Hit %1, indir %2, indirRange %3, caliber %4, pen %5, guidance %6", _hit, _indirHit, _indirRange, _caliber, _penetration, _guidanceMod]};
+
+        _hit = _hit min _penetration*1.5;		// hack to workaround RHS AT weirdness
+        0.1*(_hit + _penetration)^1.2 + _indirPayload + _guidanceMod;
+    };
+    if (_simType == "shotilluminating") exitWith {
+        private _intensity = getNumber (_cfgAmmo >> "intensity");
+        private _brightness = 2500 * getNumber (_cfgAmmo >> "brightness") ^ 2;
+        private _timeToLive = getNumber (_cfgAmmo >> "timeToLive");
+        //if (_log) then {diag_log format ["Intensity %1, brightness %2, ttl %3", _intensity, _brightness, _timeToLive]};
+        _timeToLive * (_intensity max _brightness) / 8000;
+    };
+    60;		// Smokes are all the same?
 };
 
-// Normalized for 50cal at approx 10
 private _fnc_ammoPriceCalculator = {
-	params ["_className", ["_log", false]];
+    params ["_className", ["_log", false]];
 
     // No way to get reasonable initSpeed from CfgAmmo, need to read from CfgMagazines
     if (isNil "A3A_ammoInitSpeed") then {
@@ -54,81 +53,81 @@ private _fnc_ammoPriceCalculator = {
         } forEach ("true" configClasses (configFile >> "CfgMagazines"));
     };
 
-	private _cfgAmmo = configFile >> "CfgAmmo" >> _className;
-	if (!isClass _cfgAmmo) exitWith { Error_1("Ammo %1 does not exist", _className); 10000 };
-	if (isNumber (_cfgAmmo >> "A3A_price")) exitWith { getNumber (_cfgAmmo >> "A3A_price") };
+    private _cfgAmmo = configFile >> "CfgAmmo" >> _className;
+    if (!isClass _cfgAmmo) exitWith { Error_1("Ammo %1 does not exist", _className); 10000 };
+    if (isNumber (_cfgAmmo >> "A3A_price")) exitWith { getNumber (_cfgAmmo >> "A3A_price") };
 
     private _rocketSims = ["shotrocket", "shotmissile"];
     private _utilSims = ["shotsmoke", "shotsmokex", "shotilluminating", "shotnvgmarker"];
     private _mineSims = ["shotmine", "shotdirectionalbomb", "shotboundingmine", "shotgrenade"];
 
-	private _simType = tolower getText(_cfgAmmo >> "simulation");
-	//if (_log) then {diag_log format ["Data for ammo %1:", _className]};
+    private _simType = tolower getText(_cfgAmmo >> "simulation");
+    //if (_log) then {diag_log format ["Data for ammo %1:", _className]};
 
-	private _guidanceMod = call {
-		if (getNumber (_cfgAmmo >> "weaponLockSystem") != 0) exitWith { getNumber (_cfgAmmo >> "missileLockMaxDistance") / 40 };
-		if (getNumber (_cfgAmmo >> "manualControl") != 0) exitWith { getNumber (_cfgAmmo >> "maxControlRange") / 40 };
-		0;
-	};
+    private _guidanceMod = call {
+        if (getNumber (_cfgAmmo >> "weaponLockSystem") != 0) exitWith { getNumber (_cfgAmmo >> "missileLockMaxDistance") / 40 };
+        if (getNumber (_cfgAmmo >> "manualControl") != 0) exitWith { getNumber (_cfgAmmo >> "maxControlRange") / 40 };
+        0;
+    };
 
     // Add in thrust for rockets and maneuvrability for guided missiles (iron bombs are missile sim, so need to check guidance)
-	private _velocity = A3A_ammoInitSpeed getOrDefault [_className, 0];
-	private _totThrust = 0;
-	if (_simType in _rocketSims) then {
-		_totThrust = getNumber (_cfgAmmo >> "thrust") * getNumber (_cfgAmmo >> "thrustTime");
+    private _velocity = A3A_ammoInitSpeed getOrDefault [_className, 0];
+    private _totThrust = 0;
+    if (_simType in _rocketSims) then {
+        _totThrust = getNumber (_cfgAmmo >> "thrust") * getNumber (_cfgAmmo >> "thrustTime");
         if (_guidanceMod > 0) then {
             private _maneuvrability = getNumber (_cfgAmmo >> "maxSpeed")^2 * getNumber (_cfgAmmo >> "maneuvrability") / 1500;
             _maneuvrability = _maneuvrability max (getNumber (_cfgAmmo >> "maxSpeed") * getNumber (_cfgAmmo >> "maneuvrability") / 5);
             //if (_log) then {diag_log format ["thrust %1, maxSpeed %2, maneuvrability %3, guidanceMod %4", _totThrust, getNumber (_cfgAmmo >> "maxSpeed"), getNumber (_cfgAmmo >> "maneuvrability"), _guidanceMod]};
-    		_totThrust = _totThrust + _maneuvrability;
+            _totThrust = _totThrust + _maneuvrability;
         };
-	};
-	//if (_log) then {diag_log format ["Sim %1, velocity %2, thrust %3, guidanceMod %4", _simType, _velocity, _totThrust, _guidanceMod]};
-	
-	// submunitionAmmo can be either [type, prob, type2, prob2] array or just type string
-	private _subAmmoType = getText (_cfgAmmo >> "submunitionAmmo");
-	if (isArray (_cfgAmmo >> "submunitionAmmo")) then { _subAmmoType = getArray (_cfgAmmo >> "submunitionAmmo") # 0 };
+    };
+    //if (_log) then {diag_log format ["Sim %1, velocity %2, thrust %3, guidanceMod %4", _simType, _velocity, _totThrust, _guidanceMod]};
 
-	private _subVelocity = _velocity;       // used for payload value later
-	private _subCount = 1;
-	while {_subAmmoType != ""} do
-	{
-		private _subConeType = getArray (_cfgAmmo >> "submunitionConeType");
-		if (count _subConeType >= 2) then {
-			private _thisSubCount = if (_subConeType#1 isEqualType 0) then { _subConeType#1 } else { count (_subConeType#1) };
-			_subCount = _subCount * _thisSubCount;
-		};
-		if (getNumber (_cfgAmmo >> "submunitionInitSpeed") > 0) then {                // _simType != "shotdeploy" ? Not sure which is correct
+    // submunitionAmmo can be either [type, prob, type2, prob2] array or just type string
+    private _subAmmoType = getText (_cfgAmmo >> "submunitionAmmo");
+    if (isArray (_cfgAmmo >> "submunitionAmmo")) then { _subAmmoType = getArray (_cfgAmmo >> "submunitionAmmo") # 0 };
+
+    private _subVelocity = _velocity;       // used for payload value later
+    private _subCount = 1;
+    while {_subAmmoType != ""} do
+    {
+        private _subConeType = getArray (_cfgAmmo >> "submunitionConeType");
+        if (count _subConeType >= 2) then {
+            private _thisSubCount = if (_subConeType#1 isEqualType 0) then { _subConeType#1 } else { count (_subConeType#1) };
+            _subCount = _subCount * _thisSubCount;
+        };
+        if (getNumber (_cfgAmmo >> "submunitionInitSpeed") > 0) then {                // _simType != "shotdeploy" ? Not sure which is correct
             _subVelocity = getNumber (_cfgAmmo >> "submunitionInitSpeed");
-    		_totThrust = _totThrust + (_subVelocity - _velocity);
+            _totThrust = _totThrust + (_subVelocity - _velocity);
         };
 
         // Submunitions can have thrust/guidance/maneuver too. Add that in.
-		_cfgAmmo = configFile >> "CfgAmmo" >> _subAmmoType;			// replace main ammo
-		_simType = tolower getText (_cfgAmmo >> "simulation");
-		if (_simType in _rocketSims) then {
-			_subVelocity = _subVelocity + getNumber (_cfgAmmo >> "thrust") * getNumber (_cfgAmmo >> "thrustTime");
+        _cfgAmmo = configFile >> "CfgAmmo" >> _subAmmoType;			// replace main ammo
+        _simType = tolower getText (_cfgAmmo >> "simulation");
+        if (_simType in _rocketSims) then {
+            _subVelocity = _subVelocity + getNumber (_cfgAmmo >> "thrust") * getNumber (_cfgAmmo >> "thrustTime");
             if (getNumber (_cfgAmmo >> "weaponLockSystem") != 0) then {
                 private _maneuvrability = getNumber (_cfgAmmo >> "maxSpeed")^2 * getNumber (_cfgAmmo >> "maneuvrability") / 1500;
                 //if (_log) then {diag_log format ["thrust %1, maxSpeed %2, maneuvrability %3", _totThrust, getNumber (_cfgAmmo >> "maxSpeed"), getNumber (_cfgAmmo >> "maneuvrability")]};
                 _totThrust = _totThrust + _maneuvrability;
             };
-		};
-		//if (_log) then {diag_log format ["SubammoType %1, subVelocity %2, subCount %3", _subAmmoType, _subVelocity, _subCount]};
+        };
+        //if (_log) then {diag_log format ["SubammoType %1, subVelocity %2, subCount %3", _subAmmoType, _subVelocity, _subCount]};
 
-		// iteration, in case of chained submunitions
-		_subAmmoType = getText (_cfgAmmo >> "submunitionAmmo");
-		if (isArray (_cfgAmmo >> "submunitionAmmo")) then { _subAmmoType = getArray (_cfgAmmo >> "submunitionAmmo") # 0 };
-	};
+        // iteration, in case of chained submunitions
+        _subAmmoType = getText (_cfgAmmo >> "submunitionAmmo");
+        if (isArray (_cfgAmmo >> "submunitionAmmo")) then { _subAmmoType = getArray (_cfgAmmo >> "submunitionAmmo") # 0 };
+    };
 
-	// hit & indirHit for final projectile (assuming original doesn't matter for subProjectile)
-	private _payload = [_cfgAmmo, _log] call _fnc_payloadValue;
-	private _totPayload = _payload * _subCount + _guidanceMod;
+    // hit & indirHit for final projectile (assuming original doesn't matter for subProjectile)
+    private _payload = [_cfgAmmo, _log] call _fnc_payloadValue;
+    private _totPayload = _payload * _subCount + _guidanceMod;
 
     // Normalized to 5.56/6.5mm ~= 1
-	private _price = 0.0002 * (450 + _velocity + _totThrust) * _totPayload;
-	//if (_log) then {diag_log format ["Payload %1, vMul %2, Price %3, end", _totPayload, 450 + _velocity + _totThrust, _price]};
-	_price;
+    private _price = 0.0002 * (450 + _velocity + _totThrust) * _totPayload;
+    //if (_log) then {diag_log format ["Payload %1, vMul %2, Price %3, end", _totPayload, 450 + _velocity + _totThrust, _price]};
+    _price;
 };
 
 private _fnc_ammoPriceCalculatorCache = {

--- a/A3A/addons/gui/functions/gunShop/fn_calculateItemPrice.sqf
+++ b/A3A/addons/gui/functions/gunShop/fn_calculateItemPrice.sqf
@@ -22,9 +22,7 @@ private _fnc_payloadValue = {
         private _penetration = (15/1000) * _caliber * _subVelocity;		// should be mm of RHS steel
         _hit = _hit min _penetration*1.5;  // hack to workaround RHS AT weirdness
 
-        private _indirPayload = _indirHit*_indirRange;
-        _indirPayload = if (_simType in _mineSims) then { _indirPayload^0.7 } else { 0.6*_indirPayload^0.9 };
-
+		private _indirPayload = 0.8*_indirHit^0.75*_indirRange^1.2;
         private _fuseCost = 2.4*_indirPayload^0.4;		// use to buff cost of small HE rounds
         if (_isHEAT or getNumber (_cfgAmmo >> "explosive") > 0) then { _fuseCost = _fuseCost + _penetration^0.6 };		// add on HEAT rounds
 

--- a/A3A/addons/gui/functions/gunShop/fn_createGunShopTab.sqf
+++ b/A3A/addons/gui/functions/gunShop/fn_createGunShopTab.sqf
@@ -47,8 +47,8 @@ switch(_selectedTab) do
 
     _pictureBox = [0, 0, 6, 6];
     _displayBox = [7.5, 0, 55.5, 3];
-    _priceBox = [13, 3, 6, 3];
-    _stockBox = [20, 3, 30, 3];
+    _priceBox = [9, 3, 8, 3];
+    _stockBox = [18, 3, 16, 3];
     _logoBox = [70, 0, 6, 6];
     _addBox = [76, 0, 24, 6];
 
@@ -177,7 +177,8 @@ private _createdCtrls = [];
 
     private _displayPrice = _display ctrlCreate ["A3A_StructuredText", -1, _itemControlsGroup];
     _displayPrice ctrlSetPosition _priceBox;
-    _displayPrice ctrlSetStructuredText parseText (format ["<t size='0.65' align='left' valign='middle' color='#52D273' shadow='2'>€ %1</t>", _itemPrice]);
+    private _priceAlign = ["left", "right"] select (_columnCount == 1);
+    _displayPrice ctrlSetStructuredText parseText (format ["<t size='0.65' align='%2' valign='middle' color='#52D273' shadow='2'>€ %1</t>", _itemPrice, _priceAlign]);
     _displayPrice ctrlCommit 0;
 
     private _modLogo = _display ctrlCreate ["A3A_PictureStroke", -1, _itemControlsGroup];


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Reworked and expanded the gun shop's ammo price calculation to handle vehicle weapons better, including various aerial ordnance, weird submunitions and hopefully everything else. Only tested against vanilla so far but in theory it should be ok. Doesn't change infantry weapons very much.

Ammo price value normalized to ~1 for 6.5mm. Probably want a divisor of around 4 for vehicle refills if we don't want static weapons to be less expensive than their ammunition. That brings 50cal down to ~80 per belt.

Noticed a formatting error in the gun shop while testing (ammo prices disappear when >2 chars wide) so I'll probably throw in a fix for that later.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)
