### PR TITLE
Reduce vehicle state and make it work for any parked rebel vehicle

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -82,6 +82,7 @@ class CfgFunctions
             class categoryOverrides {};
             class checkRadiosUnlocked {};
             class configSort {};
+            class clampVehicleAmmo {};
             class dress {};
             class empty {};
             class equipmentClassToCategories {};

--- a/A3A/addons/core/functions/AI/fn_mortyAI.sqf
+++ b/A3A/addons/core/functions/AI/fn_mortyAI.sqf
@@ -2,6 +2,7 @@
 FIX_LINE_NUMBERS()
 private ["_morty0","_mortarX","_pos","_typeX","_b0","_b1","_morty1"];
 
+private _savedMags = -1;
 _groupX = _this select 0;
 _morty0 = units _groupX select 0;
 _morty1 = units _groupX select 1;
@@ -16,6 +17,12 @@ while {(alive _morty0) and (alive _morty1)} do
 	_mortarX = _typeX createVehicle _pos;
 	removeBackpackGlobal _morty0;
 	removeBackpackGlobal _morty1;
+
+	if (_savedMags isNotEqualTo -1) then {
+		[_mortarX, _savedMags] call HR_GRG_fnc_setAmmoData;
+	} else {
+		[_mortarX] call A3A_fnc_clampVehicleAmmo;
+	};
 
 // Removed as workaround for probable Arma AI bug with Podnos mortar + long distance (~200m) moves
 // After a long move, non-gunner will attempt to move into the second mortar seat unless this is removed
@@ -36,6 +43,7 @@ while {(alive _morty0) and (alive _morty1)} do
 		};
 		unassignVehicle _morty1;
 		moveOut _morty1;
+		_savedMags = [_mortarX] call HR_GRG_fnc_getAmmoData;
 		deleteVehicle _mortarX;
 		};
 	};

