### PR TITLE
Added situational counterattacks

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -132,6 +132,7 @@ class CfgFunctions
             class citySideChange {};
             class citySupportChange {};
             class commsMP {};
+            class considerCounterattack {};
             class createBreachChargeText {};
             class createOutpostsFIA {};
             class createPetros {};

--- a/A3A/addons/core/functions/Base/fn_aggressionUpdateLoop.sqf
+++ b/A3A/addons/core/functions/Base/fn_aggressionUpdateLoop.sqf
@@ -73,6 +73,7 @@ while {true} do
         A3A_resourcesDefenceOcc = (A3A_resourcesDefenceOcc + _resRateDef) min _maxDef;
         A3A_resourcesAttackOcc = A3A_resourcesAttackOcc + _resRateAtk;
 
+        A3A_choosingAttack = true;
         if (A3A_resourcesAttackOcc > 0 && !bigAttackInProgress) then
         {
             private _success = [Occupants] call A3A_fnc_chooseAttack;
@@ -81,6 +82,7 @@ while {true} do
                 A3A_resourcesAttackOcc = A3A_resourcesAttackOcc - _resRateAtk*10;
             };
         };
+        A3A_choosingAttack = nil;
     };
 
     if (gameMode != 3) then
@@ -102,6 +104,7 @@ while {true} do
         A3A_resourcesDefenceInv = (A3A_resourcesDefenceInv + _resRateDef) min _maxDef;
         A3A_resourcesAttackInv = A3A_resourcesAttackInv + _resRateAtk;
 
+        A3A_choosingAttack = true;
         if (A3A_resourcesAttackInv > 0 && !bigAttackInProgress) then
         {
             private _success = [Invaders] call A3A_fnc_chooseAttack;
@@ -110,6 +113,7 @@ while {true} do
                 A3A_resourcesAttackInv = A3A_resourcesAttackInv - _resRateAtk*10;
             };
         };
