### PR TITLE
Make UAVs garageable

### DIFF
--- a/A3A/addons/garage/Core/fn_confirmPlacement.sqf
+++ b/A3A/addons/garage/Core/fn_confirmPlacement.sqf
@@ -302,7 +302,17 @@ HR_GRG_EH_keyDown = findDisplay 46 displayAddEventHandler ["KeyDown", {
                 _veh setPylonLoadout [_pylonIndex, _mag, _forced, _turret]
             } forEach HR_GRG_CP_pylons;
         };
-        _veh spawn {sleep 0.5;_this allowDamage true;_this enableSimulation true; { _x allowDamage true; } forEach (attachedObjects _this); };
+        _veh spawn {
+            sleep 0.5;
+            _this allowDamage true;
+            _this enableSimulation true; 
+            { _x allowDamage true; } forEach (attachedObjects _this);
+            if (unitIsUAV _this) then {
+                private _group = createGroup side player;
+                createVehicleCrew _this;
+                crew _this joinSilent _group;
+            };
+        };
         ([_veh] + HR_GRG_CP_callBackArgs) call HR_GRG_CP_callbackPlace;
     };
 

--- a/A3A/addons/garage/Public/fn_addVehicle.sqf
+++ b/A3A/addons/garage/Public/fn_addVehicle.sqf
@@ -102,10 +102,12 @@ if (_vehicle getVariable ['A3A_canGarage', false]) exitwith {
 if !((_vehicle getVariable ["SA_Tow_Ropes",objNull]) isEqualTo objNull) exitWith {["STR_HR_GRG_Feedback_addVehicle_SATow"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
 
     //crewed
+private _isUAV = unitIsUAV _vehicle;
 private _exit = false;
 if ( ( {alive _x} count (crew _vehicle) ) > 0) then { _exit = true };
 { if ( ( {alive _x} count (crew _x) ) > 0) exitWith {_exit = true} } forEach attachedObjects _vehicle;
-if (_exit) exitWith { ["STR_HR_GRG_Feedback_addVehicle_Crewed"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
+if (_exit && (!_isUAV)) exitWith { ["STR_HR_GRG_Feedback_addVehicle_Crewed"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
+if (_isUAV && (crew _vehicle isNotEqualTo [] && {side _vehicle isNotEqualTo side player})) exitWith {  ["STR_HR_GRG_Feedback_addVehicle_HostileUAV"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
 
     // valid vehicle for garage
 private _cat = [_class] call HR_GRG_fnc_getCatIndex;
@@ -201,6 +203,8 @@ private _catsRequiringUpdate = [];
     if (typeOf _x in ["ACE_Wheel", "ACE_Track"]) then { continue };
     [_x, _vehicle] call ace_cargo_fnc_unloadItem;
 } forEach (_vehicle getVariable ["ace_cargo_loaded", []]);
+
+if (_isUAV) then {{deleteVehicle _x} forEach (crew _vehicle)};
 
 // Can only deal correctly with static weapons here. Drop everything else where it is.
 {

--- a/A3A/addons/garage/Public/fn_addVehicle.sqf
+++ b/A3A/addons/garage/Public/fn_addVehicle.sqf
@@ -107,7 +107,7 @@ private _exit = false;
 if ( ( {alive _x} count (crew _vehicle) ) > 0) then { _exit = true };
 { if ( ( {alive _x} count (crew _x) ) > 0) exitWith {_exit = true} } forEach attachedObjects _vehicle;
 if (_exit && (!_isUAV)) exitWith { ["STR_HR_GRG_Feedback_addVehicle_Crewed"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
-if (_isUAV && (crew _vehicle isNotEqualTo [] && {side _vehicle isNotEqualTo side player})) exitWith {  ["STR_HR_GRG_Feedback_addVehicle_HostileUAV"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
+if (_isUAV && (crew _vehicle isNotEqualTo [] && {side _vehicle isNotEqualTo side _player})) exitWith {  ["STR_HR_GRG_Feedback_addVehicle_HostileUAV"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
 
     // valid vehicle for garage
 private _cat = [_class] call HR_GRG_fnc_getCatIndex;

--- a/A3A/addons/garage/Stringtable.xml
+++ b/A3A/addons/garage/Stringtable.xml
@@ -159,6 +159,9 @@
         <Turkish>Düşmanlar yakınınızdayken araçları garaja koyamazsınız</Turkish>
         <Chinesesimp>你不能在敌人附近存放载具</Chinesesimp>
       </Key>
+      <Key ID="STR_HR_GRG_Feedback_addVehicle_HostileUAV">
+        <Original>You can't garage a drone that doesnt belong to your side. Hack this drone before trying to garage it.</Original>
+      </Key>
       <Key ID="STR_HR_GRG_Feedback_addVehicle_Ammo_sold">
         <Original>Ammo crate sold</Original>
       </Key>


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
UAVs that are either empty or that belong to your side can be put into the garage. They'll get AI on your side when pulled back out.
Should be agnostic enough for the garage. Note that the crew are added later because new-garrison code has a `setOwner` which doesnt play well with us immediately adding AI units.

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
