### PR TITLE
Remove income dependence on map resource/factory counts

### DIFF
--- a/A3A/addons/core/functions/init/fn_initZones.sqf
+++ b/A3A/addons/core/functions/init/fn_initZones.sqf
@@ -275,6 +275,12 @@ A3A_rebelHRTickMult = 10 / _sumPop;
 // Goal for lump sum is to fill garrisons
 A3A_rebelHRLumpMult = _reqGarrison / _sumPop;
 
+// Goal for resources is ~4k per tick lategame, most from resources
+// Factories multiply by 2x total, so 1k + 1.5k
+A3A_rebelCashPopMult = 1000 / _sumPop;
+A3A_rebelCashResMult = 1500 / count resourcesX;
+A3A_rebelCashFactMult = 1.4 / count factories;
+
 // Set typical number of city battles equal to number of outposts
 private _allPops = citiesX apply { sqrt (A3A_cityPop get _x) };
 _allPops sort false;		// largest first

--- a/A3A/addons/core/functions/init/fn_resourcecheck.sqf
+++ b/A3A/addons/core/functions/init/fn_resourcecheck.sqf
@@ -15,9 +15,7 @@ while {true} do
 	private _resAdd = 50;//0
 	private _hrAdd = 2; // A3A_balancePlayerScaleBase;
 
-	private _suppBoost = 0.5 * (1+ ({sidesX getVariable [_x,sideUnknown] == teamPlayer} count seaports));
-	private _resBoost = 1 + (0.25*({(sidesX getVariable [_x,sideUnknown] == teamPlayer) and !(_x in destroyedSites)} count factories));
-
+	//private _suppBoost = 0.5 * (1+ ({sidesX getVariable [_x,sideUnknown] == teamPlayer} count seaports));
 	{
 		private _city = _x;
 		if (_city in destroyedSites) then { continue };
@@ -26,7 +24,7 @@ while {true} do
 		_cityData params ["_numCiv", "_supportReb"];
 
 		private _ownerMul = [0.5, 1] select (sidesX getVariable _city == teamPlayer);
-		private _resAddCity = _ownerMul * sqrt _numCiv * (_supportReb / 100);
+		private _resAddCity = _ownerMul * sqrt _numCiv * (_supportReb / 100) * A3A_rebelCashPopMult;
 		private _hrAddCity = _ownerMul * sqrt _numCiv * (_supportReb / 100) * A3A_rebelHRTickMult;
 
 		_resAdd = _resAdd + _resAddCity;
@@ -37,12 +35,12 @@ while {true} do
 	[] call A3A_fnc_tierCheck;
 	[] spawn A3A_fnc_checkCampaignEnd; // check for population win
 
-	{
-		if ((sidesX getVariable [_x,sideUnknown] == teamPlayer) and !(_x in destroyedSites)) then
-		{
-			_resAdd = _resAdd + (300 * _resBoost);
-		};
-	} forEach resourcesX;
+	private _resourcesRebel = {sidesX getVariable _x == teamPlayer and !(_x in destroyedSites)} count resourcesX;
+	_resAdd = _resAdd + _resourcesRebel * A3A_rebelCashResMult;
+
+	private _factoriesRebel = {sidesX getVariable _x == teamPlayer and !(_x in destroyedSites)} count factories;
+	private _resBoost = 1 + _factoriesRebel * A3A_rebelCashFactMult;
+	_resAdd = _resAdd * _resBoost;
 
 	Debug_2("Occupant radio keys: %1 - Invader radio keys: %2", occRadioKeys, invRadioKeys);
 


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Rebalanced cash income and removed overall dependence on resource, factory and population counts. All maps should now give a typical ~4k income in lategame.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