--- a/A3A/addons/core/functions/Ammunition/fn_clampVehicleAmmo.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_clampVehicleAmmo.sqf
@@ -1,0 +1,28 @@
+/*
+    Clamp vehicle ammo to 3/4 of vehicle cost
+
+*/
+
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+
+params ["_vehicle"];
+
+private _vehPrice = server getVariable typeof _vehicle;
+if (isNil "_vehPrice") exitWith {
+    Error_1("Vehicle type %1 has no price?", typeof _vehicle);
+};
+_vehPrice = _vehPrice * 0.75;
+
+private _blacklistMags = ["FakeWeapon", "FakeMagazine"];
+private _allMags = magazinesAllTurrets _vehicle apply {_x#0} select {!(_x in _blacklistMags)};
+if (count _allMags == 0) exitWith {};
+
+private _magPrice = 0;
+{
+    _magPrice = _magPrice + 0.25 * ([_x, "mag"] call A3A_GUI_fnc_calculateItemPrice);
+} forEach _allMags;
+
+if (_vehPrice < _magPrice) then {
+    _vehicle setVehicleAmmo (_vehPrice / _magPrice)
+};

--- a/A3A/addons/core/functions/Base/fn_vehicleBoxRestore.sqf
+++ b/A3A/addons/core/functions/Base/fn_vehicleBoxRestore.sqf
@@ -68,11 +68,11 @@ private _hqVehicles = (vehicles inAreaArray [_posHQ, 150, 150]) select {
     _x setVariable ["A3A_reported", nil, true];
 } forEach _hqVehicles;
 
-if (HR_GRG_hasAmmoSource) then {
+/*if (HR_GRG_hasAmmoSource) then {
     {
         [_x,1] remoteExec ["setVehicleAmmo",_x];
     } forEach _hqVehicles;
-};
+};*/
 
 if (HR_GRG_hasRepairSource) then {
     {
@@ -93,9 +93,9 @@ private _additiveTexts = [localize "STR_A3A_base_vehicleBoxRestore_noreported"];
 if (HR_GRG_hasRepairSource) then { 
 	_additiveTexts pushBack (localize "STR_A3A_base_vehicleBoxRestore_repaired"); 
 }; 
-if (HR_GRG_hasAmmoSource) then { 
+/*if (HR_GRG_hasAmmoSource) then { 
 	_additiveTexts pushBack (localize "STR_A3A_base_vehicleBoxRestore_rearmed"); 
-}; 
+};*/ 
 if (HR_GRG_hasFuelSource) then { 
 	_additiveTexts pushBack (localize "STR_A3A_base_vehicleBoxRestore_refueled"); 
 }; 

--- a/A3A/addons/core/functions/GarrisonLocal/fn_spawnGarrisonVehicles.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_spawnGarrisonVehicles.sqf
@@ -38,6 +38,7 @@ private _fullCrewTypes = ["vehicleAA", "vehicleArty", "vehicleSAM", "boat"];
 private _supportVehIDs = _garrison get "vehActions" apply { _x#0 };
 
 private _potentialBlockers = (_markerPos nearEntities 700) + (allDead inAreaArray [_markerPos, 700, 700]);
+if (_marker == "Synd_HQ") then { _potentialBlockers = _potentialBlockers - [boxX, flagX, vehicleBox, fireX, mapX, petros] };
 
 // pass in _pos, _class and _marker
 private _fnc_isBlocked = {

--- a/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_updateVehData.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_updateVehData.sqf
@@ -44,6 +44,6 @@ private _usedVehicles = [];
     };
     // Update pos/dir, in case it got nudged
     _x set [1, [getPosWorld _veh, vectorDir _veh, vectorUp _veh]];
-    if !(_veh isKindOf "StaticWeapon") then { _x set [4, _veh call HR_GRG_fnc_getState] };
+    _x set [2, _veh call HR_GRG_fnc_getState];
     _usedVehicles pushBack _veh;
 } forEach (_garrison get "vehicles");

--- a/A3A/addons/core/functions/REINF/fn_addFIAveh.sqf
+++ b/A3A/addons/core/functions/REINF/fn_addFIAveh.sqf
@@ -34,6 +34,7 @@ private _fnc_placed = {
 		_vehicle setVariable ["ownerX",getPlayerUID player,true];
 	};
 	_vehicle setFuel random [0.10, 0.175, 0.25];
+	[_vehicle] call A3A_fnc_clampVehicleAmmo;
 	[_vehicle, teamPlayer] call A3A_fnc_AIVehInit;
 	[_vehicle] remoteExec ["A3A_fnc_rebelVehPlacedWorker", 2];
 };

--- a/A3A/addons/core/functions/REINF/fn_spawnHCGroup.sqf
+++ b/A3A/addons/core/functions/REINF/fn_spawnHCGroup.sqf
@@ -32,6 +32,9 @@ params [
     , ["_vehicle", objNull, [objNull]]
 ];
 
+// Clamp vehicle ammo according to price, if excessive mags
+[_vehicle] call A3A_fnc_clampVehicleAmmo;
+
 //calculate base cost
 private _cost = if (isNull _vehicle) then { 0 } else { [typeOf _vehicle] call A3A_fnc_vehiclePrice };
 private _costHR = 0;
@@ -92,6 +95,7 @@ switch _special do {
     //vehicle squad
     case "BuildAA": {
         private _static = ((attachedObjects _vehicle) select {typeOf _x in FactionGet(reb,"staticAA")})#0;
+        [_static] call A3A_fnc_clampVehicleAmmo;
         (_units # (_countUnits -1)) moveInDriver _vehicle;
         (_units # _countUnits) moveInGunner _static;
         call _initVeh;

--- a/A3A/addons/core/functions/init/fn_initVarCommon.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarCommon.sqf
@@ -21,6 +21,9 @@ A3A_vestDamageAdj = createHashMap;
 // Data to prevent over-using the same loadouts
 A3A_loadoutShuffleBuffers = createHashMap;
 
+// Price cache for mags & weapons
+A3A_itemPriceCache = createHashMap;
+
 ////////////////////////////////////
 //     BEGIN SIDES AND COLORS    ///
 ////////////////////////////////////

--- a/A3A/addons/core/functions/init/fn_resourcecheck.sqf
+++ b/A3A/addons/core/functions/init/fn_resourcecheck.sqf
@@ -102,7 +102,7 @@ while {true} do
 
 	[] spawn A3A_fnc_reinforcementsAI;
 
-	{
+/*	{
 	_veh = _x;
 	if ((_veh isKindOf "StaticWeapon") and ({isPlayer _x} count crew _veh == 0) and (alive _veh)) then
 		{
@@ -110,6 +110,7 @@ while {true} do
 		[_veh,1] remoteExec ["setVehicleAmmo",_veh];
 		};
 	} forEach vehicles;
+*/
 	sleep 3;
 
 	// 20% chance of spawning a radio tower repair mission

--- a/A3A/addons/garage/CfgFunctions.hpp
+++ b/A3A/addons/garage/CfgFunctions.hpp
@@ -66,6 +66,7 @@ class CfgFunctions
             class getAmmoCargo {};
             class getAmmoData {};
             class getDamage {};
+            class getDefaultMags {};
             class getFuel {};
             class getState {};
             class prepPylons {};

--- a/A3A/addons/garage/Core/fn_reloadPreview.sqf
+++ b/A3A/addons/garage/Core/fn_reloadPreview.sqf
@@ -47,8 +47,6 @@ HR_GRG_previewVehState = _veh#4;
 [HR_GRG_previewVeh, HR_GRG_previewVehState] call HR_GRG_fnc_setState;
 HR_GRG_previewVeh allowDamage false;
 
-Trace_1("Preview vehicle Fuel: %1", fuel HR_GRG_previewVeh);
-
 //set customisation
 private _customisation = _veh param [6, [false,false]];
 ([HR_GRG_previewVeh]+_customisation) call BIS_fnc_initVehicle;

--- a/A3A/addons/garage/Core/fn_reloadPreview.sqf
+++ b/A3A/addons/garage/Core/fn_reloadPreview.sqf
@@ -47,6 +47,8 @@ HR_GRG_previewVehState = _veh#4;
 [HR_GRG_previewVeh, HR_GRG_previewVehState] call HR_GRG_fnc_setState;
 HR_GRG_previewVeh allowDamage false;
 
+Trace_1("Preview vehicle Fuel: %1", fuel HR_GRG_previewVeh);
+
 //set customisation
 private _customisation = _veh param [6, [false,false]];
 ([HR_GRG_previewVeh]+_customisation) call BIS_fnc_initVehicle;

--- a/A3A/addons/garage/Extras/fn_reloadExtras.sqf
+++ b/A3A/addons/garage/Extras/fn_reloadExtras.sqf
@@ -184,6 +184,7 @@ _sellPrice = [localize "STR_HR_GRG_InfoPanel_salePrice",_sellPrice] joinString "
 
 //state indicator
 private _getPercentageAmmo = {
+    if (_this isEqualType 0) exitWith {_this};
     if (count _this isEqualTo 0) exitWith {0};
     private _sumPercent = 0;
     private _weaponsWithAmmo = 0;
@@ -204,8 +205,8 @@ private _getPercentageAmmo = {
 
 private _hasAmmo = (HR_GRG_previewVehState#2) isNotEqualTo [];//Preview state >> Ammo data
 private _avgAmmo = (HR_GRG_previewVehState#2) call _getPercentageAmmo; //Preview state >> Ammo data
-private _avgFuel = HR_GRG_previewVehState#0#0; //Preview state >> Fuel data >> Fuel
-private _avgDmg = 1 - (HR_GRG_previewVehState#1#0); //Preview state >> Damage data >> Damage
+private _avgFuel = fuel HR_GRG_previewVeh;      //HR_GRG_previewVehState#0#0; //Preview state >> Fuel data >> Fuel
+private _avgDmg = 1 - damage HR_GRG_previewVeh; //(HR_GRG_previewVehState#1#0); //Preview state >> Damage data >> Damage
 private _selectStateColor = {
     switch true do {
         case (_this > 0.5): {"#ffffff"}; // white

--- a/A3A/addons/garage/Public/config.inc
+++ b/A3A/addons/garage/Public/config.inc
@@ -172,6 +172,7 @@ HR_GRG_useNewPylonSys = true; // new rearm system, blocks pylons entirely. turn 
 HR_GRG_useNewRearmSys = true; // new rearm system
 HR_GRG_useNewRepairSys = false; // new repair system
 HR_GRG_useNewRefuelSys = false; // new refuel system
+HR_GRG_reduceState = true;      // Compress stored state (not fully backwards compatible)
 
 HR_GRG_getResourceCargo = {
     params ["_veh", "_search"];

--- a/A3A/addons/garage/Public/fn_initServer.sqf
+++ b/A3A/addons/garage/Public/fn_initServer.sqf
@@ -23,6 +23,9 @@ if !(isClass (missionConfigFile/"A3A")) exitWith {};//not A3 Antistasi mission
 #include "config.inc"
 #include "defines.inc"
 FIX_LINE_NUMBERS()
+
+HR_GRG_defaultMags = createHashMap;
+
 if (!isServer) exitWith {};
 
 Trace("Running server init");

--- a/A3A/addons/garage/Pylons/fn_reloadPylons.sqf
+++ b/A3A/addons/garage/Pylons/fn_reloadPylons.sqf
@@ -68,7 +68,7 @@ private _presetComboCtrl = _disp displayCtrl HR_GRG_IDC_ExtraPylonsPresetsCombo;
 lbClear _presetComboCtrl;
 private _index = _presetComboCtrl lbAdd localize "STR_HR_GRG_Pylons_CustomPreset";
 _presetComboCtrl lbSetData [_index, "[]"];
-HR_GRG_DefaultMags = [];
+HR_GRG_DefaultPylons = [];
 {
     private _displayName = getText (_x >> "displayName");
     private _attachement = getArray (_x >> "attachment");
@@ -77,7 +77,7 @@ HR_GRG_DefaultMags = [];
 
     //get all mags used by default presets
     _loadoutMags = _attachement apply { getText (configFile >> "CfgMagazines" >> _x >> "pylonWeapon") };
-    {HR_GRG_DefaultMags pushBackUnique _x} forEach _loadoutMags;
+    {HR_GRG_DefaultPylons pushBackUnique _x} forEach _loadoutMags;
 
 } forEach (configProperties [(_pylonsCfg >> "Presets")]);
 

--- a/A3A/addons/garage/StatePreservation/fn_getAmmoCargo.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_getAmmoCargo.sqf
@@ -23,6 +23,9 @@
 */
 params [["_veh", objNull, [objNull]]];
 
+// This one was new anyway, so returning an empty array or nil is fully backwards compatible
+if (getNumber (configOf _veh/"ace_rearm_defaultSupply") <= 0 and getNumber (configOf _veh/"transportAmmo") <= 0) exitWith {[]};
+
 private _baseAmmoCargo = if (HR_GRG_useNewRearmSys) then {
     [_veh, "rearm"] call HR_GRG_getResourceCargo;
 } else {

--- a/A3A/addons/garage/StatePreservation/fn_getAmmoData.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_getAmmoData.sqf
@@ -27,6 +27,8 @@
                 <Int> Magazine ammo count
             ] Pylon data
         ]
+        or
+        <Int> Scalar vehicle ammo
     ] Ammo Data
 
     Scope: Any
@@ -40,9 +42,30 @@
 */
 params [["_veh", objNull, [objNull]]];
 
+private _pylonsCfg = (configOf _veh >> "Components" >> "TransportPylonsComponent");
+
+scopeName "main";
+if (!isClass _pylonsCfg and HR_GRG_reduceState) then {
+    private _blacklistMags = ["FakeWeapon", "FakeMagazine"];
+    private _allMags = magazinesAllTurrets _veh select {!(_x#0 in _blacklistMags)};
+    if (count _allMags == 0) then { [] breakOut "main"};        // may as well keep this one
+
+    private _totalRounds = 0;
+    private _maxRounds = 0;
+    {
+        _totalRounds = _totalRounds + _x#2;
+        _maxRounds = _maxRounds + getNumber (configFile >> "CfgMagazines" >> _x#0 >> "count");
+    } forEach _allMags;
+
+    // If the ammo can be set with setVehicleAmmo (no pylons, [0, 1] or all same magazine), just return scalar
+    private _magName = _allMags#0#0;
+    if (_maxRounds in [0, _totalRounds] or _allMags findIf {_magName != _x#0} == -1) then {
+        _totalRounds / (_maxRounds max 1) breakOut "main";
+    };
+};
+
 private _nonPylon = magazinesAllTurrets _veh select {!("pylon" in toLower (_x#0))} apply { [false, [_x#0,_x#1,_x#2]] }; //[is Pylon, [magName, path, ammo]]
 
-private _pylonsCfg = (configFile >> "CfgVehicles" >> typeOf _veh >> "Components" >> "TransportPylonsComponent");
 private _pylonAmmo = [];
 private _magName = getPylonMagazines _veh;
 {

--- a/A3A/addons/garage/StatePreservation/fn_getAmmoData.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_getAmmoData.sqf
@@ -47,26 +47,18 @@ private _pylonsCfg = (configOf _veh >> "Components" >> "TransportPylonsComponent
 scopeName "main";
 if (!isClass _pylonsCfg and HR_GRG_reduceState) then {
     private _blacklistMags = ["FakeWeapon", "FakeMagazine"];
-    private _turrets = typeof _veh call BIS_fnc_allTurrets;         // need to use config because setVehicleAmmo deletes mags
-    private _configs = _turrets apply {[_veh, _x] call BIS_fnc_turretConfig};
-    private _mags = _configs apply {getArray (_x >> "magazines")};
-    private _originalMags = flatten _mags + getArray (configOf _veh >> "magazines") select {!(_x in _blacklistMags)};
+    private _originalMags = (typeOf _veh call HR_GRG_fnc_getDefaultMags) select {!(_x#0 in _blacklistMags)};
     if (count _originalMags == 0) then { [] breakOut "main" };        // may as well keep this one
-
-    private _maxRounds = 0;
-    {
-        _maxRounds = _maxRounds + getNumber (configFile >> "CfgMagazines" >> _x >> "count");
-    } forEach _originalMags;
 
     private _curMags = magazinesAllTurrets _veh select {!(_x#0 in _blacklistMags)};
     private _totalRounds = 0;
-    {
-        _totalRounds = _totalRounds + _x#2;
-    } forEach _curMags;
+    { _totalRounds = _totalRounds + _x#2 } forEach _curMags;
+    private _maxRounds = 0;
+    { _maxRounds = _maxRounds + _x#2 } forEach _originalMags;
 
     // If the ammo can be set with setVehicleAmmo (no pylons, [0, 1] or all same magazine), just return scalar
-    private _magName = _originalMags#0;
-    if (_totalRounds in [0, _maxRounds] or _originalMags findIf {_magName != _x} == -1) then {
+    private _magName = _originalMags#0#0;
+    if (_totalRounds in [0, _maxRounds] or _originalMags findIf {_magName != _x#0} == -1) then {
         _totalRounds / (_maxRounds max 1) breakOut "main";
     };
 };

--- a/A3A/addons/garage/StatePreservation/fn_getAmmoData.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_getAmmoData.sqf
@@ -47,19 +47,26 @@ private _pylonsCfg = (configOf _veh >> "Components" >> "TransportPylonsComponent
 scopeName "main";
 if (!isClass _pylonsCfg and HR_GRG_reduceState) then {
     private _blacklistMags = ["FakeWeapon", "FakeMagazine"];
-    private _allMags = magazinesAllTurrets _veh select {!(_x#0 in _blacklistMags)};
-    if (count _allMags == 0) then { [] breakOut "main"};        // may as well keep this one
+    private _turrets = typeof _veh call BIS_fnc_allTurrets;         // need to use config because setVehicleAmmo deletes mags
+    private _configs = _turrets apply {[_veh, _x] call BIS_fnc_turretConfig};
+    private _mags = _configs apply {getArray (_x >> "magazines")};
+    private _originalMags = flatten _mags + getArray (configOf _veh >> "magazines") select {!(_x in _blacklistMags)};
+    if (count _originalMags == 0) then { [] breakOut "main" };        // may as well keep this one
 
-    private _totalRounds = 0;
     private _maxRounds = 0;
     {
+        _maxRounds = _maxRounds + getNumber (configFile >> "CfgMagazines" >> _x >> "count");
+    } forEach _originalMags;
+
+    private _curMags = magazinesAllTurrets _veh select {!(_x#0 in _blacklistMags)};
+    private _totalRounds = 0;
+    {
         _totalRounds = _totalRounds + _x#2;
-        _maxRounds = _maxRounds + getNumber (configFile >> "CfgMagazines" >> _x#0 >> "count");
-    } forEach _allMags;
+    } forEach _curMags;
 
     // If the ammo can be set with setVehicleAmmo (no pylons, [0, 1] or all same magazine), just return scalar
-    private _magName = _allMags#0#0;
-    if (_maxRounds in [0, _totalRounds] or _allMags findIf {_magName != _x#0} == -1) then {
+    private _magName = _originalMags#0;
+    if (_totalRounds in [0, _maxRounds] or _originalMags findIf {_magName != _x} == -1) then {
         _totalRounds / (_maxRounds max 1) breakOut "main";
     };
 };

--- a/A3A/addons/garage/StatePreservation/fn_getDamage.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_getDamage.sqf
@@ -9,9 +9,11 @@
     Return Value:
         <Array> [
             <Scalar> Overall damage
-            <Array> Hitpoint damage
+            <Array> Optional: Hitpoint damage
             <Scalar> Repair cargo
         ] Damage state
+        or 
+        <Scalar> Overall damage
 
     Scope: Any
     Environment: Any
@@ -23,11 +25,19 @@
     License: APL-ND
 */
 params ["_vehicle"];
-private _dmg = damage _vehicle min 0.89;
-private _hitPointDamage = getAllHitPointsDamage _vehicle;
-if !(_hitPointDamage isEqualTo []) then { //ensure it has hitpoints
-    _hitPointDamage = _hitPointDamage#2
-};
-private _repairCargo = getRepairCargo _vehicle;
+private _restoreState = [0,1] select (HR_GRG_hasRepairSource && !HR_GRG_ServiceDisabled_Repair);
 
-[_dmg, _hitPointDamage, _repairCargo];
+private _output = [damage _vehicle min 0.89];
+private _hitPointDamage = getAllHitPointsDamage _vehicle;
+if (_hitPointDamage isNotEqualTo []) then { //ensure it has hitpoints
+    // Skip storing hitpoints if damage is low or we can repair it
+    if (HR_GRG_reduceState and (selectMax (_hitPointDamage#2) < 0.15 or _restoreState == 1)) exitWith {};
+    _output pushBack _hitPointDamage#2;
+};
+
+// Set repair cargo only if it exists
+if (getNumber (configOf _vehicle/"transportRepair") > 0) then { _output set [2, getRepairCargo _vehicle] };
+
+// If we only have overall damage, just return that
+if (count _output == 1) exitWith { _output#0 };
+_output;

--- a/A3A/addons/garage/StatePreservation/fn_getDefaultMags.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_getDefaultMags.sqf
@@ -1,0 +1,47 @@
+/*
+    Author: [John Jordan]
+    Description:
+        Returns cached array of default non-pylon magazines for a vehicle
+
+    Arguments:
+    0. <String> Vehicle classname
+
+    Return Value:
+    <Array>
+        <Struct> [
+            <String> Magazine classname
+            <Array> Turret path ([-1] for driver)
+            <Number> Number of bullets in magazine
+        ]
+    ]
+
+    Scope: Any
+    Environment: Any
+    Public: Yes
+    Dependencies: HR_GRG_defaultMags, created by initServer at postInit
+
+    Example: [typeof cursorObject] call HR_GRG_fnc_getDefaultMags;
+
+    License: APL-ND
+*/
+
+params ["_vehClass"];
+
+if (_vehClass in HR_GRG_defaultMags) exitWith { HR_GRG_defaultMags get _vehClass };
+
+private _driverMags = getArray (configFile >> "CfgVehicles" >> _vehClass >> "magazines");
+private _output = _driverMags apply { [_x, [-1]] };
+
+private _turrets = _vehClass call BIS_fnc_allTurrets;         // need to use config because setVehicleAmmo deletes mags
+{
+    private _path = _x;
+    private _mags = getArray ([_vehClass, _path] call BIS_fnc_turretConfig >> "magazines");
+    _output append (_mags apply { [_x, _path] });
+} forEach _turrets;
+
+{
+    _x pushBack getNumber (configFile >> "CfgMagazines" >> _x#0 >> "count");
+} forEach _output;
+
+HR_GRG_defaultMags set [_vehClass, _output];
+_output;

--- a/A3A/addons/garage/StatePreservation/fn_getFuel.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_getFuel.sqf
@@ -12,6 +12,8 @@
             <Int> Fuel cargo
             <Int> Ace Fuel cargo
         ] Fuel state
+        or
+        <Int> Fuel if it doesn't have cargo
 
     Scope: Any
     Environment: Any
@@ -23,6 +25,8 @@
     License: APL-ND
 */
 params [["_vehicle", objNull, [objNull]]];
-private _fuelCargo = getFuelCargo _vehicle;
+
+private _maxFuelCargo = getNumber (configOf _vehicle/"transportFuel");
 private _maxAceFuelCargo = getNumber (configOf _vehicle/"ace_refuel_fuelCargo");
-[fuel _vehicle, _fuelCargo, if (A3A_hasAce) then { _vehicle getVariable ["ace_refuel_currentFuelCargo",_maxAceFuelCargo] } else {nil} ];
+if (HR_GRG_reduceState and (_maxFuelCargo <= 0 and _maxAceFuelCargo <= 0)) exitWith { fuel _vehicle };
+[fuel _vehicle, getFuelCargo _vehicle, _vehicle getVariable ["ace_refuel_currentFuelCargo", _maxAceFuelCargo]];

--- a/A3A/addons/garage/StatePreservation/fn_setAmmoData.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_setAmmoData.sqf
@@ -26,6 +26,8 @@
             ] Pylon data
         ]
     ] Ammo Data
+    or
+    <Scalar> Total vehicle ammo
 
     Return Value:
     <Nil>
@@ -42,7 +44,10 @@
 params ["_vehicle", "_ammoData"];
 if !(local _vehicle) exitWith {};
 if (_ammoData isEqualTo []) exitWith {};
-if (HR_GRG_hasAmmoSource && !HR_GRG_ServiceDisabled_Rearm) exitWith {};
+if (HR_GRG_hasAmmoSource && !(HR_GRG_ServiceDisabled_Rearm || HR_GRG_useNewRearmSys)) exitWith {};
+
+if (_ammoData isEqualType 0) exitWith { _vehicle setVehicleAmmo _ammoData };
+
 private _weaponData = _ammoData select {!(_x#0)};
 private _pylonData = _ammoData - _weaponData;
 

--- a/A3A/addons/garage/StatePreservation/fn_setDamage.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_setDamage.sqf
@@ -10,6 +10,8 @@
             <Array> Hitpoint damage
             <Scalar> Repair cargo
         ] Damage state
+        or
+        <Scalar> Overall damage
 
     Return Value: <nil>
 
@@ -24,8 +26,11 @@
 */
 params ["_vehicle", "_dmgStats"];
 if !(local _vehicle) exitWith {};
-_dmgStats params [["_dmg",0,[0]], ["_hitDmg", [], [[]]], ["_repairCargo", -1, [0]]];
+
 private _restoreState = [0,1] select (HR_GRG_hasRepairSource && !HR_GRG_ServiceDisabled_Repair);
+if (_dmgStats isEqualType 0) exitWith { _vehicle setDamage ([_dmg, 0] # _restoreState) };
+
+_dmgStats params [["_dmg",0,[0]], ["_hitDmg", [], [[]]], ["_repairCargo", -1, [0]]];
 _vehicle setDamage ([_dmg, 0] # _restoreState);
 
 if (_hitDmg#0 isEqualTo []) then {_hitDmg = _hitDmg#1}; //temp compat while testing, old had selection names we no longer care about those

--- a/A3A/addons/garage/StatePreservation/fn_setDamage.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_setDamage.sqf
@@ -28,7 +28,7 @@ params ["_vehicle", "_dmgStats"];
 if !(local _vehicle) exitWith {};
 
 private _restoreState = [0,1] select (HR_GRG_hasRepairSource && !HR_GRG_ServiceDisabled_Repair);
-if (_dmgStats isEqualType 0) exitWith { _vehicle setDamage ([_dmg, 0] # _restoreState) };
+if (_dmgStats isEqualType 0) exitWith { _vehicle setDamage ([_dmgStats, 0] # _restoreState) };
 
 _dmgStats params [["_dmg",0,[0]], ["_hitDmg", [], [[]]], ["_repairCargo", -1, [0]]];
 _vehicle setDamage ([_dmg, 0] # _restoreState);

--- a/A3A/addons/garage/StatePreservation/fn_setFuel.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_setFuel.sqf
@@ -26,7 +26,7 @@
 */
 params ["_vehicle", "_fuelStats"];
 if !(local _vehicle) exitWith {};
-if (_fuelStats isEqualType 0) exitWith {_vehicle setFuel _fuel};
+if (_fuelStats isEqualType 0) exitWith {_vehicle setFuel _fuelStats};
 
 _fuelStats params [["_fuel",1, [0]], ["_fuelCargo",-1,[0]], "_aceFuel"];
 _vehicle setFuel _fuel;

--- a/A3A/addons/garage/StatePreservation/fn_setFuel.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_setFuel.sqf
@@ -10,6 +10,8 @@
             <Int> Fuel cargo
             <Int> Ace Fuel cargo
         ] Fuel state
+        or
+        <Scalar> Fuel
 
     Return Value: <nil>
 
@@ -24,6 +26,8 @@
 */
 params ["_vehicle", "_fuelStats"];
 if !(local _vehicle) exitWith {};
+if (_fuelStats isEqualType 0) exitWith {_vehicle setFuel _fuel};
+
 _fuelStats params [["_fuel",1, [0]], ["_fuelCargo",-1,[0]], "_aceFuel"];
 _vehicle setFuel _fuel;
 _vehicle setFuelCargo _fuelCargo;

--- a/A3A/addons/garage/StatePreservation/fn_setState.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_setState.sqf
@@ -61,7 +61,7 @@
 */
 params [["_vehicle", objNull, [objNull]], ["_state", [], [[]]]];
 if (isNull _vehicle) exitWith {};
-_state params [["_fuelStats", 1, [[],0]], ["_dmgStats", 0, [[],0]], ["_ammoStats", 1, [[],0]], ["_ammoCargo", [], [[]]]];
+_state params [["_fuelStats", 1, [[],0]], ["_dmgStats", 0, [[],0]], ["_ammoStats", [], [[],0]], ["_ammoCargo", [], [[]]]];
 
 [_vehicle, _fuelStats] call HR_GRG_fnc_setFuel;
 [_vehicle, _dmgStats] call HR_GRG_fnc_setDamage;

--- a/A3A/addons/garage/StatePreservation/fn_setState.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_setState.sqf
@@ -61,7 +61,7 @@
 */
 params [["_vehicle", objNull, [objNull]], ["_state", [], [[]]]];
 if (isNull _vehicle) exitWith {};
-_state params [["_fuelStats", [], [[]]], ["_dmgStats", [], [[]]], ["_ammoStats", [], [[]]], ["_ammoCargo", [], [[]]]];
+_state params [["_fuelStats", 1, [[],0]], ["_dmgStats", 0, [[],0]], ["_ammoStats", 1, [[],0]], ["_ammoCargo", [], [[]]]];
 
 [_vehicle, _fuelStats] call HR_GRG_fnc_setFuel;
 [_vehicle, _dmgStats] call HR_GRG_fnc_setDamage;

--- a/A3A/addons/gui/functions/RRR/fn_vehServiceDialog.sqf
+++ b/A3A/addons/gui/functions/RRR/fn_vehServiceDialog.sqf
@@ -385,7 +385,6 @@ switch (_mode) do
 
         ([_mode, getPosATL player, 25] call A3A_fnc_lookForSupplyVehicle) params ["_selSupplyVehicle", "_remCargo"];
         _display setVariable ["A3A_supplyVehicle", _selSupplyVehicle];
-        if (isNil "A3A_itemPriceCache") then { A3A_itemPriceCache = createHashMap };
 
         switch (_mode) do {
             case "rearm": {

--- a/A3A/addons/gui/functions/gunShop/fn_gatherGunShopLists.sqf
+++ b/A3A/addons/gui/functions/gunShop/fn_gatherGunShopLists.sqf
@@ -35,9 +35,6 @@ private _fnc_generateList = {
 // Clear the data, so other functions know it's in progress
 A3A_gunShopData = createHashMap;
 
-// Set up the item price cache
-if (isNil "A3A_itemPriceCache") then { A3A_itemPriceCache = createHashMap };
-
 // Build arsenal item quantity lookup table
 private _arsenalCountHM = createHashMap;
 { _arsenalCountHM insert _x } forEach ((jna_dataList select [0,3]) + (jna_dataList select [18,9]));


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [X] Change
3. [X] Enhancement

### What have you changed and why?
- Fixed a bug where the state of garrison vehicles wasn't being saved, and extended saving to statics.
- Optimized vehicle state saving so that it uses less space when it doesn't need to store the full hitpoint damage or magazine arrays. The new data won't break older garage versions but information will be lost. Other compatibility cases should all work.


### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

Need to test some corner cases that may have been broken already, like pylons and various cargos.