### PR TITLE
Fix garage static mounting not working on DS

### DIFF
--- a/A3A/addons/garage/Extras/fn_findMount.sqf
+++ b/A3A/addons/garage/Extras/fn_findMount.sqf
@@ -44,5 +44,5 @@ if !((_mount#3) in ["", _UID]) exitWith _failed; //Checked out by someone else
 
 //check out mount
 _mount set [3, _CheckedUID];
-[nil, _CheckedUID, 4, _vehUID, _player, false] call HR_GRG_fnc_broadcast;
+[nil, _CheckedUID, HR_GRG_STATICINDEX, _vehUID, _player, false] call HR_GRG_fnc_broadcast;
 true;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Another hangover from the garage categories PR. The function that confirms a static mounting request used the original "4" instead of the correct static category. It worked on localhost because it sets the data correctly on the server, so it doesn't matter that the broadcast function fails to set it. This is actually a nil reference but Arma doesn't signal it because it runs in unscheduled.

### Please specify which Issue this PR Resolves.
closes #3814

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
