### PR TITLE
3CB People's Liberation Militia, Tanoan National Militia enemy factions

### DIFF
--- a/A3A/addons/config_fixes/3CB/CfgVehicles.hpp
+++ b/A3A/addons/config_fixes/3CB/CfgVehicles.hpp
@@ -17,6 +17,7 @@ class CfgVehicles
         displayName = "Mig (Faux)";
         faction = "UK3CB_CW_SOV_O_EARLY";
         side = 0;
+        textureList[] = {"MIG",1};
     };
     class a3a_UK3CB_Fake_Sabre : UK3CB_MDF_O_Mystere {
         hiddenSelectionsMaterials[] = {"UK3CB_Factions\addons\UK3CB_Factions_Vehicles\air\UK3CB_Factions_Vehicles_Mystere\data\sabre.rvmat"};
@@ -25,6 +26,7 @@ class CfgVehicles
         displayName = "Sabre (Faux)";
         faction = "UK3CB_CW_US_B_EARLY";
         side = 1;
+        textureList[] = {"SABRE",1};
     };
 };
 

--- a/A3A/addons/config_fixes/RHS/CfgWeapons.hpp
+++ b/A3A/addons/config_fixes/RHS/CfgWeapons.hpp
@@ -34,6 +34,14 @@ class CfgWeapons
         };
         modes[] = {"FullAuto","Ai_Burst"};
     };
+	
+	class rhs_weap_makarov_pm;
+	class rhs_weap_pb_6p9 : rhs_weap_makarov_pm {
+		baseWeapon = "a3a_rhs_weap_pb_6p9_noSup";
+	};
+	class a3a_rhs_weap_pb_6p9_noSup : rhs_weap_pb_6p9 {
+		class LinkedItems{};
+	};
 
     // Price overrides for gun shop
     // Subsonic sniper

--- a/A3A/addons/config_fixes/RHS/hidf_rhs.hpp
+++ b/A3A/addons/config_fixes/RHS/hidf_rhs.hpp
@@ -7,6 +7,9 @@ class a3a_rhs_m966_olive : rhsusf_m966_w{
 	faction = "rhsgref_faction_hidf";
 	animationList[] = {"hide_CIP",1,"hide_A2_Parts",1,"Hide_A2Bumper",1,"Hide_Brushguard",0.5};
 	HiddenSelectionsTextures[] = {"rhsgref\addons\rhsgref_vehicles_ret\data\hidf\hmmwv\m998_exterior_lg_co.paa","rhsgref\addons\rhsgref_vehicles_ret\data\hidf\hmmwv\m998_interior_lg_co.paa","rhsgref\addons\rhsgref_vehicles_ret\data\hidf\hmmwv\A2_parts_lg_co.paa","rhsgref\addons\rhsgref_vehicles_ret\data\hidf\hmmwv\wheel_wranglermt_lg_co.paa","rhsgref\addons\rhsgref_vehicles_ret\data\hidf\hmmwv\m998_mainbody_lg_co.paa","rhsusf\addons\rhsusf_hmmwv\textures\gratting_w_co.paa","rhsgref\addons\rhsgref_vehicles_ret\data\hidf\hmmwv\tile_exmetal_lg_co.paa","rhsgref\addons\rhsgref_vehicles_ret\data\hidf\hmmwv\m1025_lg_co.paa","rhsgref\addons\rhsgref_vehicles_ret\data\hidf\hmmwv\mk64mount_lg_co.paa","",""};
+
+	class TransportMagazines{};
+	class TransportWeapons{};
 };
 
 class rhsusf_m113tank_base;
@@ -28,6 +31,9 @@ class a3a_rhs_m113_olive_medical : rhsusf_m113_usarmy_medical{
 		};
 	};
 	hiddenSelectionsTextures[] = {"rhsusf\addons\rhsusf_m113\data_new\m113a3_01_od_med_co.paa","rhsusf\addons\rhsusf_m113\data_new\m113a3_02_od_l_co.paa","rhsusf\addons\rhsusf_m113\data_new\m113a3_03_wd_co.paa","rhsusf\addons\rhsusf_m113\data_new\m113a3_int03_wd_co.paa"};
+
+	class TransportMagazines{};
+	class TransportWeapons{};
 };
 
 class rhsusf_m113_usarmy_M240 : rhsusf_m113tank_base{
@@ -50,6 +56,9 @@ class a3a_rhs_m113_hidf_M240 : a3a_rhs_m113_hidf_M240_base{
 		};
 	};
 	hiddenSelectionsTextures[] = {"rhsgref\addons\rhsgref_vehicles_ret\data\hidf\m113a3_01_lg_l_co.paa","rhsgref\addons\rhsgref_vehicles_ret\data\hidf\m113a3_02_lg_l_co.paa","rhsgref\addons\rhsgref_vehicles_ret\data\hidf\m113a3_03_lg_co.paa","rhsusf\addons\rhsusf_m113\data_new\m113a3_int03_wd_co.paa","rhsusf\addons\rhsusf_m113\data_new\m23_pintle_wd_co.paa",""};
+
+	class TransportMagazines{};
+	class TransportWeapons{};
 };
 
 class APC_Tracked_03_base_F;
@@ -71,4 +80,7 @@ class a3a_RHS_M2A2_olive : RHS_M2A2{
 		};
 	};
 	hiddenSelectionsTextures[] = {"rhsusf\addons\rhsusf_a2port_armor\m2a2_bradley\data\woodland\m6_base_co.paa","rhsusf\addons\rhsusf_a2port_armor\m2a2_bradley\data\woodland\m6_a3_co.paa","rhsusf\addons\rhsusf_a2port_armor\m2a2_bradley\data\woodland\ultralp_co.paa","rhsusf\addons\rhsusf_a2port_armor\m2a2_bradley\data\woodland\m6_base_co.paa","rhsusf\addons\rhsusf_a2port_armor\m2a2_bradley\data\woodland\m6_base_co.paa"};
+
+	class TransportMagazines{};
+	class TransportWeapons{};
 };

--- a/A3A/addons/config_fixes/RHS/tla_rhs.hpp
+++ b/A3A/addons/config_fixes/RHS/tla_rhs.hpp
@@ -3,22 +3,22 @@
 //Air
 class a3a_rhs_Mi8MTV3_tla : RHS_Mi8MTV3_vvsc
 {
-	crew = "rhsgref_ins_pilot";
+	crew = "rhsgref_tla_crew";
 	dlc = "RHS_GREF";
-	faction = "rhsgref_faction_chdkz";
+	faction = "rhsgref_faction_tla";
 	hiddenSelectionsTextures[] ={"rhsafrf\addons\rhs_a2port_air\mi17\data\camo\mi8_body_g_camo3_co.paa","rhsafrf\addons\rhs_a2port_air\mi17\data\camo\mi8_det_g_camo_mvd_co.paa","a3\data_f\clear_empty.paa","rhsafrf\addons\rhs_a2port_air\mi17\data\mi8_decals_ca.paa","rhsafrf\addons\rhs_decals\data\numbers\aviared\5_ca.paa","rhsafrf\addons\rhs_decals\data\numbers\aviared\0_ca.paa","rhsafrf\addons\rhs_decals\data\labels\aviation\vvs_ca.paa"};
 };
 class a3a_rhs_Mi8MTV3_heavy_tla : RHS_Mi8MTV3_heavy_vvsc
 {
-	crew = "rhsgref_ins_pilot";
+	crew = "rhsgref_tla_crew";
 	dlc = "RHS_GREF";
-	faction = "rhsgref_faction_chdkz";
+	faction = "rhsgref_faction_tla";
 	hiddenSelectionsTextures[] ={"rhsafrf\addons\rhs_a2port_air\mi17\data\camo\mi8_body_g_camo3_co.paa","rhsafrf\addons\rhs_a2port_air\mi17\data\camo\mi8_det_g_camo_mvd_co.paa","a3\data_f\clear_empty.paa","rhsafrf\addons\rhs_a2port_air\mi17\data\mi8_decals_ca.paa","rhsafrf\addons\rhs_decals\data\numbers\aviared\7_ca.paa","rhsafrf\addons\rhs_decals\data\numbers\aviared\5_ca.paa","rhsafrf\addons\rhs_decals\data\labels\aviation\vvs_ca.paa"};
 };
 class a3a_rhs_Mi8AMTSh_tla : RHS_Mi8AMTSh_vvsc
 {
-	crew = "rhsgref_ins_pilot";
+	crew = "rhsgref_tla_crew";
 	dlc = "RHS_GREF";
-	faction = "rhsgref_faction_chdkz";
+	faction = "rhsgref_faction_tla";
 	hiddenSelectionsTextures[] ={"rhsafrf\addons\rhs_a2port_air\mi17\data\camo\mi_171_camo_mvd_co.paa","rhsafrf\addons\rhs_a2port_air\mi17\data\camo\mi8_det_g_camo_mvd_co.paa","a3\data_f\clear_empty.paa","rhsafrf\addons\rhs_a2port_air\mi17\data\mi8_decals_ca.paa","rhsafrf\addons\rhs_decals\data\numbers\aviared\6_ca.paa","rhsafrf\addons\rhs_decals\data\numbers\aviared\7_ca.paa","rhsafrf\addons\rhs_decals\data\labels\aviation\vvs_ca.paa"};
 };

--- a/A3A/addons/core/Templates/Templates.hpp
+++ b/A3A/addons/core/Templates/Templates.hpp
@@ -1016,6 +1016,17 @@ class Templates
         shortName = "LSM";
         lore = $STR_A3A_templates_lore_3CB_Reb_LSM;
     };
+
+    class 3CBF_SPI : 3CBF_Base
+    {
+        side = "Civ";
+        flagTexture = "\A3\Data_F_Exp\Flags\flag_Tanoa_CO.paa";
+        name = "3CB South Pacific";
+        file = "3CB_Civ_SPI";
+        shortName = "Civilian";
+        lore = $STR_A3A_templates_lore_CIV;
+    };
+
     class 3CBF_CHC : 3CBF_Base
     {
         side = "Civ";

--- a/A3A/addons/core/Templates/Templates.hpp
+++ b/A3A/addons/core/Templates/Templates.hpp
@@ -149,7 +149,7 @@ class Templates
         flagTexture = "\A3\Data_F_exp\Flags\Flag_Synd_CO.paa";
         name = "A3 SDK";
         file = "Vanilla_Reb_SDK";
-        maps[] = {"Tanoa"};
+        maps[] = {"tanoa"};
         climate[] = {"tropical"};
         forceDLC[] = {"expansion"};
         shortName = "SDK";
@@ -198,7 +198,7 @@ class Templates
         name = "A3 Tanoan Civilians";
         file = "Vanilla_Civ_TNA";
         shortName = "Tanoan";
-        maps[] = {"Tanoa"};
+        maps[] = {"tanoa"};
         lore = $STR_A3A_templates_lore_CIV;
     };
 
@@ -468,7 +468,7 @@ class Templates
         flagTexture = "\A3\Data_F_exp\Flags\Flag_Synd_CO.paa";
         name = "Aegis SDK";
         file = "Aegis_Reb_SDK";
-        maps[] = {"Tanoa"};
+        maps[] = {"tanoa"};
         climate[] = {"tropical"};
         forceDLC[] = {"expansion"};
     };
@@ -545,7 +545,7 @@ class Templates
         flagTexture = "\A3\Data_F_Exp\Flags\flag_GEN_CO.paa";
         name = "RHS HIDF";
         file = "RHS_AI_HIDF";
-        maps[] = {"Tanoa"};
+        maps[] = {"tanoa"};
         climate[] = {"tropical"};
         logo = "\rhsgref\addons\rhsgref_main\data\rhs_logo_ca.paa";
         shortName = "HIDF";
@@ -558,7 +558,7 @@ class Templates
         flagTexture = "\rhsafrf\addons\rhs_main\data\Flag_trn_CO.paa";
         name = "RHS TLA";
         file = "RHS_AI_TLA";
-        maps[] = {"Tanoa"};
+        maps[] = {"tanoa"};
         climate[] = {"tropical"};
         logo = "\rhsgref\addons\rhsgref_main\data\rhs_logo_ca.paa";
         shortName = "TLA";
@@ -621,7 +621,7 @@ class Templates
         flagTexture = "\A3\Data_F_exp\Flags\Flag_Synd_CO.paa";
         name = "RHS SDK";
         file = "RHS_Reb_SDK";
-        maps[] = {"Tanoa"};
+        maps[] = {"tanoa"};
         climate[] = {"tropical"};
     };
 
@@ -967,6 +967,8 @@ class Templates
         flagTexture = "\UK3CB_Factions\addons\UK3CB_Factions_CCM\Flag\ccm_i_flag_co.paa";
         name = "3CB CCM";
         file = "3CB_Reb_CNM";
+        climate[] = {"temperate", "arctic"};
+        maps[] = {"chernarus","chernarus_summer","chernarus_winter","cup_chernarus_a3"};
         shortName = "CCM";
         lore = $STR_A3A_templates_lore_3CB_Reb_CCM;
     };
@@ -986,6 +988,7 @@ class Templates
         name = "3CB TKM";
         file = "3CB_Reb_TKM";
         maps[] = {"takistan","tem_anizay","kunduz"};
+        climate[] = {"arid"};
         shortName = "TKM";
         lore = $STR_A3A_templates_lore_TKM;
     };
@@ -996,6 +999,8 @@ class Templates
         name = "3CB FIA";
         file = "3CB_Reb_FIA";
         shortName = "FIA";
+        climate[] = {"arid"};
+        maps[] = {"altis","malden","sara","tembelan"};
         lore = $STR_A3A_templates_lore_FIA;
     };
     class 3CB_TFIA : 3CBF_Base
@@ -1004,7 +1009,8 @@ class Templates
         flagTexture = "\A3\Data_F_Exp\Flags\flag_Tanoa_CO.paa";
         name = "3CB TFIA";
         file = "3CB_Reb_SDK";
-        maps[] = {"Tanoa"};
+        climate[] = {"tropical"};
+        maps[] = {"tanoa", "umb_colombia", "pulau"};
     };
     class 3CB_Reb_LSM : 3CBF_Base
     {
@@ -1012,6 +1018,7 @@ class Templates
         flagTexture = "\UK3CB_Factions\addons\UK3CB_Factions_LSM\Flag\LSM_flag_co.paa";
         name = "3CB LSM";
         file = "3CB_Reb_LSM";
+        climate[] = {"temperate"};
         maps[] = {"enoch"};
         shortName = "LSM";
         lore = $STR_A3A_templates_lore_3CB_Reb_LSM;
@@ -1024,6 +1031,20 @@ class Templates
         name = "3CB South Pacific";
         file = "3CB_Civ_SPI";
         shortName = "Civilian";
+        climate[] = {"tropical"};
+        maps[] = {"tanoa", "umb_colombia", "pulau"};
+        lore = $STR_A3A_templates_lore_CIV;
+    };
+
+    class 3CBF_RAS : 3CBF_Base
+    {
+        side = "Civ";
+        flagTexture = "\A3\Data_F\Flags\Flag_Altis_CO.paa";
+        name = "3CB Mediterranean";
+        file = "3CB_Civ_RAS";
+        shortName = "Civilian";
+        climate[] = {"arid"};
+        maps[] = {"altis","malden","sara","tembelan"};
         lore = $STR_A3A_templates_lore_CIV;
     };
 
@@ -1033,6 +1054,8 @@ class Templates
         flagTexture = "uk3cb_factions\addons\uk3cb_factions_chc\flag\chc_flag_co.paa";
         name = "3CB Cherno";
         file = "3CB_Civ_CHC";
+        climate[] = {"temperate"};
+        maps[] = {"chernarus","chernarus_summer","chernarus_winter","cup_chernarus_a3"};
         shortName = "Civilian";
         lore = $STR_A3A_templates_lore_CHC;
     };
@@ -1043,29 +1066,30 @@ class Templates
         flagTexture = "uk3cb_factions\addons\uk3cb_factions_tkc\flag\tkc_flag_co.paa";
         name = "3CB Takistan";
         file = "3CB_Civ_TKC";
-        maps[] = {"takistan","tem_anizay","kunduz"};
+        maps[] = {"takistan","kunduz"};
+        climate[] = {"arid"};
         shortName = "Civilian";
         lore = $STR_A3A_templates_lore_TKC;
     };
 
-        class 3CBF_MEC : 3CBF_Base
+    class 3CBF_MEC : 3CBF_Base
     {
         side = "Civ";
         flagTexture = "uk3cb_factions\addons\uk3cb_factions_mec\flag\mec_flag_co.paa";
         name = "3CB Middle Eastern";
         file = "3CB_Civ_MEC";
-        maps[] = {"takistan","tem_anizay","kunduz"};
+        maps[] = {"tem_anizay","kunduz"};
         climate[] = {"arid"};
         shortName = "Civilian";
         lore = $STR_A3A_templates_lore_MEC;
     };
-        class 3CBF_ADC : 3CBF_Base
+    class 3CBF_ADC : 3CBF_Base
     {
         side = "Civ";
         flagTexture = "uk3cb_factions\addons\uk3cb_factions_adc\flag\adc_flag_co.paa";
         name = "3CB African Desert";
         file = "3CB_Civ_ADC";
-        maps[] = {"takistan","tem_anizay","kunduz"};
+        maps[] = {"isladuala3", "tem_kujari", "regero"};
         climate[] = {"arid","tropical"};
         shortName = "Civilian";
         lore = $STR_A3A_templates_lore_ADC;
@@ -1665,7 +1689,7 @@ class Templates
         flagTexture = "\x\A3A\addons\core\Pictures\Flags\ifa_ak.paa";
         name = "IFA Polish Resistance";
         file = "IFA_REB_AK";
-        maps[] = {"Staszow"};
+        maps[] = {"staszow"};
         climate[] = {};
         shortName = "AK";
         lore = $STR_A3A_templates_IFA_REB_AK;
@@ -1687,7 +1711,7 @@ class Templates
         flagTexture = "\x\A3A\addons\core\Pictures\Flags\ifa_pl.paa";
         name = "IFA Polish";
         file = "IFA_CIV_PL";
-        maps[] = {"Staszow"};
+        maps[] = {"staszow"};
         climate[] = {};
         shortName = "CIV";
         lore = $STR_A3A_templates_IFA_CIV_PL;
@@ -2054,7 +2078,7 @@ class Templates
         flagTexture = "\A3\ui_f\data\map\markers\flags\CzechRepublic_ca.paa";
         name = "CSLA Arid";
         file = "CSLA_AI_CSLA_Arid";
-        climate[] = {"Arid"};
+        climate[] = {"arid"};
         shortName = "CSLA";
     };
 
@@ -2084,7 +2108,7 @@ class Templates
         flagTexture = "cup\baseconfigs\cup_baseconfigs\data\flags\flag_napa_co.paa";
         name = "CSLA NAPA";
         file = "CSLA_Reb_NAPA";
-        climate[] = {"Temperate"};
+        climate[] = {"temperate"};
         shortName = "NAPA";
     };
 
@@ -2094,7 +2118,7 @@ class Templates
         flagTexture = "\CUP\BaseConfigs\CUP_BaseConfigs\data\Flags\flag_tka_co.paa";
         name = "CIV_TC";
         file = "CSLA_Civ_TC";
-        climate[] = {"Temperate"};
+        climate[] = {"temperate"};
         shortName = "FIA";
     };
   

--- a/A3A/addons/core/Templates/Templates.hpp
+++ b/A3A/addons/core/Templates/Templates.hpp
@@ -786,9 +786,29 @@ class Templates
     class 3CBF_TLA : 3CBF_Base
     {
         side = "Inv";
-        flagTexture = "uk3cb_factions\addons\uk3cb_factions_cw_sov\flag\cw_sov_army_flag_co.paa";
+        flagTexture = "\rhsafrf\addons\rhs_main\data\Flag_trn_CO.paa";
         name = "3CB TLA";
         file = "3CB_AI_TLA";
+        maps[] = {"tanoa"};
+        climate[] = {"tropical"};
+    };
+	
+    class 3CBF_PLM : 3CBF_Base
+    {
+        side = "Occ";
+        flagTexture = "\UK3CB_Factions\addons\UK3CB_Factions_PLM\Flag\PLM_flag_co.paa";
+        name = "3CB PLM";
+        file = "3CB_AI_PLM";
+        maps[] = {"tanoa"};
+        climate[] = {"tropical"};
+    };
+	
+    class 3CBF_TNM : 3CBF_Base
+    {
+        side = "Inv";
+        flagTexture = "\UK3CB_Factions\addons\UK3CB_Factions_TNM\Flag\TNM_flag_co.paa";
+        name = "3CB TNM";
+        file = "3CB_AI_TNM";
         maps[] = {"tanoa"};
         climate[] = {"tropical"};
     };