+        A3A_choosingAttack = nil;
     };
 
     {

--- a/A3A/addons/core/functions/Base/fn_considerCounterattack.sqf
+++ b/A3A/addons/core/functions/Base/fn_considerCounterattack.sqf
@@ -13,7 +13,7 @@ FIX_LINE_NUMBERS()
 params ["_target", "_enemySide"];
 
 // okay. So sleep for some random time first... Balance dependent?
-//sleep (random 120);
+sleep (random 120);
 
 private _targetsAndWeights = [teamPlayer, _enemySide, [_target]] call A3A_fnc_findAttackTargets;
 _targetsAndWeights params ["_targets", "_weights"];

--- a/A3A/addons/core/functions/Base/fn_considerCounterattack.sqf
+++ b/A3A/addons/core/functions/Base/fn_considerCounterattack.sqf
@@ -1,0 +1,46 @@
+/*
+Maintainer: John Jordan
+    Decide whether to launch a counterattack against a location that an enemy just lost to rebels
+
+Arguments:
+    <STRING> Target marker
+    <SIDE> Source side for attack
+
+*/
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+
+params ["_target", "_enemySide"];
+
+// okay. So sleep for some random time first... Balance dependent?
+//sleep (random 120);
+
+private _targetsAndWeights = [teamPlayer, _enemySide, [_target]] call A3A_fnc_findAttackTargets;
+_targetsAndWeights params ["_targets", "_weights"];
+private _total = 0; _weights apply { _total = _total + _x };
+private _valueProb = linearConversion [0.2, 0.7, _total, 0, 1, true];
+
+private _attackResources = [A3A_resourcesAttackOcc, A3A_resourcesAttackInv] select (_enemySide == Invaders);
+private _resourceProb = linearConversion [-1000, -200, _attackResources, 0, 1, true];
+
+Debug_3("Checking counterAttack against %1 with %2 valueProb and %3 resourceProb", _target, _valueProb, _resourceProb);
+if (_attackResources > -200) exitWith { Debug_1("Aborted counterattack vs %1 because attack is nearly ready", _target) };
+if (_valueProb * _resourceProb < 0.3 + random 0.4) exitWith {
+    Debug_1("Aborted counterattack vs %1 due to low value", _target);
+};
+
+isNil {
+    if (!isNil "A3A_choosingAttack") exitWith { Debug_1("Aborted counterattack vs %1 due to choosing attack", _target) };
+    if (sidesX getVariable _target != teamPlayer) exitWith { Debug_1("Aborted counterattack vs %1 due to side switch", _target) };
+    if (bigAttackInProgress) exitWith { Debug_1("Aborted counterattack vs %1 due to attack in progress", _target) };
+
+    private _targetData = _targets selectRandomWeighted _weights;
+    _targetData params ["_targetMrk", "_originMrk", "_targetValue", "_localThreat", "_flyoverThreat", "_countLandAttackBases"];
+    Debug_1("Selected attack is %1", _targetData);
+
+    // Sending real attack, execute the fight
+    Info_2("Starting counterattack from %1 to %2", _originMrk, _targetMrk);
+    [-250, _enemySide, "attack"] call A3A_fnc_addEnemyResources;             // more expensive than usual, rushed
+    bigAttackInProgress = true; publicVariable "bigAttackInProgress";
+    [_targetMrk, _originMrk, 1, true] spawn A3A_fnc_wavedAttack;
+};

--- a/A3A/addons/core/functions/Base/fn_findAttackTargets.sqf
+++ b/A3A/addons/core/functions/Base/fn_findAttackTargets.sqf
@@ -5,6 +5,7 @@ Maintainer: John Jordan
 Arguments:
     <SIDE> Target side
     <SIDE> Attacking side
+    <ARRAY> Optional: List of target locations to check. Must match target side
 
 Return Value:
     <ARRAY,ARRAY> [targets, weights]
@@ -14,20 +15,22 @@ Return Value:
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
 
-params ["_targetSide", "_side"];
+params ["_targetSide", "_side", "_possibleTargets"];
 
 
 private _possibleStartBases = airportsX select {sidesX getVariable [_x, sideUnknown] == _side} select { [_x] call A3A_fnc_airportCanAttack };
 _possibleStartBases pushBack (["NATO_carrier", "CSAT_carrier"] select (_side == Invaders));
 private _airportPositions = _possibleStartBases apply { markerPos _x };
 
-private _possibleTargets = airportsX + outposts + seaports + factories + resourcesX + (citiesX - destroyedSites);
-//if (_targetSide == teamPlayer) then {_possibleTargets = _possibleTargets + citiesX};      // enemy cities are now valid targets
-_possibleTargets = _possibleTargets select {sidesX getVariable [_x,sideUnknown] == _targetSide};
+if (isNil "_possibleTargets") then {
+    _possibleTargets = airportsX + outposts + seaports + factories + resourcesX + (citiesX - destroyedSites);
+    //if (_targetSide == teamPlayer) then {_possibleTargets = _possibleTargets + citiesX};      // enemy cities are now valid targets
+    _possibleTargets = _possibleTargets select {sidesX getVariable _x == _targetSide};
 
-// Add rebel HQ as attack target if the enemy side knows about it
-private _hqInfo = [A3A_curHQInfoOcc, A3A_curHQInfoInv] select (_side == Invaders);
-if (_targetSide == teamPlayer and _hqInfo >= 1) then { _possibleTargets pushBack "Synd_HQ" };
+    // Add rebel HQ as attack target if the enemy side knows about it
+    private _hqInfo = [A3A_curHQInfoOcc, A3A_curHQInfoInv] select (_side == Invaders);
+    if (_targetSide == teamPlayer and _hqInfo >= 1) then { _possibleTargets pushBack "Synd_HQ" };
+};
 
 if (count _possibleTargets == 0 || count _possibleStartBases == 0) exitWith {
     Info("Attack found no suitable targets or no suitable start bases, aborting!"); [[], []];
@@ -49,7 +52,7 @@ private _maxThreatDist = distanceForAirAttack + 1000;
     private _garrison = A3A_garrison get _x;
     private _threat = if (_markerSide == teamPlayer) then {
         private _threat = 10 * count (_garrison get "troops");
-        _threat + 50 * count (_garrison get "vehicles");          // TODO: do this properly
+        _threat + 50 * count (_garrison get "vehicles");          // TODO: do this properly. Tricky to tell what's crewed though
     } else {
         // based on typical static count
         private _threat = 10 * (_garrison get "troops" select 0);
@@ -63,7 +66,7 @@ private _maxThreatDist = distanceForAirAttack + 1000;
     //Debug_2("Marker %1, threat %2", _x, _threat);           // temp, disable for release
     if (_threat == 0) then { continue };
     _markersXYT pushBack [markerPos _x # 0, markerPos _x # 1, _threat];
-} forEach (markersX + controlsX + outpostsFIA);
+} forEach (markersX);       // + controlsX + outpostsFIA);      Remove roadblocks from threat, causes odd decisions
 
 
 private _lowAir = Faction(_side) getOrDefault ["attributeLowAir", false];

--- a/A3A/addons/core/functions/Base/fn_markerChange.sqf
+++ b/A3A/addons/core/functions/Base/fn_markerChange.sqf
@@ -51,30 +51,10 @@ if (_scripted) exitWith {
 	if (_winner != teamPlayer) then { [_markerX] call A3A_fnc_buildEnemyGarrison };
 };
 
-// Generate counterattack
-/*if (_winner == teamPlayer) then
-{
-	// Cap to 0.6 max to reward captures without previous support calls
-	private _resources = [_loser, teamPlayer, _markerX, 0.6] call A3A_fnc_maxDefenceSpend;
-
-	// Don't send anything if it'd be too small
-	private _minAttack = (1 + random 0.5) * A3A_balanceResourceRate;
-	if (_resources < _minAttack) exitWith {
-		Debug_2("Available resources (%1) below minimum attack (%2), sending no counterattack", _resources, _minAttack);
-	};
-
-	private _vehCount = round (random 0.5 + _resources / A3A_balanceVehicleCost);
-	private _reveal = [markerPos _markerX] call A3A_fnc_calculateSupportCallReveal;
-	_reveal = [_loser, markerPos _markerX, _reveal] call A3A_fnc_useRadioKey;
-
-	// Run on server for now because it needs availableBases functions
-	[_markerX, _loser, _vehCount, _reveal] spawn A3A_fnc_singleAttack;
-
-	// just estimates here. 
-	A3A_supportStrikes pushBack [_loser, "TROOPS", markerPos _markerX, time + 2700, 2700, _resources];
-    A3A_supportSpends pushBack [_loser, markerPos _markerX, markerPos _markerX, _resources, time];
+// Generate counterattack if appropriate
+if (_winner == teamPlayer) then {
+	[_markerX, _loser] spawn A3A_fnc_considerCounterattack;
 };
-*/
 
 private _loserName = Faction(_loser) get "name";
 private _prestigeOccupants = [0, 0];


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Added situational counterattacks using a single-wave major attack. They're triggered when rebels capture a (non-city) site from an enemy. They're more likely if that enemy is close to launching a major attack, and if the site is a good attack target (area is relatively friendly for enemies).

Not sure on the probability yet. It likely works out as "occasional", like 1 in 10 captures.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)
