### PR TITLE
Force aircraft pylons to driver control

### DIFF
--- a/A3A/addons/core/functions/Base/fn_setPlaneLoadout.sqf
+++ b/A3A/addons/core/functions/Base/fn_setPlaneLoadout.sqf
@@ -46,7 +46,7 @@ if !(_loadout isEqualTo []) then
 {
     Debug_2("Selected new loadout for %1, now equipping %2 with it",typeOf _plane, _plane);
     {
-        _plane setPylonLoadout [_forEachIndex + 1, _x, true];
+        _plane setPylonLoadout [_forEachIndex + 1, _x, true, [-1]];
         _plane setVariable ["loadout", _loadout];
     } forEach _loadout;
 };


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Anything set in `setPlaneLoadout` will now be put under driver control. This fixes issues with some CAS planes where they wouldnt fire weapon stations that were technically under gunner control. Tested and working on SOG two-seater CAS.

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