--- a/A3A/addons/core/Templates/Templates.hpp
+++ b/A3A/addons/core/Templates/Templates.hpp
@@ -787,7 +787,7 @@ class Templates
     {
         side = "Inv";
         flagTexture = "\rhsafrf\addons\rhs_main\data\Flag_trn_CO.paa";
-        name = "3CB TLA";
+        name = "3CB Cold War TLA";
         file = "3CB_AI_TLA";
         maps[] = {"tanoa"};
         climate[] = {"tropical"};
@@ -797,7 +797,7 @@ class Templates
     {
         side = "Occ";
         flagTexture = "\UK3CB_Factions\addons\UK3CB_Factions_PLM\Flag\PLM_flag_co.paa";
-        name = "3CB PLM";
+        name = "3CB Cold War PLM";
         file = "3CB_AI_PLM";
         maps[] = {"tanoa"};
         climate[] = {"tropical"};
@@ -807,7 +807,7 @@ class Templates
     {
         side = "Inv";
         flagTexture = "\UK3CB_Factions\addons\UK3CB_Factions_TNM\Flag\TNM_flag_co.paa";
-        name = "3CB TNM";
+        name = "3CB Cold War TNM";
         file = "3CB_AI_TNM";
         maps[] = {"tanoa"};
         climate[] = {"tropical"};

--- a/A3A/addons/core/Templates/Templates/3CB/3CBFactions_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CBFactions_Vehicle_Attributes.sqf
@@ -38,7 +38,8 @@
     ["UK3CB_MDF_B_T28Trojan_NAVY_CAS", ["cost", 120]],
     ["UK3CB_B_Mystere_HIDF_CAS1", ["cost", 200]],           // not many missiles. Gun is actually good though
     ["UK3CB_B_Mystere_HIDF_AA1", ["cost", 200]],            // no mid-range AA missiles
-    ["UK3CB_MDF_B_Mystere_AA1", ["cost", 200]]
+    ["UK3CB_MDF_B_Mystere_AA1", ["cost", 200]],
+    ["a3a_UK3CB_Fake_Mig", ["cost", 200]]
 
     // American attack helis with hellfires & chaingun, better than Russian stuff
 /*    ["UK3CB_AAF_B_AH1Z", ["cost", 300]],

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_HIDF.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_HIDF.sqf
@@ -32,7 +32,7 @@
 ["vehiclesTanks", ["UK3CB_B_M60A3_HIDF", "UK3CB_B_M60A1_HIDF", "UK3CB_CW_US_B_EARLY_M1A1"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["RHS_M6_wd"]] call _fnc_saveToTemplate;
 
-["vehiclesTransportBoats", ["rhsgref_hidf_assault_boat", "rhsgref_hidf_rhib"]] call _fnc_saveToTemplate;
+["vehiclesTransportBoats", ["rhsgref_hidf_rhib"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["UK3CB_TKA_B_RHIB_Gunboat"]] call _fnc_saveToTemplate;
 ["vehiclesAmphibious", ["UK3CB_B_LAV25_HIDF", "UK3CB_B_AAV_HIDF"]] call _fnc_saveToTemplate;
 

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_PLM.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_PLM.sqf
@@ -1,0 +1,1013 @@
+//////////////////////////
+//   Side Information   //
+//////////////////////////
+//Tanoan Liberation Army, natural enemies of the HIDF, CW US, US, and SDK
+["name", "TLA"] call _fnc_saveToTemplate;
+["spawnMarkerName", "TLA Support Corridor"] call _fnc_saveToTemplate;
+
+["flag", "Flag_CW_SOV_ARMY"] call _fnc_saveToTemplate;
+["flagTexture", "uk3cb_factions\addons\uk3cb_factions_cw_sov\flag\cw_sov_army_flag_co.paa"] call _fnc_saveToTemplate;
+["flagMarkerType", "UK3CB_Marker_CW_SOV_ARMY"] call _fnc_saveToTemplate;
+
+//////////////////////////
+//       Vehicles       //
+//////////////////////////
+
+
+["attributeLowAir", true] call _fnc_saveToTemplate;             // Use fewer air units in general
+["attributeMoreTrucks", true] call _fnc_saveToTemplate;         // Use more truck for transports
+
+["ammobox", "B_supplyCrate_F"] call _fnc_saveToTemplate;
+["surrenderCrate", "Box_IND_Wps_F"] call _fnc_saveToTemplate;
+["equipmentBox", "Box_NATO_Equip_F"] call _fnc_saveToTemplate;
+
+// vehicles can be placed in more than one category if they fit between both. Cost will be derived by the higher category
+["vehiclesBasic", ["UK3CB_ARD_O_YAVA"]] call _fnc_saveToTemplate; 
+["vehiclesLightUnarmed", ["UK3CB_ARD_O_Hilux_Open","UK3CB_ARD_O_Hilux_Closed","UK3CB_CW_SOV_O_EARLY_BRDM2_UM","UK3CB_CW_SOV_O_EARLY_BTR40","UK3CB_CW_SOV_O_EARLY_UAZ_Closed","UK3CB_CW_SOV_O_EARLY_UAZ_Open"]] call _fnc_saveToTemplate;
+["vehiclesLightArmed", ["UK3CB_ARD_O_Hilux_Dshkm","UK3CB_ARD_O_Hilux_M2","UK3CB_ARD_O_Hilux_GMG","UK3CB_ARD_O_Hilux_Spg9","UK3CB_ARD_O_Hilux_Metis",
+"UK3CB_CW_SOV_O_EARLY_BRDM2_HQ","UK3CB_CW_SOV_O_EARLY_BTR40_MG",
+"UK3CB_CW_SOV_O_EARLY_Gaz66_ZU23"]] call _fnc_saveToTemplate;
+["vehiclesTrucks", ["UK3CB_CW_SOV_O_EARLY_Gaz66_Covered","UK3CB_CW_SOV_O_EARLY_Gaz66_Open"]] call _fnc_saveToTemplate;
+["vehiclesCargoTrucks", ["UK3CB_CW_SOV_O_EARLY_Gaz66_Covered_Flatbed","UK3CB_CW_SOV_O_EARLY_Gaz66_Open_Flatbed","UK3CB_CW_SOV_O_EARLY_Zil131_Covered"]] call _fnc_saveToTemplate;
+["vehiclesAmmoTrucks", ["UK3CB_CW_SOV_O_EARLY_Gaz66_Ammo"]] call _fnc_saveToTemplate;
+["vehiclesRepairTrucks", ["UK3CB_CW_SOV_O_EARLY_Gaz66_Repair","UK3CB_CW_SOV_O_EARLY_Ural_Repair"]] call _fnc_saveToTemplate;
+["vehiclesFuelTrucks", ["UK3CB_CW_SOV_O_EARLY_Ural_Fuel"]] call _fnc_saveToTemplate;
+["vehiclesMedical", ["UK3CB_CW_SOV_O_EARLY_Gaz66_Med"]] call _fnc_saveToTemplate;
+["vehiclesLightAPCs", ["UK3CB_CW_SOV_O_EARLY_BRDM2"]] call _fnc_saveToTemplate;
+["vehiclesAPCs", ["UK3CB_CW_SOV_O_EARLY_BTR60","UK3CB_CW_SOV_O_EARLY_BTR70"]] call _fnc_saveToTemplate;
+["vehiclesIFVs", ["UK3CB_CW_SOV_O_EARLY_BMP1","UK3CB_CW_SOV_O_EARLY_BMP2","UK3CB_CW_SOV_O_EARLY_BMP2K"]] call _fnc_saveToTemplate;
+["vehiclesLightTanks", ["UK3CB_ARD_O_T34"]] call _fnc_saveToTemplate;
+["vehiclesTanks", ["UK3CB_CW_SOV_O_EARLY_T72A","UK3CB_CW_SOV_O_EARLY_T55","UK3CB_CW_SOV_O_EARLY_T55","UK3CB_ARD_O_T34"]] call _fnc_saveToTemplate;
+["vehiclesHeavyTanks", ["UK3CB_CW_SOV_O_EARLY_T72A"]] call _fnc_saveToTemplate;             // Just to push up the T-72 probability at higher war levels
+["vehiclesAA", ["UK3CB_CW_SOV_O_EARLY_ZsuTank"]] call _fnc_saveToTemplate;
+
+
+["vehiclesTransportBoats", ["UK3CB_MDF_B_RHIB"]] call _fnc_saveToTemplate;
+["vehiclesGunBoats", ["UK3CB_CHD_O_Fishing_Boat_DSHKM"]] call _fnc_saveToTemplate;
+["vehiclesAmphibious", ["UK3CB_CW_SOV_O_EARLY_MTLB_PKT","UK3CB_CW_SOV_O_EARLY_MTLB_KPVT","UK3CB_CW_SOV_O_EARLY_MTLB_BMP"]] call _fnc_saveToTemplate;
+
+["vehiclesPlanesCAS", ["UK3CB_CW_SOV_O_EARLY_MIG21_AT","a3a_UK3CB_Fake_Mig"]] call _fnc_saveToTemplate;             
+["vehiclesPlanesAA", ["UK3CB_CW_SOV_O_EARLY_MIG21_AA","a3a_UK3CB_Fake_Mig"]] call _fnc_saveToTemplate;              
+["vehiclesPlanesTransport", ["UK3CB_CW_SOV_O_EARLY_LI2"]] call _fnc_saveToTemplate;
+
+["vehiclesHelisLight", ["UK3CB_CW_SOV_O_EARLY_Mi8AMT"]] call _fnc_saveToTemplate;
+["vehiclesHelisTransport", ["RHS_Mi24Vt_vvsc","UK3CB_CW_SOV_O_EARLY_Mi8","UK3CB_CW_SOV_O_EARLY_Mi8","UK3CB_CW_SOV_O_EARLY_Mi8","UK3CB_CW_SOV_O_EARLY_Mi8"]] call _fnc_saveToTemplate; //Mi24Vt has 1x 12.7mm turret, and disabled pylons
+// Should be capable of dealing damage to ground targets without additional scripting
+["vehiclesHelisLightAttack", ["UK3CB_CW_SOV_O_EARLY_Mi8AMTSh","UK3CB_CW_SOV_O_EARLY_Mi8AMTSh","UK3CB_CW_SOV_O_EARLY_Mi_24P"]] call _fnc_saveToTemplate;      // Mi24P lacks a gun turret
+["vehiclesHelisAttack", ["UK3CB_CW_SOV_O_EARLY_Mi_24V"]] call _fnc_saveToTemplate;           // Proper attack helis: Apache, Hind etc
+
+["vehiclesArtillery", ["UK3CB_CW_SOV_O_EARLY_BM21","rhs_D30_msv","rhs_D30_msv"]] call _fnc_saveToTemplate;
+["magazines", createHashMapFromArray [
+["UK3CB_CW_SOV_O_EARLY_BM21", ["rhs_mag_m21of_1"]],
+["rhs_D30_msv", ["rhs_mag_3of56_10"]]
+]] call _fnc_saveToTemplate; //element format: [Vehicle class, [Magazines]]
+
+["uavsAttack", []] call _fnc_saveToTemplate;
+["uavsPortable", []] call _fnc_saveToTemplate;
+
+//Config special vehicles
+["vehiclesMilitiaLightArmed", ["UK3CB_CW_SOV_O_EARLY_UAZ_MG"]] call _fnc_saveToTemplate;
+["vehiclesMilitiaTrucks", ["UK3CB_CW_SOV_O_EARLY_Zil131_Covered"]] call _fnc_saveToTemplate;
+["vehiclesMilitiaCars", ["UK3CB_CW_SOV_O_EARLY_UAZ_Closed","UK3CB_CW_SOV_O_EARLY_UAZ_Open"]] call _fnc_saveToTemplate;
+
+["vehiclesPolice", ["UK3CB_ARD_O_Hilux_Open", "UK3CB_ARD_O_Hilux_Pkm"]] call _fnc_saveToTemplate;
+
+["staticMGs", ["rhsgref_cdf_b_DSHKM","RHS_M2StaticMG_D", "UK3CB_NAP_I_PKM_High"]] call _fnc_saveToTemplate;
+["staticAT", ["rhsgref_cdf_b_SPG9","rhsgref_cdf_b_SPG9M"]] call _fnc_saveToTemplate;
+["staticAA", ["RHS_ZU23_MSV","rhs_Igla_AA_pod_msv"]] call _fnc_saveToTemplate;
+["staticMortars", ["rhs_2b14_82mm_msv"]] call _fnc_saveToTemplate;
+
+["mortarMagazineHE", "rhs_mag_3vo18_10"] call _fnc_saveToTemplate;             //this line determines available HE-shells for the static mortars - !needs to be comtible with the mortar! -- Example: ["mortarMagazineHE", "8Rnd_82mm_Mo_shells"] - ENTER ONLY ONE OPTION
+["mortarMagazineSmoke", "rhs_mag_d832du_10"] call _fnc_saveToTemplate;         //this line determines smoke-shells for the static mortar - !needs to be comtible with the mortar! -- Example: ["mortarMagazineSmoke", "8Rnd_82mm_Mo_Smoke_white"] - ENTER ONLY ONE OPTION
+["mortarMagazineFlare", "rhs_mag_3vs25m_10"] call _fnc_saveToTemplate;
+
+//Minefield definition
+//CFGVehicles variant of Mines are needed "ATMine", "APERSTripMine", "APERSMine"
+["minefieldAT", ["rhs_mine_tm62m"]] call _fnc_saveToTemplate;
+["minefieldAPERS", ["rhs_mine_pmn2"]] call _fnc_saveToTemplate;
+
+#include "3CBFactions_Vehicle_Attributes.sqf"
+
+/////////////////////
+///  Identities   ///
+/////////////////////
+//Faces and Voices given to AI Factions.
+["faces", ["TanoanHead_A3_01","TanoanHead_A3_02","TanoanHead_A3_03","TanoanHead_A3_04",
+"TanoanHead_A3_05","TanoanHead_A3_06","TanoanHead_A3_07","TanoanHead_A3_08"]] call _fnc_saveToTemplate;
+["voices", ["Male01FRE","Male02FRE","Male03FRE"]] call _fnc_saveToTemplate;
+"TanoanMen" call _fnc_saveNames;
+
+
+//////////////////////////
+//       Loadouts       //
+//////////////////////////
+private _loadoutData = call _fnc_createLoadoutData;
+_loadoutData set ["rifles", []];
+_loadoutData set ["carbines", []];
+_loadoutData set ["grenadeLaunchers", []];
+_loadoutData set ["SMGs", []];
+_loadoutData set ["machineGuns", []];
+_loadoutData set ["marksmanRifles", []];
+_loadoutData set ["sniperRifles", []];
+
+_loadoutData set ["lightATLaunchers", [
+    "rhs_weap_m72a7", 
+    "rhs_weap_rpg18",
+    "rhs_weap_rpg26",
+    "rhs_weap_rpg75",
+    "rhs_weap_rshg2"
+]];
+_loadoutData set ["ATLaunchers", [
+    ["rhs_weap_rpg7", "", "", "rhs_acc_pgo7v3",["rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag"], [], ""],
+    ["rhs_weap_rpg7", "", "", "rhs_acc_pgo7v3",["rhs_rpg7_PG7VM_mag", "rhs_rpg7_PG7VS_mag"], [], ""],
+    ["rhs_weap_rpg7", "", "", "rhs_acc_pgo7v3",["rhs_rpg7_PG7V_mag", "rhs_rpg7_type69_airburst_mag", "rhs_rpg7_OG7V_mag"], [], ""],
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag"], [], ""],
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7VM_mag", "rhs_rpg7_PG7VS_mag"], [], ""],
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_type69_airburst_mag", "rhs_rpg7_OG7V_mag"], [], ""],
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag"], [], ""],
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7VM_mag", "rhs_rpg7_PG7VS_mag"], [], ""],
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_type69_airburst_mag", "rhs_rpg7_OG7V_mag"], [], ""]
+]];
+_loadoutData set ["heavyATLaunchers", [
+    ["rhs_weap_rpg7", "", "", "rhs_acc_pgo7v3",["rhs_rpg7_PG7VL_mag", "rhs_rpg7_PG7VS_mag"], [], ""],
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7VL_mag", "rhs_rpg7_PG7VS_mag"], [], ""],
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7VL_mag", "rhs_rpg7_PG7VS_mag"], [], ""]
+]];
+_loadoutData set ["AALaunchers", ["rhs_weap_igla"]];
+_loadoutData set ["sidearms", ["rhs_weap_tt33","rhs_weap_makarov_pm"]];
+
+_loadoutData set ["ATMines", ["rhs_mine_tm62m_mag"]];
+_loadoutData set ["APMines", ["rhs_mine_pmn2_mag"]];
+_loadoutData set ["lightExplosives", ["rhs_ec200_mag"]];
+_loadoutData set ["heavyExplosives", ["rhs_ec400_mag"]];
+
+_loadoutData set ["antiTankGrenades", []];
+_loadoutData set ["antiInfantryGrenades", ["rhs_mag_f1","rhs_mag_rgd5","rhs_mag_rgo","rhs_mag_rgn","rhs_grenade_khattabka_vog17_mag","rhs_grenade_khattabka_vog25_mag"]];
+_loadoutData set ["smokeGrenades", ["rhs_mag_rdg2_white"]];
+_loadoutData set ["signalsmokeGrenades", ["rhs_mag_nspd"]];
+
+
+//Basic equipment. Shouldn't need touching most of the time.
+//Mods might override this, or certain mods might want items removed (No GPSs in WW2, for example)
+_loadoutData set ["maps", ["ItemMap"]];
+_loadoutData set ["watches", ["ItemWatch"]];
+_loadoutData set ["compasses", ["ItemCompass"]];
+_loadoutData set ["radios", ["ItemRadio"]];
+_loadoutData set ["gpses", []];
+_loadoutData set ["NVGs", ["rhs_1PN138"]];
+_loadoutData set ["binoculars", ["rhsusf_bino_m24"]];
+_loadoutData set ["rangefinders", ["rhsusf_bino_m24"]];
+
+_loadoutData set ["uniforms", []];
+_loadoutData set ["vests", []];
+_loadoutData set ["backpacks", ["B_FieldPack_cbr","rhs_assault_umbts","rhs_sidor","UK3CB_UN_B_B_ASS"]];
+_loadoutData set ["medBackpacks", ["rhs_medic_bag"]];
+_loadoutData set ["atBackpacks", ["rhs_rpg_empty"]];
+_loadoutData set ["aaBackpacks", ["B_Carryall_oli"]];
+_loadoutData set ["mgBackpacks", ["rhs_rd54"]];
+_loadoutData set ["longRangeRadios", []];
+_loadoutData set ["helmets", []];
+
+_loadoutData set ["facewear", []];
+
+//Item *set* definitions. These are added in their entirety to unit loadouts. No randomisation is applied.
+_loadoutData set ["items_medical_basic", ["BASIC"] call A3A_fnc_itemset_medicalSupplies];
+_loadoutData set ["items_medical_standard", ["STANDARD"] call A3A_fnc_itemset_medicalSupplies];
+_loadoutData set ["items_medical_medic", ["MEDIC"] call A3A_fnc_itemset_medicalSupplies];
+_loadoutData set ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials];
+
+//Unit type specific item sets. Add or remove these, depending on the unit types in use.
+_loadoutData set ["items_squadLeader_extras", []];
+_loadoutData set ["items_rifleman_extras", []];
+_loadoutData set ["items_medic_extras", []];
+_loadoutData set ["items_grenadier_extras", []];
+_loadoutData set ["items_explosivesExpert_extras", ["ToolKit", "MineDetector"]];
+_loadoutData set ["items_engineer_extras", ["ToolKit", "MineDetector"]];
+_loadoutData set ["items_lat_extras", []];
+_loadoutData set ["items_at_extras", []];
+_loadoutData set ["items_aa_extras", []];
+_loadoutData set ["items_machineGunner_extras", []];
+_loadoutData set ["items_marksman_extras", []];
+_loadoutData set ["items_sniper_extras", []];
+_loadoutData set ["items_police_extras", []];
+_loadoutData set ["items_crew_extras", []];
+_loadoutData set ["items_unarmed_extras", []];
+
+//TODO - ACE overrides for misc essentials, medical and engineer gear
+
+///////////////////////////////////////
+//    Special Forces Loadout Data    //
+///////////////////////////////////////
+
+private _sfLoadoutData = _loadoutData call _fnc_copyLoadoutData;
+_sfLoadoutData set ["uniforms", ["UK3CB_CHD_B_U_CombatUniform_08"]];
+_sfLoadoutData set ["vests", ["UK3CB_V_Belt_Rig_KHK","UK3CB_MDF_B_V_TacVest_LIZ","UK3CB_MD99_VEST_Rifleman_KHK","UK3CB_MD12_VEST_Rifleman_OLI"]];
+_sfLoadoutData set ["helmets", ["rhs_headband", "rhs_6b27m_ml", "rhsgref_6b27m_ttsko_mountain"]];
+_sfLoadoutData set ["facewear", ["rhsusf_shemagh2_grn", "rhsusf_shemagh2_od", "rhsusf_shemagh2_tan", "rhsusf_shemagh2_white","UK3CB_G_KLR_BLK","UK3CB_G_KLR_Oli","UK3CB_G_KLR_TAN"]];
+//["Weapon", "Muzzle", "Rail", "Sight", [], [], "Bipod"];
+
+_sfLoadoutData set ["lightATLaunchers", [
+    "rhs_weap_m72a7", 
+    "rhs_weap_rshg2",
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7VS_mag", "rhs_rpg7_type69_airburst_mag", "rhs_rpg7_OG7V_mag"], [], ""]
+]];
+_sfLoadoutData set ["ATLaunchers", [
+    ["rhs_weap_rpg7", "", "", "rhs_acc_pgo7v3",["rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7VS_mag"], [], ""],
+    ["rhs_weap_rpg7", "", "", "rhs_acc_pgo7v3",["rhs_rpg7_PG7VM_mag", "rhs_rpg7_PG7VS_mag"], [], ""],
+    ["rhs_weap_rpg7", "", "", "rhs_acc_pgo7v3",["rhs_rpg7_PG7VS_mag", "rhs_rpg7_type69_airburst_mag", "rhs_rpg7_OG7V_mag"], [], ""]
+]];
+_sfLoadoutData set ["heavyATLaunchers", [
+    ["rhs_weap_rpg7", "", "", "rhs_acc_pgo7v3",["rhs_rpg7_PG7VL_mag","rhs_rpg7_PG7VR_mag"], [], ""]
+]];
+_sfLoadoutData set ["slRifles", [
+    ["rhs_weap_aks74un", "rhs_acc_pbs4", "", "rhs_acc_okp7_dovetail", ["rhs_30Rnd_545x39_7N10_AK"], [], ""],
+    ["rhs_weap_m92", "rhs_acc_pbs1", "", "", ["UK3CB_AK47_45Rnd_Magazine_GT", "UK3CB_AK47_45Rnd_Magazine_G", "UK3CB_AK47_45Rnd_Magazine","rhs_30Rnd_762x39mm_bakelite", "rhs_30Rnd_762x39mm_bakelite_tracer"], [], ""],
+    ["rhs_weap_ak74n_gp25", "rhs_acc_dtk4short", "", "", ["rhs_30Rnd_545x39_7N10_AK"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
+    ["UK3CB_M16A2_UGL", "", "", "", ["UK3CB_M16_30rnd_556x45","UK3CB_M16_30rnd_556x45_G"], ["rhs_mag_M441_HE", "rhs_mag_M441_HE", "rhs_mag_M433_HEDP", "rhs_mag_m714_White"], ""],
+    ["UK3CB_M16A1", "", "", "", ["UK3CB_M16_30rnd_556x45","UK3CB_M16_30rnd_556x45_G"], [], ""]
+]];
+_sfLoadoutData set ["rifles", [
+    ["rhs_weap_l1a1_wood", "rhsgref_sdn6_suppressor", "", "", 	["UK3CB_FNFAL_30rnd_762x51_G","UK3CB_FNFAL_30rnd_762x51_GT"], [], ""],
+    ["rhs_weap_ak74n", "rhs_acc_dtk", "rhs_acc_perst1ik", 	"rhs_acc_ekp1", ["rhs_30Rnd_545x39_7N10_AK"], [], ""],
+    ["rhs_weap_ak74n", "rhs_acc_dtk4short", "rhs_acc_perst1ik", "rhs_acc_pkas", ["rhs_30Rnd_545x39_7N10_AK"], [], ""],
+    ["rhs_weap_aks74n", "rhs_acc_dtk", "rhs_acc_perst1ik", 	"rhs_acc_ekp1", ["rhs_30Rnd_545x39_7N10_AK"], [], ""],
+    ["rhs_weap_aks74n", "rhs_acc_dtk4short", "rhs_acc_perst1ik", "rhs_acc_pkas", ["rhs_30Rnd_545x39_7N10_AK"], [], ""],
+    ["rhs_weap_rpk74m", "rhs_acc_tgpa", "rhs_acc_perst1ik", "rhs_acc_ekp1", 	["rhs_30Rnd_545x39_7U1_AK"], [], ""]
+]];
+_sfLoadoutData set ["carbines", [
+    ["UK3CB_M16A1", "", "", "", ["UK3CB_M16_30rnd_556x45","UK3CB_M16_30rnd_556x45_G"], [], ""],
+    ["rhs_weap_aks74un", "rhs_acc_dtk", "", "rhs_acc_okp7_dovetail", ["rhs_30Rnd_545x39_7N10_AK"], [], ""],
+    ["rhs_weap_aks74un", "rhs_acc_pbs4", "", "rhs_acc_okp7_dovetail", ["rhs_30Rnd_545x39_7N10_AK"], [], ""],
+    ["rhs_weap_m92", "rhs_acc_pbs1", "", "", ["UK3CB_AK47_45Rnd_Magazine_GT", "UK3CB_AK47_45Rnd_Magazine_G", "UK3CB_AK47_45Rnd_Magazine","rhs_30Rnd_762x39mm_bakelite", "rhs_30Rnd_762x39mm_bakelite_tracer"], [], ""],
+    ["rhs_weap_m92", "rhs_acc_pbs1", "", "", ["UK3CB_AK47_45Rnd_Magazine_GT", "UK3CB_AK47_45Rnd_Magazine_G", "UK3CB_AK47_45Rnd_Magazine","rhs_30Rnd_762x39mm_bakelite", "rhs_30Rnd_762x39mm_bakelite_tracer"], [], ""]
+]];
+_sfLoadoutData set ["grenadeLaunchers", [
+    ["rhs_weap_ak74n_gp25", "rhs_acc_dtk1983", "", "", ["rhs_30Rnd_545x39_7N10_AK"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
+    ["rhs_weap_ak74n_gp25", "rhs_acc_dtk4short", "", "", ["rhs_30Rnd_545x39_7N10_AK"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
+    ["UK3CB_M16A2_UGL", "", "", "", ["UK3CB_M16_30rnd_556x45","UK3CB_M16_30rnd_556x45_G"], ["rhs_mag_M441_HE", "rhs_mag_M441_HE", "rhs_mag_M433_HEDP", "rhs_mag_m714_White"], ""]
+]];
+_sfLoadoutData set ["SMGs", [
+    ["rhs_weap_aks74un", "rhs_acc_pbs4", "", "rhs_acc_okp7_dovetail", ["rhs_30Rnd_545x39_7U1_AK"], [], ""],
+    ["rhs_weap_asval", "", "", "rhs_acc_okp7_dovetail", ["rhs_20rnd_9x39mm_SP5","rhs_20rnd_9x39mm_SP6"], [], ""]
+]];
+_sfLoadoutData set ["machineGuns", [
+    ["rhs_weap_rpk74m", "rhs_acc_tgpa", "rhs_acc_perst1ik", "rhs_acc_ekp1", 	["rhs_45Rnd_545X39_7U1_AK"], [], ""],
+    ["UK3CB_RPK_74N_BLK", "", "", "rhs_acc_1p29", 	["UK3CB_RPK74_60rnd_545x39_GM", "UK3CB_RPK74_60rnd_545x39_GT"], [], ""],
+    ["UK3CB_RPD", "rhs_acc_pbs1", "", "", 	["UK3CB_RPD_100rnd_762x39"], [], ""]
+]];
+_sfLoadoutData set ["marksmanRifles", [
+    ["UK3CB_SVD_OLD", "rhs_acc_tgpv", "", "rhs_acc_pso1m2", ["rhs_10Rnd_762x54mmR_7N1"], [], ""],
+    ["rhs_weap_l1a1_wood", "rhsgref_sdn6_suppressor", "", "rhsgref_acc_l1a1_l2a2", 	["UK3CB_FNFAL_20rnd_762x51_G","UK3CB_FNFAL_20rnd_762x51_GT"], [], ""],
+    ["rhs_weap_asval_grip", "", "rhs_acc_perst1ik_ris", "rhs_acc_pso1m21", 	["rhs_10rnd_9x39mm_SP5","rhs_10rnd_9x39mm_SP6"], [], "rhs_acc_grip_rk6"]
+]];
+_sfLoadoutData set ["sniperRifles", [
+    ["UK3CB_SVD_OLD", "rhs_acc_tgpv", "", "rhs_acc_pso1m2", ["rhs_10Rnd_762x54mmR_7N1"], [], ""],
+    ["rhs_weap_asval_grip", "", "rhs_acc_perst1ik_ris", "rhs_acc_pso1m21", 	["rhs_10rnd_9x39mm_SP5","rhs_10rnd_9x39mm_SP6"], [], "rhs_acc_grip_rk6"]
+]];
+_sfLoadoutData set ["sidearms", [
+    ["rhs_weap_pb_6p9", "", "", "", ["rhs_mag_9x18_8_57N181S"], [], ""],
+    ["rhs_weap_pb_6p9", "rhs_acc_6p9_suppressor", "", "", ["rhs_mag_9x18_8_57N181S"], [], ""]
+]];
+/////////////////////////////////
+//    Military Loadout Data    //
+/////////////////////////////////
+
+private _militaryLoadoutData = _loadoutData call _fnc_copyLoadoutData;
+_militaryLoadoutData set ["uniforms", ["UK3CB_CHD_B_U_CombatUniform_08"]];
+_militaryLoadoutData set ["vests", ["rhs_6b2_RPK","rhs_6b2_lifchik","rhs_6b2_chicom","rhs_6b2_AK","rhs_lifchik","rhsgref_chicom"]];
+_militaryLoadoutData set ["helmets", ["H_Bandanna_khk", "rhs_ssh60","rhs_ssh68","rhs_ssh68_2", "rhsgref_M56","H_Booniehat_oli","H_Hat_Safari_olive_F"]];
+
+_militaryLoadoutData set ["slRifles", [
+    ["UK3CB_FNFAL_FOREGRIP", "", "", "", 	["UK3CB_FNFAL_20rnd_762x51_G","UK3CB_FNFAL_20rnd_762x51_GT"], [], ""],
+    ["rhs_weap_akmn", "rhs_acc_dtkakm", "rhs_acc_2dpZenit", "", ["rhs_30Rnd_762x39mm", "rhs_30Rnd_762x39mm_tracer"], [], ""],
+    ["rhs_weap_akmn", "rhs_acc_dtkakm", "rhs_acc_2dpZenit", "", ["rhs_30Rnd_762x39mm_bakelite", "rhs_30Rnd_762x39mm_bakelite_tracer"], [], ""],
+    ["rhs_weap_akmn_gp25", "rhs_acc_dtkakm", "", "", ["rhs_30Rnd_762x39mm", "rhs_30Rnd_762x39mm_tracer"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
+    ["rhs_weap_ak74n_gp25", "rhs_acc_dtk1983", "", "", ["rhs_30Rnd_545x39_7N6M_AK"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
+    ["UK3CB_M16A1", "", "", "", ["UK3CB_M16_20rnd_556x45","UK3CB_M16_20rnd_556x45_G"], [], ""],
+    ["UK3CB_M16A2", "", "", "", ["UK3CB_M16_20rnd_556x45","UK3CB_M16_20rnd_556x45_G"], [], ""],
+    ["UK3CB_M16A2_UGL", "", "", "", ["UK3CB_M16_20rnd_556x45","UK3CB_M16_20rnd_556x45_G"], ["rhs_mag_M441_HE", "rhs_mag_M441_HE", "rhs_mag_M433_HEDP", "rhs_mag_m714_White"], ""]
+]];
+_militaryLoadoutData set ["rifles", [
+    ["rhs_weap_l1a1_wood", "rhsgref_acc_falMuzzle_l1a1", "", "", 	["UK3CB_FNFAL_20rnd_762x51_G","UK3CB_FNFAL_20rnd_762x51_GT"], [], ""],
+    ["rhs_weap_akmn", "rhs_acc_dtkakm", "rhs_acc_2dpZenit", "", ["rhs_30Rnd_762x39mm", "rhs_30Rnd_762x39mm_tracer"], [], ""]
+]];
+_militaryLoadoutData set ["carbines", [
+    ["uk3cb_sks_01", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
+    ["rhs_weap_aks74un", "rhs_acc_dtk", "", "", ["rhs_30Rnd_545x39_7N6M_AK"], [], ""],
+    ["rhs_weap_m92", "", "", "", ["rhs_30Rnd_762x39mm_bakelite", "rhs_30Rnd_762x39mm_bakelite_tracer"], [], ""]
+]];
+_militaryLoadoutData set ["grenadeLaunchers", [
+    ["rhs_weap_m79", "", "", "", ["rhs_mag_M433_HEDP", "rhs_mag_M441_HE"], ["rhs_mag_M433_HEDP","rhs_mag_M441_HE","rhs_mag_m576","rhs_mag_m662_red","rhs_mag_m713_Red","rhs_mag_m714_White"], ""],
+    ["rhs_weap_akmn_gp25", "rhs_acc_dtkakm", "", "", ["rhs_30Rnd_762x39mm", "rhs_30Rnd_762x39mm_tracer"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
+    ["rhs_weap_ak74n_gp25", "rhs_acc_dtk1983", "", "", ["rhs_30Rnd_545x39_7N6M_AK"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
+    ["rhs_weap_aks74n_gp25", "rhs_acc_dtk1983", "", "", ["rhs_30Rnd_545x39_7N6M_AK"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
+    ["rhs_weap_ak74n_gp25_npz", "rhs_acc_dtk1983", "", "", ["rhs_30Rnd_545x39_7N6M_AK"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""]
+]];
+_militaryLoadoutData set ["SMGs", [
+    ["rhs_weap_m3a1",  "", "", "", ["rhsgref_30rnd_1143x23_M1T_2mag_SMG", "rhsgref_30rnd_1143x23_M1911B_2mag_SMG", "rhsgref_30rnd_1143x23_M1T_SMG", "rhsgref_30rnd_1143x23_M1911B_SMG"], [], ""],
+    ["uk3cb_mat49", "", "", "", ["UK3CB_MAT49_32Rnd_9x19_Magazine_G", "UK3CB_MAT49_32Rnd_9x19_Magazine_GT", "UK3CB_MAT49_32Rnd_9x19_Magazine"], [], ""],
+    ["uk3cb_ppsh41", "", "", "", ["uk3cb_PPSH_71rnd_magazine_GM","uk3cb_PPSH_71rnd_magazine_GM","uk3cb_PPSH_35rnd_magazine_G"], [], ""]
+]];
+_militaryLoadoutData set ["machineGuns", [
+    ["UK3CB_FNLAR", "", "", "", 	["UK3CB_FNFAL_30rnd_762x51_GT", "UK3CB_FNFAL_30rnd_762x51_G", "UK3CB_FNFAL_20rnd_762x51_GT", "UK3CB_FNFAL_20rnd_762x51_G"], [], ""],
+    ["UK3CB_M60", "", "", "", ["UK3CB_M60_100rnd_762x51_GM","UK3CB_M60_100rnd_762x51_GT"], [], ""],
+    ["rhs_weap_mg42", "", "", "", 	["rhsgref_50Rnd_792x57_SmE_drum","rhsgref_50Rnd_792x57_SmE_drum","rhsgref_50Rnd_792x57_SmK_drum"], [], ""],
+    ["rhs_weap_pkm", "", "", "", ["UK3CB_RPD_100rnd_762x39", "UK3CB_RPD_100rnd_762x39_GM"], [], ""],
+    ["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39", "UK3CB_RPD_100rnd_762x39_GM"], [], ""],
+    ["UK3CB_RPK", "", "", "", ["rhs_75Rnd_762x39mm_89", "UK3CB_RPK_40rnd_762x39_GM"], [], ""],
+    ["UK3CB_RPK_74N", "", "", "rhs_acc_1p29", ["rhs_45Rnd_545X39_7N6M_AK", "rhs_45Rnd_545X39_AK_Green"], [], ""]
+]];
+_militaryLoadoutData set ["marksmanRifles", [
+    ["UK3CB_SVD_OLD", "", "", "rhs_acc_pso1m2", ["rhs_10Rnd_762x54mmR_7N1"], [], ""],
+    ["rhs_weap_l1a1_wood", "rhsgref_acc_falMuzzle_l1a1", "", "rhsgref_acc_l1a1_l2a2", 	["UK3CB_FNFAL_20rnd_762x51_G","UK3CB_FNFAL_20rnd_762x51_GT"], [], ""],
+    ["rhs_weap_ak74n", "rhs_acc_dtk", "rhs_acc_2dpZenit", "rhs_acc_pso1m21", ["rhs_30Rnd_545x39_7N6M_AK", "rhs_30Rnd_545x39_7N6M_AK"], [], ""],
+    ["rhs_weap_akmn", "rhs_acc_dtkakm", "", "rhs_acc_pso1m21", ["rhs_30Rnd_762x39mm_tracer", "rhs_30Rnd_762x39mm", "rhs_30Rnd_762x39mm_tracer"], [], ""],
+    ["uk3cb_enfield_no4t_walnut", "", "", "uk3cb_optic_no32", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""],
+    ["uk3cb_enfield_no4t", "", "", "uk3cb_optic_no32", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""]
+]];
+_militaryLoadoutData set ["sniperRifles", [
+    ["UK3CB_SVD_OLD", "", "", "rhs_acc_pso1m2", ["rhs_10Rnd_762x54mmR_7N1"], [], ""],
+    ["UK3CB_SVD_OLD", "", "", "rhs_acc_pso1m2", ["rhs_10Rnd_762x54mmR_7N1"], [], ""],
+    ["uk3cb_enfield_no4t_walnut", "", "", "uk3cb_optic_no32", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""],
+    ["uk3cb_enfield_no4t", "", "", "uk3cb_optic_no32", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""]
+]];
+_militaryLoadoutData set ["sidearms", ["rhs_weap_tt33","rhs_weap_makarov_pm"]];
+
+///////////////////////////////
+//    Police Loadout Data    //
+///////////////////////////////
+
+private _policeLoadoutData = _loadoutData call _fnc_copyLoadoutData;
+
+_policeLoadoutData set ["uniforms", ["UK3CB_CW_SOV_O_Early_U_Tank_Crew_Uniform_02_BLK"]];
+_policeLoadoutData set ["vests", ["UK3CB_ADA_B_V_TacVest_BLK"]];
+_policeLoadoutData set ["helmets", ["H_Hat_Safari_sand_F", "H_Hat_Safari_olive_F", "UK3CB_H_Safari_Hat_Brown"]];
+_policeLoadoutData set ["facewear", ["rhsusf_shemagh2_grn", "rhs_scarf","UK3CB_G_Bandanna_red_check"]];
+_policeLoadoutData set ["NVGs", []];
+_policeLoadoutData set ["gpses", []];
+
+_policeLoadoutData set ["rifles", [
+    ["uk3cb_enfield_no3", "", "", "", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""]
+]];
+_policeLoadoutData set ["carbines", [
+    ["uk3cb_sks_01", "uk3cb_muzzle_sks_bayonet", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
+    ["uk3cb_sks_01", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
+    ["uk3cb_sks_02", "uk3cb_muzzle_sks_bayonet", "", "", ["rhs_10Rnd_762x39mm_U"], [], ""],
+    ["uk3cb_sks_02", "", "", "", ["rhs_30Rnd_762x39mm_U", "rhs_10Rnd_762x39mm_U"], [], ""]
+]];
+_policeLoadoutData set ["SMGs", [
+    ["rhs_weap_m3a1",  "", "", "", ["rhsgref_30rnd_1143x23_M1T_2mag_SMG", "rhsgref_30rnd_1143x23_M1911B_2mag_SMG", "rhsgref_30rnd_1143x23_M1T_SMG", "rhsgref_30rnd_1143x23_M1911B_SMG"], [], ""],
+    ["uk3cb_mat49", "", "", "", ["UK3CB_MAT49_32Rnd_9x19_Magazine_G", "UK3CB_MAT49_32Rnd_9x19_Magazine_GT", "UK3CB_MAT49_32Rnd_9x19_Magazine"], [], ""]
+]];
+_policeLoadoutData set ["sidearms", ["rhs_weap_makarov_pm"]];
+
+////////////////////////////////
+//    Militia Loadout Data    //
+////////////////////////////////
+
+private _militiaLoadoutData = _loadoutData call _fnc_copyLoadoutData;
+_militiaLoadoutData set ["uniforms", ["UK3CB_ADM_B_U_Shirt_Pants_01_BRN_WDL", "UK3CB_ADM_B_U_Shirt_Pants_01_BRN_WDL_ALT", "UK3CB_ADC_C_Shorts_U_02"]];
+_militiaLoadoutData set ["vests", ["rhsgref_alice_webbing","rhsgref_chestrig","rhsgref_chicom", "UK3CB_V_Belt_Rig_KHK","UK3CB_V_Chicom_Brown","UK3CB_TKA_I_V_vydra_3m_Tan","V_BandollierB_oli"]];
+_militiaLoadoutData set ["helmets", ["H_Hat_Safari_sand_F", "H_Hat_Safari_olive_F", "UK3CB_H_Safari_Hat_Brown"]];
+_militiaLoadoutData set ["NVGs", []];
+_militiaLoadoutData set ["gpses", []];
+
+_militiaLoadoutData set ["ATLaunchers", [
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7VM_mag"], [], ""],
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7VM_mag", "rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag"], [], ""],
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_type69_airburst_mag", "rhs_rpg7_OG7V_mag"], [], ""]
+]];
+_militiaLoadoutData set ["heavyATLaunchers", [
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7VS_mag"], [], ""]
+]];
+
+_militiaLoadoutData set ["slRifles", [
+    ["rhs_weap_akm_gp25", "rhs_acc_dtkakm", "", "", ["rhs_30Rnd_762x39mm", "rhs_30Rnd_762x39mm_tracer"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
+    ["rhs_weap_aks74u", "rhs_acc_dtk", "", "", ["rhs_30Rnd_545x39_7N6M_AK"], [], ""],
+    ["rhs_weap_l1a1_wood", "rhsgref_acc_falMuzzle_l1a1", "", "", 	["UK3CB_FNFAL_20rnd_762x51_G","UK3CB_FNFAL_20rnd_762x51_GT"], [], ""],
+    ["rhs_weap_akms", "rhs_acc_dtkakm", "rhs_acc_2dpZenit", "", ["rhs_30Rnd_762x39mm", "rhs_30Rnd_762x39mm_tracer"], [], ""],
+    ["uk3cb_mat49", "", "", "", ["UK3CB_MAT49_32Rnd_9x19_Magazine_G", "UK3CB_MAT49_32Rnd_9x19_Magazine_GT", "UK3CB_MAT49_32Rnd_9x19_Magazine"], [], ""]
+]];
+_militiaLoadoutData set ["rifles", [
+    ["uk3cb_enfield_no3", "", "", "", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""],
+    ["uk3cb_sks_01", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
+    ["rhs_weap_l1a1_wood", "rhsgref_acc_falMuzzle_l1a1", "", "", 	["UK3CB_FNFAL_20rnd_762x51_G","UK3CB_FNFAL_20rnd_762x51_GT"], [], ""],
+    ["rhs_weap_akms", "rhs_acc_dtkakm", "rhs_acc_2dpZenit", "", ["rhs_30Rnd_762x39mm", "rhs_30Rnd_762x39mm_tracer"], [], ""]
+]];
+_militiaLoadoutData set ["carbines", [
+    ["rhs_weap_aks74u", "rhs_acc_dtk", "", "", ["rhs_30Rnd_545x39_7N6M_AK"], [], ""]
+]];
+_militiaLoadoutData set ["grenadeLaunchers", [
+    ["rhs_weap_akms_gp25", "rhs_acc_dtkakm", "", "", ["rhs_30Rnd_762x39mm", "rhs_30Rnd_762x39mm_tracer"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
+    ["uk3cb_enfield_no4", "", "", "", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], ["uk3cb_1rnd_riflegrenade_mas_ap", "uk3cb_1rnd_riflegrenade_mas_ap", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
+    ["uk3cb_enfield_no4_walnut", "", "", "", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], ["uk3cb_1rnd_riflegrenade_mas_ap", "uk3cb_1rnd_riflegrenade_mas_ap", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
+    ["uk3cb_enfield_no4", "", "", "", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], ["uk3cb_1rnd_riflegrenade_mas_at_l", "uk3cb_1rnd_riflegrenade_mas_at_s", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
+    ["rhs_weap_m79", "", "", "", ["rhs_mag_M433_HEDP", "rhs_mag_M441_HE"], ["rhs_mag_M433_HEDP","rhs_mag_M441_HE","rhs_mag_m576","rhs_mag_m662_red","rhs_mag_m713_Red","rhs_mag_m714_White"], ""]
+]];
+_militiaLoadoutData set ["SMGs", [
+    ["rhs_weap_m3a1",  "", "", "", ["rhsgref_30rnd_1143x23_M1T_2mag_SMG", "rhsgref_30rnd_1143x23_M1911B_2mag_SMG", "rhsgref_30rnd_1143x23_M1T_SMG", "rhsgref_30rnd_1143x23_M1911B_SMG"], [], ""],
+    ["uk3cb_mat49", "", "", "", ["UK3CB_MAT49_32Rnd_9x19_Magazine_G", "UK3CB_MAT49_32Rnd_9x19_Magazine_GT", "UK3CB_MAT49_32Rnd_9x19_Magazine"], [], ""]
+]];
+_militiaLoadoutData set ["machineGuns", [
+    ["UK3CB_Bren_303", "", "", "", ["UK3CB_Bren_30Rnd_303_Magazine", "UK3CB_Bren_30Rnd_303_Magazine", "UK3CB_Bren_30Rnd_303_Magazine_GT"], [], ""],
+    ["UK3CB_Bren_303", "", "", "", ["UK3CB_Bren_30Rnd_303_Magazine", "UK3CB_Bren_30Rnd_303_Magazine", "UK3CB_Bren_30Rnd_303_Magazine_GT"], [], ""],
+    ["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39_GM"], [], ""],
+    ["UK3CB_RPK", "", "", "", ["UK3CB_RPK_40rnd_762x39_GM", "UK3CB_RPK_40rnd_762x39_GM"], [], ""]
+]];
+_militiaLoadoutData set ["marksmanRifles", [
+    ["uk3cb_enfield_no3t", "", "", "uk3cb_optic_no32", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""],
+    ["uk3cb_enfield_no3t", "", "", "uk3cb_optic_no32", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""],
+    ["uk3cb_enfield_no4t", "", "", "uk3cb_optic_no32", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""]
+]];
+_militiaLoadoutData set ["sniperRifles", [
+    ["uk3cb_enfield_no3t", "", "", "uk3cb_optic_no32", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""],
+    ["uk3cb_enfield_no3t", "", "", "uk3cb_optic_no32", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""],
+    ["uk3cb_enfield_no4t", "", "", "uk3cb_optic_no32", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""]
+]];
+_militiaLoadoutData set ["sidearms", ["rhs_weap_makarov_pm"]];
+
+_militiaLoadoutData set ["traitorRifle", [
+    "rhs_weap_m38"
+]];
+
+//////////////////////////
+//    Misc Loadouts     //
+//////////////////////////
+
+private _crewLoadoutData = _militaryLoadoutData call _fnc_copyLoadoutData;
+_crewLoadoutData set ["uniforms", ["rhs_uniform_afghanka"]];
+_crewLoadoutData set ["vests", ["rhs_vest_pistol_holster","rhs_vest_commander"]];
+_crewLoadoutData set ["facewear", ["rhs_balaclava1_olive","rhs_balaclava","",""]];
+_crewLoadoutData set ["helmets", ["rhs_tsh4","rhs_tsh4_ess"]];
+
+_crewLoadoutData set ["SMGs", [
+    "rhs_weap_m3a1", 
+    ["uk3cb_mat49", "", "", "", ["UK3CB_MAT49_32Rnd_9x19_Magazine_G", "UK3CB_MAT49_32Rnd_9x19_Magazine_GT", "UK3CB_MAT49_32Rnd_9x19_Magazine"], [], ""],
+    "uk3cb_ppsh41",
+    "rhs_weap_m92"
+]];
+_crewLoadoutData set ["sidearms", ["rhs_weap_tt33"]];
+
+private _pilotLoadoutData = _militaryLoadoutData call _fnc_copyLoadoutData;
+_pilotLoadoutData set ["uniforms", ["rhs_uniform_afghanka_grey"]];
+_pilotLoadoutData set ["vests", ["rhs_vest_pistol_holster","rhs_vest_commander"]];
+_pilotLoadoutData set ["facewear", ["G_Aviator"]];
+_pilotLoadoutData set ["helmets", ["rhs_zsh7a_mike_alt", "rhs_zsh7a_mike", "rhs_zsh7a_mike_green", "rhs_zsh7a_mike_green_alt"]];
+
+_pilotLoadoutData set ["SMGs", [
+    "rhs_weap_m3a1", 
+    ["uk3cb_mat49", "", "", "", ["UK3CB_MAT49_32Rnd_9x19_Magazine_G", "UK3CB_MAT49_32Rnd_9x19_Magazine_GT", "UK3CB_MAT49_32Rnd_9x19_Magazine"], [], ""]
+]];
+_pilotLoadoutData set ["sidearms", ["rhs_weap_tt33"]];
+
+private _officialLoadoutData = _militaryLoadoutData call _fnc_copyLoadoutData;
+_officialLoadoutData set ["uniforms", ["UK3CB_TKP_I_U_CombatUniform_BLK"]];
+_officialLoadoutData set ["rifles", ["rhs_weap_akms_folded"]];
+_officialLoadoutData set ["carbines", ["rhs_weap_aks74un_folded"]];
+_officialLoadoutData set ["vests", ["rhs_gear_OFF"]];
+_officialLoadoutData set ["facewear", ["rhs_googles_black", "G_Squares_Tinted","G_Aviator","G_Aviator"]];
+_officialLoadoutData set ["helmets", ["UK3CB_H_MilCap_VEG"]];
+
+/////////////////////////////////
+//    Unit Type Definitions    //
+/////////////////////////////////
+//These define the loadouts for different unit types.
+//For example, rifleman, grenadier, squad leader, etc.
+//In 95% of situations, you *should not need to edit these*.
+//Almost all factions can be set up just by modifying the loadout data above.
+//However, these exist in case you really do want to do a lot of custom alterations.
+
+private _squadLeaderTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+
+    ["backpacks"] call _fnc_setBackpack;
+
+    ["slRifles"] call _fnc_setPrimary;
+    ["primary", 5] call _fnc_addMagazines;
+    ["primary", 4] call _fnc_addAdditionalMuzzleMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_squadLeader_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["antiInfantryGrenades", 2] call _fnc_addItem;
+    ["signalsmokeGrenades", 2] call _fnc_addItem;
+    ["smokeGrenades", 2] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["gpses"] call _fnc_addGPS;
+    ["binoculars"] call _fnc_addBinoculars;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _riflemanTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+
+    [selectRandom ["rifles", "rifles", "carbines"]] call _fnc_setPrimary;
+    ["primary", 5] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_rifleman_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["antiInfantryGrenades", 2] call _fnc_addItem;
+    ["smokeGrenades", 2] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _medicTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+    ["medBackpacks"] call _fnc_setBackpack;
+	[selectRandom ["carbines", "SMGs"]] call _fnc_setPrimary;
+    ["primary", 5] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_medic"] call _fnc_addItemSet;
+    ["items_medic_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["antiInfantryGrenades", 1] call _fnc_addItem;
+    ["smokeGrenades", 2] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _grenadierTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+    ["backpacks"] call _fnc_setBackpack;
+
+    ["grenadeLaunchers"] call _fnc_setPrimary;
+    ["primary", 5] call _fnc_addMagazines;
+    ["primary", 10] call _fnc_addAdditionalMuzzleMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_grenadier_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["antiInfantryGrenades", 4] call _fnc_addItem;
+    ["smokeGrenades", 2] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _explosivesExpertTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+    ["backpacks"] call _fnc_setBackpack;
+
+    [selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+    ["primary", 5] call _fnc_addMagazines;
+
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_explosivesExpert_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+
+    ["lightExplosives", 2] call _fnc_addItem;
+    if (random 1 > 0.5) then {["heavyExplosives", 1] call _fnc_addItem;};
+    if (random 1 > 0.5) then {["atMines", 1] call _fnc_addItem;};
+    if (random 1 > 0.5) then {["apMines", 1] call _fnc_addItem;};
+
+    ["antiInfantryGrenades", 1] call _fnc_addItem;
+    ["smokeGrenades", 1] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _engineerTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+    ["backpacks"] call _fnc_setBackpack;
+
+    [selectRandom ["carbines", "SMGs"]] call _fnc_setPrimary;
+    ["primary", 5] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_engineer_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+
+    if (random 1 > 0.5) then {["lightExplosives", 1] call _fnc_addItem;};
+
+    ["antiInfantryGrenades", 1] call _fnc_addItem;
+    ["smokeGrenades", 2] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _latTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+    ["atBackpacks"] call _fnc_setBackpack;
+
+    [selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+    ["primary", 5] call _fnc_addMagazines;
+
+    [selectRandom ["lightATLaunchers", "ATLaunchers"]] call _fnc_setLauncher;
+    //TODO - Add a check if it's disposable.
+    ["launcher", 1] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_lat_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["antiInfantryGrenades", 1] call _fnc_addItem;
+    ["smokeGrenades", 1] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _atTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+    ["atBackpacks"] call _fnc_setBackpack;
+
+    [selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+    ["primary", 5] call _fnc_addMagazines;
+
+    [selectRandom["ATLaunchers","heavyATLaunchers"]] call _fnc_setLauncher;
+    //TODO - Add a check if it's disposable.
+    ["launcher", 2] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_at_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["antiInfantryGrenades", 1] call _fnc_addItem;
+    ["smokeGrenades", 1] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _aaTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+    ["aaBackpacks"] call _fnc_setBackpack;
+
+    [selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+    ["primary", 5] call _fnc_addMagazines;
+
+    ["AALaunchers"] call _fnc_setLauncher;
+    //TODO - Add a check if it's disposable.
+    ["launcher", 2] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_aa_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["antiInfantryGrenades", 1] call _fnc_addItem;
+    ["smokeGrenades", 2] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _machineGunnerTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+    ["mgBackpacks"] call _fnc_setBackpack;
+
+    ["machineGuns"] call _fnc_setPrimary;
+    ["primary", 4] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_machineGunner_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["antiInfantryGrenades", 1] call _fnc_addItem;
+    ["smokeGrenades", 2] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _marksmanTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+
+    ["marksmanRifles"] call _fnc_setPrimary;
+    ["primary", 5] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_marksman_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["antiInfantryGrenades", 1] call _fnc_addItem;
+    ["smokeGrenades", 2] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["rangefinders"] call _fnc_addBinoculars;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _sniperTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+
+    ["sniperRifles"] call _fnc_setPrimary;
+    ["primary", 7] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_sniper_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["antiInfantryGrenades", 1] call _fnc_addItem;
+    ["smokeGrenades", 2] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["rangefinders"] call _fnc_addBinoculars;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _policeTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+
+    [selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+    ["primary", 3] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 4] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_police_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["smokeGrenades", 1] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+};
+
+private _policeSlTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+
+    [selectRandom ["SMGs", "carbines"]] call _fnc_setPrimary;
+    ["primary", 3] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 4] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_police_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["smokeGrenades", 1] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+};
+
+private _crewTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+
+    ["SMGs"] call _fnc_setPrimary;
+    ["primary", 3] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 4] call _fnc_addMagazines;
+
+    ["items_medical_basic"] call _fnc_addItemSet;
+    ["items_crew_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["smokeGrenades", 2] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["gpses"] call _fnc_addGPS;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _unarmedTemplate = {
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+
+    ["items_medical_basic"] call _fnc_addItemSet;
+    ["items_unarmed_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+};
+
+private _traitorTemplate = {
+    call _unarmedTemplate;
+    ["traitorRifle"] call _fnc_setPrimary;
+    ["primary", 2] call _fnc_addMagazines;
+
+    ["facewear"] call _fnc_setFacewear;
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 5] call _fnc_addMagazines;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////
+//  You shouldn't touch below this line unless you really really know what you're doing.
+//  Things below here can and will break the gamemode if improperly changed.
+////////////////////////////////////////////////////////////////////////////////////////
+
+/////////////////////////////
+//  Special Forces Units   //
+/////////////////////////////
+private _prefix = "SF";
+private _unitTypes = [
+    ["SquadLeader", _squadLeaderTemplate],
+    ["Rifleman", _riflemanTemplate],
+    ["Medic", _medicTemplate, [["medic", true]]],
+    ["Engineer", _engineerTemplate, [["engineer", true]]],
+    ["ExplosivesExpert", _explosivesExpertTemplate, [["explosiveSpecialist", true]]],
+    ["Grenadier", _grenadierTemplate],
+    ["LAT", _latTemplate],
+    ["AT", _atTemplate],
+    ["AA", _aaTemplate],
+    ["MachineGunner", _machineGunnerTemplate],
+    ["Marksman", _marksmanTemplate],
+    ["Sniper", _sniperTemplate]
+];
+
+[_prefix, _unitTypes, _sfLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+
+/*{
+    params ["_name", "_loadoutTemplate"];
+    private _loadouts = [_sfLoadoutData, _loadoutTemplate] call _fnc_buildLoadouts;
+    private _finalName = _prefix + _name;
+    [_finalName, _loadouts] call _fnc_saveToTemplate;
+} forEach _unitTypes;
+*/
+
+///////////////////////
+//  Military Units   //
+///////////////////////
+private _prefix = "military";
+private _unitTypes = [
+    ["SquadLeader", _squadLeaderTemplate, nil, 8],
+    ["Rifleman", _riflemanTemplate],
+    ["Medic", _medicTemplate, [["medic", true]]],
+    ["Engineer", _engineerTemplate, [["engineer", true]]],
+    ["ExplosivesExpert", _explosivesExpertTemplate, [["explosiveSpecialist", true]]],
+    ["Grenadier", _grenadierTemplate],
+    ["LAT", _latTemplate],
+    ["AT", _atTemplate],
+    ["AA", _aaTemplate],
+    ["MachineGunner", _machineGunnerTemplate],
+    ["Marksman", _marksmanTemplate],
+    ["Sniper", _sniperTemplate]
+];
+
+[_prefix, _unitTypes, _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+
+////////////////////////
+//    Police Units    //
+////////////////////////
+private _prefix = "police";
+private _unitTypes = [
+    ["SquadLeader", _policeSlTemplate],
+    ["Standard", _policeTemplate]
+];
+
+[_prefix, _unitTypes, _policeLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+
+////////////////////////
+//    Militia Units    //
+////////////////////////
+private _prefix = "militia";
+private _unitTypes = [
+    ["SquadLeader", _squadLeaderTemplate],
+    ["Rifleman", _riflemanTemplate],
+    ["Medic", _medicTemplate, [["medic", true]]],
+    ["Engineer", _engineerTemplate, [["engineer", true]]],
+    ["ExplosivesExpert", _explosivesExpertTemplate, [["explosiveSpecialist", true]]],
+    ["Grenadier", _grenadierTemplate],
+    ["LAT", _latTemplate],
+    ["AT", _atTemplate],
+    ["AA", _aaTemplate],
+    ["MachineGunner", _machineGunnerTemplate],
+    ["Marksman", _marksmanTemplate],
+    ["Sniper", _sniperTemplate]
+];
+
+[_prefix, _unitTypes, _militiaLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+
+//////////////////////
+//    Misc Units    //
+//////////////////////
+
+//The following lines are determining the loadout of vehicle crew
+["other", [["Crew", _crewTemplate]], _crewLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout of the pilots
+["other", [["Pilot", _crewTemplate]], _pilotLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the unit used in the "kill the official" mission
+["other", [["Official", _policeTemplate, nil, 2]], _officialLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "kill the traitor" mission
+["other", [["Traitor", _traitorTemplate]], _militiaLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_PLM.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_PLM.sqf
@@ -36,7 +36,7 @@
 ["vehiclesIFVs", []] call _fnc_saveToTemplate;
 ["vehiclesLightTanks", ["UK3CB_PLM_O_T34"]] call _fnc_saveToTemplate;
 ["vehiclesTanks", ["UK3CB_PLM_O_T55"]] call _fnc_saveToTemplate;
-["vehiclesHeavyTanks", []] call _fnc_saveToTemplate;             // Just to push up the T-72 probability at higher war levels
+["vehiclesHeavyTanks", []] call _fnc_saveToTemplate;
 ["vehiclesAA", ["UK3CB_PLM_O_BTR40_ZU23", "UK3CB_PLM_O_Ural_Zu23"]] call _fnc_saveToTemplate;
 
 
@@ -258,18 +258,23 @@ private _militaryLoadoutData = _loadoutData call _fnc_copyLoadoutData;
 _militaryLoadoutData set ["uniforms", ["UK3CB_PLM_B_U_CombatUniform_01", "UK3CB_PLM_B_U_CombatUniform_02"]];
 _militaryLoadoutData set ["SLuniforms", ["UK3CB_PLM_B_U_Officer_CombatUniform_01"]];
 _militaryLoadoutData set ["vests", ["rhs_chicom","rhs_chicom_khk", "rhs_6b2","rhs_6b2_holster", "rhs_vydra_3m"]];
-_militaryLoadoutData set ["helmets", ["UK3CB_PLM_B_H_SSh68","UK3CB_PLM_B_H_SSh68_Covered", "rhsgref_M56","UK3CB_PLM_B_H_Headband_Red","UK3CB_PLM_B_H_Fieldcap_Early_GRN", "UK3CB_H_CAP_PLM"]];
+_militaryLoadoutData set ["helmets", ["UK3CB_PLM_B_H_SSh68","UK3CB_PLM_B_H_SSh68","UK3CB_PLM_B_H_SSh68_Covered", "rhsgref_M56","rhsgref_M56","UK3CB_PLM_B_H_Headband_Red","UK3CB_PLM_B_H_Fieldcap_Early_GRN", "UK3CB_H_CAP_PLM"]];
 
 _militaryLoadoutData set ["slRifles", [
+    ["uk3cb_sks_02", "", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], [], ""],
     ["rhs_weap_akms_gp25", "rhs_acc_dtkakm", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VG40OP_red", "rhs_GRD40_Green", "rhs_VG40OP_white", "rhs_GRD40_White"], ""],
     ["rhs_weap_akm_gp25", "rhs_acc_dtkakm", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VG40OP_green", "rhs_GRD40_Red", "rhs_VG40OP_white", "rhs_GRD40_White"], ""]
 ]];
 _militaryLoadoutData set ["rifles", [
     ["uk3cb_sks_01", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
     ["uk3cb_sks_01_sling", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
-    ["uk3cb_sks_02", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""]
+    ["uk3cb_sks_01", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
+    ["uk3cb_sks_01_sling", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
+    ["uk3cb_sks_02", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
+    ["uk3cb_sks_02", "", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], [], ""]
 ]];
 _militaryLoadoutData set ["carbines", [
+    ["uk3cb_sks_02", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
     ["uk3cb_sks_01", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
     ["rhs_weap_akm", "", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], [], ""],
     ["rhs_weap_akms", "", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], [], ""]
@@ -303,8 +308,7 @@ private _policeLoadoutData = _loadoutData call _fnc_copyLoadoutData;
 
 _policeLoadoutData set ["uniforms", ["UK3CB_PLM_B_U_Shorts_Uniform_07"]];
 _policeLoadoutData set ["vests", ["UK3CB_V_SOV_CHICOM_GRN_TAN","UK3CB_V_SOV_CHICOM_GRN", "UK3CB_V_SOV_CHICOM_TAN_GRN","UK3CB_V_SOV_CHICOM_TAN"]];
-_policeLoadoutData set ["helmets", ["UK3CB_H_CAP_PLM_BLK", "UK3CB_PLM_B_H_Fieldcap_Early_BLK", "UK3CB_PLM_B_H_SSh68_Covered_BLK", "UK3CB_PLM_B_H_SSh68_BLK"]];
-_policeLoadoutData set ["facewear", ["rhsusf_shemagh2_grn", "rhs_scarf","UK3CB_G_Bandanna_red_check"]];
+_policeLoadoutData set ["helmets", ["UK3CB_H_CAP_PLM_BLK", "UK3CB_PLM_B_H_Fieldcap_Early_BLK", "UK3CB_PLM_B_H_SSh68_BLK"]];
 _policeLoadoutData set ["NVGs", []];
 _policeLoadoutData set ["gpses", []];
 
@@ -346,6 +350,8 @@ _militiaLoadoutData set ["heavyATLaunchers", [
 ]];
 
 _militiaLoadoutData set ["slRifles", [
+    "rhs_weap_m38","rhs_weap_m38","rhs_weap_m38",
+    ["rhs_weap_akm", "", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], [], ""],
     ["rhs_weap_akms_gp25", "rhs_acc_dtkakm", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VG40OP_red", "rhs_GRD40_Green", "rhs_VG40OP_white", "rhs_GRD40_White"], ""],
     ["rhs_weap_akm_gp25", "rhs_acc_dtkakm", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VG40OP_green", "rhs_GRD40_Red", "rhs_VG40OP_white", "rhs_GRD40_White"], ""]
 ]];
@@ -387,30 +393,17 @@ _militiaLoadoutData set ["traitorRifle", [
 //////////////////////////
 
 private _crewLoadoutData = _militaryLoadoutData call _fnc_copyLoadoutData;
-_crewLoadoutData set ["uniforms", ["rhs_uniform_afghanka"]];
+_crewLoadoutData set ["uniforms", ["UK3CB_PLM_O_U_CombatUniform_01"]];
 _crewLoadoutData set ["vests", ["rhs_vest_pistol_holster","rhs_vest_commander"]];
-_crewLoadoutData set ["facewear", ["rhs_balaclava1_olive","rhs_balaclava","",""]];
+_crewLoadoutData set ["facewear", ["rhs_balaclava1_olive","rhs_balaclava","G_Balaclava_blk","UK3CB_G_Bandanna_red"]];
 _crewLoadoutData set ["helmets", ["rhs_tsh4","rhs_tsh4_ess"]];
 
-_crewLoadoutData set ["SMGs", [
-    "rhs_weap_m3a1", 
-    ["uk3cb_mat49", "", "", "", ["UK3CB_MAT49_32Rnd_9x19_Magazine_G", "UK3CB_MAT49_32Rnd_9x19_Magazine_GT", "UK3CB_MAT49_32Rnd_9x19_Magazine"], [], ""],
-    "uk3cb_ppsh41",
-    "rhs_weap_m92"
-]];
-_crewLoadoutData set ["sidearms", ["rhs_weap_tt33", "rhs_weap_makarov_pm"]];
-
 private _pilotLoadoutData = _militaryLoadoutData call _fnc_copyLoadoutData;
-_pilotLoadoutData set ["uniforms", ["rhs_uniform_afghanka_grey"]];
+_pilotLoadoutData set ["uniforms", ["UK3CB_PLM_O_U_CombatUniform_01"]];
 _pilotLoadoutData set ["vests", ["rhs_vest_pistol_holster","rhs_vest_commander"]];
-_pilotLoadoutData set ["facewear", ["G_Aviator"]];
-_pilotLoadoutData set ["helmets", ["rhs_zsh7a_mike_alt", "rhs_zsh7a_mike", "rhs_zsh7a_mike_green", "rhs_zsh7a_mike_green_alt"]];
+_pilotLoadoutData set ["facewear", ["G_Aviator", "G_Balaclava_blk", "UK3CB_G_Bandanna_red"]];
+_pilotLoadoutData set ["helmets", ["rhs_tsh4","rhs_tsh4_ess"]];
 
-_pilotLoadoutData set ["SMGs", [
-    "rhs_weap_m3a1", 
-    ["uk3cb_mat49", "", "", "", ["UK3CB_MAT49_32Rnd_9x19_Magazine_G", "UK3CB_MAT49_32Rnd_9x19_Magazine_GT", "UK3CB_MAT49_32Rnd_9x19_Magazine"], [], ""]
-]];
-_pilotLoadoutData set ["sidearms", ["rhs_weap_tt33", "rhs_weap_makarov_pm"]];
 
 private _officialLoadoutData = _militaryLoadoutData call _fnc_copyLoadoutData;
 _officialLoadoutData set ["uniforms", ["UK3CB_TKP_I_U_CombatUniform_BLK"]];

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_PLM.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_PLM.sqf
@@ -62,7 +62,7 @@
 ["uavsPortable", []] call _fnc_saveToTemplate;
 
 //Config special vehicles
-["vehiclesMilitiaLightArmed", ["UK3CB_PLM_O_MB4WD_LMG"]] call _fnc_saveToTemplate;
+["vehiclesMilitiaLightArmed", ["UK3CB_PLM_I_UAZ_MG"]] call _fnc_saveToTemplate;
 ["vehiclesMilitiaTrucks", ["UK3CB_PLM_O_Zil131_Open"]] call _fnc_saveToTemplate;
 ["vehiclesMilitiaCars", ["UK3CB_PLM_O_Datsun_Open"]] call _fnc_saveToTemplate;
 

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_PLM.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_PLM.sqf
@@ -410,7 +410,7 @@ _pilotLoadoutData set ["helmets", ["rhs_tsh4","rhs_tsh4_ess"]];
 private _officialLoadoutData = _militaryLoadoutData call _fnc_copyLoadoutData;
 _officialLoadoutData set ["uniforms", ["UK3CB_TKP_I_U_CombatUniform_BLK"]];
 _officialLoadoutData set ["rifles", ["rhs_weap_akms_folded"]];
-_officialLoadoutData set ["carbines", ["rhs_weap_aks74un_folded"]];
+_officialLoadoutData set ["carbines", ["rhs_weap_akms_folded"]];
 _officialLoadoutData set ["vests", ["rhs_gear_OFF"]];
 _officialLoadoutData set ["facewear", ["rhs_googles_black", "G_Squares_Tinted","G_Aviator","G_Aviator"]];
 _officialLoadoutData set ["helmets", ["UK3CB_H_MilCap_VEG"]];

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_PLM.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_PLM.sqf
@@ -49,14 +49,12 @@
 ["vehiclesPlanesTransport", ["UK3CB_CW_SOV_O_EARLY_LI2"]] call _fnc_saveToTemplate;
 
 ["vehiclesHelisLight", ["UK3CB_CW_SOV_O_EARLY_Mi8AMT"]] call _fnc_saveToTemplate;
-["vehiclesHelisTransport", []] call _fnc_saveToTemplate; //Mi24Vt has 1x 12.7mm turret, and disabled pylons
-// Should be capable of dealing damage to ground targets without additional scripting
+["vehiclesHelisTransport", []] call _fnc_saveToTemplate;
 ["vehiclesHelisLightAttack", ["UK3CB_CW_SOV_O_EARLY_Mi8AMTSh","UK3CB_CW_SOV_O_EARLY_Mi8AMTSh","UK3CB_CW_SOV_O_EARLY_Mi_24P"]] call _fnc_saveToTemplate;      // Mi24P lacks a gun turret
 ["vehiclesHelisAttack", ["UK3CB_CW_SOV_O_EARLY_Mi_24V"]] call _fnc_saveToTemplate;           // Proper attack helis: Apache, Hind etc
 
-["vehiclesArtillery", ["UK3CB_PLM_O_Ural_BM21","rhs_D30_msv","rhs_D30_msv"]] call _fnc_saveToTemplate;
+["vehiclesArtillery", ["rhs_D30_msv"]] call _fnc_saveToTemplate;
 ["magazines", createHashMapFromArray [
-["UK3CB_PLM_O_Ural_BM21", ["rhs_mag_m21of_1"]],
 ["rhs_D30_msv", ["rhs_mag_3of56_10"]]
 ]] call _fnc_saveToTemplate; //element format: [Vehicle class, [Magazines]]
 
@@ -128,7 +126,7 @@ _loadoutData set ["heavyATLaunchers", [
     ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7VL_mag", "rhs_rpg7_PG7VS_mag"], [], ""]
 ]];
 _loadoutData set ["AALaunchers", ["rhs_weap_igla"]];
-_loadoutData set ["sidearms", ["rhs_weap_tt33","rhs_weap_makarov_pm"]];
+_loadoutData set ["sidearms", []];
 
 _loadoutData set ["ATMines", ["rhs_mine_tm62m_mag"]];
 _loadoutData set ["APMines", ["rhs_mine_pmn2_mag"]];
@@ -199,7 +197,7 @@ _sfLoadoutData set ["uniforms", ["UK3CB_PLM_B_U_Pants_Shirt_02"]];
 _sfLoadoutData set ["SLuniforms", ["UK3CB_PLM_B_U_Officer_Comm_CombatUniform_01"]];
 _sfLoadoutData set ["vests", ["rhs_6b2_chicom"]];
 _sfLoadoutData set ["helmets", ["UK3CB_PLM_B_H_SSh68_Covered_BLK", "UK3CB_PLM_B_H_Headband_Red"]];
-_sfLoadoutData set ["facewear", []];
+_sfLoadoutData set ["facewear", ["G_Balaclava_blk"]];
 //["Weapon", "Muzzle", "Rail", "Sight", [], [], "Bipod"];
 
 _sfLoadoutData set ["lightATLaunchers", [
@@ -218,35 +216,53 @@ _sfLoadoutData set ["heavyATLaunchers", [
 ]];
 _sfLoadoutData set ["slRifles", [
     ["rhs_weap_akmn_gp25", "rhs_acc_pbs1", "", "rhs_acc_1pn93_1", ["UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VG40OP_red", "rhs_GRD40_Green", "rhs_VG40OP_white", "rhs_GRD40_White"], ""],
-    ["rhs_weap_akmn_gp25", "rhs_acc_pbs1", "", "rhs_acc_1pn93_2", ["UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VG40OP_green", "rhs_GRD40_Red", "rhs_VG40OP_white", "rhs_GRD40_White"], ""]
+    ["rhs_weap_akmn_gp25", "rhs_acc_pbs1", "", "rhs_acc_1pn93_2", ["UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VG40OP_green", "rhs_GRD40_Red", "rhs_VG40OP_white", "rhs_GRD40_White"], ""],
+    ["rhs_weap_akmn_gp25", "rhs_acc_pbs1", "", "rhs_acc_pkas", ["UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VG40OP_red", "rhs_GRD40_Green", "rhs_VG40OP_white", "rhs_GRD40_White"], ""],
+    ["rhs_weap_akmn_gp25", "rhs_acc_pbs1", "", "rhs_acc_okp7_dovetail", ["UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VG40OP_green", "rhs_GRD40_Red", "rhs_VG40OP_white", "rhs_GRD40_White"], ""]
 ]];
 _sfLoadoutData set ["rifles", [
-    ["rhs_weap_akmn", "rhs_acc_pbs1", "", "rhs_acc_1pn93_2", ["UK3CB_AK47_30Rnd_Magazine"], [], ""]
+    ["rhs_weap_akmn", "rhs_acc_pbs1", "", "rhs_acc_1pn93_2", ["UK3CB_AK47_30Rnd_Magazine"], [], ""],
+    ["rhs_weap_akmn", "rhs_acc_pbs1", "", "rhs_acc_pkas", ["UK3CB_AK47_30Rnd_Magazine"], [], ""],
+    ["rhs_weap_akmn", "rhs_acc_pbs1", "", "rhs_acc_okp7_dovetail", ["UK3CB_AK47_30Rnd_Magazine"], [], ""]
 ]];
 _sfLoadoutData set ["carbines", [
-    ["rhs_weap_akmn", "rhs_acc_pbs1", "", "rhs_acc_1pn93_2", ["UK3CB_AK47_30Rnd_Magazine"], [], ""]
+    ["rhs_weap_akmn", "rhs_acc_pbs1", "", "rhs_acc_1pn93_2", ["UK3CB_AK47_30Rnd_Magazine"], [], ""],
+    ["rhs_weap_akmn", "rhs_acc_pbs1", "", "rhs_acc_pkas", ["UK3CB_AK47_30Rnd_Magazine"], [], ""],
+    ["rhs_weap_akmn", "rhs_acc_pbs1", "", "rhs_acc_okp7_dovetail", ["UK3CB_AK47_30Rnd_Magazine"], [], ""]
 ]];
 _sfLoadoutData set ["grenadeLaunchers", [
     ["rhs_weap_akmn_gp25", "rhs_acc_pbs1", "", "rhs_acc_1pn93_1", ["UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white", "rhs_GRD40_White"], ""],
-    ["rhs_weap_akmn_gp25", "rhs_acc_pbs1", "", "rhs_acc_1pn93_2", ["UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white", "rhs_VG40MD"], ""]
+    ["rhs_weap_akmn_gp25", "rhs_acc_pbs1", "", "rhs_acc_1pn93_2", ["UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white", "rhs_VG40MD"], ""],
+    ["rhs_weap_akmn_gp25", "rhs_acc_pbs1", "", "rhs_acc_pkas", ["UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white", "rhs_GRD40_White"], ""],
+    ["rhs_weap_akmn_gp25", "rhs_acc_pbs1", "", "rhs_acc_okp7_dovetail", ["UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white", "rhs_VG40MD"], ""]
 ]];
 _sfLoadoutData set ["SMGs", [
     ["rhs_weap_asval_grip", "", "rhs_acc_perst1ik_ris", "rhs_acc_1pn93_2", ["rhs_20rnd_9x39mm_SP5"], [], "rhs_acc_grip_rk6"],
-    ["rhs_weap_asval", "", "", "rhs_acc_1pn93_2", ["rhs_20rnd_9x39mm_SP6"], [], ""]
+    ["rhs_weap_asval", "", "", "rhs_acc_1pn93_2", ["rhs_20rnd_9x39mm_SP6"], [], ""],
+    ["rhs_weap_asval_grip", "", "rhs_acc_perst1ik_ris", "rhs_acc_pkas", ["rhs_20rnd_9x39mm_SP5"], [], "rhs_acc_grip_rk6"],
+    ["rhs_weap_asval", "", "", "rhs_acc_okp7_dovetail", ["rhs_20rnd_9x39mm_SP6"], [], ""]
 ]];
 _sfLoadoutData set ["machineGuns", [
     ["UK3CB_RPD", "rhs_acc_pbs1", "", "", ["UK3CB_RPD_100rnd_762x39"], [], ""],
-    ["UK3CB_RPKN_BLK", "rhs_acc_pbs1", "", "rhs_acc_1pn93_2", ["UK3CB_RPK_75rnd_762x39"], [], ""]
+    ["UK3CB_RPD", "rhs_acc_pbs1", "", "", ["UK3CB_RPD_100rnd_762x39"], [], ""],
+    ["UK3CB_RPKN_BLK", "rhs_acc_pbs1", "", "rhs_acc_1pn93_2", ["UK3CB_RPK_75rnd_762x39"], [], ""],
+    ["UK3CB_RPKN_BLK", "rhs_acc_pbs1", "", "rhs_acc_1p78_3d", ["UK3CB_RPK_75rnd_762x39"], [], ""]
 ]];
 _sfLoadoutData set ["marksmanRifles", [
     ["UK3CB_SVD_OLD", "rhs_acc_tgpv", "", "rhs_acc_1pn34", ["UK3CB_SVD_10rnd_762x54","UK3CB_SVD_10rnd_762x54_G", "UK3CB_SVD_10rnd_762x54_GT"], [], ""],
-    ["rhs_weap_vss_grip", "", "rhs_acc_perst1ik_ris", "rhs_acc_1pn93_1", ["rhs_20rnd_9x39mm_SP5"], [], "rhs_acc_grip_rk6"],
-    ["rhs_weap_vss", "", "", "rhs_acc_1pn93_1", ["rhs_20rnd_9x39mm_SP6"], [], ""]
+    ["UK3CB_SVD_OLD", "rhs_acc_tgpv", "", "rhs_acc_pso1m2", ["UK3CB_SVD_10rnd_762x54","UK3CB_SVD_10rnd_762x54_G", "UK3CB_SVD_10rnd_762x54_GT"], [], ""],
+    ["rhs_weap_vss_grip", "", "rhs_acc_perst1ik_ris", "rhs_acc_1pn93_1", ["rhs_20rnd_9x39mm_SP6"], [], "rhs_acc_grip_rk6"],
+    ["rhs_weap_vss_grip", "", "rhs_acc_perst1ik_ris", "rhs_acc_pso1m21", ["rhs_20rnd_9x39mm_SP5"], [], "rhs_acc_grip_rk6"],
+    ["rhs_weap_vss", "", "", "rhs_acc_1pn93_1", ["rhs_20rnd_9x39mm_SP6"], [], ""],
+    ["rhs_weap_vss", "", "", "rhs_acc_pso1m21", ["rhs_20rnd_9x39mm_SP5"], [], ""]
 ]];
 _sfLoadoutData set ["sniperRifles", [
     ["UK3CB_SVD_OLD", "rhs_acc_tgpv", "", "rhs_acc_1pn34", ["UK3CB_SVD_10rnd_762x54","UK3CB_SVD_10rnd_762x54_G", "UK3CB_SVD_10rnd_762x54_GT"], [], ""],
-    ["rhs_weap_vss_grip", "", "rhs_acc_perst1ik_ris", "rhs_acc_1pn93_1", ["rhs_20rnd_9x39mm_SP5"], [], "rhs_acc_grip_rk6"],
-    ["rhs_weap_vss", "", "", "rhs_acc_1pn93_1", ["rhs_20rnd_9x39mm_SP6"], [], ""]
+    ["UK3CB_SVD_OLD", "rhs_acc_tgpv", "", "rhs_acc_pso1m2", ["UK3CB_SVD_10rnd_762x54","UK3CB_SVD_10rnd_762x54_G", "UK3CB_SVD_10rnd_762x54_GT"], [], ""],
+    ["rhs_weap_vss_grip", "", "rhs_acc_perst1ik_ris", "rhs_acc_1pn93_1", ["rhs_20rnd_9x39mm_SP6"], [], "rhs_acc_grip_rk6"],
+    ["rhs_weap_vss_grip", "", "rhs_acc_perst1ik_ris", "rhs_acc_pso1m21", ["rhs_20rnd_9x39mm_SP5"], [], "rhs_acc_grip_rk6"],
+    ["rhs_weap_vss", "", "", "rhs_acc_1pn93_1", ["rhs_20rnd_9x39mm_SP6"], [], ""],
+    ["rhs_weap_vss", "", "", "rhs_acc_pso1m21", ["rhs_20rnd_9x39mm_SP5"], [], ""]
 ]];
 _sfLoadoutData set ["sidearms", [
     ["rhs_weap_pb_6p9", "", "", "", ["rhs_mag_9x18_8_57N181S"], [], ""],
@@ -264,16 +280,19 @@ _militaryLoadoutData set ["helmets", ["UK3CB_PLM_B_H_SSh68","UK3CB_PLM_B_H_SSh68
 
 _militaryLoadoutData set ["slRifles", [
     ["uk3cb_sks_02", "", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], [], ""],
+    ["uk3cb_sks_02", "", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], [], ""],
     ["rhs_weap_akms_gp25", "rhs_acc_dtkakm", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VG40OP_red", "rhs_GRD40_Green", "rhs_VG40OP_white", "rhs_GRD40_White"], ""],
-    ["rhs_weap_akm_gp25", "rhs_acc_dtkakm", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VG40OP_green", "rhs_GRD40_Red", "rhs_VG40OP_white", "rhs_GRD40_White"], ""]
+    ["rhs_weap_akm_gp25", "rhs_acc_dtkakm", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VG40OP_green", "rhs_GRD40_Red", "rhs_VG40OP_white", "rhs_GRD40_White"], ""],
+    ["rhs_weap_akmn", "rhs_acc_dtkakm", "", "rhs_acc_pkas", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], [], ""],
+    ["rhs_weap_akmn", "rhs_acc_dtkakm", "", "rhs_acc_okp7_dovetail", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], [], ""]
 ]];
 _militaryLoadoutData set ["rifles", [
     ["uk3cb_sks_01", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
     ["uk3cb_sks_01_sling", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
     ["uk3cb_sks_01", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
     ["uk3cb_sks_01_sling", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
-    ["uk3cb_sks_02", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
-    ["uk3cb_sks_02", "", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], [], ""]
+    ["uk3cb_sks_02", "", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine", "uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
+    ["uk3cb_sks_02", "", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine", "uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""]
 ]];
 _militaryLoadoutData set ["carbines", [
     ["uk3cb_sks_02", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
@@ -290,17 +309,17 @@ _militaryLoadoutData set ["SMGs", [
     ["uk3cb_ppsh41", "", "", "", ["uk3cb_PPSH_35rnd_magazine_GM","uk3cb_PPSH_35rnd_magazine_GM","uk3cb_PPSH_35rnd_magazine_GT"], [], ""]
 ]];
 _militaryLoadoutData set ["machineGuns", [
-    ["UK3CB_RPD", "rhs_acc_dtkakm", "", "", ["UK3CB_RPD_100rnd_762x39_GT", "UK3CB_RPD_100rnd_762x39_GM", "UK3CB_RPD_100rnd_762x39_G", "UK3CB_RPD_100rnd_762x39"], [], ""],
+    ["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39_GT", "UK3CB_RPD_100rnd_762x39_GM", "UK3CB_RPD_100rnd_762x39_G", "UK3CB_RPD_100rnd_762x39"], [], ""],
     ["UK3CB_RPK", "", "", "", ["UK3CB_RPK_75rnd_762x39_GM", "UK3CB_RPK_40rnd_762x39_GT", "UK3CB_RPK_40rnd_762x39_GM", "UK3CB_RPK_40rnd_762x39_G", "UK3CB_RPK_40rnd_762x39"], [], ""]
 ]];
 _militaryLoadoutData set ["marksmanRifles", [
+    ["UK3CB_SVD_OLD", "", "", "", ["UK3CB_SVD_10rnd_762x54","UK3CB_SVD_10rnd_762x54_G", "UK3CB_SVD_10rnd_762x54_GT"], [], ""],
     ["UK3CB_SVD_OLD", "", "", "rhs_acc_pso1m2", ["UK3CB_SVD_10rnd_762x54","UK3CB_SVD_10rnd_762x54_G", "UK3CB_SVD_10rnd_762x54_GT"], [], ""]
 ]];
 _militaryLoadoutData set ["sniperRifles", [
     ["UK3CB_SVD_OLD", "", "", "rhs_acc_pso1m2", ["UK3CB_SVD_10rnd_762x54","UK3CB_SVD_10rnd_762x54_G", "UK3CB_SVD_10rnd_762x54_GT"], [], ""]
 ]];
-_militaryLoadoutData set ["sidearms", [
-    "rhs_weap_tt33","rhs_weap_makarov_pm"]];
+_militaryLoadoutData set ["sidearms", []];
 
 ///////////////////////////////
 //    Police Loadout Data    //
@@ -371,7 +390,8 @@ _militiaLoadoutData set ["carbines", [
 _militiaLoadoutData set ["grenadeLaunchers", [
     ["uk3cb_sks_01", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
     ["uk3cb_sks_01_sling", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
-    ["uk3cb_sks_02", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""]
+    ["uk3cb_sks_02", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
+    ["rhs_weap_akm_gp25", "rhs_acc_dtkakm", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VOG25", "rhs_VG40OP_white"], ""]
 ]];
 _militiaLoadoutData set ["SMGs", [
     ["uk3cb_ppsh41", "", "", "", ["uk3cb_PPSH_35rnd_magazine_GM","uk3cb_PPSH_35rnd_magazine_GM","uk3cb_PPSH_35rnd_magazine_GT"], [], ""]

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_PLM.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_PLM.sqf
@@ -2,12 +2,12 @@
 //   Side Information   //
 //////////////////////////
 //Tanoan Liberation Army, natural enemies of the HIDF, CW US, US, and SDK
-["name", "TLA"] call _fnc_saveToTemplate;
-["spawnMarkerName", "TLA Support Corridor"] call _fnc_saveToTemplate;
+["name", "PLM"] call _fnc_saveToTemplate;
+["spawnMarkerName", "PLM Support Corridor"] call _fnc_saveToTemplate;
 
 ["flag", "Flag_CW_SOV_ARMY"] call _fnc_saveToTemplate;
-["flagTexture", "uk3cb_factions\addons\uk3cb_factions_cw_sov\flag\cw_sov_army_flag_co.paa"] call _fnc_saveToTemplate;
-["flagMarkerType", "UK3CB_Marker_CW_SOV_ARMY"] call _fnc_saveToTemplate;
+["flagTexture", "\UK3CB_Factions\addons\UK3CB_Factions_PLM\Flag\PLM_flag_co.paa"] call _fnc_saveToTemplate;
+["flagMarkerType", "UK3CB_Marker_PLM"] call _fnc_saveToTemplate;
 
 //////////////////////////
 //       Vehicles       //
@@ -293,7 +293,6 @@ _militaryLoadoutData set ["sniperRifles", [
     ["UK3CB_SVD_OLD", "", "", "rhs_acc_pso1m2", ["UK3CB_SVD_10rnd_762x54","UK3CB_SVD_10rnd_762x54_G", "UK3CB_SVD_10rnd_762x54_GT"], [], ""]
 ]];
 _militaryLoadoutData set ["sidearms", [
-    ["rhs_weap_pb_6p9", "", "", "", ["rhs_mag_9x18_8_57N181S"], [], ""],
     "rhs_weap_tt33","rhs_weap_makarov_pm"]];
 
 ///////////////////////////////
@@ -399,7 +398,7 @@ _crewLoadoutData set ["SMGs", [
     "uk3cb_ppsh41",
     "rhs_weap_m92"
 ]];
-_crewLoadoutData set ["sidearms", ["rhs_weap_tt33"]];
+_crewLoadoutData set ["sidearms", ["rhs_weap_tt33", "rhs_weap_makarov_pm"]];
 
 private _pilotLoadoutData = _militaryLoadoutData call _fnc_copyLoadoutData;
 _pilotLoadoutData set ["uniforms", ["rhs_uniform_afghanka_grey"]];
@@ -411,7 +410,7 @@ _pilotLoadoutData set ["SMGs", [
     "rhs_weap_m3a1", 
     ["uk3cb_mat49", "", "", "", ["UK3CB_MAT49_32Rnd_9x19_Magazine_G", "UK3CB_MAT49_32Rnd_9x19_Magazine_GT", "UK3CB_MAT49_32Rnd_9x19_Magazine"], [], ""]
 ]];
-_pilotLoadoutData set ["sidearms", ["rhs_weap_tt33"]];
+_pilotLoadoutData set ["sidearms", ["rhs_weap_tt33", "rhs_weap_makarov_pm"]];
 
 private _officialLoadoutData = _militaryLoadoutData call _fnc_copyLoadoutData;
 _officialLoadoutData set ["uniforms", ["UK3CB_TKP_I_U_CombatUniform_BLK"]];

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_PLM.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_PLM.sqf
@@ -203,7 +203,9 @@ _sfLoadoutData set ["facewear", []];
 //["Weapon", "Muzzle", "Rail", "Sight", [], [], "Bipod"];
 
 _sfLoadoutData set ["lightATLaunchers", [
-    ["rhs_weap_rpg7", "", "", "rhs_acc_1pn93_2",["rhs_rpg7_type69_airburst_mag", "rhs_rpg7_OG7V_mag", "rhs_rpg7_PG7V_mag"], [], ""]
+    ["rhs_weap_rpg7", "", "", "rhs_acc_1pn93_2",["rhs_rpg7_type69_airburst_mag", "rhs_rpg7_OG7V_mag", "rhs_rpg7_PG7V_mag"], [], ""], 
+    "rhs_weap_rpg26",
+    "rhs_weap_rshg2"
 ]];
 _sfLoadoutData set ["ATLaunchers", [
     ["rhs_weap_rpg7", "", "", "rhs_acc_pgo7v3",["rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7VS_mag"], [], ""],
@@ -215,7 +217,7 @@ _sfLoadoutData set ["heavyATLaunchers", [
     ["rhs_weap_rpg7", "", "", "rhs_acc_pgo7v3",["rhs_rpg7_TBG7V_mag","rhs_rpg7_PG7VL_mag","rhs_rpg7_PG7VR_mag"], [], ""]
 ]];
 _sfLoadoutData set ["slRifles", [
-    ["rhs_weap_akms_gp25", "rhs_acc_pbs1", "", "rhs_acc_1pn93_1", ["UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VG40OP_red", "rhs_GRD40_Green", "rhs_VG40OP_white", "rhs_GRD40_White"], ""],
+    ["rhs_weap_akmn_gp25", "rhs_acc_pbs1", "", "rhs_acc_1pn93_1", ["UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VG40OP_red", "rhs_GRD40_Green", "rhs_VG40OP_white", "rhs_GRD40_White"], ""],
     ["rhs_weap_akmn_gp25", "rhs_acc_pbs1", "", "rhs_acc_1pn93_2", ["UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VG40OP_green", "rhs_GRD40_Red", "rhs_VG40OP_white", "rhs_GRD40_White"], ""]
 ]];
 _sfLoadoutData set ["rifles", [
@@ -225,7 +227,7 @@ _sfLoadoutData set ["carbines", [
     ["rhs_weap_akmn", "rhs_acc_pbs1", "", "rhs_acc_1pn93_2", ["UK3CB_AK47_30Rnd_Magazine"], [], ""]
 ]];
 _sfLoadoutData set ["grenadeLaunchers", [
-    ["rhs_weap_akms_gp25", "rhs_acc_pbs1", "", "rhs_acc_1pn93_1", ["UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white", "rhs_GRD40_White"], ""],
+    ["rhs_weap_akmn_gp25", "rhs_acc_pbs1", "", "rhs_acc_1pn93_1", ["UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white", "rhs_GRD40_White"], ""],
     ["rhs_weap_akmn_gp25", "rhs_acc_pbs1", "", "rhs_acc_1pn93_2", ["UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white", "rhs_VG40MD"], ""]
 ]];
 _sfLoadoutData set ["SMGs", [

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_PLM.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_PLM.sqf
@@ -22,43 +22,41 @@
 ["equipmentBox", "Box_NATO_Equip_F"] call _fnc_saveToTemplate;
 
 // vehicles can be placed in more than one category if they fit between both. Cost will be derived by the higher category
-["vehiclesBasic", ["UK3CB_ARD_O_YAVA"]] call _fnc_saveToTemplate; 
-["vehiclesLightUnarmed", ["UK3CB_ARD_O_Hilux_Open","UK3CB_ARD_O_Hilux_Closed","UK3CB_CW_SOV_O_EARLY_BRDM2_UM","UK3CB_CW_SOV_O_EARLY_BTR40","UK3CB_CW_SOV_O_EARLY_UAZ_Closed","UK3CB_CW_SOV_O_EARLY_UAZ_Open"]] call _fnc_saveToTemplate;
-["vehiclesLightArmed", ["UK3CB_ARD_O_Hilux_Dshkm","UK3CB_ARD_O_Hilux_M2","UK3CB_ARD_O_Hilux_GMG","UK3CB_ARD_O_Hilux_Spg9","UK3CB_ARD_O_Hilux_Metis",
-"UK3CB_CW_SOV_O_EARLY_BRDM2_HQ","UK3CB_CW_SOV_O_EARLY_BTR40_MG",
-"UK3CB_CW_SOV_O_EARLY_Gaz66_ZU23"]] call _fnc_saveToTemplate;
-["vehiclesTrucks", ["UK3CB_CW_SOV_O_EARLY_Gaz66_Covered","UK3CB_CW_SOV_O_EARLY_Gaz66_Open"]] call _fnc_saveToTemplate;
-["vehiclesCargoTrucks", ["UK3CB_CW_SOV_O_EARLY_Gaz66_Covered_Flatbed","UK3CB_CW_SOV_O_EARLY_Gaz66_Open_Flatbed","UK3CB_CW_SOV_O_EARLY_Zil131_Covered"]] call _fnc_saveToTemplate;
-["vehiclesAmmoTrucks", ["UK3CB_CW_SOV_O_EARLY_Gaz66_Ammo"]] call _fnc_saveToTemplate;
-["vehiclesRepairTrucks", ["UK3CB_CW_SOV_O_EARLY_Gaz66_Repair","UK3CB_CW_SOV_O_EARLY_Ural_Repair"]] call _fnc_saveToTemplate;
-["vehiclesFuelTrucks", ["UK3CB_CW_SOV_O_EARLY_Ural_Fuel"]] call _fnc_saveToTemplate;
-["vehiclesMedical", ["UK3CB_CW_SOV_O_EARLY_Gaz66_Med"]] call _fnc_saveToTemplate;
-["vehiclesLightAPCs", ["UK3CB_CW_SOV_O_EARLY_BRDM2"]] call _fnc_saveToTemplate;
-["vehiclesAPCs", ["UK3CB_CW_SOV_O_EARLY_BTR60","UK3CB_CW_SOV_O_EARLY_BTR70"]] call _fnc_saveToTemplate;
-["vehiclesIFVs", ["UK3CB_CW_SOV_O_EARLY_BMP1","UK3CB_CW_SOV_O_EARLY_BMP2","UK3CB_CW_SOV_O_EARLY_BMP2K"]] call _fnc_saveToTemplate;
-["vehiclesLightTanks", ["UK3CB_ARD_O_T34"]] call _fnc_saveToTemplate;
-["vehiclesTanks", ["UK3CB_CW_SOV_O_EARLY_T72A","UK3CB_CW_SOV_O_EARLY_T55","UK3CB_CW_SOV_O_EARLY_T55","UK3CB_ARD_O_T34"]] call _fnc_saveToTemplate;
-["vehiclesHeavyTanks", ["UK3CB_CW_SOV_O_EARLY_T72A"]] call _fnc_saveToTemplate;             // Just to push up the T-72 probability at higher war levels
-["vehiclesAA", ["UK3CB_CW_SOV_O_EARLY_ZsuTank"]] call _fnc_saveToTemplate;
+["vehiclesBasic", ["UK3CB_PLM_O_YAVA"]] call _fnc_saveToTemplate; 
+["vehiclesLightUnarmed", ["UK3CB_PLM_O_BRDM2_UM","UK3CB_PLM_O_BTR40"]] call _fnc_saveToTemplate;
+["vehiclesLightArmed", ["UK3CB_PLM_O_BRDM2_HQ","UK3CB_PLM_O_BTR40_DSHKMS","UK3CB_PLM_O_BTR40_GMG","UK3CB_PLM_O_BTR40_MG","UK3CB_PLM_O_BTR40_METIS","UK3CB_PLM_O_BTR40_PKM"]] call _fnc_saveToTemplate;
+["vehiclesTrucks", ["UK3CB_PLM_O_Zil131_Covered"]] call _fnc_saveToTemplate;
+["vehiclesCargoTrucks", ["UK3CB_PLM_O_Zil131_Flatbed"]] call _fnc_saveToTemplate;
+["vehiclesAmmoTrucks", ["UK3CB_PLM_O_BTR40_REAMMO","UK3CB_PLM_O_Ural_Ammo"]] call _fnc_saveToTemplate;
+["vehiclesRepairTrucks", ["UK3CB_PLM_O_BTR40_REPAIR","UK3CB_PLM_O_Ural_Repair"]] call _fnc_saveToTemplate;
+["vehiclesFuelTrucks", ["UK3CB_PLM_O_BTR40_REFUEL","UK3CB_PLM_O_Ural_Fuel"]] call _fnc_saveToTemplate;
+["vehiclesMedical", ["UK3CB_PLM_O_BTR40_AMBULANCE"]] call _fnc_saveToTemplate;
+["vehiclesLightAPCs", ["UK3CB_PLM_O_BRDM2"]] call _fnc_saveToTemplate;
+["vehiclesAPCs", []] call _fnc_saveToTemplate;
+["vehiclesIFVs", []] call _fnc_saveToTemplate;
+["vehiclesLightTanks", ["UK3CB_PLM_O_T34"]] call _fnc_saveToTemplate;
+["vehiclesTanks", ["UK3CB_PLM_O_T55"]] call _fnc_saveToTemplate;
+["vehiclesHeavyTanks", []] call _fnc_saveToTemplate;             // Just to push up the T-72 probability at higher war levels
+["vehiclesAA", ["UK3CB_PLM_O_BTR40_ZU23", "UK3CB_PLM_O_Ural_Zu23"]] call _fnc_saveToTemplate;
 
 
 ["vehiclesTransportBoats", ["UK3CB_MDF_B_RHIB"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["UK3CB_CHD_O_Fishing_Boat_DSHKM"]] call _fnc_saveToTemplate;
-["vehiclesAmphibious", ["UK3CB_CW_SOV_O_EARLY_MTLB_PKT","UK3CB_CW_SOV_O_EARLY_MTLB_KPVT","UK3CB_CW_SOV_O_EARLY_MTLB_BMP"]] call _fnc_saveToTemplate;
+["vehiclesAmphibious", []] call _fnc_saveToTemplate;
 
 ["vehiclesPlanesCAS", ["UK3CB_CW_SOV_O_EARLY_MIG21_AT","a3a_UK3CB_Fake_Mig"]] call _fnc_saveToTemplate;             
 ["vehiclesPlanesAA", ["UK3CB_CW_SOV_O_EARLY_MIG21_AA","a3a_UK3CB_Fake_Mig"]] call _fnc_saveToTemplate;              
 ["vehiclesPlanesTransport", ["UK3CB_CW_SOV_O_EARLY_LI2"]] call _fnc_saveToTemplate;
 
 ["vehiclesHelisLight", ["UK3CB_CW_SOV_O_EARLY_Mi8AMT"]] call _fnc_saveToTemplate;
-["vehiclesHelisTransport", ["RHS_Mi24Vt_vvsc","UK3CB_CW_SOV_O_EARLY_Mi8","UK3CB_CW_SOV_O_EARLY_Mi8","UK3CB_CW_SOV_O_EARLY_Mi8","UK3CB_CW_SOV_O_EARLY_Mi8"]] call _fnc_saveToTemplate; //Mi24Vt has 1x 12.7mm turret, and disabled pylons
+["vehiclesHelisTransport", []] call _fnc_saveToTemplate; //Mi24Vt has 1x 12.7mm turret, and disabled pylons
 // Should be capable of dealing damage to ground targets without additional scripting
 ["vehiclesHelisLightAttack", ["UK3CB_CW_SOV_O_EARLY_Mi8AMTSh","UK3CB_CW_SOV_O_EARLY_Mi8AMTSh","UK3CB_CW_SOV_O_EARLY_Mi_24P"]] call _fnc_saveToTemplate;      // Mi24P lacks a gun turret
 ["vehiclesHelisAttack", ["UK3CB_CW_SOV_O_EARLY_Mi_24V"]] call _fnc_saveToTemplate;           // Proper attack helis: Apache, Hind etc
 
-["vehiclesArtillery", ["UK3CB_CW_SOV_O_EARLY_BM21","rhs_D30_msv","rhs_D30_msv"]] call _fnc_saveToTemplate;
+["vehiclesArtillery", ["UK3CB_PLM_O_Ural_BM21","rhs_D30_msv","rhs_D30_msv"]] call _fnc_saveToTemplate;
 ["magazines", createHashMapFromArray [
-["UK3CB_CW_SOV_O_EARLY_BM21", ["rhs_mag_m21of_1"]],
+["UK3CB_PLM_O_Ural_BM21", ["rhs_mag_m21of_1"]],
 ["rhs_D30_msv", ["rhs_mag_3of56_10"]]
 ]] call _fnc_saveToTemplate; //element format: [Vehicle class, [Magazines]]
 
@@ -66,14 +64,14 @@
 ["uavsPortable", []] call _fnc_saveToTemplate;
 
 //Config special vehicles
-["vehiclesMilitiaLightArmed", ["UK3CB_CW_SOV_O_EARLY_UAZ_MG"]] call _fnc_saveToTemplate;
-["vehiclesMilitiaTrucks", ["UK3CB_CW_SOV_O_EARLY_Zil131_Covered"]] call _fnc_saveToTemplate;
-["vehiclesMilitiaCars", ["UK3CB_CW_SOV_O_EARLY_UAZ_Closed","UK3CB_CW_SOV_O_EARLY_UAZ_Open"]] call _fnc_saveToTemplate;
+["vehiclesMilitiaLightArmed", ["UK3CB_PLM_O_MB4WD_LMG"]] call _fnc_saveToTemplate;
+["vehiclesMilitiaTrucks", ["UK3CB_PLM_O_Zil131_Open"]] call _fnc_saveToTemplate;
+["vehiclesMilitiaCars", ["UK3CB_PLM_O_Datsun_Open"]] call _fnc_saveToTemplate;
 
-["vehiclesPolice", ["UK3CB_ARD_O_Hilux_Open", "UK3CB_ARD_O_Hilux_Pkm"]] call _fnc_saveToTemplate;
+["vehiclesPolice", ["UK3CB_PLM_O_MB4WD_Unarmed"]] call _fnc_saveToTemplate;
 
-["staticMGs", ["rhsgref_cdf_b_DSHKM","RHS_M2StaticMG_D", "UK3CB_NAP_I_PKM_High"]] call _fnc_saveToTemplate;
-["staticAT", ["rhsgref_cdf_b_SPG9","rhsgref_cdf_b_SPG9M"]] call _fnc_saveToTemplate;
+["staticMGs", ["rhsgref_cdf_b_DSHKM", "UK3CB_NAP_I_PKM_High"]] call _fnc_saveToTemplate;
+["staticAT", ["rhsgref_cdf_b_SPG9","rhsgref_cdf_b_SPG9","rhsgref_cdf_b_SPG9M"]] call _fnc_saveToTemplate;
 ["staticAA", ["RHS_ZU23_MSV","rhs_Igla_AA_pod_msv"]] call _fnc_saveToTemplate;
 ["staticMortars", ["rhs_2b14_82mm_msv"]] call _fnc_saveToTemplate;
 
@@ -92,10 +90,9 @@
 ///  Identities   ///
 /////////////////////
 //Faces and Voices given to AI Factions.
-["faces", ["TanoanHead_A3_01","TanoanHead_A3_02","TanoanHead_A3_03","TanoanHead_A3_04",
-"TanoanHead_A3_05","TanoanHead_A3_06","TanoanHead_A3_07","TanoanHead_A3_08"]] call _fnc_saveToTemplate;
-["voices", ["Male01FRE","Male02FRE","Male03FRE"]] call _fnc_saveToTemplate;
-"TanoanMen" call _fnc_saveNames;
+["voices", ["Male01CHI","Male02CHI","Male03CHI"]] call _fnc_saveToTemplate;
+["faces", ["AsianHead_A3_01","AsianHead_A3_02","AsianHead_A3_03","AsianHead_A3_04","AsianHead_A3_05","AsianHead_A3_06","AsianHead_A3_07"]] call _fnc_saveToTemplate;
+"ChineseMen" call _fnc_saveNames;
 
 
 //////////////////////////
@@ -111,22 +108,19 @@ _loadoutData set ["marksmanRifles", []];
 _loadoutData set ["sniperRifles", []];
 
 _loadoutData set ["lightATLaunchers", [
-    "rhs_weap_m72a7", 
-    "rhs_weap_rpg18",
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag"], [], ""],
+    "rhs_weap_rpg18", 
     "rhs_weap_rpg26",
     "rhs_weap_rpg75",
     "rhs_weap_rshg2"
 ]];
 _loadoutData set ["ATLaunchers", [
     ["rhs_weap_rpg7", "", "", "rhs_acc_pgo7v3",["rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag"], [], ""],
-    ["rhs_weap_rpg7", "", "", "rhs_acc_pgo7v3",["rhs_rpg7_PG7VM_mag", "rhs_rpg7_PG7VS_mag"], [], ""],
     ["rhs_weap_rpg7", "", "", "rhs_acc_pgo7v3",["rhs_rpg7_PG7V_mag", "rhs_rpg7_type69_airburst_mag", "rhs_rpg7_OG7V_mag"], [], ""],
     ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag"], [], ""],
-    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7VM_mag", "rhs_rpg7_PG7VS_mag"], [], ""],
     ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_type69_airburst_mag", "rhs_rpg7_OG7V_mag"], [], ""],
     ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag"], [], ""],
-    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7VM_mag", "rhs_rpg7_PG7VS_mag"], [], ""],
-    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_type69_airburst_mag", "rhs_rpg7_OG7V_mag"], [], ""]
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_OG7V_mag", "rhs_rpg7_type69_airburst_mag", "rhs_rpg7_PG7V_mag"], [], ""]
 ]];
 _loadoutData set ["heavyATLaunchers", [
     ["rhs_weap_rpg7", "", "", "rhs_acc_pgo7v3",["rhs_rpg7_PG7VL_mag", "rhs_rpg7_PG7VS_mag"], [], ""],
@@ -141,9 +135,9 @@ _loadoutData set ["APMines", ["rhs_mine_pmn2_mag"]];
 _loadoutData set ["lightExplosives", ["rhs_ec200_mag"]];
 _loadoutData set ["heavyExplosives", ["rhs_ec400_mag"]];
 
-_loadoutData set ["antiTankGrenades", []];
-_loadoutData set ["antiInfantryGrenades", ["rhs_mag_f1","rhs_mag_rgd5","rhs_mag_rgo","rhs_mag_rgn","rhs_grenade_khattabka_vog17_mag","rhs_grenade_khattabka_vog25_mag"]];
-_loadoutData set ["smokeGrenades", ["rhs_mag_rdg2_white"]];
+_loadoutData set ["antiTankGrenades", ["rhsgref_mag_rkg3em"]];
+_loadoutData set ["antiInfantryGrenades", ["rhs_mag_f1","rhs_mag_rgd5"]];
+_loadoutData set ["smokeGrenades", ["rhs_mag_rdg2_white", "rhs_mag_rdg2_black"]];
 _loadoutData set ["signalsmokeGrenades", ["rhs_mag_nspd"]];
 
 
@@ -159,8 +153,9 @@ _loadoutData set ["binoculars", ["rhsusf_bino_m24"]];
 _loadoutData set ["rangefinders", ["rhsusf_bino_m24"]];
 
 _loadoutData set ["uniforms", []];
+_loadoutData set ["SLuniforms", []];
 _loadoutData set ["vests", []];
-_loadoutData set ["backpacks", ["B_FieldPack_cbr","rhs_assault_umbts","rhs_sidor","UK3CB_UN_B_B_ASS"]];
+_loadoutData set ["backpacks", ["UK3CB_PLM_B_B_RD54_RIF_01", "UK3CB_PLM_B_B_FIELDPACK_RIF_01", "UK3CB_PLM_B_B_Sidor_RIF_01"]];
 _loadoutData set ["medBackpacks", ["rhs_medic_bag"]];
 _loadoutData set ["atBackpacks", ["rhs_rpg_empty"]];
 _loadoutData set ["aaBackpacks", ["B_Carryall_oli"]];
@@ -168,7 +163,7 @@ _loadoutData set ["mgBackpacks", ["rhs_rd54"]];
 _loadoutData set ["longRangeRadios", []];
 _loadoutData set ["helmets", []];
 
-_loadoutData set ["facewear", []];
+_loadoutData set ["facewear", ["UK3CB_G_Bandanna_red_check", "UK3CB_G_Bandanna_red"]];
 
 //Item *set* definitions. These are added in their entirety to unit loadouts. No randomisation is applied.
 _loadoutData set ["items_medical_basic", ["BASIC"] call A3A_fnc_itemset_medicalSupplies];
@@ -200,16 +195,15 @@ _loadoutData set ["items_unarmed_extras", []];
 ///////////////////////////////////////
 
 private _sfLoadoutData = _loadoutData call _fnc_copyLoadoutData;
-_sfLoadoutData set ["uniforms", ["UK3CB_CHD_B_U_CombatUniform_08"]];
-_sfLoadoutData set ["vests", ["UK3CB_V_Belt_Rig_KHK","UK3CB_MDF_B_V_TacVest_LIZ","UK3CB_MD99_VEST_Rifleman_KHK","UK3CB_MD12_VEST_Rifleman_OLI"]];
-_sfLoadoutData set ["helmets", ["rhs_headband", "rhs_6b27m_ml", "rhsgref_6b27m_ttsko_mountain"]];
-_sfLoadoutData set ["facewear", ["rhsusf_shemagh2_grn", "rhsusf_shemagh2_od", "rhsusf_shemagh2_tan", "rhsusf_shemagh2_white","UK3CB_G_KLR_BLK","UK3CB_G_KLR_Oli","UK3CB_G_KLR_TAN"]];
+_sfLoadoutData set ["uniforms", ["UK3CB_PLM_B_U_Pants_Shirt_02"]];
+_sfLoadoutData set ["SLuniforms", ["UK3CB_PLM_B_U_Officer_Comm_CombatUniform_01"]];
+_sfLoadoutData set ["vests", ["rhs_6b2_chicom"]];
+_sfLoadoutData set ["helmets", ["UK3CB_PLM_B_H_SSh68_Covered_BLK", "UK3CB_PLM_B_H_Headband_Red"]];
+_sfLoadoutData set ["facewear", []];
 //["Weapon", "Muzzle", "Rail", "Sight", [], [], "Bipod"];
 
 _sfLoadoutData set ["lightATLaunchers", [
-    "rhs_weap_m72a7", 
-    "rhs_weap_rshg2",
-    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7VS_mag", "rhs_rpg7_type69_airburst_mag", "rhs_rpg7_OG7V_mag"], [], ""]
+    ["rhs_weap_rpg7", "", "", "rhs_acc_1pn93_2",["rhs_rpg7_type69_airburst_mag", "rhs_rpg7_OG7V_mag", "rhs_rpg7_PG7V_mag"], [], ""]
 ]];
 _sfLoadoutData set ["ATLaunchers", [
     ["rhs_weap_rpg7", "", "", "rhs_acc_pgo7v3",["rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7VS_mag"], [], ""],
@@ -217,52 +211,40 @@ _sfLoadoutData set ["ATLaunchers", [
     ["rhs_weap_rpg7", "", "", "rhs_acc_pgo7v3",["rhs_rpg7_PG7VS_mag", "rhs_rpg7_type69_airburst_mag", "rhs_rpg7_OG7V_mag"], [], ""]
 ]];
 _sfLoadoutData set ["heavyATLaunchers", [
-    ["rhs_weap_rpg7", "", "", "rhs_acc_pgo7v3",["rhs_rpg7_PG7VL_mag","rhs_rpg7_PG7VR_mag"], [], ""]
+    ["rhs_weap_rpg7", "", "", "rhs_acc_pgo7v3",["rhs_rpg7_PG7VL_mag","rhs_rpg7_PG7VR_mag"], [], ""],
+    ["rhs_weap_rpg7", "", "", "rhs_acc_pgo7v3",["rhs_rpg7_TBG7V_mag","rhs_rpg7_PG7VL_mag","rhs_rpg7_PG7VR_mag"], [], ""]
 ]];
 _sfLoadoutData set ["slRifles", [
-    ["rhs_weap_aks74un", "rhs_acc_pbs4", "", "rhs_acc_okp7_dovetail", ["rhs_30Rnd_545x39_7N10_AK"], [], ""],
-    ["rhs_weap_m92", "rhs_acc_pbs1", "", "", ["UK3CB_AK47_45Rnd_Magazine_GT", "UK3CB_AK47_45Rnd_Magazine_G", "UK3CB_AK47_45Rnd_Magazine","rhs_30Rnd_762x39mm_bakelite", "rhs_30Rnd_762x39mm_bakelite_tracer"], [], ""],
-    ["rhs_weap_ak74n_gp25", "rhs_acc_dtk4short", "", "", ["rhs_30Rnd_545x39_7N10_AK"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
-    ["UK3CB_M16A2_UGL", "", "", "", ["UK3CB_M16_30rnd_556x45","UK3CB_M16_30rnd_556x45_G"], ["rhs_mag_M441_HE", "rhs_mag_M441_HE", "rhs_mag_M433_HEDP", "rhs_mag_m714_White"], ""],
-    ["UK3CB_M16A1", "", "", "", ["UK3CB_M16_30rnd_556x45","UK3CB_M16_30rnd_556x45_G"], [], ""]
+    ["rhs_weap_akms_gp25", "rhs_acc_pbs1", "", "rhs_acc_1pn93_1", ["UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VG40OP_red", "rhs_GRD40_Green", "rhs_VG40OP_white", "rhs_GRD40_White"], ""],
+    ["rhs_weap_akmn_gp25", "rhs_acc_pbs1", "", "rhs_acc_1pn93_2", ["UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VG40OP_green", "rhs_GRD40_Red", "rhs_VG40OP_white", "rhs_GRD40_White"], ""]
 ]];
 _sfLoadoutData set ["rifles", [
-    ["rhs_weap_l1a1_wood", "rhsgref_sdn6_suppressor", "", "", 	["UK3CB_FNFAL_30rnd_762x51_G","UK3CB_FNFAL_30rnd_762x51_GT"], [], ""],
-    ["rhs_weap_ak74n", "rhs_acc_dtk", "rhs_acc_perst1ik", 	"rhs_acc_ekp1", ["rhs_30Rnd_545x39_7N10_AK"], [], ""],
-    ["rhs_weap_ak74n", "rhs_acc_dtk4short", "rhs_acc_perst1ik", "rhs_acc_pkas", ["rhs_30Rnd_545x39_7N10_AK"], [], ""],
-    ["rhs_weap_aks74n", "rhs_acc_dtk", "rhs_acc_perst1ik", 	"rhs_acc_ekp1", ["rhs_30Rnd_545x39_7N10_AK"], [], ""],
-    ["rhs_weap_aks74n", "rhs_acc_dtk4short", "rhs_acc_perst1ik", "rhs_acc_pkas", ["rhs_30Rnd_545x39_7N10_AK"], [], ""],
-    ["rhs_weap_rpk74m", "rhs_acc_tgpa", "rhs_acc_perst1ik", "rhs_acc_ekp1", 	["rhs_30Rnd_545x39_7U1_AK"], [], ""]
+    ["rhs_weap_akmn", "rhs_acc_pbs1", "", "rhs_acc_1pn93_2", ["UK3CB_AK47_30Rnd_Magazine"], [], ""]
 ]];
 _sfLoadoutData set ["carbines", [
-    ["UK3CB_M16A1", "", "", "", ["UK3CB_M16_30rnd_556x45","UK3CB_M16_30rnd_556x45_G"], [], ""],
-    ["rhs_weap_aks74un", "rhs_acc_dtk", "", "rhs_acc_okp7_dovetail", ["rhs_30Rnd_545x39_7N10_AK"], [], ""],
-    ["rhs_weap_aks74un", "rhs_acc_pbs4", "", "rhs_acc_okp7_dovetail", ["rhs_30Rnd_545x39_7N10_AK"], [], ""],
-    ["rhs_weap_m92", "rhs_acc_pbs1", "", "", ["UK3CB_AK47_45Rnd_Magazine_GT", "UK3CB_AK47_45Rnd_Magazine_G", "UK3CB_AK47_45Rnd_Magazine","rhs_30Rnd_762x39mm_bakelite", "rhs_30Rnd_762x39mm_bakelite_tracer"], [], ""],
-    ["rhs_weap_m92", "rhs_acc_pbs1", "", "", ["UK3CB_AK47_45Rnd_Magazine_GT", "UK3CB_AK47_45Rnd_Magazine_G", "UK3CB_AK47_45Rnd_Magazine","rhs_30Rnd_762x39mm_bakelite", "rhs_30Rnd_762x39mm_bakelite_tracer"], [], ""]
+    ["rhs_weap_akmn", "rhs_acc_pbs1", "", "rhs_acc_1pn93_2", ["UK3CB_AK47_30Rnd_Magazine"], [], ""]
 ]];
 _sfLoadoutData set ["grenadeLaunchers", [
-    ["rhs_weap_ak74n_gp25", "rhs_acc_dtk1983", "", "", ["rhs_30Rnd_545x39_7N10_AK"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
-    ["rhs_weap_ak74n_gp25", "rhs_acc_dtk4short", "", "", ["rhs_30Rnd_545x39_7N10_AK"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
-    ["UK3CB_M16A2_UGL", "", "", "", ["UK3CB_M16_30rnd_556x45","UK3CB_M16_30rnd_556x45_G"], ["rhs_mag_M441_HE", "rhs_mag_M441_HE", "rhs_mag_M433_HEDP", "rhs_mag_m714_White"], ""]
+    ["rhs_weap_akms_gp25", "rhs_acc_pbs1", "", "rhs_acc_1pn93_1", ["UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white", "rhs_GRD40_White"], ""],
+    ["rhs_weap_akmn_gp25", "rhs_acc_pbs1", "", "rhs_acc_1pn93_2", ["UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white", "rhs_VG40MD"], ""]
 ]];
 _sfLoadoutData set ["SMGs", [
-    ["rhs_weap_aks74un", "rhs_acc_pbs4", "", "rhs_acc_okp7_dovetail", ["rhs_30Rnd_545x39_7U1_AK"], [], ""],
-    ["rhs_weap_asval", "", "", "rhs_acc_okp7_dovetail", ["rhs_20rnd_9x39mm_SP5","rhs_20rnd_9x39mm_SP6"], [], ""]
+    ["rhs_weap_asval_grip", "", "rhs_acc_perst1ik_ris", "rhs_acc_1pn93_2", ["rhs_20rnd_9x39mm_SP5"], [], "rhs_acc_grip_rk6"],
+    ["rhs_weap_asval", "", "", "rhs_acc_1pn93_2", ["rhs_20rnd_9x39mm_SP6"], [], ""]
 ]];
 _sfLoadoutData set ["machineGuns", [
-    ["rhs_weap_rpk74m", "rhs_acc_tgpa", "rhs_acc_perst1ik", "rhs_acc_ekp1", 	["rhs_45Rnd_545X39_7U1_AK"], [], ""],
-    ["UK3CB_RPK_74N_BLK", "", "", "rhs_acc_1p29", 	["UK3CB_RPK74_60rnd_545x39_GM", "UK3CB_RPK74_60rnd_545x39_GT"], [], ""],
-    ["UK3CB_RPD", "rhs_acc_pbs1", "", "", 	["UK3CB_RPD_100rnd_762x39"], [], ""]
+    ["UK3CB_RPD", "rhs_acc_pbs1", "", "", ["UK3CB_RPD_100rnd_762x39"], [], ""],
+    ["UK3CB_RPKN_BLK", "rhs_acc_pbs1", "", "rhs_acc_1pn93_2", ["UK3CB_RPK_75rnd_762x39"], [], ""]
 ]];
 _sfLoadoutData set ["marksmanRifles", [
-    ["UK3CB_SVD_OLD", "rhs_acc_tgpv", "", "rhs_acc_pso1m2", ["rhs_10Rnd_762x54mmR_7N1"], [], ""],
-    ["rhs_weap_l1a1_wood", "rhsgref_sdn6_suppressor", "", "rhsgref_acc_l1a1_l2a2", 	["UK3CB_FNFAL_20rnd_762x51_G","UK3CB_FNFAL_20rnd_762x51_GT"], [], ""],
-    ["rhs_weap_asval_grip", "", "rhs_acc_perst1ik_ris", "rhs_acc_pso1m21", 	["rhs_10rnd_9x39mm_SP5","rhs_10rnd_9x39mm_SP6"], [], "rhs_acc_grip_rk6"]
+    ["UK3CB_SVD_OLD", "rhs_acc_tgpv", "", "rhs_acc_1pn34", ["UK3CB_SVD_10rnd_762x54","UK3CB_SVD_10rnd_762x54_G", "UK3CB_SVD_10rnd_762x54_GT"], [], ""],
+    ["rhs_weap_vss_grip", "", "rhs_acc_perst1ik_ris", "rhs_acc_1pn93_1", ["rhs_20rnd_9x39mm_SP5"], [], "rhs_acc_grip_rk6"],
+    ["rhs_weap_vss", "", "", "rhs_acc_1pn93_1", ["rhs_20rnd_9x39mm_SP6"], [], ""]
 ]];
 _sfLoadoutData set ["sniperRifles", [
-    ["UK3CB_SVD_OLD", "rhs_acc_tgpv", "", "rhs_acc_pso1m2", ["rhs_10Rnd_762x54mmR_7N1"], [], ""],
-    ["rhs_weap_asval_grip", "", "rhs_acc_perst1ik_ris", "rhs_acc_pso1m21", 	["rhs_10rnd_9x39mm_SP5","rhs_10rnd_9x39mm_SP6"], [], "rhs_acc_grip_rk6"]
+    ["UK3CB_SVD_OLD", "rhs_acc_tgpv", "", "rhs_acc_1pn34", ["UK3CB_SVD_10rnd_762x54","UK3CB_SVD_10rnd_762x54_G", "UK3CB_SVD_10rnd_762x54_GT"], [], ""],
+    ["rhs_weap_vss_grip", "", "rhs_acc_perst1ik_ris", "rhs_acc_1pn93_1", ["rhs_20rnd_9x39mm_SP5"], [], "rhs_acc_grip_rk6"],
+    ["rhs_weap_vss", "", "", "rhs_acc_1pn93_1", ["rhs_20rnd_9x39mm_SP6"], [], ""]
 ]];
 _sfLoadoutData set ["sidearms", [
     ["rhs_weap_pb_6p9", "", "", "", ["rhs_mag_9x18_8_57N181S"], [], ""],
@@ -273,65 +255,46 @@ _sfLoadoutData set ["sidearms", [
 /////////////////////////////////
 
 private _militaryLoadoutData = _loadoutData call _fnc_copyLoadoutData;
-_militaryLoadoutData set ["uniforms", ["UK3CB_CHD_B_U_CombatUniform_08"]];
-_militaryLoadoutData set ["vests", ["rhs_6b2_RPK","rhs_6b2_lifchik","rhs_6b2_chicom","rhs_6b2_AK","rhs_lifchik","rhsgref_chicom"]];
-_militaryLoadoutData set ["helmets", ["H_Bandanna_khk", "rhs_ssh60","rhs_ssh68","rhs_ssh68_2", "rhsgref_M56","H_Booniehat_oli","H_Hat_Safari_olive_F"]];
+_militaryLoadoutData set ["uniforms", ["UK3CB_PLM_B_U_CombatUniform_01", "UK3CB_PLM_B_U_CombatUniform_02"]];
+_militaryLoadoutData set ["SLuniforms", ["UK3CB_PLM_B_U_Officer_CombatUniform_01"]];
+_militaryLoadoutData set ["vests", ["rhs_chicom","rhs_chicom_khk", "rhs_6b2","rhs_6b2_holster", "rhs_vydra_3m"]];
+_militaryLoadoutData set ["helmets", ["UK3CB_PLM_B_H_SSh68","UK3CB_PLM_B_H_SSh68_Covered", "rhsgref_M56","UK3CB_PLM_B_H_Headband_Red","UK3CB_PLM_B_H_Fieldcap_Early_GRN", "UK3CB_H_CAP_PLM"]];
 
 _militaryLoadoutData set ["slRifles", [
-    ["UK3CB_FNFAL_FOREGRIP", "", "", "", 	["UK3CB_FNFAL_20rnd_762x51_G","UK3CB_FNFAL_20rnd_762x51_GT"], [], ""],
-    ["rhs_weap_akmn", "rhs_acc_dtkakm", "rhs_acc_2dpZenit", "", ["rhs_30Rnd_762x39mm", "rhs_30Rnd_762x39mm_tracer"], [], ""],
-    ["rhs_weap_akmn", "rhs_acc_dtkakm", "rhs_acc_2dpZenit", "", ["rhs_30Rnd_762x39mm_bakelite", "rhs_30Rnd_762x39mm_bakelite_tracer"], [], ""],
-    ["rhs_weap_akmn_gp25", "rhs_acc_dtkakm", "", "", ["rhs_30Rnd_762x39mm", "rhs_30Rnd_762x39mm_tracer"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
-    ["rhs_weap_ak74n_gp25", "rhs_acc_dtk1983", "", "", ["rhs_30Rnd_545x39_7N6M_AK"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
-    ["UK3CB_M16A1", "", "", "", ["UK3CB_M16_20rnd_556x45","UK3CB_M16_20rnd_556x45_G"], [], ""],
-    ["UK3CB_M16A2", "", "", "", ["UK3CB_M16_20rnd_556x45","UK3CB_M16_20rnd_556x45_G"], [], ""],
-    ["UK3CB_M16A2_UGL", "", "", "", ["UK3CB_M16_20rnd_556x45","UK3CB_M16_20rnd_556x45_G"], ["rhs_mag_M441_HE", "rhs_mag_M441_HE", "rhs_mag_M433_HEDP", "rhs_mag_m714_White"], ""]
+    ["rhs_weap_akms_gp25", "rhs_acc_dtkakm", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VG40OP_red", "rhs_GRD40_Green", "rhs_VG40OP_white", "rhs_GRD40_White"], ""],
+    ["rhs_weap_akm_gp25", "rhs_acc_dtkakm", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VG40OP_green", "rhs_GRD40_Red", "rhs_VG40OP_white", "rhs_GRD40_White"], ""]
 ]];
 _militaryLoadoutData set ["rifles", [
-    ["rhs_weap_l1a1_wood", "rhsgref_acc_falMuzzle_l1a1", "", "", 	["UK3CB_FNFAL_20rnd_762x51_G","UK3CB_FNFAL_20rnd_762x51_GT"], [], ""],
-    ["rhs_weap_akmn", "rhs_acc_dtkakm", "rhs_acc_2dpZenit", "", ["rhs_30Rnd_762x39mm", "rhs_30Rnd_762x39mm_tracer"], [], ""]
+    ["uk3cb_sks_01", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
+    ["uk3cb_sks_01_sling", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
+    ["uk3cb_sks_02", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""]
 ]];
 _militaryLoadoutData set ["carbines", [
     ["uk3cb_sks_01", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
-    ["rhs_weap_aks74un", "rhs_acc_dtk", "", "", ["rhs_30Rnd_545x39_7N6M_AK"], [], ""],
-    ["rhs_weap_m92", "", "", "", ["rhs_30Rnd_762x39mm_bakelite", "rhs_30Rnd_762x39mm_bakelite_tracer"], [], ""]
+    ["rhs_weap_akm", "", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], [], ""],
+    ["rhs_weap_akms", "", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], [], ""]
 ]];
 _militaryLoadoutData set ["grenadeLaunchers", [
-    ["rhs_weap_m79", "", "", "", ["rhs_mag_M433_HEDP", "rhs_mag_M441_HE"], ["rhs_mag_M433_HEDP","rhs_mag_M441_HE","rhs_mag_m576","rhs_mag_m662_red","rhs_mag_m713_Red","rhs_mag_m714_White"], ""],
-    ["rhs_weap_akmn_gp25", "rhs_acc_dtkakm", "", "", ["rhs_30Rnd_762x39mm", "rhs_30Rnd_762x39mm_tracer"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
-    ["rhs_weap_ak74n_gp25", "rhs_acc_dtk1983", "", "", ["rhs_30Rnd_545x39_7N6M_AK"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
-    ["rhs_weap_aks74n_gp25", "rhs_acc_dtk1983", "", "", ["rhs_30Rnd_545x39_7N6M_AK"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
-    ["rhs_weap_ak74n_gp25_npz", "rhs_acc_dtk1983", "", "", ["rhs_30Rnd_545x39_7N6M_AK"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""]
+    ["rhs_weap_akms_gp25", "rhs_acc_dtkakm", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white", "rhs_GRD40_White"], ""],
+    ["rhs_weap_akm_gp25", "rhs_acc_dtkakm", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white", "rhs_VG40MD"], ""]
 ]];
 _militaryLoadoutData set ["SMGs", [
-    ["rhs_weap_m3a1",  "", "", "", ["rhsgref_30rnd_1143x23_M1T_2mag_SMG", "rhsgref_30rnd_1143x23_M1911B_2mag_SMG", "rhsgref_30rnd_1143x23_M1T_SMG", "rhsgref_30rnd_1143x23_M1911B_SMG"], [], ""],
-    ["uk3cb_mat49", "", "", "", ["UK3CB_MAT49_32Rnd_9x19_Magazine_G", "UK3CB_MAT49_32Rnd_9x19_Magazine_GT", "UK3CB_MAT49_32Rnd_9x19_Magazine"], [], ""],
-    ["uk3cb_ppsh41", "", "", "", ["uk3cb_PPSH_71rnd_magazine_GM","uk3cb_PPSH_71rnd_magazine_GM","uk3cb_PPSH_35rnd_magazine_G"], [], ""]
+    ["uk3cb_ppsh41", "", "", "", ["uk3cb_PPSH_71rnd_magazine_GM","uk3cb_PPSH_35rnd_magazine_G","uk3cb_PPSH_35rnd_magazine_G"], [], ""],
+    ["uk3cb_ppsh41", "", "", "", ["uk3cb_PPSH_35rnd_magazine_GM","uk3cb_PPSH_35rnd_magazine_GM","uk3cb_PPSH_35rnd_magazine_GT"], [], ""]
 ]];
 _militaryLoadoutData set ["machineGuns", [
-    ["UK3CB_FNLAR", "", "", "", 	["UK3CB_FNFAL_30rnd_762x51_GT", "UK3CB_FNFAL_30rnd_762x51_G", "UK3CB_FNFAL_20rnd_762x51_GT", "UK3CB_FNFAL_20rnd_762x51_G"], [], ""],
-    ["UK3CB_M60", "", "", "", ["UK3CB_M60_100rnd_762x51_GM","UK3CB_M60_100rnd_762x51_GT"], [], ""],
-    ["rhs_weap_mg42", "", "", "", 	["rhsgref_50Rnd_792x57_SmE_drum","rhsgref_50Rnd_792x57_SmE_drum","rhsgref_50Rnd_792x57_SmK_drum"], [], ""],
-    ["rhs_weap_pkm", "", "", "", ["UK3CB_RPD_100rnd_762x39", "UK3CB_RPD_100rnd_762x39_GM"], [], ""],
-    ["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39", "UK3CB_RPD_100rnd_762x39_GM"], [], ""],
-    ["UK3CB_RPK", "", "", "", ["rhs_75Rnd_762x39mm_89", "UK3CB_RPK_40rnd_762x39_GM"], [], ""],
-    ["UK3CB_RPK_74N", "", "", "rhs_acc_1p29", ["rhs_45Rnd_545X39_7N6M_AK", "rhs_45Rnd_545X39_AK_Green"], [], ""]
+    ["UK3CB_RPD", "rhs_acc_dtkakm", "", "", ["UK3CB_RPD_100rnd_762x39_GT", "UK3CB_RPD_100rnd_762x39_GM", "UK3CB_RPD_100rnd_762x39_G", "UK3CB_RPD_100rnd_762x39"], [], ""],
+    ["UK3CB_RPK", "", "", "", ["UK3CB_RPK_75rnd_762x39_GM", "UK3CB_RPK_40rnd_762x39_GT", "UK3CB_RPK_40rnd_762x39_GM", "UK3CB_RPK_40rnd_762x39_G", "UK3CB_RPK_40rnd_762x39"], [], ""]
 ]];
 _militaryLoadoutData set ["marksmanRifles", [
-    ["UK3CB_SVD_OLD", "", "", "rhs_acc_pso1m2", ["rhs_10Rnd_762x54mmR_7N1"], [], ""],
-    ["rhs_weap_l1a1_wood", "rhsgref_acc_falMuzzle_l1a1", "", "rhsgref_acc_l1a1_l2a2", 	["UK3CB_FNFAL_20rnd_762x51_G","UK3CB_FNFAL_20rnd_762x51_GT"], [], ""],
-    ["rhs_weap_ak74n", "rhs_acc_dtk", "rhs_acc_2dpZenit", "rhs_acc_pso1m21", ["rhs_30Rnd_545x39_7N6M_AK", "rhs_30Rnd_545x39_7N6M_AK"], [], ""],
-    ["rhs_weap_akmn", "rhs_acc_dtkakm", "", "rhs_acc_pso1m21", ["rhs_30Rnd_762x39mm_tracer", "rhs_30Rnd_762x39mm", "rhs_30Rnd_762x39mm_tracer"], [], ""],
-    ["uk3cb_enfield_no4t_walnut", "", "", "uk3cb_optic_no32", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""],
-    ["uk3cb_enfield_no4t", "", "", "uk3cb_optic_no32", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""]
+    ["UK3CB_SVD_OLD", "", "", "rhs_acc_pso1m2", ["UK3CB_SVD_10rnd_762x54","UK3CB_SVD_10rnd_762x54_G", "UK3CB_SVD_10rnd_762x54_GT"], [], ""]
 ]];
 _militaryLoadoutData set ["sniperRifles", [
-    ["UK3CB_SVD_OLD", "", "", "rhs_acc_pso1m2", ["rhs_10Rnd_762x54mmR_7N1"], [], ""],
-    ["UK3CB_SVD_OLD", "", "", "rhs_acc_pso1m2", ["rhs_10Rnd_762x54mmR_7N1"], [], ""],
-    ["uk3cb_enfield_no4t_walnut", "", "", "uk3cb_optic_no32", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""],
-    ["uk3cb_enfield_no4t", "", "", "uk3cb_optic_no32", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""]
+    ["UK3CB_SVD_OLD", "", "", "rhs_acc_pso1m2", ["UK3CB_SVD_10rnd_762x54","UK3CB_SVD_10rnd_762x54_G", "UK3CB_SVD_10rnd_762x54_GT"], [], ""]
 ]];
-_militaryLoadoutData set ["sidearms", ["rhs_weap_tt33","rhs_weap_makarov_pm"]];
+_militaryLoadoutData set ["sidearms", [
+    ["rhs_weap_pb_6p9", "", "", "", ["rhs_mag_9x18_8_57N181S"], [], ""],
+    "rhs_weap_tt33","rhs_weap_makarov_pm"]];
 
 ///////////////////////////////
 //    Police Loadout Data    //
@@ -339,92 +302,82 @@ _militaryLoadoutData set ["sidearms", ["rhs_weap_tt33","rhs_weap_makarov_pm"]];
 
 private _policeLoadoutData = _loadoutData call _fnc_copyLoadoutData;
 
-_policeLoadoutData set ["uniforms", ["UK3CB_CW_SOV_O_Early_U_Tank_Crew_Uniform_02_BLK"]];
-_policeLoadoutData set ["vests", ["UK3CB_ADA_B_V_TacVest_BLK"]];
-_policeLoadoutData set ["helmets", ["H_Hat_Safari_sand_F", "H_Hat_Safari_olive_F", "UK3CB_H_Safari_Hat_Brown"]];
+_policeLoadoutData set ["uniforms", ["UK3CB_PLM_B_U_Shorts_Uniform_07"]];
+_policeLoadoutData set ["vests", ["UK3CB_V_SOV_CHICOM_GRN_TAN","UK3CB_V_SOV_CHICOM_GRN", "UK3CB_V_SOV_CHICOM_TAN_GRN","UK3CB_V_SOV_CHICOM_TAN"]];
+_policeLoadoutData set ["helmets", ["UK3CB_H_CAP_PLM_BLK", "UK3CB_PLM_B_H_Fieldcap_Early_BLK", "UK3CB_PLM_B_H_SSh68_Covered_BLK", "UK3CB_PLM_B_H_SSh68_BLK"]];
 _policeLoadoutData set ["facewear", ["rhsusf_shemagh2_grn", "rhs_scarf","UK3CB_G_Bandanna_red_check"]];
 _policeLoadoutData set ["NVGs", []];
 _policeLoadoutData set ["gpses", []];
 
 _policeLoadoutData set ["rifles", [
-    ["uk3cb_enfield_no3", "", "", "", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""]
+    "rhs_weap_m38"
 ]];
 _policeLoadoutData set ["carbines", [
+    ["uk3cb_sks_01", "uk3cb_muzzle_sks_bayonet", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
     ["uk3cb_sks_01", "uk3cb_muzzle_sks_bayonet", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
     ["uk3cb_sks_01", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
     ["uk3cb_sks_02", "uk3cb_muzzle_sks_bayonet", "", "", ["rhs_10Rnd_762x39mm_U"], [], ""],
     ["uk3cb_sks_02", "", "", "", ["rhs_30Rnd_762x39mm_U", "rhs_10Rnd_762x39mm_U"], [], ""]
 ]];
 _policeLoadoutData set ["SMGs", [
-    ["rhs_weap_m3a1",  "", "", "", ["rhsgref_30rnd_1143x23_M1T_2mag_SMG", "rhsgref_30rnd_1143x23_M1911B_2mag_SMG", "rhsgref_30rnd_1143x23_M1T_SMG", "rhsgref_30rnd_1143x23_M1911B_SMG"], [], ""],
-    ["uk3cb_mat49", "", "", "", ["UK3CB_MAT49_32Rnd_9x19_Magazine_G", "UK3CB_MAT49_32Rnd_9x19_Magazine_GT", "UK3CB_MAT49_32Rnd_9x19_Magazine"], [], ""]
+    ["uk3cb_ppsh41", "", "", "", ["uk3cb_PPSH_35rnd_magazine_GM","uk3cb_PPSH_35rnd_magazine_GM","uk3cb_PPSH_35rnd_magazine_GT"], [], ""]
 ]];
-_policeLoadoutData set ["sidearms", ["rhs_weap_makarov_pm"]];
 
 ////////////////////////////////
 //    Militia Loadout Data    //
 ////////////////////////////////
 
 private _militiaLoadoutData = _loadoutData call _fnc_copyLoadoutData;
-_militiaLoadoutData set ["uniforms", ["UK3CB_ADM_B_U_Shirt_Pants_01_BRN_WDL", "UK3CB_ADM_B_U_Shirt_Pants_01_BRN_WDL_ALT", "UK3CB_ADC_C_Shorts_U_02"]];
-_militiaLoadoutData set ["vests", ["rhsgref_alice_webbing","rhsgref_chestrig","rhsgref_chicom", "UK3CB_V_Belt_Rig_KHK","UK3CB_V_Chicom_Brown","UK3CB_TKA_I_V_vydra_3m_Tan","V_BandollierB_oli"]];
-_militiaLoadoutData set ["helmets", ["H_Hat_Safari_sand_F", "H_Hat_Safari_olive_F", "UK3CB_H_Safari_Hat_Brown"]];
+_militiaLoadoutData set ["uniforms", ["UK3CB_PLM_B_U_Shorts_Uniform_06","UK3CB_PLM_B_U_Shorts_Uniform_05","UK3CB_PLM_B_U_Shorts_Uniform_04","UK3CB_PLM_B_U_Shorts_Uniform_03","UK3CB_PLM_B_U_Shorts_Uniform_02", "UK3CB_PLM_B_U_Shorts_Uniform_01"]];
+_militiaLoadoutData set ["SLuniforms", ["UK3CB_PLM_B_U_Pants_Shirt_01"]];
+_militiaLoadoutData set ["vests", ["UK3CB_V_SOV_CHICOM_GRN_TAN","UK3CB_V_SOV_CHICOM_GRN", "UK3CB_V_SOV_CHICOM_TAN_GRN","UK3CB_V_SOV_CHICOM_TAN"]];
+_militiaLoadoutData set ["helmets", ["rhsgref_M56","rhsgref_M56","UK3CB_PLM_B_H_Headband_Red","UK3CB_PLM_B_H_Headband_Red","UK3CB_PLM_B_H_Fieldcap_Early_GRN", "UK3CB_H_CAP_PLM"]];
 _militiaLoadoutData set ["NVGs", []];
-_militiaLoadoutData set ["gpses", []];
+_militiaLoadoutData set ["antiInfantryGrenades", ["rhs_grenade_sthgr24_mag","rhs_grenade_sthgr43_mag"]];
+
+_militiaLoadoutData set ["backpacks", ["UK3CB_PLM_B_B_RD54_RIF_02", "UK3CB_PLM_B_B_FIELDPACK_RIF_02", "UK3CB_PLM_B_B_Sidor_RIF_02"]];
 
 _militiaLoadoutData set ["ATLaunchers", [
-    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7VM_mag"], [], ""],
-    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7VM_mag", "rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag"], [], ""],
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag", "rhs_rpg7_OG7V_mag"], [], ""],
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_OG7V_mag", "rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag"], [], ""],
     ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_type69_airburst_mag", "rhs_rpg7_OG7V_mag"], [], ""]
 ]];
 _militiaLoadoutData set ["heavyATLaunchers", [
-    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7VS_mag"], [], ""]
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag"], [], ""]
 ]];
 
 _militiaLoadoutData set ["slRifles", [
-    ["rhs_weap_akm_gp25", "rhs_acc_dtkakm", "", "", ["rhs_30Rnd_762x39mm", "rhs_30Rnd_762x39mm_tracer"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
-    ["rhs_weap_aks74u", "rhs_acc_dtk", "", "", ["rhs_30Rnd_545x39_7N6M_AK"], [], ""],
-    ["rhs_weap_l1a1_wood", "rhsgref_acc_falMuzzle_l1a1", "", "", 	["UK3CB_FNFAL_20rnd_762x51_G","UK3CB_FNFAL_20rnd_762x51_GT"], [], ""],
-    ["rhs_weap_akms", "rhs_acc_dtkakm", "rhs_acc_2dpZenit", "", ["rhs_30Rnd_762x39mm", "rhs_30Rnd_762x39mm_tracer"], [], ""],
-    ["uk3cb_mat49", "", "", "", ["UK3CB_MAT49_32Rnd_9x19_Magazine_G", "UK3CB_MAT49_32Rnd_9x19_Magazine_GT", "UK3CB_MAT49_32Rnd_9x19_Magazine"], [], ""]
+    ["rhs_weap_akms_gp25", "rhs_acc_dtkakm", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VG40OP_red", "rhs_GRD40_Green", "rhs_VG40OP_white", "rhs_GRD40_White"], ""],
+    ["rhs_weap_akm_gp25", "rhs_acc_dtkakm", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], ["rhs_VOG25", "rhs_VG40OP_green", "rhs_GRD40_Red", "rhs_VG40OP_white", "rhs_GRD40_White"], ""]
 ]];
 _militiaLoadoutData set ["rifles", [
-    ["uk3cb_enfield_no3", "", "", "", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""],
+    "rhs_weap_m38",
     ["uk3cb_sks_01", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
-    ["rhs_weap_l1a1_wood", "rhsgref_acc_falMuzzle_l1a1", "", "", 	["UK3CB_FNFAL_20rnd_762x51_G","UK3CB_FNFAL_20rnd_762x51_GT"], [], ""],
-    ["rhs_weap_akms", "rhs_acc_dtkakm", "rhs_acc_2dpZenit", "", ["rhs_30Rnd_762x39mm", "rhs_30Rnd_762x39mm_tracer"], [], ""]
+    ["uk3cb_sks_01_sling", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
+    ["uk3cb_sks_02", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""]
 ]];
 _militiaLoadoutData set ["carbines", [
-    ["rhs_weap_aks74u", "rhs_acc_dtk", "", "", ["rhs_30Rnd_545x39_7N6M_AK"], [], ""]
+    ["uk3cb_sks_01", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
+    ["uk3cb_sks_01_sling", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
+    ["uk3cb_sks_02", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""]
 ]];
 _militiaLoadoutData set ["grenadeLaunchers", [
-    ["rhs_weap_akms_gp25", "rhs_acc_dtkakm", "", "", ["rhs_30Rnd_762x39mm", "rhs_30Rnd_762x39mm_tracer"], ["rhs_VOG25", "rhs_VOG25", "rhs_VOG25P", "rhs_VG40OP_white"], ""],
-    ["uk3cb_enfield_no4", "", "", "", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], ["uk3cb_1rnd_riflegrenade_mas_ap", "uk3cb_1rnd_riflegrenade_mas_ap", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
-    ["uk3cb_enfield_no4_walnut", "", "", "", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], ["uk3cb_1rnd_riflegrenade_mas_ap", "uk3cb_1rnd_riflegrenade_mas_ap", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
-    ["uk3cb_enfield_no4", "", "", "", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], ["uk3cb_1rnd_riflegrenade_mas_at_l", "uk3cb_1rnd_riflegrenade_mas_at_s", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
-    ["rhs_weap_m79", "", "", "", ["rhs_mag_M433_HEDP", "rhs_mag_M441_HE"], ["rhs_mag_M433_HEDP","rhs_mag_M441_HE","rhs_mag_m576","rhs_mag_m662_red","rhs_mag_m713_Red","rhs_mag_m714_White"], ""]
+    ["uk3cb_sks_01", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
+    ["uk3cb_sks_01_sling", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""],
+    ["uk3cb_sks_02", "", "", "", ["uk3cb_10rnd_magazine_sks", "uk3cb_10rnd_magazine_sks_G", "uk3cb_10rnd_magazine_sks_GT"], [], ""]
 ]];
 _militiaLoadoutData set ["SMGs", [
-    ["rhs_weap_m3a1",  "", "", "", ["rhsgref_30rnd_1143x23_M1T_2mag_SMG", "rhsgref_30rnd_1143x23_M1911B_2mag_SMG", "rhsgref_30rnd_1143x23_M1T_SMG", "rhsgref_30rnd_1143x23_M1911B_SMG"], [], ""],
-    ["uk3cb_mat49", "", "", "", ["UK3CB_MAT49_32Rnd_9x19_Magazine_G", "UK3CB_MAT49_32Rnd_9x19_Magazine_GT", "UK3CB_MAT49_32Rnd_9x19_Magazine"], [], ""]
+    ["uk3cb_ppsh41", "", "", "", ["uk3cb_PPSH_35rnd_magazine_GM","uk3cb_PPSH_35rnd_magazine_GM","uk3cb_PPSH_35rnd_magazine_GT"], [], ""]
 ]];
 _militiaLoadoutData set ["machineGuns", [
-    ["UK3CB_Bren_303", "", "", "", ["UK3CB_Bren_30Rnd_303_Magazine", "UK3CB_Bren_30Rnd_303_Magazine", "UK3CB_Bren_30Rnd_303_Magazine_GT"], [], ""],
-    ["UK3CB_Bren_303", "", "", "", ["UK3CB_Bren_30Rnd_303_Magazine", "UK3CB_Bren_30Rnd_303_Magazine", "UK3CB_Bren_30Rnd_303_Magazine_GT"], [], ""],
-    ["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39_GM"], [], ""],
-    ["UK3CB_RPK", "", "", "", ["UK3CB_RPK_40rnd_762x39_GM", "UK3CB_RPK_40rnd_762x39_GM"], [], ""]
+    ["UK3CB_RPK", "", "", "", ["UK3CB_AK47_30Rnd_Magazine_GT", "UK3CB_AK47_30Rnd_Magazine_G", "UK3CB_AK47_30Rnd_Magazine"], [], ""]
 ]];
 _militiaLoadoutData set ["marksmanRifles", [
-    ["uk3cb_enfield_no3t", "", "", "uk3cb_optic_no32", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""],
-    ["uk3cb_enfield_no3t", "", "", "uk3cb_optic_no32", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""],
-    ["uk3cb_enfield_no4t", "", "", "uk3cb_optic_no32", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""]
+    "rhs_weap_m38"
 ]];
 _militiaLoadoutData set ["sniperRifles", [
-    ["uk3cb_enfield_no3t", "", "", "uk3cb_optic_no32", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""],
-    ["uk3cb_enfield_no3t", "", "", "uk3cb_optic_no32", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""],
-    ["uk3cb_enfield_no4t", "", "", "uk3cb_optic_no32", ["uk3cb_no4_enfield_303_10Rnd_magazine_G","uk3cb_no4_enfield_303_10Rnd_magazine_GT"], [], ""]
+    "rhs_weap_m38"
 ]];
-_militiaLoadoutData set ["sidearms", ["rhs_weap_makarov_pm"]];
 
 _militiaLoadoutData set ["traitorRifle", [
     "rhs_weap_m38"

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TLA.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TLA.sqf
@@ -312,7 +312,7 @@ _militaryLoadoutData set ["machineGuns", [
     ["UK3CB_FNLAR", "", "", "", 	["UK3CB_FNFAL_30rnd_762x51_GT", "UK3CB_FNFAL_30rnd_762x51_G", "UK3CB_FNFAL_20rnd_762x51_GT", "UK3CB_FNFAL_20rnd_762x51_G"], [], ""],
     ["UK3CB_M60", "", "", "", ["UK3CB_M60_100rnd_762x51_GM","UK3CB_M60_100rnd_762x51_GT"], [], ""],
     ["rhs_weap_mg42", "", "", "", 	["rhsgref_50Rnd_792x57_SmE_drum","rhsgref_50Rnd_792x57_SmE_drum","rhsgref_50Rnd_792x57_SmK_drum"], [], ""],
-    ["rhs_weap_pkm", "", "", "", ["UK3CB_RPD_100rnd_762x39", "UK3CB_RPD_100rnd_762x39_GM"], [], ""],
+    ["rhs_weap_pkm", "", "", "", ["rhs_100Rnd_762x54mmR","rhs_100Rnd_762x54mmR_green","rhs_100Rnd_762x54mmR_7N13","rhs_100Rnd_762x54mmR_7N26","rhs_100Rnd_762x54mmR_7BZ3"], [], ""],
     ["UK3CB_RPD", "", "", "", ["UK3CB_RPD_100rnd_762x39", "UK3CB_RPD_100rnd_762x39_GM"], [], ""],
     ["UK3CB_RPK", "", "", "", ["rhs_75Rnd_762x39mm_89", "UK3CB_RPK_40rnd_762x39_GM"], [], ""],
     ["UK3CB_RPK_74N", "", "", "rhs_acc_1p29", ["rhs_45Rnd_545X39_7N6M_AK", "rhs_45Rnd_545X39_AK_Green"], [], ""]

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TNM.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TNM.sqf
@@ -1,0 +1,967 @@
+//////////////////////////
+//   Side Information   //
+//////////////////////////
+//Tanoan Liberation Army, natural enemies of the HIDF, CW US, US, and SDK
+["name", "TNM"] call _fnc_saveToTemplate;
+["spawnMarkerName", "TNM Support Corridor"] call _fnc_saveToTemplate;
+
+["flag", "Flag_CW_SOV_ARMY"] call _fnc_saveToTemplate;
+["flagTexture", "\UK3CB_Factions\addons\UK3CB_Factions_TNM\Flag\TNM_flag_co.paa"] call _fnc_saveToTemplate;
+["flagMarkerType", "UK3CB_Marker_TNM"] call _fnc_saveToTemplate;
+
+//////////////////////////
+//       Vehicles       //
+//////////////////////////
+
+
+["attributeMoreTrucks", true] call _fnc_saveToTemplate;         // Use more truck for transports
+
+["ammobox", "B_supplyCrate_F"] call _fnc_saveToTemplate;
+["surrenderCrate", "Box_IND_Wps_F"] call _fnc_saveToTemplate;
+["equipmentBox", "Box_NATO_Equip_F"] call _fnc_saveToTemplate;
+
+// vehicles can be placed in more than one category if they fit between both. Cost will be derived by the higher category
+["vehiclesBasic", ["UK3CB_TNM_B_TT650"]] call _fnc_saveToTemplate; 
+["vehiclesLightUnarmed", ["UK3CB_TNM_B_Hilux_Open","UK3CB_TNM_B_Hilux_Closed", "UK3CB_FIA_B_LR_SF_WMIK_FFV"]] call _fnc_saveToTemplate;
+["vehiclesLightArmed", ["UK3CB_B_M939_Guntruck_HIDF","UK3CB_FIA_B_LR_SF_WMIK_M2_M240","UK3CB_FIA_B_LR_SF_WMIK_M2_M240","UK3CB_FIA_B_LR_SF_WMIK_MILAN_M240","UK3CB_FIA_B_LR_SF_WMIK_MK19_M240"]] call _fnc_saveToTemplate;
+["vehiclesTrucks", ["UK3CB_TNM_B_LR_Softtop_Transport_Closed", "UK3CB_B_M939_Open_HIDF"]] call _fnc_saveToTemplate;
+["vehiclesCargoTrucks", ["UK3CB_TNM_B_Van_transport"]] call _fnc_saveToTemplate;
+["vehiclesAmmoTrucks", ["UK3CB_PLM_O_BTR40_REAMMO","UK3CB_PLM_O_Ural_Ammo"]] call _fnc_saveToTemplate;
+["vehiclesRepairTrucks", ["UK3CB_PLM_O_BTR40_REPAIR","UK3CB_PLM_O_Ural_Repair"]] call _fnc_saveToTemplate;
+["vehiclesFuelTrucks", ["UK3CB_PLM_O_BTR40_REFUEL","UK3CB_PLM_O_Ural_Fuel"]] call _fnc_saveToTemplate;
+["vehiclesMedical", ["UK3CB_PLM_O_BTR40_AMBULANCE"]] call _fnc_saveToTemplate;
+["vehiclesLightAPCs", ["UK3CB_PLM_O_BRDM2"]] call _fnc_saveToTemplate;
+["vehiclesAPCs", []] call _fnc_saveToTemplate;
+["vehiclesIFVs", []] call _fnc_saveToTemplate;
+["vehiclesLightTanks", []] call _fnc_saveToTemplate;
+["vehiclesTanks", ["UK3CB_B_M60A3_HIDF", "UK3CB_B_M60A1_HIDF", "UK3CB_TNM_B_T55"]] call _fnc_saveToTemplate;
+["vehiclesHeavyTanks", []] call _fnc_saveToTemplate;             // Just to push up the T-72 probability at higher war levels
+["vehiclesAA", ["a3a_green_M270_Avenger"]] call _fnc_saveToTemplate;
+
+
+["vehiclesTransportBoats", ["UK3CB_MDF_B_RHIB"]] call _fnc_saveToTemplate;
+["vehiclesGunBoats", ["UK3CB_TKA_B_RHIB_Gunboat"]] call _fnc_saveToTemplate;
+["vehiclesAmphibious", []] call _fnc_saveToTemplate;
+
+["vehiclesPlanesCAS", ["RHSGREF_A29B_HIDF", "UK3CB_B_T28Trojan_HIDF_CAS"]] call _fnc_saveToTemplate;      // "UK3CB_B_Mystere_HIDF_CAS1" -> commented for testing of A29 & T28
+["vehiclesPlanesAA", ["UK3CB_B_Mystere_HIDF_AA1"]] call _fnc_saveToTemplate;
+["vehiclesPlanesTransport", ["UK3CB_B_C47_Late_HIDF"]] call _fnc_saveToTemplate;
+
+["vehiclesHelisLight", ["rhs_uh1h_hidf_unarmed"]] call _fnc_saveToTemplate;
+["vehiclesHelisTransport", ["rhs_uh1h_hidf"]] call _fnc_saveToTemplate; //Mi24Vt has 1x 12.7mm turret, and disabled pylons
+// Should be capable of dealing damage to ground targets without additional scripting
+["vehiclesHelisLightAttack", ["rhs_uh1h_hidf_gunship"]] call _fnc_saveToTemplate;      // Mi24P lacks a gun turret
+["vehiclesHelisAttack", []] call _fnc_saveToTemplate;           // Proper attack helis: Apache, Hind etc
+
+["vehiclesAirPatrol", ["rhs_uh1h_hidf", "UK3CB_B_Cessna_T41_HIDF"]] call _fnc_saveToTemplate;
+
+["vehiclesArtillery", ["RHS_M119_WD"]] call _fnc_saveToTemplate;
+["magazines", createHashMapFromArray [
+["RHS_M119_WD", ["RHS_mag_m1_he_12"]]
+]] call _fnc_saveToTemplate; //element format: [Vehicle class, [Magazines]]
+
+["uavsAttack", []] call _fnc_saveToTemplate;
+["uavsPortable", []] call _fnc_saveToTemplate;
+
+//Config special vehicles
+["vehiclesMilitiaLightArmed", ["UK3CB_FIA_B_LR_SF_WMIK_M240_M240", "UK3CB_FIA_B_LR_WMIK_DSHKM", "UK3CB_FIA_B_LR_WMIK_M2", "UK3CB_FIA_B_LR_WMIK_M240"]] call _fnc_saveToTemplate;
+["vehiclesMilitiaTrucks", ["UK3CB_TNM_B_LR_Softtop_Transport_Open", "UK3CB_B_M939_Closed_HIDF"]] call _fnc_saveToTemplate;
+["vehiclesMilitiaCars", ["UK3CB_TNM_B_Datsun_Open"]] call _fnc_saveToTemplate;
+
+["vehiclesPolice", ["UK3CB_TNM_B_Pickup"]] call _fnc_saveToTemplate;
+
+["staticMGs", ["RHS_M2StaticMG_WD"]] call _fnc_saveToTemplate;
+["staticAT", ["RHS_TOW_TriPod_WD"]] call _fnc_saveToTemplate;
+["staticAA", ["RHS_Stinger_AA_pod_D"]] call _fnc_saveToTemplate;
+["staticMortars", ["a3a_RHS_M252"]] call _fnc_saveToTemplate;
+
+["mortarMagazineHE", "rhs_12Rnd_m821_HE"] call _fnc_saveToTemplate;
+["mortarMagazineSmoke", "8Rnd_82mm_Mo_Smoke_white"] call _fnc_saveToTemplate;
+["mortarMagazineFlare", "8Rnd_82mm_Mo_Flare_white"] call _fnc_saveToTemplate;
+
+//Minefield definition
+//CFGVehicles variant of Mines are needed "ATMine", "APERSTripMine", "APERSMine"
+["minefieldAT", ["rhsusf_mine_M19"]] call _fnc_saveToTemplate;
+["minefieldAPERS", ["rhs_mine_Mk2_tripwire", "rhsusf_mine_m49a1_6m"]] call _fnc_saveToTemplate;
+
+#include "3CBFactions_Vehicle_Attributes.sqf"
+
+/////////////////////
+///  Identities   ///
+/////////////////////
+//Faces and Voices given to AI Factions.
+["faces", ["TanoanHead_A3_01","TanoanHead_A3_02","TanoanHead_A3_03","TanoanHead_A3_04",
+"TanoanHead_A3_05","TanoanHead_A3_06","TanoanHead_A3_07","TanoanHead_A3_08"]] call _fnc_saveToTemplate;
+["voices", ["Male01FRE","Male02FRE","Male03FRE"]] call _fnc_saveToTemplate;
+"TanoanMen" call _fnc_saveNames;
+
+//////////////////////////
+//       Loadouts       //
+//////////////////////////
+private _loadoutData = call _fnc_createLoadoutData;
+_loadoutData set ["rifles", []];
+_loadoutData set ["carbines", []];
+_loadoutData set ["grenadeLaunchers", []];
+_loadoutData set ["SMGs", []];
+_loadoutData set ["machineGuns", []];
+_loadoutData set ["marksmanRifles", []];
+_loadoutData set ["sniperRifles", []];
+
+_loadoutData set ["lightATLaunchers", [
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag", "rhs_rpg7_type69_airburst_mag"], [], ""],
+    "rhs_weap_m72a7", 
+    "uk3cb_m72a1_law_loaded"
+]];
+_loadoutData set ["ATLaunchers", [
+    ["rhs_weap_maaws", "", "", "rhs_optic_maaws",["rhs_mag_maaws_HEDP", "rhs_mag_maaws_HE"], [], ""],
+    ["rhs_weap_maaws", "", "", "rhs_optic_maaws",["rhs_mag_maaws_HEAT", "rhs_mag_maaws_HE"], [], ""],
+    ["rhs_weap_maaws", "", "", "",["rhs_mag_maaws_HEDP", "rhs_mag_maaws_HE"], [], ""],
+    ["rhs_weap_maaws", "", "", "",["rhs_mag_maaws_HEAT", "rhs_mag_maaws_HE"], [], ""],
+    ["rhs_weap_maaws", "", "", "",["rhs_mag_maaws_HE", "rhs_mag_maaws_HEDP"], [], ""]
+]];
+_loadoutData set ["heavyATLaunchers", [
+    "uk3cb_m47"
+]];
+_loadoutData set ["AALaunchers", ["UK3CB_Blowpipe", "rhs_weap_fim92"]];
+_loadoutData set ["sidearms", ["UK3CB_BHP","rhsusf_weap_m1911a1"]];
+
+_loadoutData set ["ATMines", ["rhs_mine_M19_mag"]];
+_loadoutData set ["APMines", ["rhs_mine_m2a3b_trip_mag","rhs_mine_m2a3b_press_mag", "rhs_mine_M3_tripwire_mag","rhs_mine_m3_pressure_mag","rhs_mine_Mk2_tripwire_mag","rhs_mine_mk2_pressure_mag","rhsusf_mine_m49a1_3m_mag","rhsusf_mine_m49a1_6m_mag","rhsusf_mine_m49a1_10m_mag"]];
+_loadoutData set ["lightExplosives", ["rhs_ec200_mag"]];
+_loadoutData set ["heavyExplosives", ["rhs_ec400_mag"]];
+
+_loadoutData set ["antiTankGrenades", []];
+_loadoutData set ["antiInfantryGrenades", ["rhs_grenade_mkii_mag","rhs_grenade_mkiiia1_mag","rhs_mag_mk3a2"]];
+_loadoutData set ["smokeGrenades", ["rhs_mag_an_m8hc", "rhs_grenade_anm8_mag", "rhs_grenade_m15_mag"]];
+_loadoutData set ["signalsmokeGrenades", ["rhs_mag_m18_green", "rhs_mag_m18_purple", "rhs_mag_m18_red", "rhs_mag_m18_yellow"]];
+
+
+//Basic equipment. Shouldn't need touching most of the time.
+//Mods might override this, or certain mods might want items removed (No GPSs in WW2, for example)
+_loadoutData set ["maps", ["ItemMap"]];
+_loadoutData set ["watches", ["ItemWatch"]];
+_loadoutData set ["compasses", ["ItemCompass"]];
+_loadoutData set ["radios", ["ItemRadio"]];
+_loadoutData set ["gpses", []];
+_loadoutData set ["NVGs", ["rhs_1PN138"]];
+_loadoutData set ["binoculars", ["rhsusf_bino_m24"]];
+_loadoutData set ["rangefinders", ["rhsusf_bino_m24"]];
+
+_loadoutData set ["uniforms", ["UK3CB_TNM_B_U_CombatUniform_01", "UK3CB_TNM_B_U_CombatUniform_02"]];
+_loadoutData set ["SLuniforms", ["UK3CB_TNM_B_U_Officer_CombatUniform_01"]];
+_loadoutData set ["vests", []];
+_loadoutData set ["backpacks", ["UK3CB_PLM_B_B_RD54_RIF_01", "UK3CB_PLM_B_B_FIELDPACK_RIF_01", "UK3CB_PLM_B_B_Sidor_RIF_01"]];
+_loadoutData set ["medBackpacks", ["rhs_medic_bag"]];
+_loadoutData set ["atBackpacks", ["rhs_rpg_empty"]];
+_loadoutData set ["aaBackpacks", ["B_Carryall_oli"]];
+_loadoutData set ["mgBackpacks", ["rhs_rd54"]];
+_loadoutData set ["longRangeRadios", []];
+_loadoutData set ["helmets", ["UK3CB_TNM_B_H_Cap_KHK","UK3CB_TNM_B_H_Cap_CAC", "UK3CB_TNM_B_H_BoonieHat_KHK","UK3CB_TNM_B_H_BoonieHat_CAC","UK3CB_TNM_B_H_Bandanna_KHK", "UK3CB_TNM_B_H_Bandanna_CAC"]];
+_loadoutData set ["slHelmets", ["UK3CB_TNM_B_H_Patrolcap_Mic_CAC_Patch", "UK3CB_TNM_B_H_Infantry_Beret"]];
+_loadoutData set ["sinHelmets", ["UK3CB_TNM_B_H_BoonieHat_CAC"]];
+
+_loadoutData set ["facewear", []];
+
+//Item *set* definitions. These are added in their entirety to unit loadouts. No randomisation is applied.
+_loadoutData set ["items_medical_basic", ["BASIC"] call A3A_fnc_itemset_medicalSupplies];
+_loadoutData set ["items_medical_standard", ["STANDARD"] call A3A_fnc_itemset_medicalSupplies];
+_loadoutData set ["items_medical_medic", ["MEDIC"] call A3A_fnc_itemset_medicalSupplies];
+_loadoutData set ["items_miscEssentials", [] call A3A_fnc_itemset_miscEssentials];
+
+//Unit type specific item sets. Add or remove these, depending on the unit types in use.
+_loadoutData set ["items_squadLeader_extras", []];
+_loadoutData set ["items_rifleman_extras", []];
+_loadoutData set ["items_medic_extras", []];
+_loadoutData set ["items_grenadier_extras", []];
+_loadoutData set ["items_explosivesExpert_extras", ["ToolKit", "MineDetector"]];
+_loadoutData set ["items_engineer_extras", ["ToolKit", "MineDetector"]];
+_loadoutData set ["items_lat_extras", []];
+_loadoutData set ["items_at_extras", []];
+_loadoutData set ["items_aa_extras", []];
+_loadoutData set ["items_machineGunner_extras", []];
+_loadoutData set ["items_marksman_extras", []];
+_loadoutData set ["items_sniper_extras", []];
+_loadoutData set ["items_police_extras", []];
+_loadoutData set ["items_crew_extras", []];
+_loadoutData set ["items_unarmed_extras", []];
+
+//TODO - ACE overrides for misc essentials, medical and engineer gear
+
+///////////////////////////////////////
+//    Special Forces Loadout Data    //
+///////////////////////////////////////
+
+private _sfLoadoutData = _loadoutData call _fnc_copyLoadoutData;
+_sfLoadoutData set ["uniforms", ["UK3CB_TNM_B_U_SF_CombatUniform_01"]];
+_sfLoadoutData set ["SLuniforms", ["UK3CB_TNM_B_U_SF_CombatUniform_01"]];
+_sfLoadoutData set ["vests", ["UK3CB_ADA_B_V_TacVest_BLK"]];
+_sfLoadoutData set ["helmets", ["UK3CB_TNM_B_H_Bandanna_CAC_BLK", "UK3CB_TNM_B_H_Patrolcap_Mic_CAC_BLK", "UK3CB_TNM_B_H_BoonieHat_CAC_BLK"]];
+_sfLoadoutData set ["slHelmets", ["UK3CB_TNM_B_H_SF_Beret", "UK3CB_TNM_B_H_Patrolcap_Mic_CAC_BLK_Patch"]];
+_sfLoadoutData set ["sinHelmets", ["UK3CB_TNM_B_H_BoonieHat_CAC_BLK"]];
+_sfLoadoutData set ["facewear", []];
+//["Weapon", "Muzzle", "Rail", "Sight", [], [], "Bipod"];
+
+_sfLoadoutData set ["slRifles", [
+    ["UK3CB_M16A2_UGL", "rhsusf_acc_rotex5_grey", "", "rhsusf_acc_RX01_NoFilter", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], ["rhs_mag_M433_HEDP", "rhs_mag_M433_HEDP", "rhs_mag_m714_White", "rhs_mag_m713_Red", "rhs_mag_m662_red", "rhs_mag_m661_green"], ""]
+    ["UK3CB_M16A3_UGL", "rhsusf_acc_rotex5_grey", "", "rhsusf_acc_compm4", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], ["rhs_mag_M433_HEDP", "rhs_mag_M433_HEDP", "rhs_mag_m714_White", "rhs_mag_m713_Red", "rhs_mag_m662_red", "rhs_mag_m661_green"], ""]
+]];
+_sfLoadoutData set ["rifles", [    
+    ["UK3CB_AR10_Porto_Carbine_Sup_OD", "uk3cb_muzzle_snds_M14", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], [], ""],
+    ["UK3CB_M14", "uk3cb_muzzle_snds_M14", "", "uk3cb_optic_artel_m14", ["UK3CB_M14_20rnd_762x51"], [], ""],
+    ["uk3cb_ar18", "rhsusf_acc_rotex5_grey", "", "", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], [], ""]
+]];
+_sfLoadoutData set ["carbines", [
+    ["uk3cb_ar18_shorty", "", "", "", ["UK3CB_M16_30rnd_556x45", "UK3CB_M16_30rnd_556x45_R", "UK3CB_M16_30rnd_556x45_RT"], [], ""],
+    ["uk3cb_ar18_carbine", "rhsusf_acc_rotex5_grey", "", "", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], [], ""],
+    ["UK3CB_M16A3", "rhsusf_acc_rotex5_grey", "", "rhsusf_acc_compm4", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], [], ""]
+]];
+_sfLoadoutData set ["grenadeLaunchers", [
+    ["UK3CB_M16A2_UGL", "rhsusf_acc_rotex5_grey", "", "rhsusf_acc_RX01_NoFilter", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], ["rhs_mag_M433_HEDP", "rhs_mag_m714_White", "rhs_mag_m662_red"], ""],
+    ["rhs_weap_m79", "", "", "", ["rhs_mag_M433_HEDP"], ["rhs_mag_M433_HEDP", "rhs_mag_m714_White", "rhs_mag_m662_red"], ""]
+]];
+_sfLoadoutData set ["SMGs", [
+    ["uk3cb_ar18_shorty", "", "", "", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], [], ""],
+    ["rhs_weap_m3a1_specops", "", "", "", ["rhs_weap_m3a1","rhsgref_30rnd_1143x23_M1T_SMG","rhsgref_30rnd_1143x23_M1T_2mag_SMG","rhsgref_30rnd_1143x23_M1911B_2mag_SMG"], [], ""]
+]];
+_sfLoadoutData set ["machineGuns", [
+    ["UK3CB_M60", "", "", "", ["UK3CB_M60_100rnd_762x51_RM", "UK3CB_M60_100rnd_762x51"], [], ""],
+    ["UK3CB_M60", "", "", "", ["UK3CB_M60_100rnd_762x51_RT", "UK3CB_M60_100rnd_762x51"], [], ""],
+    ["UK3CB_M60", "", "", "", ["UK3CB_M60_100rnd_762x51_R", "UK3CB_M60_100rnd_762x51"], [], ""]
+]];
+_sfLoadoutData set ["marksmanRifles", [
+    ["UK3CB_M14", "uk3cb_muzzle_snds_M14", "", "uk3cb_optic_artel_m14", ["UK3CB_M14_20rnd_762x51"], [], ""]
+]];
+_sfLoadoutData set ["sniperRifles", [
+    ["rhs_weap_m24sws", "rhsusf_acc_m24_silencer_black", "", "rhsusf_acc_LEUPOLDMK4", ["rhsusf_5Rnd_762x51_m62_Mag"], [], "rhsusf_acc_harris_swivel"],
+    ["UK3CB_M14", "uk3cb_muzzle_snds_M14", "", "uk3cb_optic_artel_m14", ["UK3CB_M14_20rnd_762x51"], [], ""]
+]];
+_sfLoadoutData set ["sidearms", [
+    ["rhs_weap_pb_6p9", "", "", "", ["rhs_mag_9x18_8_57N181S"], [], ""],
+    ["rhs_weap_pb_6p9", "rhs_acc_6p9_suppressor", "", "", ["rhs_mag_9x18_8_57N181S"], [], ""]
+]];
+/////////////////////////////////
+//    Military Loadout Data    //
+/////////////////////////////////
+
+private _militaryLoadoutData = _loadoutData call _fnc_copyLoadoutData;
+_militaryLoadoutData set ["vests", ["rhsgref_alice_webbing", "rhsgref_chestrig", "UK3CB_ADA_B_V_TacVest_WDL", "UK3CB_MDF_B_V_TacVest_LIZ"]];
+_militaryLoadoutData set ["helmets", ["UK3CB_TNM_B_H_Cap_CAC", "UK3CB_TNM_B_H_BoonieHat_CAC", "UK3CB_TNM_B_H_Bandanna_CAC", "UK3CB_H_M1_Helmet_Net_OLI", "UK3CB_H_M1_Helmet_Covered_Band_OLI", "UK3CB_H_M1_Helmet_Covered_OLI", "UK3CB_H_M1_Helmet"]];
+
+_militaryLoadoutData set ["slRifles", [
+    ["UK3CB_AR10_Porto_Carbine", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
+    ["UK3CB_AR10_Porto_Carbine", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
+    ["UK3CB_AR10_Porto_Carbine", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
+    ["uk3cb_ar18_shorty", "", "", "", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], [], ""]
+]];
+_militaryLoadoutData set ["rifles", [
+    ["UK3CB_AR10_OD", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], [], ""],
+    ["UK3CB_AR10_OD", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], [], ""]
+]];
+_militaryLoadoutData set ["carbines", [
+    ["uk3cb_m2carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
+    ["uk3cb_m2a1_carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
+    ["UK3CB_AR10_Porto_Carbine_Sup_OD", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], [], ""],
+    ["UK3CB_AR10_Porto_Carbine_Sup_OD", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], [], ""],
+    ["UK3CB_AR10_Porto_Carbine_Sup_OD", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], [], ""],
+    ["uk3cb_ar18", "", "", "", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], [], ""],
+    ["uk3cb_ar18_carbine", "", "", "", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], [], ""]
+]];
+_militaryLoadoutData set ["grenadeLaunchers", [
+    ["UK3CB_AR10_Porto", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
+    ["UK3CB_AR10_Porto", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
+    ["UK3CB_AR10_Porto", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
+    ["UK3CB_M16A2_UGL", "", "", "", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], ["rhs_mag_M433_HEDP", "rhs_mag_m714_White", "rhs_mag_m662_red"], ""]
+]];
+_militaryLoadoutData set ["SMGs", [
+    ["uk3cb_m2carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
+    ["uk3cb_m2a1_carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
+    ["rhs_weap_m3a1", "", "", "", ["rhs_weap_m3a1","rhsgref_30rnd_1143x23_M1T_SMG","rhsgref_30rnd_1143x23_M1T_2mag_SMG","rhsgref_30rnd_1143x23_M1911B_2mag_SMG"], [], ""],
+    ["rhs_weap_m3a1", "", "", "", ["rhs_weap_m3a1","rhsgref_30rnd_1143x23_M1T_SMG","rhsgref_30rnd_1143x23_M1T_2mag_SMG","rhsgref_30rnd_1143x23_M1911B_2mag_SMG"], [], ""],
+    ["uk3cb_thompson_m1a1", "", "", "", ["UK3CB_Thompson_30rnd_1143x23_M1911B_Magazine_RT","UK3CB_Thompson_30rnd_1143x23_M1911B_Magazine_R","UK3CB_Thompson_30rnd_1143x23_M1911B_Magazine"], [], ""]
+]];
+_militaryLoadoutData set ["machineGuns", [
+    ["UK3CB_M60", "", "", "", ["UK3CB_M60_100rnd_762x51_RM", "UK3CB_M60_100rnd_762x51"], [], ""],
+    ["UK3CB_M1919A6_Browning", "", "", "", ["UK3CB_M1919_50Rnd_3006_Magazine_RT", "UK3CB_M1919_50Rnd_3006_Magazine_RM", "UK3CB_M1919_50Rnd_3006_Magazine_R", "UK3CB_M1919_50Rnd_3006_Magazine"], [], ""],
+    ["UK3CB_M1919A6_Browning", "", "", "", ["UK3CB_M1919_50Rnd_3006_Magazine_RT", "UK3CB_M1919_50Rnd_3006_Magazine_RM", "UK3CB_M1919_50Rnd_3006_Magazine_R", "UK3CB_M1919_50Rnd_3006_Magazine"], [], ""],
+    ["UK3CB_M1919A6_Browning", "", "", "", ["UK3CB_M1919_50Rnd_3006_Magazine_RT", "UK3CB_M1919_50Rnd_3006_Magazine_RM", "UK3CB_M1919_50Rnd_3006_Magazine_R", "UK3CB_M1919_50Rnd_3006_Magazine"], [], ""]
+]];
+_militaryLoadoutData set ["marksmanRifles", [
+    ["UK3CB_AR10_Porto_Marksman_Sup_ALU", "", "", "uk3cb_optic_ar_delft3x25", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], [], ""],
+    ["UK3CB_AR10_Porto_Marksman_Sup_ALU", "", "", "uk3cb_optic_ar_delft3x25_3d", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], [], ""]
+]];
+_militaryLoadoutData set ["sniperRifles", [
+    ["UK3CB_M1903A1_unertl", "", "", "", ["UK3CB_M1903A1_3006_5rnd_Magazine", "UK3CB_M1903A1_3006_5rnd_Magazine_RT", "UK3CB_M1903A1_3006_5rnd_Magazine_R"], [], ""],
+    ["UK3CB_M1903A1_unertl", "", "", "", ["UK3CB_M1903A1_3006_5rnd_Magazine", "UK3CB_M1903A1_3006_5rnd_Magazine_RT", "UK3CB_M1903A1_3006_5rnd_Magazine_R"], [], ""],
+    ["UK3CB_M14", "", "", "uk3cb_optic_artel_m14", ["UK3CB_M14_20rnd_762x51", "UK3CB_M14_20rnd_762x51_R", "UK3CB_M14_20rnd_762x51_RT"], [], ""]
+]];
+_militaryLoadoutData set ["sidearms", ["rhsusf_weap_m1911a1", "", ""]];
+
+///////////////////////////////
+//    Police Loadout Data    //
+///////////////////////////////
+
+private _policeLoadoutData = _loadoutData call _fnc_copyLoadoutData;
+
+_policeLoadoutData set ["uniforms", ["UK3CB_TNM_B_U_Navy_CombatUniform_01"]];
+_policeLoadoutData set ["vests", ["rhsgref_alice_webbing", "rhsgref_chestrig"]];
+_policeLoadoutData set ["helmets", ["UK3CB_TNM_B_H_Cap_CAC_NAVY", "UK3CB_TNM_B_H_BoonieHat_CAC_NAVY", "UK3CB_TNM_B_H_Navy_Beret", "UK3CB_TNM_B_H_Bandanna_CAC_NAVY"]];
+_policeLoadoutData set ["facewear", []];
+_policeLoadoutData set ["NVGs", []];
+_policeLoadoutData set ["gpses", []];
+
+_policeLoadoutData set ["rifles", [
+    ["uk3cb_m1_advisor_carbine", "", "", "", ["UK3CB_M1_30Rnd_30Carbine_Magazine_W", "UK3CB_M1_15Rnd_30Carbine_Magazine_RT", "UK3CB_M1_15Rnd_30Carbine_Magazine_RT"], [], ""],
+    ["UK3CB_M1903A1", "", "", "", ["UK3CB_M1903A1_3006_5rnd_Magazine", "UK3CB_M1903A1_3006_5rnd_Magazine_RT", "UK3CB_M1903A1_3006_5rnd_Magazine_R"], [], ""],
+    ["rhs_weap_M590_8RD", "", "", "", ["rhsusf_8Rnd_Slug", "rhsusf_8Rnd_Slug", "rhsusf_8Rnd_Slug", "rhsusf_8Rnd_00Buck", "rhsusf_8Rnd_00Buck"], [], ""]
+]];
+_policeLoadoutData set ["carbines", [
+    ["uk3cb_m1carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
+    ["UK3CB_M1903A1", "", "", "", ["UK3CB_M1903A1_3006_5rnd_Magazine", "UK3CB_M1903A1_3006_5rnd_Magazine_RT", "UK3CB_M1903A1_3006_5rnd_Magazine_R"], [], ""],
+    ["rhs_weap_m1garand_sa43", "", "", "", ["rhsgref_8Rnd_762x63_Tracer_M1T_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle"], [], ""]
+]];
+_policeLoadoutData set ["SMGs", [
+    ["uk3cb_thompson_m1928a1", "", "", "", ["UK3CB_Thompson_20rnd_1143x23_M1911B_Magazine_RT","UK3CB_Thompson_20rnd_1143x23_M1911B_Magazine_R","UK3CB_Thompson_20rnd_1143x23_M1911B_Magazine"], [], ""]
+]];
+
+////////////////////////////////
+//    Militia Loadout Data    //
+////////////////////////////////
+
+private _militiaLoadoutData = _loadoutData call _fnc_copyLoadoutData;
+_militiaLoadoutData set ["vests", ["rhsgref_alice_webbing", "rhsgref_chestrig"]];
+_militiaLoadoutData set ["helmets", ["UK3CB_TNM_B_H_Cap_KHK","UK3CB_TNM_B_H_Cap_CAC", "UK3CB_TNM_B_H_BoonieHat_KHK","UK3CB_TNM_B_H_BoonieHat_CAC","UK3CB_TNM_B_H_Bandanna_KHK", "UK3CB_TNM_B_H_Bandanna_CAC"]];
+
+_militiaLoadoutData set ["ATLaunchers", [
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag", "rhs_rpg7_OG7V_mag"], [], ""],
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_OG7V_mag", "rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag"], [], ""],
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_type69_airburst_mag", "rhs_rpg7_OG7V_mag"], [], ""]
+]];
+_militiaLoadoutData set ["heavyATLaunchers", [
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag"], [], ""]
+]];
+
+_militiaLoadoutData set ["slRifles", [
+    ["uk3cb_m2a1_carbine", "", "", "", ["UK3CB_M1_30Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], ["uk3cb_1rnd_riflegrenade_mas_ap", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
+    ["uk3cb_m2carbine", "", "", "", ["UK3CB_M1_30Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""]
+]];
+_militiaLoadoutData set ["rifles", [
+    ["uk3cb_m1carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
+    ["UK3CB_M1903A1", "", "", "", ["UK3CB_M1903A1_3006_5rnd_Magazine", "UK3CB_M1903A1_3006_5rnd_Magazine_RT", "UK3CB_M1903A1_3006_5rnd_Magazine_R"], [], ""],
+    ["rhs_weap_m1garand_sa43", "", "", "", ["rhsgref_8Rnd_762x63_Tracer_M1T_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle"], [], ""],
+    ["uk3cb_m2carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""]
+]];
+_militiaLoadoutData set ["carbines", [
+    ["rhs_weap_m1garand_sa43", "", "", "", ["rhsgref_8Rnd_762x63_Tracer_M1T_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle"], [], ""],
+    ["uk3cb_m2a1_carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
+    ["uk3cb_m1a1_carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""]
+]];
+_militiaLoadoutData set ["grenadeLaunchers", [
+    ["uk3cb_m1a1_carbine", "", "", "", ["UK3CB_M1_30Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""]
+]];
+_militiaLoadoutData set ["SMGs", [
+    ["uk3cb_m2a1_carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
+    ["rhs_weap_m3a1", "", "", "", ["rhs_weap_m3a1","rhsgref_30rnd_1143x23_M1T_SMG","rhsgref_30rnd_1143x23_M1T_2mag_SMG","rhsgref_30rnd_1143x23_M1911B_2mag_SMG"], [], ""],
+    ["uk3cb_thompson_m1a1", "", "", "", ["UK3CB_Thompson_20rnd_1143x23_M1911B_Magazine_RT","UK3CB_Thompson_20rnd_1143x23_M1911B_Magazine_R","UK3CB_Thompson_20rnd_1143x23_M1911B_Magazine"], [], ""],
+    ["uk3cb_thompson_m1928a1", "", "", "", ["UK3CB_Thompson_30rnd_1143x23_M1911B_Magazine_RT","UK3CB_Thompson_30rnd_1143x23_M1911B_Magazine_R","UK3CB_Thompson_30rnd_1143x23_M1911B_Magazine"], [], ""]
+]];
+_militiaLoadoutData set ["machineGuns", [
+    ["UK3CB_M1919A4_Browning", "", "", "", ["UK3CB_M1919_50Rnd_3006_Magazine_RT", "UK3CB_M1919_50Rnd_3006_Magazine_RM", "UK3CB_M1919_50Rnd_3006_Magazine_R", "UK3CB_M1919_50Rnd_3006_Magazine"], [], ""]
+]];
+_militiaLoadoutData set ["marksmanRifles", [
+    ["uk3cb_m1a1_carbine", "uk3cb_muzzle_m1_flash_hider", "", "uk3cb_scope_m1_m84", ["UK3CB_M1_15Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
+    ["UK3CB_M1903A1_unertl", "", "", "", ["UK3CB_M1903A1_3006_5rnd_Magazine", "UK3CB_M1903A1_3006_5rnd_Magazine_RT", "UK3CB_M1903A1_3006_5rnd_Magazine_R"], [], ""]
+]];
+_militiaLoadoutData set ["sniperRifles", [
+    ["UK3CB_M1903A1_unertl", "", "", "", ["UK3CB_M1903A1_3006_5rnd_Magazine", "UK3CB_M1903A1_3006_5rnd_Magazine_RT", "UK3CB_M1903A1_3006_5rnd_Magazine_R"], [], ""]
+]];
+_militiaLoadoutData set ["sidearms", ["rhsusf_weap_m1911a1", "", ""]];
+
+_militiaLoadoutData set ["traitorRifle", [
+    "uk3cb_m1carbine", "UK3CB_M1903A1"
+]];
+
+//////////////////////////
+//    Misc Loadouts     //
+//////////////////////////
+
+private _crewLoadoutData = _militaryLoadoutData call _fnc_copyLoadoutData;
+_crewLoadoutData set ["uniforms", ["UK3CB_TNM_B_U_SF_CombatUniform_01"]];
+_crewLoadoutData set ["vests", ["rhsgref_alice_webbing"]];
+_crewLoadoutData set ["facewear", ["rhs_balaclava1_olive","rhs_balaclava","",""]];
+_crewLoadoutData set ["helmets", ["UK3CB_TNM_B_H_Radio_Cap_CAC_BLK"]];
+
+_crewLoadoutData set ["SMGs", [
+    "rhs_weap_m3a1", 
+    "rhs_weap_m3a1", 
+    "rhs_weap_m3a1", 
+    "uk3cb_ar18_carbine",
+    "uk3cb_ar18_shorty",
+    "uk3cb_m1_advisor_carbine"
+]];
+
+private _pilotLoadoutData = _militaryLoadoutData call _fnc_copyLoadoutData;
+_pilotLoadoutData set ["uniforms", ["UK3CB_TNM_B_U_Airforce_CombatUniform_01"]];
+_pilotLoadoutData set ["vests", ["rhsgref_alice_webbing", "UK3CB_V_Pilot_Vest_Black"]];
+_pilotLoadoutData set ["facewear", ["G_Aviator"]];
+_pilotLoadoutData set ["helmets", ["UK3CB_TNM_B_H_Radio_Cap_CAC_AIR", "UK3CB_TNM_B_H_Patrolcap_Mic_CAC_AIR_Patch", "UK3CB_TNM_B_H_BoonieHat_CAC_AIR", "UK3CB_TNM_B_H_Bandanna_CAC_AIR"]];
+
+_pilotLoadoutData set ["SMGs", [
+    "rhs_weap_m3a1", 
+    "rhs_weap_m3a1", 
+    "rhs_weap_m3a1", 
+    "uk3cb_ar18_carbine",
+    "uk3cb_ar18_shorty",
+    "uk3cb_m1_advisor_carbine"
+]];
+
+private _officialLoadoutData = _militaryLoadoutData call _fnc_copyLoadoutData;
+_officialLoadoutData set ["uniforms", ["UK3CB_TNM_B_U_Commander_CombatUniform_01"]];
+_officialLoadoutData set ["rifles", ["UK3CB_AR10_Porto_Carbine_Sup"]];
+_officialLoadoutData set ["carbines", ["uk3cb_ar18_carbine"]];
+_officialLoadoutData set ["vests", ["rhs_gear_OFF"]];
+_officialLoadoutData set ["facewear", ["rhs_googles_black", "G_Squares_Tinted","G_Aviator","G_Aviator"]];
+_officialLoadoutData set ["slHelmets", ["UK3CB_TNM_B_H_Patrolcap_Mic_CAC_COM_Patch", "UK3CB_TNM_B_H_Comm_Beret"]];
+
+/////////////////////////////////
+//    Unit Type Definitions    //
+/////////////////////////////////
+//These define the loadouts for different unit types.
+//For example, rifleman, grenadier, squad leader, etc.
+//In 95% of situations, you *should not need to edit these*.
+//Almost all factions can be set up just by modifying the loadout data above.
+//However, these exist in case you really do want to do a lot of custom alterations.
+
+private _squadLeaderTemplate = {
+    ["slHelmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+
+    ["backpacks"] call _fnc_setBackpack;
+
+    ["slRifles"] call _fnc_setPrimary;
+    ["primary", 5] call _fnc_addMagazines;
+    ["primary", 4] call _fnc_addAdditionalMuzzleMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_squadLeader_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["antiInfantryGrenades", 2] call _fnc_addItem;
+    ["signalsmokeGrenades", 2] call _fnc_addItem;
+    ["smokeGrenades", 2] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["gpses"] call _fnc_addGPS;
+    ["binoculars"] call _fnc_addBinoculars;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _riflemanTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+
+    [selectRandom ["rifles", "rifles", "carbines"]] call _fnc_setPrimary;
+    ["primary", 5] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_rifleman_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["antiInfantryGrenades", 2] call _fnc_addItem;
+    ["smokeGrenades", 2] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _medicTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+    ["medBackpacks"] call _fnc_setBackpack;
+	[selectRandom ["carbines", "SMGs"]] call _fnc_setPrimary;
+    ["primary", 5] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_medic"] call _fnc_addItemSet;
+    ["items_medic_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["antiInfantryGrenades", 1] call _fnc_addItem;
+    ["smokeGrenades", 2] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _grenadierTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+    ["backpacks"] call _fnc_setBackpack;
+
+    ["grenadeLaunchers"] call _fnc_setPrimary;
+    ["primary", 5] call _fnc_addMagazines;
+    ["primary", 10] call _fnc_addAdditionalMuzzleMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_grenadier_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["antiInfantryGrenades", 4] call _fnc_addItem;
+    ["smokeGrenades", 2] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _explosivesExpertTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+    ["backpacks"] call _fnc_setBackpack;
+
+    [selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+    ["primary", 5] call _fnc_addMagazines;
+
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_explosivesExpert_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+
+    ["lightExplosives", 2] call _fnc_addItem;
+    if (random 1 > 0.5) then {["heavyExplosives", 1] call _fnc_addItem;};
+    if (random 1 > 0.5) then {["atMines", 1] call _fnc_addItem;};
+    if (random 1 > 0.5) then {["apMines", 1] call _fnc_addItem;};
+
+    ["antiInfantryGrenades", 1] call _fnc_addItem;
+    ["smokeGrenades", 1] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _engineerTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+    ["backpacks"] call _fnc_setBackpack;
+
+    [selectRandom ["carbines", "SMGs"]] call _fnc_setPrimary;
+    ["primary", 5] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_engineer_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+
+    if (random 1 > 0.5) then {["lightExplosives", 1] call _fnc_addItem;};
+
+    ["antiInfantryGrenades", 1] call _fnc_addItem;
+    ["smokeGrenades", 2] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _latTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+    ["atBackpacks"] call _fnc_setBackpack;
+
+    [selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+    ["primary", 5] call _fnc_addMagazines;
+
+    [selectRandom ["lightATLaunchers", "ATLaunchers"]] call _fnc_setLauncher;
+    //TODO - Add a check if it's disposable.
+    ["launcher", 1] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_lat_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["antiInfantryGrenades", 1] call _fnc_addItem;
+    ["smokeGrenades", 1] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _atTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+    ["atBackpacks"] call _fnc_setBackpack;
+
+    [selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+    ["primary", 5] call _fnc_addMagazines;
+
+    [selectRandom["ATLaunchers","heavyATLaunchers"]] call _fnc_setLauncher;
+    //TODO - Add a check if it's disposable.
+    ["launcher", 2] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_at_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["antiInfantryGrenades", 1] call _fnc_addItem;
+    ["smokeGrenades", 1] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _aaTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+    ["aaBackpacks"] call _fnc_setBackpack;
+
+    [selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+    ["primary", 5] call _fnc_addMagazines;
+
+    ["AALaunchers"] call _fnc_setLauncher;
+    //TODO - Add a check if it's disposable.
+    ["launcher", 2] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_aa_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["antiInfantryGrenades", 1] call _fnc_addItem;
+    ["smokeGrenades", 2] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _machineGunnerTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+    ["mgBackpacks"] call _fnc_setBackpack;
+
+    ["machineGuns"] call _fnc_setPrimary;
+    ["primary", 4] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_machineGunner_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["antiInfantryGrenades", 1] call _fnc_addItem;
+    ["smokeGrenades", 2] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _marksmanTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+
+    ["marksmanRifles"] call _fnc_setPrimary;
+    ["primary", 5] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_marksman_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["antiInfantryGrenades", 1] call _fnc_addItem;
+    ["smokeGrenades", 2] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["rangefinders"] call _fnc_addBinoculars;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _sniperTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+
+    ["sniperRifles"] call _fnc_setPrimary;
+    ["primary", 7] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 2] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_sniper_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["antiInfantryGrenades", 1] call _fnc_addItem;
+    ["smokeGrenades", 2] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["rangefinders"] call _fnc_addBinoculars;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _policeTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+
+    [selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+    ["primary", 3] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 4] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_police_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["smokeGrenades", 1] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+};
+
+private _policeSlTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+
+    [selectRandom ["SMGs", "carbines"]] call _fnc_setPrimary;
+    ["primary", 3] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 4] call _fnc_addMagazines;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+    ["items_police_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["smokeGrenades", 1] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+};
+
+private _crewTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["facewear"] call _fnc_setFacewear;
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+
+    ["SMGs"] call _fnc_setPrimary;
+    ["primary", 3] call _fnc_addMagazines;
+
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 4] call _fnc_addMagazines;
+
+    ["items_medical_basic"] call _fnc_addItemSet;
+    ["items_crew_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+    ["smokeGrenades", 2] call _fnc_addItem;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+    ["gpses"] call _fnc_addGPS;
+    ["NVGs"] call _fnc_addNVGs;
+};
+
+private _unarmedTemplate = {
+    ["vests"] call _fnc_setVest;
+    ["uniforms"] call _fnc_setUniform;
+
+    ["items_medical_basic"] call _fnc_addItemSet;
+    ["items_unarmed_extras"] call _fnc_addItemSet;
+    ["items_miscEssentials"] call _fnc_addItemSet;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+    ["radios"] call _fnc_addRadio;
+};
+
+private _traitorTemplate = {
+    call _unarmedTemplate;
+    ["traitorRifle"] call _fnc_setPrimary;
+    ["primary", 2] call _fnc_addMagazines;
+
+    ["facewear"] call _fnc_setFacewear;
+    ["sidearms"] call _fnc_setHandgun;
+    ["handgun", 5] call _fnc_addMagazines;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////
+//  You shouldn't touch below this line unless you really really know what you're doing.
+//  Things below here can and will break the gamemode if improperly changed.
+////////////////////////////////////////////////////////////////////////////////////////
+
+/////////////////////////////
+//  Special Forces Units   //
+/////////////////////////////
+private _prefix = "SF";
+private _unitTypes = [
+    ["SquadLeader", _squadLeaderTemplate],
+    ["Rifleman", _riflemanTemplate],
+    ["Medic", _medicTemplate, [["medic", true]]],
+    ["Engineer", _engineerTemplate, [["engineer", true]]],
+    ["ExplosivesExpert", _explosivesExpertTemplate, [["explosiveSpecialist", true]]],
+    ["Grenadier", _grenadierTemplate],
+    ["LAT", _latTemplate],
+    ["AT", _atTemplate],
+    ["AA", _aaTemplate],
+    ["MachineGunner", _machineGunnerTemplate],
+    ["Marksman", _marksmanTemplate],
+    ["Sniper", _sniperTemplate]
+];
+
+[_prefix, _unitTypes, _sfLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+
+/*{
+    params ["_name", "_loadoutTemplate"];
+    private _loadouts = [_sfLoadoutData, _loadoutTemplate] call _fnc_buildLoadouts;
+    private _finalName = _prefix + _name;
+    [_finalName, _loadouts] call _fnc_saveToTemplate;
+} forEach _unitTypes;
+*/
+
+///////////////////////
+//  Military Units   //
+///////////////////////
+private _prefix = "military";
+private _unitTypes = [
+    ["SquadLeader", _squadLeaderTemplate, nil, 8],
+    ["Rifleman", _riflemanTemplate],
+    ["Medic", _medicTemplate, [["medic", true]]],
+    ["Engineer", _engineerTemplate, [["engineer", true]]],
+    ["ExplosivesExpert", _explosivesExpertTemplate, [["explosiveSpecialist", true]]],
+    ["Grenadier", _grenadierTemplate],
+    ["LAT", _latTemplate],
+    ["AT", _atTemplate],
+    ["AA", _aaTemplate],
+    ["MachineGunner", _machineGunnerTemplate],
+    ["Marksman", _marksmanTemplate],
+    ["Sniper", _sniperTemplate]
+];
+
+[_prefix, _unitTypes, _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+
+////////////////////////
+//    Police Units    //
+////////////////////////
+private _prefix = "police";
+private _unitTypes = [
+    ["SquadLeader", _policeSlTemplate],
+    ["Standard", _policeTemplate]
+];
+
+[_prefix, _unitTypes, _policeLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+
+////////////////////////
+//    Militia Units    //
+////////////////////////
+private _prefix = "militia";
+private _unitTypes = [
+    ["SquadLeader", _squadLeaderTemplate],
+    ["Rifleman", _riflemanTemplate],
+    ["Medic", _medicTemplate, [["medic", true]]],
+    ["Engineer", _engineerTemplate, [["engineer", true]]],
+    ["ExplosivesExpert", _explosivesExpertTemplate, [["explosiveSpecialist", true]]],
+    ["Grenadier", _grenadierTemplate],
+    ["LAT", _latTemplate],
+    ["AT", _atTemplate],
+    ["AA", _aaTemplate],
+    ["MachineGunner", _machineGunnerTemplate],
+    ["Marksman", _marksmanTemplate],
+    ["Sniper", _sniperTemplate]
+];
+
+[_prefix, _unitTypes, _militiaLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+
+//////////////////////
+//    Misc Units    //
+//////////////////////
+
+//The following lines are determining the loadout of vehicle crew
+["other", [["Crew", _crewTemplate]], _crewLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout of the pilots
+["other", [["Pilot", _crewTemplate]], _pilotLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the unit used in the "kill the official" mission
+["other", [["Official", _policeTemplate, nil, 2]], _officialLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "kill the traitor" mission
+["other", [["Traitor", _traitorTemplate]], _militiaLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;
+//The following lines are determining the loadout for the AI used in the "Invader Punishment" mission
+["other", [["Unarmed", _UnarmedTemplate]], _militaryLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TNM.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TNM.sqf
@@ -33,7 +33,7 @@
 ["vehiclesAPCs", []] call _fnc_saveToTemplate;
 ["vehiclesIFVs", ["UK3CB_B_LAV25_HIDF"]] call _fnc_saveToTemplate;
 ["vehiclesLightTanks", []] call _fnc_saveToTemplate;
-["vehiclesTanks", ["UK3CB_B_M60A3_HIDF", "UK3CB_B_M60A1_HIDF", "UK3CB_TNM_B_T55"]] call _fnc_saveToTemplate;
+["vehiclesTanks", ["UK3CB_B_M60A1_HIDF", "UK3CB_TNM_B_T55"]] call _fnc_saveToTemplate;
 ["vehiclesHeavyTanks", []] call _fnc_saveToTemplate;             // Just to push up the T-72 probability at higher war levels
 ["vehiclesAA", ["a3a_green_M270_Avenger"]] call _fnc_saveToTemplate;
 
@@ -42,7 +42,7 @@
 ["vehiclesGunBoats", ["UK3CB_TKA_B_RHIB_Gunboat"]] call _fnc_saveToTemplate;
 ["vehiclesAmphibious", []] call _fnc_saveToTemplate;
 
-["vehiclesPlanesCAS", ["RHSGREF_A29B_HIDF", "UK3CB_B_T28Trojan_HIDF_CAS"]] call _fnc_saveToTemplate;      // "UK3CB_B_Mystere_HIDF_CAS1" -> commented for testing of A29 & T28
+["vehiclesPlanesCAS", ["RHSGREF_A29B_HIDF", "UK3CB_B_T28Trojan_HIDF_CAS"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesAA", ["UK3CB_B_Mystere_HIDF_AA1"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesTransport", ["UK3CB_B_C47_Late_HIDF"]] call _fnc_saveToTemplate;
 

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TNM.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TNM.sqf
@@ -30,11 +30,11 @@
 ["vehiclesFuelTrucks", ["UK3CB_TNM_B_LR_Softtop_Refuel_Closed","UK3CB_TNM_B_LR_Softtop_Refuel_Open","UK3CB_TNM_B_LR_Opentop_Refuel"]] call _fnc_saveToTemplate;
 ["vehiclesMedical", ["UK3CB_TNM_B_LR_Softtop_Reammo_Closed","UK3CB_TNM_B_LR_Softtop_Reammo_Open","UK3CB_TNM_B_LR_Opentop_Reammo"]] call _fnc_saveToTemplate;
 ["vehiclesLightAPCs", ["a3a_rhs_m113_hidf_M240", "rhsgref_hidf_m113a3_m2"]] call _fnc_saveToTemplate;
-["vehiclesAPCs", []] call _fnc_saveToTemplate;
-["vehiclesIFVs", ["UK3CB_B_LAV25_HIDF"]] call _fnc_saveToTemplate;
+["vehiclesAPCs", ["UK3CB_B_LAV25_HIDF"]] call _fnc_saveToTemplate;
+["vehiclesIFVs", []] call _fnc_saveToTemplate;
 ["vehiclesLightTanks", []] call _fnc_saveToTemplate;
 ["vehiclesTanks", ["UK3CB_B_M60A1_HIDF", "UK3CB_TNM_B_T55"]] call _fnc_saveToTemplate;
-["vehiclesHeavyTanks", []] call _fnc_saveToTemplate;             // Just to push up the T-72 probability at higher war levels
+["vehiclesHeavyTanks", []] call _fnc_saveToTemplate;
 ["vehiclesAA", ["a3a_green_M270_Avenger"]] call _fnc_saveToTemplate;
 
 
@@ -47,10 +47,10 @@
 ["vehiclesPlanesTransport", ["UK3CB_B_C47_Late_HIDF"]] call _fnc_saveToTemplate;
 
 ["vehiclesHelisLight", ["rhs_uh1h_hidf_unarmed"]] call _fnc_saveToTemplate;
-["vehiclesHelisTransport", ["rhs_uh1h_hidf"]] call _fnc_saveToTemplate; //Mi24Vt has 1x 12.7mm turret, and disabled pylons
+["vehiclesHelisTransport", ["rhs_uh1h_hidf"]] call _fnc_saveToTemplate;
 // Should be capable of dealing damage to ground targets without additional scripting
-["vehiclesHelisLightAttack", ["rhs_uh1h_hidf_gunship"]] call _fnc_saveToTemplate;      // Mi24P lacks a gun turret
-["vehiclesHelisAttack", []] call _fnc_saveToTemplate;           // Proper attack helis: Apache, Hind etc
+["vehiclesHelisLightAttack", ["rhs_uh1h_hidf_gunship"]] call _fnc_saveToTemplate;
+["vehiclesHelisAttack", []] call _fnc_saveToTemplate;
 
 ["vehiclesAirPatrol", ["rhs_uh1h_hidf", "UK3CB_B_Cessna_T41_HIDF"]] call _fnc_saveToTemplate;
 

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TNM.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TNM.sqf
@@ -1,7 +1,6 @@
 //////////////////////////
 //   Side Information   //
 //////////////////////////
-//Tanoan Liberation Army, natural enemies of the HIDF, CW US, US, and SDK
 ["name", "TNM"] call _fnc_saveToTemplate;
 ["spawnMarkerName", "TNM Support Corridor"] call _fnc_saveToTemplate;
 
@@ -26,13 +25,13 @@
 ["vehiclesLightArmed", ["UK3CB_B_M939_Guntruck_HIDF","UK3CB_FIA_B_LR_SF_WMIK_M2_M240","UK3CB_FIA_B_LR_SF_WMIK_M2_M240","UK3CB_FIA_B_LR_SF_WMIK_MILAN_M240","UK3CB_FIA_B_LR_SF_WMIK_MK19_M240"]] call _fnc_saveToTemplate;
 ["vehiclesTrucks", ["UK3CB_TNM_B_LR_Softtop_Transport_Closed", "UK3CB_B_M939_Open_HIDF"]] call _fnc_saveToTemplate;
 ["vehiclesCargoTrucks", ["UK3CB_TNM_B_Van_transport"]] call _fnc_saveToTemplate;
-["vehiclesAmmoTrucks", ["UK3CB_PLM_O_BTR40_REAMMO","UK3CB_PLM_O_Ural_Ammo"]] call _fnc_saveToTemplate;
-["vehiclesRepairTrucks", ["UK3CB_PLM_O_BTR40_REPAIR","UK3CB_PLM_O_Ural_Repair"]] call _fnc_saveToTemplate;
-["vehiclesFuelTrucks", ["UK3CB_PLM_O_BTR40_REFUEL","UK3CB_PLM_O_Ural_Fuel"]] call _fnc_saveToTemplate;
-["vehiclesMedical", ["UK3CB_PLM_O_BTR40_AMBULANCE"]] call _fnc_saveToTemplate;
-["vehiclesLightAPCs", ["UK3CB_PLM_O_BRDM2"]] call _fnc_saveToTemplate;
+["vehiclesAmmoTrucks", ["UK3CB_TNM_B_LR_Softtop_Reammo_Closed","UK3CB_TNM_B_LR_Softtop_Reammo_Open","UK3CB_TNM_B_LR_Opentop_Reammo"]] call _fnc_saveToTemplate;
+["vehiclesRepairTrucks", ["UK3CB_TNM_B_LR_Softtop_Repair_Closed","UK3CB_TNM_B_LR_Softtop_Repair_Open","UK3CB_TNM_B_LR_Opentop_Repair"]] call _fnc_saveToTemplate;
+["vehiclesFuelTrucks", ["UK3CB_TNM_B_LR_Softtop_Refuel_Closed","UK3CB_TNM_B_LR_Softtop_Refuel_Open","UK3CB_TNM_B_LR_Opentop_Refuel"]] call _fnc_saveToTemplate;
+["vehiclesMedical", ["UK3CB_TNM_B_LR_Softtop_Reammo_Closed","UK3CB_TNM_B_LR_Softtop_Reammo_Open","UK3CB_TNM_B_LR_Opentop_Reammo"]] call _fnc_saveToTemplate;
+["vehiclesLightAPCs", ["a3a_rhs_m113_hidf_M240", "rhsgref_hidf_m113a3_m2"]] call _fnc_saveToTemplate;
 ["vehiclesAPCs", []] call _fnc_saveToTemplate;
-["vehiclesIFVs", []] call _fnc_saveToTemplate;
+["vehiclesIFVs", ["UK3CB_B_LAV25_HIDF"]] call _fnc_saveToTemplate;
 ["vehiclesLightTanks", []] call _fnc_saveToTemplate;
 ["vehiclesTanks", ["UK3CB_B_M60A3_HIDF", "UK3CB_B_M60A1_HIDF", "UK3CB_TNM_B_T55"]] call _fnc_saveToTemplate;
 ["vehiclesHeavyTanks", []] call _fnc_saveToTemplate;             // Just to push up the T-72 probability at higher war levels
@@ -70,7 +69,7 @@
 
 ["vehiclesPolice", ["UK3CB_TNM_B_Pickup"]] call _fnc_saveToTemplate;
 
-["staticMGs", ["RHS_M2StaticMG_WD"]] call _fnc_saveToTemplate;
+["staticMGs", ["RHS_M2StaticMG_WD", "RHS_M2StaticMG_WD", "UK3CB_B_Static_M240_High_HIDF"]] call _fnc_saveToTemplate;
 ["staticAT", ["RHS_TOW_TriPod_WD"]] call _fnc_saveToTemplate;
 ["staticAA", ["RHS_Stinger_AA_pod_D"]] call _fnc_saveToTemplate;
 ["staticMortars", ["a3a_RHS_M252"]] call _fnc_saveToTemplate;
@@ -82,7 +81,7 @@
 //Minefield definition
 //CFGVehicles variant of Mines are needed "ATMine", "APERSTripMine", "APERSMine"
 ["minefieldAT", ["rhsusf_mine_M19"]] call _fnc_saveToTemplate;
-["minefieldAPERS", ["rhs_mine_Mk2_tripwire", "rhsusf_mine_m49a1_6m"]] call _fnc_saveToTemplate;
+["minefieldAPERS", ["rhs_mine_mk2_pressure", "rhs_mine_Mk2_tripwire", "rhsusf_mine_m49a1_6m"]] call _fnc_saveToTemplate;
 
 #include "3CBFactions_Vehicle_Attributes.sqf"
 
@@ -275,9 +274,10 @@ _militaryLoadoutData set ["grenadeLaunchers", [
 _militaryLoadoutData set ["SMGs", [
     ["uk3cb_m2carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
     ["uk3cb_m2a1_carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
-    ["rhs_weap_m3a1", "", "", "", ["rhs_weap_m3a1","rhsgref_30rnd_1143x23_M1T_SMG","rhsgref_30rnd_1143x23_M1T_2mag_SMG","rhsgref_30rnd_1143x23_M1911B_2mag_SMG"], [], ""],
-    ["rhs_weap_m3a1", "", "", "", ["rhs_weap_m3a1","rhsgref_30rnd_1143x23_M1T_SMG","rhsgref_30rnd_1143x23_M1T_2mag_SMG","rhsgref_30rnd_1143x23_M1911B_2mag_SMG"], [], ""],
-    ["uk3cb_thompson_m1a1", "", "", "", ["UK3CB_Thompson_30rnd_1143x23_M1911B_Magazine_RT","UK3CB_Thompson_30rnd_1143x23_M1911B_Magazine_R","UK3CB_Thompson_30rnd_1143x23_M1911B_Magazine"], [], ""]
+    ["rhs_weap_m3a1", "", "", "", ["rhsgref_30rnd_1143x23_M1911B_SMG","rhsgref_30rnd_1143x23_M1T_SMG","rhsgref_30rnd_1143x23_M1T_2mag_SMG","rhsgref_30rnd_1143x23_M1911B_2mag_SMG"], [], ""],
+    ["rhs_weap_m3a1", "", "", "", ["rhsgref_30rnd_1143x23_M1911B_SMG","rhsgref_30rnd_1143x23_M1T_SMG","rhsgref_30rnd_1143x23_M1T_2mag_SMG","rhsgref_30rnd_1143x23_M1911B_2mag_SMG"], [], ""],
+    ["uk3cb_thompson_m1a1", "", "", "", ["UK3CB_Thompson_30rnd_1143x23_M1911B_Magazine_RT","UK3CB_Thompson_30rnd_1143x23_M1911B_Magazine_R","UK3CB_Thompson_30rnd_1143x23_M1911B_Magazine", "UK3CB_Thompson_20rnd_1143x23_M1911B_Magazine_RT","UK3CB_Thompson_20rnd_1143x23_M1911B_Magazine_R","UK3CB_Thompson_20rnd_1143x23_M1911B_Magazine"], [], ""],
+    ["uk3cb_thompson_m1a1", "", "", "", ["UK3CB_Thompson_30rnd_1143x23_M1911B_Magazine_RT","UK3CB_Thompson_30rnd_1143x23_M1911B_Magazine_R","UK3CB_Thompson_30rnd_1143x23_M1911B_Magazine", "UK3CB_Thompson_20rnd_1143x23_M1911B_Magazine_RT","UK3CB_Thompson_20rnd_1143x23_M1911B_Magazine_R","UK3CB_Thompson_20rnd_1143x23_M1911B_Magazine"], [], ""]
 ]];
 _militaryLoadoutData set ["machineGuns", [
     ["UK3CB_M60", "", "", "", ["UK3CB_M60_100rnd_762x51_RM", "UK3CB_M60_100rnd_762x51"], [], ""],
@@ -310,7 +310,7 @@ _policeLoadoutData set ["NVGs", []];
 _policeLoadoutData set ["gpses", []];
 
 _policeLoadoutData set ["rifles", [
-    ["uk3cb_m1_advisor_carbine", "", "", "", ["UK3CB_M1_30Rnd_30Carbine_Magazine_W", "UK3CB_M1_15Rnd_30Carbine_Magazine_RT", "UK3CB_M1_15Rnd_30Carbine_Magazine_RT"], [], ""],
+    ["uk3cb_m1_advisor_carbine", "", "", "", ["UK3CB_M1_30Rnd_30Carbine_Magazine_W", "UK3CB_M1_15Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine_R"], [], ""],
     ["UK3CB_M1903A1", "", "", "", ["UK3CB_M1903A1_3006_5rnd_Magazine", "UK3CB_M1903A1_3006_5rnd_Magazine_RT", "UK3CB_M1903A1_3006_5rnd_Magazine_R"], [], ""],
     ["rhs_weap_M590_8RD", "", "", "", ["rhsusf_8Rnd_Slug", "rhsusf_8Rnd_Slug", "rhsusf_8Rnd_Slug", "rhsusf_8Rnd_00Buck", "rhsusf_8Rnd_00Buck"], [], ""]
 ]];
@@ -332,21 +332,25 @@ _militiaLoadoutData set ["vests", ["rhsgref_alice_webbing", "rhsgref_chestrig"]]
 _militiaLoadoutData set ["helmets", ["UK3CB_TNM_B_H_Cap_KHK","UK3CB_TNM_B_H_Cap_CAC", "UK3CB_TNM_B_H_BoonieHat_KHK","UK3CB_TNM_B_H_BoonieHat_CAC","UK3CB_TNM_B_H_Bandanna_KHK", "UK3CB_TNM_B_H_Bandanna_CAC"]];
 
 _militiaLoadoutData set ["ATLaunchers", [
-    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag", "rhs_rpg7_OG7V_mag"], [], ""],
-    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_OG7V_mag", "rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag"], [], ""],
-    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_type69_airburst_mag", "rhs_rpg7_OG7V_mag"], [], ""]
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_type69_airburst_mag", "rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag"], [], ""],
+    "rhs_weap_m72a7", 
+    "uk3cb_m72a1_law_loaded"
 ]];
 _militiaLoadoutData set ["heavyATLaunchers", [
-    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag"], [], ""]
+    ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag", "rhs_rpg7_type69_airburst_mag"], [], ""],
+    "rhs_weap_m72a7", 
+    "uk3cb_m72a1_law_loaded"
 ]];
 
 _militiaLoadoutData set ["slRifles", [
+    ["rhs_weap_m1garand_sa43", "", "", "", ["rhsgref_8Rnd_762x63_Tracer_M1T_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle"], [], ""],
     ["uk3cb_m2a1_carbine", "", "", "", ["UK3CB_M1_30Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], ["uk3cb_1rnd_riflegrenade_mas_ap", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
     ["uk3cb_m2carbine", "", "", "", ["UK3CB_M1_30Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""]
 ]];
 _militiaLoadoutData set ["rifles", [
     ["uk3cb_m1carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
     ["UK3CB_M1903A1", "", "", "", ["UK3CB_M1903A1_3006_5rnd_Magazine", "UK3CB_M1903A1_3006_5rnd_Magazine_RT", "UK3CB_M1903A1_3006_5rnd_Magazine_R"], [], ""],
+    ["rhs_weap_m1garand_sa43", "", "", "", ["rhsgref_8Rnd_762x63_Tracer_M1T_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle"], [], ""],
     ["rhs_weap_m1garand_sa43", "", "", "", ["rhsgref_8Rnd_762x63_Tracer_M1T_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle"], [], ""],
     ["uk3cb_m2carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""]
 ]];
@@ -356,13 +360,13 @@ _militiaLoadoutData set ["carbines", [
     ["uk3cb_m1a1_carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""]
 ]];
 _militiaLoadoutData set ["grenadeLaunchers", [
-    ["uk3cb_m1a1_carbine", "", "", "", ["UK3CB_M1_30Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""]
+    ["uk3cb_m1carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""]
 ]];
 _militiaLoadoutData set ["SMGs", [
     ["uk3cb_m2a1_carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
-    ["rhs_weap_m3a1", "", "", "", ["rhs_weap_m3a1","rhsgref_30rnd_1143x23_M1T_SMG","rhsgref_30rnd_1143x23_M1T_2mag_SMG","rhsgref_30rnd_1143x23_M1911B_2mag_SMG"], [], ""],
+    ["rhs_weap_m3a1", "", "", "", ["rhsgref_30rnd_1143x23_M1911B_SMG","rhsgref_30rnd_1143x23_M1T_SMG","rhsgref_30rnd_1143x23_M1T_2mag_SMG","rhsgref_30rnd_1143x23_M1911B_2mag_SMG"], [], ""],
     ["uk3cb_thompson_m1a1", "", "", "", ["UK3CB_Thompson_20rnd_1143x23_M1911B_Magazine_RT","UK3CB_Thompson_20rnd_1143x23_M1911B_Magazine_R","UK3CB_Thompson_20rnd_1143x23_M1911B_Magazine"], [], ""],
-    ["uk3cb_thompson_m1928a1", "", "", "", ["UK3CB_Thompson_30rnd_1143x23_M1911B_Magazine_RT","UK3CB_Thompson_30rnd_1143x23_M1911B_Magazine_R","UK3CB_Thompson_30rnd_1143x23_M1911B_Magazine"], [], ""]
+    ["uk3cb_thompson_m1928a1", "", "", "", ["UK3CB_Thompson_20rnd_1143x23_M1911B_Magazine_RT","UK3CB_Thompson_20rnd_1143x23_M1911B_Magazine_R","UK3CB_Thompson_20rnd_1143x23_M1911B_Magazine"], [], ""]
 ]];
 _militiaLoadoutData set ["machineGuns", [
     ["UK3CB_M1919A4_Browning", "", "", "", ["UK3CB_M1919_50Rnd_3006_Magazine_RT", "UK3CB_M1919_50Rnd_3006_Magazine_RM", "UK3CB_M1919_50Rnd_3006_Magazine_R", "UK3CB_M1919_50Rnd_3006_Magazine"], [], ""]
@@ -393,10 +397,12 @@ _crewLoadoutData set ["helmets", ["UK3CB_TNM_B_H_Radio_Cap_CAC_BLK"]];
 _crewLoadoutData set ["SMGs", [
     "rhs_weap_m3a1", 
     "rhs_weap_m3a1", 
-    "rhs_weap_m3a1", 
+    "rhs_weap_m3a1",
+    "uk3cb_m1_advisor_carbine",
+    "uk3cb_m1_advisor_carbine",
+    "uk3cb_m1_advisor_carbine", 
     "uk3cb_ar18_carbine",
-    "uk3cb_ar18_shorty",
-    "uk3cb_m1_advisor_carbine"
+    "uk3cb_ar18_shorty"
 ]];
 
 private _pilotLoadoutData = _militaryLoadoutData call _fnc_copyLoadoutData;
@@ -408,10 +414,12 @@ _pilotLoadoutData set ["helmets", ["UK3CB_TNM_B_H_Radio_Cap_CAC_AIR", "UK3CB_TNM
 _pilotLoadoutData set ["SMGs", [
     "rhs_weap_m3a1", 
     "rhs_weap_m3a1", 
-    "rhs_weap_m3a1", 
+    "rhs_weap_m3a1",
+    "uk3cb_m1_advisor_carbine",
+    "uk3cb_m1_advisor_carbine",
+    "uk3cb_m1_advisor_carbine", 
     "uk3cb_ar18_carbine",
-    "uk3cb_ar18_shorty",
-    "uk3cb_m1_advisor_carbine"
+    "uk3cb_ar18_shorty"
 ]];
 
 private _officialLoadoutData = _militaryLoadoutData call _fnc_copyLoadoutData;

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TNM.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TNM.sqf
@@ -259,6 +259,7 @@ _militaryLoadoutData set ["rifles", [
 _militaryLoadoutData set ["carbines", [
     ["uk3cb_m2carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
     ["uk3cb_m2a1_carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
+    ["uk3cb_m2a1_carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
     ["UK3CB_AR10_Porto_Carbine_Sup_OD", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], [], ""],
     ["UK3CB_AR10_Porto_Carbine_Sup_OD", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], [], ""],
     ["UK3CB_AR10_Porto_Carbine_Sup_OD", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], [], ""],

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TNM.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TNM.sqf
@@ -89,8 +89,9 @@
 ///  Identities   ///
 /////////////////////
 //Faces and Voices given to AI Factions.
-["faces", ["TanoanHead_A3_01","TanoanHead_A3_02","TanoanHead_A3_03","TanoanHead_A3_04",
-"TanoanHead_A3_05","TanoanHead_A3_06","TanoanHead_A3_07","TanoanHead_A3_08"]] call _fnc_saveToTemplate;
+["faces", ["TanoanHead_A3_01","TanoanHead_A3_02","TanoanHead_A3_03","TanoanHead_A3_04","TanoanHead_A3_05","TanoanHead_A3_06","TanoanHead_A3_07","TanoanHead_A3_08",
+"TanoanHead_A3_01","TanoanHead_A3_02","TanoanHead_A3_03","TanoanHead_A3_04","TanoanHead_A3_05","TanoanHead_A3_06","TanoanHead_A3_07","TanoanHead_A3_08",
+"AsianHead_A3_01","AsianHead_A3_02","AsianHead_A3_03","AsianHead_A3_04","AsianHead_A3_05","AsianHead_A3_06","AsianHead_A3_07"]] call _fnc_saveToTemplate;
 ["voices", ["Male01FRE","Male02FRE","Male03FRE"]] call _fnc_saveToTemplate;
 "TanoanMen" call _fnc_saveNames;
 
@@ -108,10 +109,13 @@ _loadoutData set ["sniperRifles", []];
 
 _loadoutData set ["lightATLaunchers", [
     ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag", "rhs_rpg7_type69_airburst_mag"], [], ""],
-    "rhs_weap_m72a7", 
+    "rhs_weap_m72a7",
+    "rhs_weap_m72a7",
+    "uk3cb_m72a1_law_loaded",
     "uk3cb_m72a1_law_loaded"
 ]];
 _loadoutData set ["ATLaunchers", [
+    "rhs_weap_m72a7", 
     ["rhs_weap_maaws", "", "", "rhs_optic_maaws",["rhs_mag_maaws_HEDP", "rhs_mag_maaws_HE"], [], ""],
     ["rhs_weap_maaws", "", "", "rhs_optic_maaws",["rhs_mag_maaws_HEAT", "rhs_mag_maaws_HE"], [], ""],
     ["rhs_weap_maaws", "", "", "",["rhs_mag_maaws_HEDP", "rhs_mag_maaws_HE"], [], ""],
@@ -119,6 +123,8 @@ _loadoutData set ["ATLaunchers", [
     ["rhs_weap_maaws", "", "", "",["rhs_mag_maaws_HE", "rhs_mag_maaws_HEDP"], [], ""]
 ]];
 _loadoutData set ["heavyATLaunchers", [
+    ["rhs_weap_maaws", "", "", "rhs_optic_maaws",["rhs_mag_maaws_HEAT"], [], ""],
+    "uk3cb_m47",
     "uk3cb_m47"
 ]];
 _loadoutData set ["AALaunchers", ["UK3CB_Blowpipe", "rhs_weap_fim92"]];
@@ -142,18 +148,18 @@ _loadoutData set ["watches", ["ItemWatch"]];
 _loadoutData set ["compasses", ["ItemCompass"]];
 _loadoutData set ["radios", ["ItemRadio"]];
 _loadoutData set ["gpses", []];
-_loadoutData set ["NVGs", ["rhs_1PN138"]];
+_loadoutData set ["NVGs", ["rhsusf_ANPVS_14"]];
 _loadoutData set ["binoculars", ["rhsusf_bino_m24"]];
 _loadoutData set ["rangefinders", ["rhsusf_bino_m24"]];
 
 _loadoutData set ["uniforms", ["UK3CB_TNM_B_U_CombatUniform_01", "UK3CB_TNM_B_U_CombatUniform_02"]];
 _loadoutData set ["SLuniforms", ["UK3CB_TNM_B_U_Officer_CombatUniform_01"]];
 _loadoutData set ["vests", []];
-_loadoutData set ["backpacks", ["UK3CB_PLM_B_B_RD54_RIF_01", "UK3CB_PLM_B_B_FIELDPACK_RIF_01", "UK3CB_PLM_B_B_Sidor_RIF_01"]];
+_loadoutData set ["backpacks", ["rhsusf_falconii", "rhssaf_kitbag_smb", "rhsusf_falconii"]];
 _loadoutData set ["medBackpacks", ["rhs_medic_bag"]];
-_loadoutData set ["atBackpacks", ["rhs_rpg_empty"]];
-_loadoutData set ["aaBackpacks", ["B_Carryall_oli"]];
-_loadoutData set ["mgBackpacks", ["rhs_rd54"]];
+_loadoutData set ["atBackpacks", ["rhsusf_falconii"]];
+_loadoutData set ["aaBackpacks", ["rhssaf_kitbag_smb"]];
+_loadoutData set ["mgBackpacks", ["rhsusf_falconii"]];
 _loadoutData set ["longRangeRadios", []];
 _loadoutData set ["helmets", ["UK3CB_TNM_B_H_Cap_KHK","UK3CB_TNM_B_H_Cap_CAC", "UK3CB_TNM_B_H_BoonieHat_KHK","UK3CB_TNM_B_H_BoonieHat_CAC","UK3CB_TNM_B_H_Bandanna_KHK", "UK3CB_TNM_B_H_Bandanna_CAC"]];
 _loadoutData set ["slHelmets", ["UK3CB_TNM_B_H_Patrolcap_Mic_CAC_Patch", "UK3CB_TNM_B_H_Infantry_Beret"]];
@@ -201,18 +207,18 @@ _sfLoadoutData set ["facewear", []];
 //["Weapon", "Muzzle", "Rail", "Sight", [], [], "Bipod"];
 
 _sfLoadoutData set ["slRifles", [
-    ["UK3CB_M16A2_UGL", "rhsusf_acc_rotex5_grey", "", "rhsusf_acc_RX01_NoFilter", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], ["rhs_mag_M433_HEDP", "rhs_mag_M433_HEDP", "rhs_mag_m714_White", "rhs_mag_m713_Red", "rhs_mag_m662_red", "rhs_mag_m661_green"], ""],
-    ["UK3CB_M16A3_UGL", "rhsusf_acc_rotex5_grey", "", "rhsusf_acc_compm4", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], ["rhs_mag_M433_HEDP", "rhs_mag_M433_HEDP", "rhs_mag_m714_White", "rhs_mag_m713_Red", "rhs_mag_m662_red", "rhs_mag_m661_green"], ""]
-]];
-_sfLoadoutData set ["rifles", [    
     ["UK3CB_AR10_Porto_Carbine_Sup_OD", "uk3cb_muzzle_snds_M14", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], [], ""],
-    ["UK3CB_M14", "uk3cb_muzzle_snds_M14", "", "uk3cb_optic_artel_m14", ["UK3CB_M14_20rnd_762x51"], [], ""],
+    ["UK3CB_M16A2_UGL", "rhsusf_acc_rotex5_grey", "", "rhsusf_acc_RX01_NoFilter", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], ["rhs_mag_M433_HEDP", "rhs_mag_M433_HEDP", "rhs_mag_m714_White", "rhs_mag_m713_Red", "rhs_mag_m662_red", "rhs_mag_m661_green"], ""]
+]];
+_sfLoadoutData set ["rifles", [
+    ["UK3CB_AR10_Porto_Carbine_Sup_OD", "uk3cb_muzzle_snds_M14", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], [], ""],
+    ["UK3CB_M14", "uk3cb_muzzle_snds_M14", "", "", ["UK3CB_M14_20rnd_762x51_R"], [], ""],
     ["uk3cb_ar18", "rhsusf_acc_rotex5_grey", "", "", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], [], ""]
 ]];
 _sfLoadoutData set ["carbines", [
     ["uk3cb_ar18_shorty", "", "", "", ["UK3CB_M16_30rnd_556x45", "UK3CB_M16_30rnd_556x45_R", "UK3CB_M16_30rnd_556x45_RT"], [], ""],
     ["uk3cb_ar18_carbine", "rhsusf_acc_rotex5_grey", "", "", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], [], ""],
-    ["UK3CB_M16A3", "rhsusf_acc_rotex5_grey", "", "rhsusf_acc_compm4", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], [], ""]
+    ["UK3CB_M16A1", "rhsusf_acc_rotex5_grey", "", "rhsusf_acc_RX01_NoFilter", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], [], ""]
 ]];
 _sfLoadoutData set ["grenadeLaunchers", [
     ["UK3CB_M16A2_UGL", "rhsusf_acc_rotex5_grey", "", "rhsusf_acc_RX01_NoFilter", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], ["rhs_mag_M433_HEDP", "rhs_mag_m714_White", "rhs_mag_m662_red"], ""],
@@ -220,7 +226,7 @@ _sfLoadoutData set ["grenadeLaunchers", [
 ]];
 _sfLoadoutData set ["SMGs", [
     ["uk3cb_ar18_shorty", "", "", "", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], [], ""],
-    ["rhs_weap_m3a1_specops", "", "", "", ["rhs_weap_m3a1","rhsgref_30rnd_1143x23_M1T_SMG","rhsgref_30rnd_1143x23_M1T_2mag_SMG","rhsgref_30rnd_1143x23_M1911B_2mag_SMG"], [], ""]
+    ["rhs_weap_m3a1_specops", "", "", "", ["rhsgref_30rnd_1143x23_M1911B_SMG","rhsgref_30rnd_1143x23_M1T_SMG","rhsgref_30rnd_1143x23_M1T_2mag_SMG","rhsgref_30rnd_1143x23_M1911B_2mag_SMG"], [], ""]
 ]];
 _sfLoadoutData set ["machineGuns", [
     ["UK3CB_M60", "", "", "", ["UK3CB_M60_100rnd_762x51_RM", "UK3CB_M60_100rnd_762x51"], [], ""],
@@ -250,27 +256,33 @@ _militaryLoadoutData set ["slRifles", [
     ["UK3CB_AR10_Porto_Carbine", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
     ["UK3CB_AR10_Porto_Carbine", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
     ["UK3CB_AR10_Porto_Carbine", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
-    ["uk3cb_ar18_shorty", "", "", "", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], [], ""]
+    ["UK3CB_M16A2_UGL", "", "", "", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], ["rhs_mag_M433_HEDP", "rhs_mag_M433_HEDP", "rhs_mag_m714_White", "rhs_mag_m713_Red", "rhs_mag_m662_red", "rhs_mag_m661_green"], ""],
+    ["uk3cb_ar18_shorty", "", "", "", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], [], ""],
+    ["uk3cb_ar18", "", "", "", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], [], ""],
+    ["uk3cb_ar18_carbine", "", "", "", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], [], ""]
 ]];
 _militaryLoadoutData set ["rifles", [
+    ["rhs_weap_m1garand_sa43", "", "", "", ["rhsgref_8Rnd_762x63_Tracer_M1T_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle"], [], ""],
+    ["uk3cb_m1carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
     ["UK3CB_AR10_OD", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], [], ""],
     ["UK3CB_AR10_OD", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], [], ""]
 ]];
 _militaryLoadoutData set ["carbines", [
+    ["rhs_weap_m1garand_sa43", "", "", "", ["rhsgref_8Rnd_762x63_Tracer_M1T_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle"], [], ""],
     ["uk3cb_m2carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
     ["uk3cb_m2a1_carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
     ["uk3cb_m2a1_carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
     ["UK3CB_AR10_Porto_Carbine_Sup_OD", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], [], ""],
     ["UK3CB_AR10_Porto_Carbine_Sup_OD", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], [], ""],
-    ["UK3CB_AR10_Porto_Carbine_Sup_OD", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], [], ""],
-    ["uk3cb_ar18", "", "", "", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], [], ""],
-    ["uk3cb_ar18_carbine", "", "", "", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], [], ""]
+    ["UK3CB_AR10_Porto_Carbine_Sup_OD", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], [], ""]
 ]];
 _militaryLoadoutData set ["grenadeLaunchers", [
+    ["rhs_weap_m79", "", "", "", ["rhs_mag_M433_HEDP"], ["rhs_mag_M433_HEDP", "rhs_mag_M433_HEDP", "rhs_mag_m714_White", "rhs_mag_m713_Red", "rhs_mag_m662_red", "rhs_mag_m661_green"], ""],
+    ["uk3cb_m1carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
+    ["uk3cb_m2carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
     ["UK3CB_AR10_Porto", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
     ["UK3CB_AR10_Porto", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
-    ["UK3CB_AR10_Porto", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
-    ["UK3CB_M16A2_UGL", "", "", "", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], ["rhs_mag_M433_HEDP", "rhs_mag_m714_White", "rhs_mag_m662_red"], ""]
+    ["UK3CB_AR10_Porto", "", "", "", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""]
 ]];
 _militaryLoadoutData set ["SMGs", [
     ["uk3cb_m2carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
@@ -282,11 +294,14 @@ _militaryLoadoutData set ["SMGs", [
 ]];
 _militaryLoadoutData set ["machineGuns", [
     ["UK3CB_M60", "", "", "", ["UK3CB_M60_100rnd_762x51_RM", "UK3CB_M60_100rnd_762x51"], [], ""],
-    ["UK3CB_M1919A6_Browning", "", "", "", ["UK3CB_M1919_50Rnd_3006_Magazine_RT", "UK3CB_M1919_50Rnd_3006_Magazine_RM", "UK3CB_M1919_50Rnd_3006_Magazine_R", "UK3CB_M1919_50Rnd_3006_Magazine"], [], ""],
+    ["UK3CB_M1919A4_Browning", "", "", "", ["UK3CB_M1919_50Rnd_3006_Magazine_RT", "UK3CB_M1919_50Rnd_3006_Magazine_RM", "UK3CB_M1919_50Rnd_3006_Magazine_R", "UK3CB_M1919_50Rnd_3006_Magazine"], [], ""],
     ["UK3CB_M1919A6_Browning", "", "", "", ["UK3CB_M1919_50Rnd_3006_Magazine_RT", "UK3CB_M1919_50Rnd_3006_Magazine_RM", "UK3CB_M1919_50Rnd_3006_Magazine_R", "UK3CB_M1919_50Rnd_3006_Magazine"], [], ""],
     ["UK3CB_M1919A6_Browning", "", "", "", ["UK3CB_M1919_50Rnd_3006_Magazine_RT", "UK3CB_M1919_50Rnd_3006_Magazine_RM", "UK3CB_M1919_50Rnd_3006_Magazine_R", "UK3CB_M1919_50Rnd_3006_Magazine"], [], ""]
 ]];
 _militaryLoadoutData set ["marksmanRifles", [
+    ["UK3CB_M1903A1_unertl", "", "", "", ["UK3CB_M1903A1_3006_5rnd_Magazine", "UK3CB_M1903A1_3006_5rnd_Magazine_RT", "UK3CB_M1903A1_3006_5rnd_Magazine_R"], [], ""],
+    ["uk3cb_m2carbine", "uk3cb_muzzle_m1_flash_hider", "", "uk3cb_scope_m1_m84", ["UK3CB_M1_15Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
+    ["uk3cb_m2carbine", "uk3cb_muzzle_m1_flash_hider", "", "uk3cb_scope_m1_m84", ["UK3CB_M1_15Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
     ["UK3CB_AR10_Porto_Marksman_Sup_ALU", "", "", "uk3cb_optic_ar_delft3x25", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], [], ""],
     ["UK3CB_AR10_Porto_Marksman_Sup_ALU", "", "", "uk3cb_optic_ar_delft3x25_3d", ["UK3CB_AR10_20rnd_762x51_RT", "UK3CB_AR10_20rnd_762x51_R", "UK3CB_AR10_20rnd_762x51"], [], ""]
 ]];
@@ -313,7 +328,7 @@ _policeLoadoutData set ["gpses", []];
 _policeLoadoutData set ["rifles", [
     ["uk3cb_m1_advisor_carbine", "", "", "", ["UK3CB_M1_30Rnd_30Carbine_Magazine_W", "UK3CB_M1_15Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine_R"], [], ""],
     ["UK3CB_M1903A1", "", "", "", ["UK3CB_M1903A1_3006_5rnd_Magazine", "UK3CB_M1903A1_3006_5rnd_Magazine_RT", "UK3CB_M1903A1_3006_5rnd_Magazine_R"], [], ""],
-    ["rhs_weap_M590_8RD", "", "", "", ["rhsusf_8Rnd_Slug", "rhsusf_8Rnd_Slug", "rhsusf_8Rnd_Slug", "rhsusf_8Rnd_00Buck", "rhsusf_8Rnd_00Buck"], [], ""]
+    ["rhs_weap_M590_8RD", "", "", "", ["rhsusf_8Rnd_Slug", "rhsusf_8Rnd_00Buck", "rhsusf_8Rnd_Slug", "rhsusf_8Rnd_00Buck", "rhsusf_8Rnd_Slug"], [], ""]
 ]];
 _policeLoadoutData set ["carbines", [
     ["uk3cb_m1carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
@@ -335,18 +350,20 @@ _militiaLoadoutData set ["helmets", ["UK3CB_TNM_B_H_Cap_KHK","UK3CB_TNM_B_H_Cap_
 _militiaLoadoutData set ["ATLaunchers", [
     ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_type69_airburst_mag", "rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag"], [], ""],
     "rhs_weap_m72a7", 
+    "uk3cb_m72a1_law_loaded", 
     "uk3cb_m72a1_law_loaded"
 ]];
 _militiaLoadoutData set ["heavyATLaunchers", [
     ["rhs_weap_rpg7", "", "", "",["rhs_rpg7_PG7V_mag", "rhs_rpg7_PG7V_mag", "rhs_rpg7_type69_airburst_mag"], [], ""],
     "rhs_weap_m72a7", 
+    "uk3cb_m72a1_law_loaded", 
     "uk3cb_m72a1_law_loaded"
 ]];
 
 _militiaLoadoutData set ["slRifles", [
     ["rhs_weap_m1garand_sa43", "", "", "", ["rhsgref_8Rnd_762x63_Tracer_M1T_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle"], [], ""],
-    ["uk3cb_m2a1_carbine", "", "", "", ["UK3CB_M1_30Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], ["uk3cb_1rnd_riflegrenade_mas_ap", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
-    ["uk3cb_m2carbine", "", "", "", ["UK3CB_M1_30Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""]
+    ["uk3cb_m2a1_carbine", "", "", "", ["UK3CB_M1_30Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], ["uk3cb_1rnd_riflegrenade_m9a1_at", "uk3cb_1rnd_riflegrenade_mas_ap", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
+    ["uk3cb_m2carbine", "", "", "", ["UK3CB_M1_30Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], ["uk3cb_1rnd_riflegrenade_m9a1_at", "uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""]
 ]];
 _militiaLoadoutData set ["rifles", [
     ["uk3cb_m1carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
@@ -357,11 +374,15 @@ _militiaLoadoutData set ["rifles", [
 ]];
 _militiaLoadoutData set ["carbines", [
     ["rhs_weap_m1garand_sa43", "", "", "", ["rhsgref_8Rnd_762x63_Tracer_M1T_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle"], [], ""],
+    ["rhs_weap_m1garand_sa43", "", "", "", ["rhsgref_8Rnd_762x63_Tracer_M1T_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle", "rhsgref_8Rnd_762x63_M2B_M1rifle"], [], ""],
     ["uk3cb_m2a1_carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
+    ["uk3cb_m1a1_carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
     ["uk3cb_m1a1_carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""]
 ]];
 _militiaLoadoutData set ["grenadeLaunchers", [
-    ["uk3cb_m1carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], ["uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""]
+    ["rhs_weap_m79", "", "", "", ["rhs_mag_M433_HEDP"], ["rhs_mag_M433_HEDP", "rhs_mag_M433_HEDP", "rhs_mag_m714_White", "rhs_mag_m713_Red", "rhs_mag_m662_red", "rhs_mag_m661_green"], ""],
+    ["uk3cb_m1carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], ["uk3cb_1rnd_riflegrenade_m9a1_at", "uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""],
+    ["uk3cb_m1carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], ["uk3cb_1rnd_riflegrenade_m9a1_at", "uk3cb_1rnd_riflegrenade_mas_dp", "uk3cb_1rnd_riflegrenade_mas_wp", "uk3cb_1rnd_riflegrenade_mas_flare"], ""]
 ]];
 _militiaLoadoutData set ["SMGs", [
     ["uk3cb_m2a1_carbine", "", "", "", ["UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
@@ -373,7 +394,7 @@ _militiaLoadoutData set ["machineGuns", [
     ["UK3CB_M1919A4_Browning", "", "", "", ["UK3CB_M1919_50Rnd_3006_Magazine_RT", "UK3CB_M1919_50Rnd_3006_Magazine_RM", "UK3CB_M1919_50Rnd_3006_Magazine_R", "UK3CB_M1919_50Rnd_3006_Magazine"], [], ""]
 ]];
 _militiaLoadoutData set ["marksmanRifles", [
-    ["uk3cb_m1a1_carbine", "uk3cb_muzzle_m1_flash_hider", "", "uk3cb_scope_m1_m84", ["UK3CB_M1_15Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
+    ["uk3cb_m1carbine", "uk3cb_muzzle_m1_flash_hider", "", "uk3cb_scope_m1_m84", ["UK3CB_M1_15Rnd_30Carbine_Magazine_R", "UK3CB_M1_15Rnd_30Carbine_Magazine", "UK3CB_M1_15Rnd_30Carbine_Magazine"], [], ""],
     ["UK3CB_M1903A1_unertl", "", "", "", ["UK3CB_M1903A1_3006_5rnd_Magazine", "UK3CB_M1903A1_3006_5rnd_Magazine_RT", "UK3CB_M1903A1_3006_5rnd_Magazine_R"], [], ""]
 ]];
 _militiaLoadoutData set ["sniperRifles", [
@@ -382,7 +403,7 @@ _militiaLoadoutData set ["sniperRifles", [
 _militiaLoadoutData set ["sidearms", ["rhsusf_weap_m1911a1", "", ""]];
 
 _militiaLoadoutData set ["traitorRifle", [
-    "uk3cb_m1carbine", "UK3CB_M1903A1"
+    "uk3cb_m1_advisor_carbine"
 ]];
 
 //////////////////////////
@@ -477,7 +498,7 @@ private _riflemanTemplate = {
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 
-    [selectRandom ["rifles", "rifles", "carbines"]] call _fnc_setPrimary;
+    ["rifles"] call _fnc_setPrimary;
     ["primary", 5] call _fnc_addMagazines;
 
     ["sidearms"] call _fnc_setHandgun;
@@ -502,7 +523,7 @@ private _medicTemplate = {
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
     ["medBackpacks"] call _fnc_setBackpack;
-	[selectRandom ["carbines", "SMGs"]] call _fnc_setPrimary;
+	["SMGs"] call _fnc_setPrimary;
     ["primary", 5] call _fnc_addMagazines;
 
     ["sidearms"] call _fnc_setHandgun;
@@ -555,7 +576,7 @@ private _explosivesExpertTemplate = {
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
 
-    [selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+    ["carbines"] call _fnc_setPrimary;
     ["primary", 5] call _fnc_addMagazines;
 
 
@@ -588,7 +609,7 @@ private _engineerTemplate = {
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
 
-    [selectRandom ["carbines", "SMGs"]] call _fnc_setPrimary;
+    ["SMGs"] call _fnc_setPrimary;
     ["primary", 5] call _fnc_addMagazines;
 
     ["sidearms"] call _fnc_setHandgun;
@@ -617,7 +638,7 @@ private _latTemplate = {
     ["uniforms"] call _fnc_setUniform;
     ["atBackpacks"] call _fnc_setBackpack;
 
-    [selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+    ["rifles"] call _fnc_setPrimary;
     ["primary", 5] call _fnc_addMagazines;
 
     [selectRandom ["lightATLaunchers", "ATLaunchers"]] call _fnc_setLauncher;
@@ -647,7 +668,7 @@ private _atTemplate = {
     ["uniforms"] call _fnc_setUniform;
     ["atBackpacks"] call _fnc_setBackpack;
 
-    [selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+    ["carbines"] call _fnc_setPrimary;
     ["primary", 5] call _fnc_addMagazines;
 
     [selectRandom["ATLaunchers","heavyATLaunchers"]] call _fnc_setLauncher;
@@ -677,7 +698,7 @@ private _aaTemplate = {
     ["uniforms"] call _fnc_setUniform;
     ["aaBackpacks"] call _fnc_setBackpack;
 
-    [selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+    ["carbines"] call _fnc_setPrimary;
     ["primary", 5] call _fnc_addMagazines;
 
     ["AALaunchers"] call _fnc_setLauncher;
@@ -784,7 +805,7 @@ private _policeTemplate = {
     ["vests"] call _fnc_setVest;
     ["uniforms"] call _fnc_setUniform;
 
-    [selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+    [selectRandom ["SMGs", "rifles", "carbines"]] call _fnc_setPrimary;
     ["primary", 3] call _fnc_addMagazines;
 
     ["sidearms"] call _fnc_setHandgun;

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TNM.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TNM.sqf
@@ -128,7 +128,7 @@ _loadoutData set ["heavyATLaunchers", [
     "uk3cb_m47"
 ]];
 _loadoutData set ["AALaunchers", ["UK3CB_Blowpipe", "rhs_weap_fim92"]];
-_loadoutData set ["sidearms", ["UK3CB_BHP","rhsusf_weap_m1911a1"]];
+_loadoutData set ["sidearms", []];
 
 _loadoutData set ["ATMines", ["rhs_mine_M19_mag"]];
 _loadoutData set ["APMines", ["rhs_mine_m2a3b_trip_mag","rhs_mine_m2a3b_press_mag", "rhs_mine_M3_tripwire_mag","rhs_mine_m3_pressure_mag","rhs_mine_Mk2_tripwire_mag","rhs_mine_mk2_pressure_mag","rhsusf_mine_m49a1_3m_mag","rhsusf_mine_m49a1_6m_mag","rhsusf_mine_m49a1_10m_mag"]];
@@ -310,7 +310,6 @@ _militaryLoadoutData set ["sniperRifles", [
     ["UK3CB_M1903A1_unertl", "", "", "", ["UK3CB_M1903A1_3006_5rnd_Magazine", "UK3CB_M1903A1_3006_5rnd_Magazine_RT", "UK3CB_M1903A1_3006_5rnd_Magazine_R"], [], ""],
     ["UK3CB_M14", "", "", "uk3cb_optic_artel_m14", ["UK3CB_M14_20rnd_762x51", "UK3CB_M14_20rnd_762x51_R", "UK3CB_M14_20rnd_762x51_RT"], [], ""]
 ]];
-_militaryLoadoutData set ["sidearms", ["rhsusf_weap_m1911a1", "", ""]];
 
 ///////////////////////////////
 //    Police Loadout Data    //
@@ -400,7 +399,6 @@ _militiaLoadoutData set ["marksmanRifles", [
 _militiaLoadoutData set ["sniperRifles", [
     ["UK3CB_M1903A1_unertl", "", "", "", ["UK3CB_M1903A1_3006_5rnd_Magazine", "UK3CB_M1903A1_3006_5rnd_Magazine_RT", "UK3CB_M1903A1_3006_5rnd_Magazine_R"], [], ""]
 ]];
-_militiaLoadoutData set ["sidearms", ["rhsusf_weap_m1911a1", "", ""]];
 
 _militiaLoadoutData set ["traitorRifle", [
     "uk3cb_m1_advisor_carbine"

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TNM.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_AI_TNM.sqf
@@ -201,7 +201,7 @@ _sfLoadoutData set ["facewear", []];
 //["Weapon", "Muzzle", "Rail", "Sight", [], [], "Bipod"];
 
 _sfLoadoutData set ["slRifles", [
-    ["UK3CB_M16A2_UGL", "rhsusf_acc_rotex5_grey", "", "rhsusf_acc_RX01_NoFilter", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], ["rhs_mag_M433_HEDP", "rhs_mag_M433_HEDP", "rhs_mag_m714_White", "rhs_mag_m713_Red", "rhs_mag_m662_red", "rhs_mag_m661_green"], ""]
+    ["UK3CB_M16A2_UGL", "rhsusf_acc_rotex5_grey", "", "rhsusf_acc_RX01_NoFilter", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], ["rhs_mag_M433_HEDP", "rhs_mag_M433_HEDP", "rhs_mag_m714_White", "rhs_mag_m713_Red", "rhs_mag_m662_red", "rhs_mag_m661_green"], ""],
     ["UK3CB_M16A3_UGL", "rhsusf_acc_rotex5_grey", "", "rhsusf_acc_compm4", ["rhs_mag_20Rnd_556x45_M193_Stanag", "rhs_mag_20Rnd_556x45_M193_2MAG_Stanag", "rhs_mag_20Rnd_556x45_M196_Stanag_Tracer_Red", "rhs_mag_20Rnd_556x45_M196_2MAG_Stanag_Tracer_Red"], ["rhs_mag_M433_HEDP", "rhs_mag_M433_HEDP", "rhs_mag_m714_White", "rhs_mag_m713_Red", "rhs_mag_m662_red", "rhs_mag_m661_green"], ""]
 ]];
 _sfLoadoutData set ["rifles", [    

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_RAS.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_RAS.sqf
@@ -75,9 +75,15 @@
 //////////////////////////
 
 private _civUniforms = [
+    "U_C_Poloshirt_blue",
+    "U_C_Poloshirt_burgundy",
+    "U_C_Poloshirt_redwhite",
     "U_C_Man_casual_1_F",
     "U_C_Man_casual_2_F",
     "U_C_Man_casual_3_F",
+    "U_C_Man_casual_4_F",
+    "U_C_Man_casual_5_F",
+    "U_C_Man_casual_6_F",
     "U_C_ArtTShirt_01_v1_F",
     "U_C_ArtTShirt_01_v2_F",
     "U_C_ArtTShirt_01_v3_F",
@@ -154,6 +160,9 @@ private _manTemplate = {
     if(random [0,0.5,1] > 0.3) then {      
         ["helmets"] call _fnc_setHelmet;
     };
+    if(random [0,0.5,1] > 0.7) then {      
+        ["backpacks"] call _fnc_setBackpack;
+    };
     ["uniforms"] call _fnc_setUniform;
 
     ["items_medical_standard"] call _fnc_addItemSet;
@@ -163,9 +172,7 @@ private _manTemplate = {
     ["compasses"] call _fnc_addCompass;
 };
 private _workerTemplate = {
-    if(random [0,0.5,1] > 0.3) then {      
-        ["helmets"] call _fnc_setHelmet;
-    };
+    ["workHelmets"] call _fnc_setHelmet;
     ["workerUniforms"] call _fnc_setUniform;
 
     ["items_medical_standard"] call _fnc_addItemSet;

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_RAS.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_RAS.sqf
@@ -6,8 +6,6 @@
 //       Vehicles       //
 //////////////////////////
 
-//TODO: Vehicles, and preferably their spawn chances, need to be added/removed/adjusted depending on the loaded factions. Stopgap fix for RF now.
-
 ["vehiclesCivCar", [
     "UK3CB_C_Ikarus_RED", 0.001                    // bus, dangerously large
     ,"UK3CB_C_Datsun_Closed", 0.01

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_RAS.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_RAS.sqf
@@ -1,0 +1,195 @@
+//////////////////////////////
+//   Civilian Information   //
+//////////////////////////////
+
+//////////////////////////
+//       Vehicles       //
+//////////////////////////
+
+//TODO: Vehicles, and preferably their spawn chances, need to be added/removed/adjusted depending on the loaded factions. Stopgap fix for RF now.
+
+["vehiclesCivCar", [
+    "UK3CB_C_Ikarus_RED", 0.001                    // bus, dangerously large
+    ,"UK3CB_C_Datsun_Closed", 0.01
+    ,"UK3CB_C_Datsun_Open", 10.0            // cargo-capable
+    ,"UK3CB_C_Hatchback", 10.0
+    ,"UK3CB_C_Hilux_Closed", 1.0
+    ,"UK3CB_C_Hilux_Open", 0.5            // cargo-capable
+    ,"UK3CB_C_LandRover_Softtop_Transport_Closed", 0.5        // land rovers
+    ,"UK3CB_C_LandRover_Softtop_Transport_Open", 1.5
+    ,"UK3CB_C_Sedan", 10.0
+    ,"UK3CB_C_Skoda", 10.0
+    ,"UK3CB_C_Gaz24", 2.5
+    ,"UK3CB_C_Octavia", 2.5
+    ,"UK3CB_C_Landcruiser", 2.5
+    ,"UK3CB_C_Lada", 1.0
+    ,"UK3CB_C_Pickup", 1.0
+    ,"C_Offroad_02_unarmed_F", 1.25]] call _fnc_saveToTemplate;
+
+["vehiclesCivIndustrial", [
+    "UK3CB_C_Forklift", 0.005
+    ,"UK3CB_C_Tractor", 0.2
+    ,"UK3CB_C_Tractor_Old", 0.2
+    ,"UK3CB_C_Kamaz_Open", 0.9
+    ,"UK3CB_C_Kamaz_Covered", 0.9                // Ural
+    ]] call _fnc_saveToTemplate;
+
+["vehiclesCivBoat", [
+    "C_Boat_Civil_01_rescue_F", 0.1            // motorboats
+    ,"C_Boat_Civil_01_police_F", 0.1
+    ,"UK3CB_C_Fishing_Boat", 0.3
+    ,"UK3CB_C_Fishing_Boat_Smuggler_VIV_FFV", 0.1
+    ,"UK3CB_C_Fishing_Boat_Smuggler", 0.2
+    ,"UK3CB_C_Fishing_Boat_VIV_FFV", 0.1
+    ,"UK3CB_C_Small_Boat_Closed", 0.7
+    ,"UK3CB_C_Small_Boat_Open", 0.8
+    ,"UK3CB_C_Small_Boat_Wood", 0.9
+    ,"C_Rubberboat", 1.0                    // rescue boat
+    ,"C_Boat_Transport_02_F", 1.0            // RHIB
+    ,"C_Scooter_Transport_01_F", 0.5]] call _fnc_saveToTemplate;
+
+["vehiclesCivRepair", [
+    "UK3CB_C_LandRover_Softtop_Repair_Closed_Port", 0.1
+    ,"UK3CB_C_Ural_Repair", 0.05]] call _fnc_saveToTemplate;
+
+["vehiclesCivMedical", [
+    "UK3CB_C_LandRover_Hardtop_Ambulance", 0.1
+    ,"UK3CB_C_Hilux_Ambulance", 0.1
+    ]] call _fnc_saveToTemplate;
+
+["vehiclesCivFuel", [
+    "UK3CB_C_LandRover_Softtop_Refuel_Open_Port", 0.1
+    ,"UK3CB_ADC_C_Ural_Fuel", 0.05]] call _fnc_saveToTemplate;
+
+/////////////////////
+///  Identities   ///
+/////////////////////
+
+["faces", ["GreekHead_A3_02", "GreekHead_A3_03", "GreekHead_A3_04", "GreekHead_A3_05", "GreekHead_A3_06",
+"GreekHead_A3_07", "GreekHead_A3_08", "GreekHead_A3_09", "Ioannou", "Barklem", "AfricanHead_02",
+"AsianHead_A3_02", "AsianHead_A3_03", "WhiteHead_05"]] call _fnc_saveToTemplate;
+"CivMen" call _fnc_saveNames;
+
+//////////////////////////
+//       Loadouts       //
+//////////////////////////
+
+private _civUniforms = [
+    "U_C_Man_casual_1_F",
+    "U_C_Man_casual_2_F",
+    "U_C_Man_casual_3_F",
+    "U_C_ArtTShirt_01_v1_F",
+    "U_C_ArtTShirt_01_v2_F",
+    "U_C_ArtTShirt_01_v3_F",
+    "U_C_ArtTShirt_01_v4_F",
+    "U_C_ArtTShirt_01_v5_F",
+    "U_C_ArtTShirt_01_v6_F",
+    "U_NikosBody",
+    "U_NikosAgedBody",
+    "U_C_Poloshirt_blue",
+    "U_C_Poloshirt_burgundy",
+    "U_C_Poloshirt_stripped",
+    "U_C_Poloshirt_tricolour",
+    "U_C_Poloshirt_salmon",
+    "U_C_Poloshirt_redwhite",
+    "U_OrestesBody",
+    "U_C_Poor_1",
+    "U_C_HunterBody_grn"
+];
+
+private _pressUniforms = [
+    "U_C_Journalist",
+    "U_Marshal"
+    ];
+
+private _workerUniforms = [
+    "UK3CB_CHC_C_U_Overall_01",
+    "UK3CB_CHC_C_U_Overall_02",
+    "UK3CB_CHC_C_U_Overall_03",
+    "UK3CB_CHC_C_U_Overall_04",
+    "UK3CB_CHC_C_U_Overall_05"
+    ];
+
+["uniforms", _civUniforms + _pressUniforms + _workerUniforms] call _fnc_saveToTemplate;
+
+private _civhats = [
+    "H_Hat_Safari_olive_F",
+    "H_Hat_Safari_sand_F",
+    "UK3CB_H_Safari_Hat_Brown",
+    "H_Booniehat_mgrn",
+    "H_Cap_surfer",
+    "H_Cap_tan",
+    "H_Cap_Lyfe",
+    "H_Cap_blu",
+    "H_Cap_grn_BI",
+    "H_Bandanna_surfer",
+    "H_Bandanna_surfer_blk",
+    "H_Bandanna_surfer_grn",
+    "UK3CB_H_Bandanna_Red_Check"
+];
+
+["headgear", _civHats] call _fnc_saveToTemplate;
+
+private _loadoutData = call _fnc_createLoadoutData;
+
+_loadoutData set ["uniforms", _civUniforms];
+_loadoutData set ["pressUniforms", _pressUniforms];
+_loadoutData set ["workerUniforms", _workerUniforms];
+_loadoutData set ["workVests", ["V_Safety_orange_F", "V_Safety_orange_F", "V_Safety_blue_F", "V_Safety_yellow_F", "V_Safety_yellow_F", "V_Safety_yellow_F", "V_Safety_yellow_F"]];
+_loadoutData set ["pressVests", ["V_Press_F"]];
+_loadoutData set ["helmets", _civHats];
+_loadoutData set ["facewear", ["G_Respirator_white_F", "G_Spectacles_Tinted", "G_Squares_Tinted", "G_Aviator", "G_Lady_Blue", "G_Shades_Black", "G_Sport_Greenblack", "G_Sport_Blackyellow", "G_Shades_Red"]];
+_loadoutData set ["workFacewear", ["G_Respirator_yellow_F", "G_EyeProtectors_F", "G_Lowprofile"]];
+_loadoutData set ["workHelmets", ["H_EarProtectors_yellow_F", "H_Construction_earprot_orange_F", "H_Construction_headset_orange_F", "H_Construction_earprot_yellow_F", "H_Construction_headset_yellow_F", "H_Construction_basic_white_F"]];
+_loadoutData set ["pressHelmets", ["H_Cap_press", "H_Cap_press", "H_Cap_press", "H_PASGT_basic_blue_press_F", "H_PASGT_neckprot_blue_press_F"]];
+
+_loadoutData set ["backpacks", ["B_Messenger_Coyote_F", "B_Messenger_Gray_F", "B_Messenger_Black_F", "B_CivilianBackpack_01_Everyday_Vrana_F", "B_CivilianBackpack_01_Sport_Blue_F", "B_CivilianBackpack_01_Sport_Green_F", "B_CivilianBackpack_01_Sport_Red_F", "B_LegStrapBag_black_F", "B_LegStrapBag_coyote_F"]];
+
+_loadoutData set ["maps", ["ItemMap"]];
+_loadoutData set ["watches", ["ItemWatch"]];
+_loadoutData set ["compasses", ["ItemCompass"]];
+
+
+private _manTemplate = {
+    if(random [0,0.5,1] > 0.3) then {      
+        ["helmets"] call _fnc_setHelmet;
+    };
+    ["uniforms"] call _fnc_setUniform;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+};
+private _workerTemplate = {
+    if(random [0,0.5,1] > 0.3) then {      
+        ["helmets"] call _fnc_setHelmet;
+    };
+    ["workerUniforms"] call _fnc_setUniform;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+};
+private _pressTemplate = {
+    ["pressHelmets"] call _fnc_setHelmet;
+    ["pressVests"] call _fnc_setVest;
+    ["pressUniforms"] call _fnc_setUniform;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+};
+private _prefix = "militia";
+private _unitTypes = [
+    ["Press", _pressTemplate],
+    ["Worker", _workerTemplate],
+    ["Man", _manTemplate, nil, 10]
+];
+
+[_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_SPI.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_SPI.sqf
@@ -22,7 +22,8 @@
     ,"UK3CB_C_Landcruiser", 0.3
     ,"UK3CB_C_Lada", 1.0
     ,"UK3CB_C_Pickup", 1.0
-    ,"C_Offroad_02_unarmed_F", 1.25]] call _fnc_saveToTemplate;
+    ,"C_Offroad_02_unarmed_F", 1.25
+    ]] call _fnc_saveToTemplate;
 
 ["vehiclesCivIndustrial", [
     "UK3CB_C_Forklift", 0.005
@@ -98,8 +99,7 @@ private _civUniforms = [
     "U_C_Man_casual_6_F",
     "U_C_Man_casual_4_F",
     "U_C_Man_casual_5_F",
-    "UK3CB_ADC_C_Shorts_U_06",
-    "UK3CB_ADC_C_U_WORK_01"
+    "UK3CB_ADC_C_Shorts_U_06"
 ];
 
 private _pressUniforms = [
@@ -160,7 +160,9 @@ private _manTemplate = {
     ["uniforms"] call _fnc_setUniform;
     ["facewear"] call _fnc_setFacewear;
 
-    if (random [0, 5, 10] > 6.66) then {["backpacks"] call _fnc_setBackpack;}
+    if(random [0,0.5,1] > 0.7) then {      
+        ["backpacks"] call _fnc_setBackpack;
+    };
 
     ["items_medical_standard"] call _fnc_addItemSet;
 

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_SPI.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_SPI.sqf
@@ -1,0 +1,202 @@
+//////////////////////////////
+//   Civilian Information   //
+//////////////////////////////
+
+//////////////////////////
+//       Vehicles       //
+//////////////////////////
+
+["vehiclesCivCar", [
+    "UK3CB_C_Ikarus_RED", 0.001                    // bus, dangerously large
+    ,"UK3CB_C_Datsun_Closed", 0.01
+    ,"UK3CB_C_Datsun_Open", 2.5            // cargo-capable
+    ,"UK3CB_C_Hatchback", 5.5
+    ,"UK3CB_C_Hilux_Closed", 1.0
+    ,"UK3CB_C_Hilux_Open", 0.5            // cargo-capable
+    ,"UK3CB_C_LandRover_Softtop_Transport_Closed", 0.5        // land rovers
+    ,"UK3CB_C_LandRover_Softtop_Transport_Open", 1.5
+    ,"UK3CB_C_Sedan", 5.5
+    ,"UK3CB_C_Skoda", 5.5
+    ,"UK3CB_C_Gaz24", 2.5
+    ,"UK3CB_C_Octavia", 0.3
+    ,"UK3CB_C_Landcruiser", 0.3
+    ,"UK3CB_C_Lada", 1.0
+    ,"UK3CB_C_Pickup", 1.0
+    ,"C_Offroad_02_unarmed_F", 0.25]] call _fnc_saveToTemplate;
+
+["vehiclesCivIndustrial", [
+    "UK3CB_C_Forklift", 0.005
+    ,"UK3CB_C_Tractor", 0.2
+    ,"UK3CB_C_Tractor_Old", 0.2
+    ,"UK3CB_C_Ural_Empty", 0.9
+    ,"UK3CB_C_Ural_Recovery", 0.9
+    ,"UK3CB_C_Ural_Covered", 0.9                // Ural
+    ]] call _fnc_saveToTemplate;
+
+["vehiclesCivBoat", [
+    "C_Boat_Civil_01_rescue_F", 0.1            // motorboats
+    ,"C_Boat_Civil_01_police_F", 0.1
+    ,"UK3CB_C_Fishing_Boat", 0.3
+    ,"UK3CB_C_Fishing_Boat_Smuggler_VIV_FFV", 0.1
+    ,"UK3CB_C_Fishing_Boat_Smuggler", 0.2
+    ,"UK3CB_C_Fishing_Boat_VIV_FFV", 0.1
+    ,"UK3CB_C_Small_Boat_Closed", 0.7
+    ,"UK3CB_C_Small_Boat_Open", 0.8
+    ,"UK3CB_C_Small_Boat_Wood", 0.9
+    ,"C_Rubberboat", 1.0                    // rescue boat
+    ,"C_Boat_Transport_02_F", 1.0            // RHIB
+    ,"C_Scooter_Transport_01_F", 0.5]] call _fnc_saveToTemplate;
+
+["vehiclesCivRepair", [
+    "UK3CB_C_LandRover_Softtop_Repair_Closed_Port", 0.1
+    ,"UK3CB_C_Ural_Repair", 0.05]] call _fnc_saveToTemplate;
+
+["vehiclesCivMedical", [
+    "UK3CB_C_LandRover_Hardtop_Ambulance", 0.1
+    ,"UK3CB_C_Hilux_Ambulance", 0.1
+    ]] call _fnc_saveToTemplate;
+
+["vehiclesCivFuel", [
+    "UK3CB_C_LandRover_Softtop_Refuel_Open_Port", 0.1
+    ,"UK3CB_ADC_C_Ural_Fuel", 0.05]] call _fnc_saveToTemplate;
+
+/////////////////////
+///  Identities   ///
+/////////////////////
+
+["faces", [
+"TanoanHead_A3_01","TanoanHead_A3_02","TanoanHead_A3_03","TanoanHead_A3_04","TanoanHead_A3_05","TanoanHead_A3_06","TanoanHead_A3_07","TanoanHead_A3_08",
+"TanoanHead_A3_01","TanoanHead_A3_02","TanoanHead_A3_03","TanoanHead_A3_04","TanoanHead_A3_05","TanoanHead_A3_06","TanoanHead_A3_07","TanoanHead_A3_08",
+"AsianHead_A3_01","AsianHead_A3_02","AsianHead_A3_03","AsianHead_A3_04","AsianHead_A3_05","AsianHead_A3_06","AsianHead_A3_07"
+]] call _fnc_saveToTemplate;
+
+//////////////////////////
+//       Loadouts       //
+//////////////////////////
+
+private _civUniforms = [    
+    "U_I_C_Soldier_Bandit_4_F",
+    "U_I_C_Soldier_Bandit_1_F",
+    "U_I_C_Soldier_Bandit_2_F",
+    "U_I_C_Soldier_Bandit_5_F",
+    "U_I_C_Soldier_Bandit_3_F",
+    "U_C_Man_casual_2_F",
+    "U_C_Man_casual_3_F",
+    "U_C_Man_casual_1_F",
+    "UK3CB_ION_B_U_CEO_SUIT_04",
+    "UK3CB_ADC_C_U_Pilot_02",
+    "U_C_Poloshirt_blue",
+    "U_C_Poloshirt_burgundy",
+    "U_C_Poloshirt_redwhite",
+    "U_OrestesBody",
+    "U_I_L_Uniform_01_tshirt_sport_F",
+    "U_C_Mechanic_01_F",
+    "U_I_C_Soldier_Para_5_F",
+    "U_C_man_sport_1_F",
+    "U_C_man_sport_3_F",
+    "U_C_man_sport_2_F",
+    "U_C_Man_casual_6_F",
+    "U_C_Man_casual_4_F",
+    "U_C_Man_casual_5_F",
+    "UK3CB_ADC_C_Shorts_U_06",
+    "UK3CB_ADC_C_U_WORK_01"
+];
+
+private _pressUniforms = [
+    "U_C_Journalist",
+    "U_Marshal"
+    ];
+
+private _workerUniforms = [
+    "UK3CB_CHC_C_U_Overall_01",
+    "UK3CB_CHC_C_U_Overall_02"
+    "UK3CB_CHC_C_U_Overall_03",
+    "UK3CB_CHC_C_U_Overall_04",
+    "UK3CB_CHC_C_U_Overall_05",
+    ];
+
+["uniforms", _civUniforms + _pressUniforms + _workerUniforms] call _fnc_saveToTemplate;
+
+private _civhats = [
+    "H_Hat_Safari_olive_F",
+    "H_Hat_Safari_sand_F",
+    "UK3CB_H_Safari_Hat_Brown",
+    "H_Booniehat_mgrn",
+    "H_Cap_surfer",
+    "H_Cap_tan",
+    "H_Cap_Lyfe",
+    "H_Cap_blu",
+    "H_Cap_grn_BI",
+    "H_Bandanna_surfer",
+    "H_Bandanna_surfer_blk",
+    "H_Bandanna_surfer_grn",
+    "UK3CB_H_Bandanna_Red_Check"
+];
+
+["headgear", _civHats] call _fnc_saveToTemplate;
+
+private _loadoutData = call _fnc_createLoadoutData;
+
+_loadoutData set ["uniforms", _civUniforms];
+_loadoutData set ["pressUniforms", _pressUniforms];
+_loadoutData set ["workerUniforms", _workerUniforms];
+_loadoutData set ["workVests", ["V_Safety_orange_F", "V_Safety_orange_F", "V_Safety_blue_F", "V_Safety_yellow_F", "V_Safety_yellow_F", "V_Safety_yellow_F", "V_Safety_yellow_F"]];
+_loadoutData set ["pressVests", ["V_Press_F"]];
+_loadoutData set ["helmets", _civHats];
+_loadoutData set ["facewear", ["G_Respirator_white_F", "G_Spectacles_Tinted", "G_Squares_Tinted", "G_Aviator", "G_Lady_Blue", "G_Shades_Black", "G_Sport_Greenblack", "G_Sport_Blackyellow", "G_Shades_Red"]];
+_loadoutData set ["workFacewear", ["G_Respirator_yellow_F", "G_EyeProtectors_F", "G_Lowprofile"]];
+_loadoutData set ["workHelmets", ["H_EarProtectors_yellow_F", "H_Construction_earprot_orange_F", "H_Construction_headset_orange_F", "H_Construction_earprot_yellow_F", "H_Construction_headset_yellow_F", "H_Construction_basic_white_F"]];
+_loadoutData set ["pressHelmets", ["H_Cap_press", "H_PASGT_basic_blue_press_F", "H_PASGT_neckprot_blue_press_F"]];
+
+_loadoutData set ["backpacks", ["B_Messenger_Coyote_F", "B_Messenger_Gray_F", "B_Messenger_Black_F", "B_CivilianBackpack_01_Everyday_Vrana_F", "B_CivilianBackpack_01_Sport_Blue_F", "B_CivilianBackpack_01_Sport_Green_F", "B_CivilianBackpack_01_Sport_Red_F", "B_LegStrapBag_black_F", "B_LegStrapBag_coyote_F"]];
+
+_loadoutData set ["maps", ["ItemMap"]];
+_loadoutData set ["watches", ["ItemWatch"]];
+_loadoutData set ["compasses", ["ItemCompass"]];
+
+
+private _manTemplate = {
+    ["helmets"] call _fnc_setHelmet;
+    ["uniforms"] call _fnc_setUniform;
+    ["facewear"] call _fnc_setFacewear;
+
+    if (random [0, 5, 10] > 6.66) then {["backpacks"] call _fnc_setBackpack;}
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+};
+private _workerTemplate = {
+    ["workHelmets"] call _fnc_setHelmet;
+    ["workerUniforms"] call _fnc_setUniform;
+    ["workVests"] call _fnc_setVest;
+    ["workFacewear"] call _fnc_setFacewear;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+};
+private _pressTemplate = {
+    ["pressHelmets"] call _fnc_setHelmet;
+    ["pressVests"] call _fnc_setVest;
+    ["pressUniforms"] call _fnc_setUniform;
+    ["facewear"] call _fnc_setFacewear;
+
+    ["items_medical_standard"] call _fnc_addItemSet;
+
+    ["maps"] call _fnc_addMap;
+    ["watches"] call _fnc_addWatch;
+    ["compasses"] call _fnc_addCompass;
+};
+private _prefix = "militia";
+private _unitTypes = [
+    ["Press", _pressTemplate],
+    ["Worker", _workerTemplate, nil, 15],
+    ["Man", _manTemplate, nil, 10]
+];
+
+[_prefix, _unitTypes, _loadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_SPI.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Civ_SPI.sqf
@@ -9,20 +9,20 @@
 ["vehiclesCivCar", [
     "UK3CB_C_Ikarus_RED", 0.001                    // bus, dangerously large
     ,"UK3CB_C_Datsun_Closed", 0.01
-    ,"UK3CB_C_Datsun_Open", 2.5            // cargo-capable
-    ,"UK3CB_C_Hatchback", 5.5
+    ,"UK3CB_C_Datsun_Open", 5.0            // cargo-capable
+    ,"UK3CB_C_Hatchback", 10.0
     ,"UK3CB_C_Hilux_Closed", 1.0
     ,"UK3CB_C_Hilux_Open", 0.5            // cargo-capable
     ,"UK3CB_C_LandRover_Softtop_Transport_Closed", 0.5        // land rovers
     ,"UK3CB_C_LandRover_Softtop_Transport_Open", 1.5
-    ,"UK3CB_C_Sedan", 5.5
+    ,"UK3CB_C_Sedan", 10.0
     ,"UK3CB_C_Skoda", 5.5
     ,"UK3CB_C_Gaz24", 2.5
     ,"UK3CB_C_Octavia", 0.3
     ,"UK3CB_C_Landcruiser", 0.3
     ,"UK3CB_C_Lada", 1.0
     ,"UK3CB_C_Pickup", 1.0
-    ,"C_Offroad_02_unarmed_F", 0.25]] call _fnc_saveToTemplate;
+    ,"C_Offroad_02_unarmed_F", 1.25]] call _fnc_saveToTemplate;
 
 ["vehiclesCivIndustrial", [
     "UK3CB_C_Forklift", 0.005
@@ -109,10 +109,10 @@ private _pressUniforms = [
 
 private _workerUniforms = [
     "UK3CB_CHC_C_U_Overall_01",
-    "UK3CB_CHC_C_U_Overall_02"
+    "UK3CB_CHC_C_U_Overall_02",
     "UK3CB_CHC_C_U_Overall_03",
     "UK3CB_CHC_C_U_Overall_04",
-    "UK3CB_CHC_C_U_Overall_05",
+    "UK3CB_CHC_C_U_Overall_05"
     ];
 
 ["uniforms", _civUniforms + _pressUniforms + _workerUniforms] call _fnc_saveToTemplate;
@@ -146,7 +146,7 @@ _loadoutData set ["helmets", _civHats];
 _loadoutData set ["facewear", ["G_Respirator_white_F", "G_Spectacles_Tinted", "G_Squares_Tinted", "G_Aviator", "G_Lady_Blue", "G_Shades_Black", "G_Sport_Greenblack", "G_Sport_Blackyellow", "G_Shades_Red"]];
 _loadoutData set ["workFacewear", ["G_Respirator_yellow_F", "G_EyeProtectors_F", "G_Lowprofile"]];
 _loadoutData set ["workHelmets", ["H_EarProtectors_yellow_F", "H_Construction_earprot_orange_F", "H_Construction_headset_orange_F", "H_Construction_earprot_yellow_F", "H_Construction_headset_yellow_F", "H_Construction_basic_white_F"]];
-_loadoutData set ["pressHelmets", ["H_Cap_press", "H_PASGT_basic_blue_press_F", "H_PASGT_neckprot_blue_press_F"]];
+_loadoutData set ["pressHelmets", ["H_Cap_press", "H_Cap_press", "H_Cap_press", "H_PASGT_basic_blue_press_F", "H_PASGT_neckprot_blue_press_F"]];
 
 _loadoutData set ["backpacks", ["B_Messenger_Coyote_F", "B_Messenger_Gray_F", "B_Messenger_Black_F", "B_CivilianBackpack_01_Everyday_Vrana_F", "B_CivilianBackpack_01_Sport_Blue_F", "B_CivilianBackpack_01_Sport_Green_F", "B_CivilianBackpack_01_Sport_Red_F", "B_LegStrapBag_black_F", "B_LegStrapBag_coyote_F"]];
 

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Reb_SDK.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Reb_SDK.sqf
@@ -21,7 +21,7 @@
 ["vehiclesCivPlane", ["UK3CB_C_Cessna_172"]] call _fnc_saveToTemplate;
 ["vehiclesMedical", ["UK3CB_FIA_I_LR_Softtop_Ambulance_Open"]] call _fnc_saveToTemplate;
 
-["vehiclesCivCar", ["UK3CB_C_Datsun_Open", "UK3CB_C_Gaz24", "UK3CB_C_Skoda", "UK3CB_C_S1203", "UK3CB_C_MMT"]] call _fnc_saveToTemplate;
+["vehiclesCivCar", ["UK3CB_C_Datsun_Open", "UK3CB_C_Sedan", "UK3CB_C_Skoda", "UK3CB_C_S1203", "UK3CB_C_MMT"]] call _fnc_saveToTemplate;
 ["vehiclesCivTruck", ["UK3CB_C_LandRover_Closed", "UK3CB_C_LandRover_Open", "RHS_Ural_Open_Civ_02", "C_Offroad_02_unarmed_F", "C_Van_01_transport_F", "C_Van_02_transport_F", "C_Van_02_vehicle_F"]] call _fnc_saveToTemplate;
 ["vehiclesCivHeli", ["UK3CB_CHC_I_Mi8AMT"]] call _fnc_saveToTemplate;
 ["vehiclesCivBoat", ["UK3CB_CHC_C_Fishing_Boat", "C_Rubberboat", "rhsgref_civ_canoe"]] call _fnc_saveToTemplate;
@@ -47,7 +47,7 @@
 ///////////////////////////
 
 private _initialRebelEquipment = [
-"rhs_weap_makarov_pm", "rhsusf_weap_m1911a1", "rhs_weap_Izh18",
+"a3a_rhs_weap_pb_6p9_noSup", "rhsusf_weap_m1911a1", "rhs_weap_Izh18",
 ["IEDUrbanSmall_Remote_Mag", 10], ["IEDLandSmall_Remote_Mag", 10], ["IEDUrbanBig_Remote_Mag", 3], ["IEDLandBig_Remote_Mag", 3],["rhs_weap_rpg18", 5],
 "rhs_mag_9x18_8_57N181S", "rhsusf_mag_7x45acp_MHP", "rhsgref_1Rnd_00Buck", "rhsgref_1Rnd_Slug", "rhs_mag_f1", "rhs_grenade_mki_mag", "rhs_mag_rdg2_black", "rhs_grenade_m15_mag",
 "B_FieldPack_blk", "B_FieldPack_cbr", "B_FieldPack_green_F", "B_FieldPack_khk", "B_FieldPack_oli",

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Reb_SDK.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Reb_SDK.sqf
@@ -9,24 +9,24 @@
 ["flagMarkerType", "flag_Tanoa"] call _fnc_saveToTemplate;
 
 ["vehiclesBasic", ["UK3CB_FIA_I_TT650"]] call _fnc_saveToTemplate;
-["vehiclesLightUnarmed", ["UK3CB_MDF_I_MB4WD_Unarmed", "UK3CB_FIA_I_LR_Closed", "UK3CB_FIA_I_LR_Open", "UK3CB_FIA_I_Datsun_Open"]] call _fnc_saveToTemplate;
-["vehiclesLightArmed", ["UK3CB_I_G_LandRover_M2", "UK3CB_MDF_I_MB4WD_LMG","UK3CB_I_G_LandRover_SF_M2"]] call _fnc_saveToTemplate;
+["vehiclesLightUnarmed", ["UK3CB_FIA_I_Datsun_Open"]] call _fnc_saveToTemplate;
+["vehiclesLightArmed", ["UK3CB_I_G_LandRover_WMIK_M2", "UK3CB_I_G_LandRover_SF_WMIK_M2_M240"]] call _fnc_saveToTemplate;
 ["vehiclesTruck", ["UK3CB_KDF_I_Gaz66_Covered","UK3CB_KDF_I_Gaz66_Open"]] call _fnc_saveToTemplate;
-["vehiclesAT", ["UK3CB_MDF_I_MB4WD_AT", "UK3CB_I_G_LandRover_SPG9"]] call _fnc_saveToTemplate;
+["vehiclesAT", ["UK3CB_MDF_I_MB4WD_AT", "UK3CB_I_G_LandRover_Opentop_SPG9"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["UK3CB_KDF_I_Gaz66_ZU23"]] call _fnc_saveToTemplate;
 
 ["vehiclesBoat", ["I_C_Boat_Transport_02_F", "UK3CB_I_G_Fishing_Boat_SPG9", "UK3CB_CHD_I_Fishing_Boat_Zu23_front"]] call _fnc_saveToTemplate;
 
-["vehiclesPlane", ["UK3CB_I_G_Antonov_An2_Armed", "UK3CB_FIA_I_C400"]] call _fnc_saveToTemplate;
+["vehiclesPlane", ["UK3CB_FIA_I_Cessna_T41_Armed_M2", "UK3CB_FIA_I_C400", "UK3CB_FIA_I_Bell412_Utility"]] call _fnc_saveToTemplate;
 ["vehiclesCivPlane", ["UK3CB_C_Cessna_172"]] call _fnc_saveToTemplate;
-["vehiclesMedical", ["UK3CB_FIA_I_Hilux_Ambulance"]] call _fnc_saveToTemplate;
+["vehiclesMedical", ["UK3CB_FIA_I_LR_Softtop_Ambulance_Open"]] call _fnc_saveToTemplate;
 
-["vehiclesCivCar", ["C_Offroad_02_unarmed_F", "UK3CB_C_LandRover_Closed", "UK3CB_C_LandRover_Open", "UK3CB_C_Datsun_Open", "UK3CB_C_Gaz24", "UK3CB_C_Skoda", "UK3CB_C_S1203", "UK3CB_C_MMT"]] call _fnc_saveToTemplate;
-["vehiclesCivTruck", ["RHS_Ural_Open_Civ_02","C_Van_01_transport_F", "C_Van_02_transport_F", "C_Van_02_vehicle_F"]] call _fnc_saveToTemplate;
-["vehiclesCivHeli", ["UK3CB_C_Mi8AMT_ADC"]] call _fnc_saveToTemplate;
+["vehiclesCivCar", ["UK3CB_C_Datsun_Open", "UK3CB_C_Gaz24", "UK3CB_C_Skoda", "UK3CB_C_S1203", "UK3CB_C_MMT"]] call _fnc_saveToTemplate;
+["vehiclesCivTruck", ["UK3CB_C_LandRover_Closed", "UK3CB_C_LandRover_Open", "RHS_Ural_Open_Civ_02", "C_Offroad_02_unarmed_F", "C_Van_01_transport_F", "C_Van_02_transport_F", "C_Van_02_vehicle_F"]] call _fnc_saveToTemplate;
+["vehiclesCivHeli", ["UK3CB_CHC_I_Mi8AMT"]] call _fnc_saveToTemplate;
 ["vehiclesCivBoat", ["UK3CB_CHC_C_Fishing_Boat", "C_Rubberboat", "rhsgref_civ_canoe"]] call _fnc_saveToTemplate;
 
-["staticMGs", ["rhsgref_tla_g_DSHKM",  "rhsgref_tla_g_DSHKM_Mini_TriPod", "rhsgref_hidf_m2_static_minitripod", "UK3CB_NAP_I_PKM_High",  "UK3CB_NAP_I_PKM_Low"]] call _fnc_saveToTemplate;
+["staticMGs", ["rhsgref_tla_g_DSHKM", "rhsgref_tla_g_DSHKM_Mini_TriPod", "rhsgref_hidf_m2_static_minitripod", "UK3CB_NAP_I_PKM_High", "UK3CB_NAP_I_PKM_Low"]] call _fnc_saveToTemplate;
 ["staticAT", ["rhsgref_tla_g_SPG9"]] call _fnc_saveToTemplate;
 ["staticAA", ["rhsgref_tla_g_ZU23"]] call _fnc_saveToTemplate;
 
@@ -47,19 +47,19 @@
 ///////////////////////////
 
 private _initialRebelEquipment = [
-"rhs_weap_makarov_pm", "rhs_weap_tt33", "rhs_weap_Izh18",
+"rhs_weap_makarov_pm", "rhsusf_weap_m1911a1", "rhs_weap_Izh18",
 ["IEDUrbanSmall_Remote_Mag", 10], ["IEDLandSmall_Remote_Mag", 10], ["IEDUrbanBig_Remote_Mag", 3], ["IEDLandBig_Remote_Mag", 3],["rhs_weap_rpg18", 5],
-"rhs_mag_9x18_8_57N181S", "rhs_mag_762x25_8", "rhsgref_1Rnd_00Buck", "rhsgref_1Rnd_Slug", "rhs_mag_f1", "rhs_grenade_mki_mag", "rhs_mag_rdg2_black", "rhs_grenade_m15_mag",
+"rhs_mag_9x18_8_57N181S", "rhsusf_mag_7x45acp_MHP", "rhsgref_1Rnd_00Buck", "rhsgref_1Rnd_Slug", "rhs_mag_f1", "rhs_grenade_mki_mag", "rhs_mag_rdg2_black", "rhs_grenade_m15_mag",
 "B_FieldPack_blk", "B_FieldPack_cbr", "B_FieldPack_green_F", "B_FieldPack_khk", "B_FieldPack_oli",
 "rhsgref_chestrig", "rhsgref_chicom", "rhs_vydra_3m", "rhs_vest_pistol_holster", "rhs_vest_commander", "rhs_6sh46", "rhsgref_alice_webbing",
 "rhs_acc_2dpZenit", "Binocular",
-"rhs_weap_rsp30_white",
-"rhs_weap_rsp30_green",
-"rhs_weap_rsp30_red"
+"rhs_weap_rsp30_white","rhs_weap_rsp30_green","rhs_weap_rsp30_red"
 ];
 
-_initialRebelEquipment append ["uk3cb_enfield_no4","uk3cb_enfield_no4_walnut","uk3cb_no4_enfield_303_10Rnd_magazine_Y","uk3cb_no4_enfield_303_10Rnd_magazine_YT",
-["uk3cb_1rnd_riflegrenade_mas_at_l", 60], ["uk3cb_1rnd_riflegrenade_mas_wp", 15], "uk3cb_1rnd_riflegrenade_mas_flare"];
+_initialRebelEquipment append [
+    "uk3cb_enfield_no4","uk3cb_enfield_no4_walnut","uk3cb_no4_enfield_303_10Rnd_magazine_Y","uk3cb_no4_enfield_303_10Rnd_magazine_YT",
+    ["uk3cb_1rnd_riflegrenade_mas_at_l", 60], ["uk3cb_1rnd_riflegrenade_mas_wp", 15], "uk3cb_1rnd_riflegrenade_mas_flare"
+];
 
 if (A3A_hasTFAR) then {_initialRebelEquipment append ["tf_microdagr", "tf_anprc154"]};
 if (A3A_hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment append ["tf_anprc155", "tf_anprc155_coyote"]};
@@ -70,16 +70,16 @@ if (A3A_hasTFARBeta && startWithLongRangeRadio) then {_initialRebelEquipment app
 ["initialRebelEquipment", _initialRebelEquipment] call _fnc_saveToTemplate;
 
 private _rebUniforms = [
-    "U_I_C_Soldier_Bandit_4_F",
     "U_I_C_Soldier_Bandit_1_F",
     "U_I_C_Soldier_Bandit_2_F",
-    "U_I_C_Soldier_Bandit_5_F",
     "U_I_C_Soldier_Bandit_3_F",
+    "U_I_C_Soldier_Bandit_4_F",
+    "U_I_C_Soldier_Bandit_5_F",
+    "U_I_C_Soldier_Para_1_F",
     "U_I_C_Soldier_Para_2_F",
     "U_I_C_Soldier_Para_3_F",
-    "U_I_C_Soldier_Para_5_F",
     "U_I_C_Soldier_Para_4_F",
-    "U_I_C_Soldier_Para_1_F",
+    "U_I_C_Soldier_Para_5_F",
     "U_I_C_Soldier_Camo_F"
 ];
 

--- a/A3A/addons/core/Templates/Templates/3CB/3CB_Reb_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/3CB/3CB_Reb_Vehicle_Attributes.sqf
@@ -2,6 +2,9 @@
     // smaller plane, AKA cheaper
     ["UK3CB_C_AC500", ["rebCost", 4000]],
 
+    //Bikes
+    ["UK3CB_C_MMT", ["rebCost", 50]],
+
     //Civ Cars
     ["UK3CB_C_Golf", ["rebCost", 225]], //No Cargo, 5 Seats, 200 speed
     ["UK3CB_C_SUV", ["rebCost", 350]], //No Cargo 6 Seats


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Adds the PLM, People's Liberation Militia and the TNM, Tanoan National Militia as enemy factions
The PLM utilises primarily SKS's and old soviet and chinese surplus.
The TNM is mostly armed with old WW2 surplus and clandestine support from abroad.

Adds two minor alterations of civilian templates, for arid european and tropical climates
Fixes a lot of the climate and maps entries in templates.hpp
Removes american guns from some HIDF vehicles that erroneously got them

Adjusted the 3CB_reb_SDK aka TFIA template
Added workaround for the 6p9 spawning with a suppressor 

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
