### PR TITLE
Round vehicle lock count on settings menu

### DIFF
--- a/A3A/addons/garage/Public/config.inc
+++ b/A3A/addons/garage/Public/config.inc
@@ -40,7 +40,7 @@ HR_GRG_Cnd_isAirbase = {
 
 // Return lock limit for specified player
 HR_GRG_getLockLimit = {
-    [HR_GRG_LockLimit_Guest, HR_GRG_LockLimit_Member] select (_this call A3A_fnc_isMember);
+    round ([HR_GRG_LockLimit_Guest, HR_GRG_LockLimit_Member] select (_this call A3A_fnc_isMember));
 };
 
 //Lock on garaged vehicles ( Values: [{""}, { getPlayerUID player }] )


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The CBA settings are sliders, so when changing the garage count you could set the garage lock limit to like 1.08 while the CBA panel displayed 1. When the garage checks if the lock limit is reached yet, 1 locked vehicle is less than 1.08 so you can lock a second vic. This PR fixes that by rounding the lock limit so it matches the CBA panel
    

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
