### PR TITLE
Various garrison/reinf fixes

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -376,6 +376,7 @@ class CfgFunctions
             class garrisonServer_clear {};
             class garrisonServer_delete {};
             class garrisonServer_despawn {};
+            class garrisonServer_initVIDs {};
             class garrisonServer_looted {};
             class garrisonServer_remUnit {};
             class garrisonServer_remUnitType {};

--- a/A3A/addons/core/functions/CREATE/fn_patrolReinf.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_patrolReinf.sqf
@@ -7,8 +7,11 @@ private _lowAir = _faction getOrDefault ["attributeLowAir", false];
 private _posDest = getMarkerPos _mrkDest;
 private _posOrigin = getMarkerPos _mrkOrigin;
 
-private _squadTypes = [[_faction get "groupPoliceSquad"], (_faction get "groupsMilitiaSquads") + (_faction get "groupsMilitiaMedium"),
-	(_faction get "groupsSquads") + (_faction get "groupsMedium"), _faction get "groupSpecOpsRandom"];
+private _squadTypes = if (_numTroops <= 4) then {
+	[[_faction get "groupPoliceSquad"], _faction get "groupsMilitiaMedium", _faction get "groupsMedium", _faction get "groupSpecOpsRandom"];
+} else {
+	[[_faction get "groupPoliceSquad"], _faction get "groupsMilitiaSquads", _faction get "groupsSquads", _faction get "groupSpecOpsRandom"];
+};
 private _groupType = selectRandom (_squadTypes select round _quality);
 
 ServerInfo_5("Spawning PatrolReinf. Dest:%1 Orig:%2 Size:%3 Side:%4 Land:%5",_mrkDest,_mrkOrigin,_numTroops,_side,_isLand);
@@ -25,7 +28,7 @@ private _vehicleType = if (_isLand) then {
 } else {
 	private _transportPlanes = _faction get "vehiclesPlanesTransport";
 	private _transportHelis = _faction get "vehiclesHelisTransport";
-	if (count _groupType <= 4 and (count (_faction get "vehiclesHelisLight")) > 0) then { _transportHelis = (_faction get "vehiclesHelisLight") };
+	if (count _groupType <= 4 and count (_faction get "vehiclesHelisLight") > 0) then { _transportHelis = _faction get "vehiclesHelisLight" };
 
 	private _transportsWeighted = [];
 	{ _transportsWeighted append [_x, 1 / count _transportPlanes] } forEach _transportPlanes;

--- a/A3A/addons/core/functions/CREATE/fn_reinforceSide.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_reinforceSide.sqf
@@ -54,7 +54,7 @@ private _weights = [];
     if !(_marker in A3A_spawnPlaceStats) then { continue };     // roadblock/camp don't reinforce vehicles atm
 
     // Filter out rebel leftovers
-    private _usedPlaces = (_garrison get "vehicles") select {count _x == 2} apply {_x#1};
+    private _usedPlaces = (_garrison get "vehicles") select {_x#1 isEqualType 0} apply {_x#1};
     {
         if (_x in _noPlaceTypes) then { continue };     // Faction has no vehicles to put here
         _y params ["_places", "_max", "_par"];

--- a/A3A/addons/core/functions/CREATE/fn_reinforceVehicle.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_reinforceVehicle.sqf
@@ -20,6 +20,8 @@ params ["_side", "_marker", "_slotType", "_vehClass"];
 
 sleep 300;          // lazy code, should check nearest base
 
+isNil {
+
 // Now check if garrison has enemies nearby
 private _nearRebels = units teamPlayer inAreaArray [markerPos _marker, 700, 700];
 if (-1 != _nearRebels findIf { _x getVariable ["spawner", false] }) exitWith {
@@ -32,7 +34,7 @@ if (sidesX getVariable _marker != _side) exitWith {
 // Determine free places. Can't re-use reinf code due to delay
 private _garrison = A3A_garrison get _marker;
 private _faction = [A3A_faction_occ, A3A_faction_inv] select (_side == Invaders);
-private _usedPlaces = (_garrison get "vehicles") select {count _x == 2} apply {_x#1};
+private _usedPlaces = (_garrison get "vehicles") select {_x#1 isEqualType 0} apply {_x#1};
 private _possiblePlaces = A3A_spawnPlaceStats get _marker get _slotType select 0;
 private _places = _possiblePlaces - _usedPlaces;
 if (_places isEqualTo []) exitWith {
@@ -44,3 +46,5 @@ private _placeNum = if (_slotType == "vehicle") then { _places # 0 } else { sele
 Info_2("Reinforcing %1 with vehicle %2", _marker, _vehClass);
 
 [-(A3A_vehicleResourceCosts get _vehClass), _side, "defence"] call A3A_fnc_addEnemyResources;
+
+};

--- a/A3A/addons/core/functions/CREATE/fn_reinforcementsAI.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_reinforcementsAI.sqf
@@ -74,19 +74,20 @@ if (AAFpatrols < round (3 * A3A_balancePlayerScale) and (random 2 < A3A_balanceP
     private _placeStats = A3A_spawnPlaceStats get _spawnKey;
     _placeStats get "civCar" params ["_places", "_max", "_par"];
 
-    private _vehicles = A3A_garrison get _spawnKey get "vehicles";
-    private _usedPlaces = _vehicles select {_x#1 in _places} apply {_x#1};		// warning, _x#1 might be position
+    isNil {
+        private _vehicles = A3A_garrison get _spawnKey get "vehicles";
+        private _usedPlaces = _vehicles select {_x#1 isEqualType 0} apply {_x#1};
 
-    // Each missing car has a ~1/100 chance of being replaced each tick at tier 1
-    private _chance = 50 * (1 + tierWar);
-    if (random _chance > _par - count _usedPlaces) then { continue };
+        // Each missing car has a ~1/100 chance of being replaced each tick at tier 1
+        private _chance = 50 * (1 + tierWar);
+        if (random _chance > _par - count _usedPlaces) exitWith {};     // continue does not work inside isNil
 
-    // Add a car
-    private _type = selectRandomWeighted civVehiclesWeighted;
-    private _placeNum = selectRandom (_places - _usedPlaces);
-    _vehicles pushBack [_type, _placeNum];
-    Debug_2("Added car %1 at %2", _type, _x);
-
+        // Add a car
+        private _type = selectRandomWeighted civVehiclesWeighted;
+        private _placeNum = selectRandom (_places - _usedPlaces);
+        [_spawnKey, _type, _placeNum] call A3A_fnc_garrisonServer_addVehicleType;
+        Debug_2("Added car %1 at %2", _type, _x);
+    };
 } forEach (citiesX - destroyedSites);
 
 
@@ -111,18 +112,10 @@ if (AAFpatrols < round (3 * A3A_balancePlayerScale) and (random 2 < A3A_balanceP
     Debug_3("Adjusting troop quality from %1 to %2 at %3", _quality, _newQuality, _marker);
     _garrison get "troops" set [1, _newQuality * 0.2 + _quality * 0.8];
 
-    private _vehicles = _garrison get "vehicles";
-    private _spawnStats = A3A_spawnPlaceStats get _marker;
-    if (_vehicles isEqualTo [] or isNil "_spawnStats") then { continue };
-
-    private _spawnPlaces = A3A_spawnPlacesHM get _marker;
-    private _usedPlaces = _vehicles select {count _x == 2} apply {_x#1};		// filter not necessary as it's despawned, but whatever
-    private _faction = [A3A_faction_occ, A3A_faction_inv] select (_side == Invaders);
-
     private _fnc_changeVehicle = {
         private _vehEntry = selectRandom _vehicles;
         if (isNil "_vehEntry") exitWith {};
-        if (_vehEntry#0 in A3A_supportVehTypes) then {continue};        // too much faff, don't bother
+        if (_vehEntry#0 in A3A_supportVehTypes) exitWith {};        // too much faff, don't bother
 
         private _placeType = _spawnPlaces#(_vehEntry#1)#0;
         if !("static" in _placeType) then {
@@ -141,7 +134,18 @@ if (AAFpatrols < round (3 * A3A_balancePlayerScale) and (random 2 < A3A_balanceP
         _vehEntry set [1, selectRandom _places];
         Debug_3("Moving %1 to place %2 at %3", _vehEntry#0, _vehEntry#1, _marker); 
     };
-    call _fnc_changeVehicle;
-    if (_siteType == "airport") then { call _fnc_changeVehicle; call _fnc_changeVehicle };
 
+    // Lockout so garrison can't change underneath us
+    isNil {
+        private _vehicles = _garrison get "vehicles";
+        private _spawnStats = A3A_spawnPlaceStats get _marker;
+        if (_vehicles isEqualTo [] or isNil "_spawnStats") exitWith {};     // continue doesn't work in isNil
+
+        private _spawnPlaces = A3A_spawnPlacesHM get _marker;
+        private _usedPlaces = _vehicles select {_x#1 isEqualType 0} apply {_x#1};
+        private _faction = [A3A_faction_occ, A3A_faction_inv] select (_side == Invaders);
+
+        call _fnc_changeVehicle;
+        if (_siteType == "airport") then { call _fnc_changeVehicle; call _fnc_changeVehicle };
+    };
 } forEach markersX;

--- a/A3A/addons/core/functions/GarrisonServer/fn_buildEnemyGarrison.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_buildEnemyGarrison.sqf
@@ -36,7 +36,7 @@ private _siteType = call {
 private _quality = [_siteType, _marker, _side] call A3A_fnc_getSiteTroopQuality;
 
 // Might be used to rebuild a garrison after a sim capture, so keep the old static info if it exists
-private _garrison = A3A_garrison getOrDefaultCall [_marker, {createHashMap}];
+private _garrison = A3A_garrison getOrDefaultCall [_marker, {createHashMap}, true];
 _garrison set ["buildings", []];
 private _troopCount = (0.7 + random 0.3) * (A3A_garrisonSize get _marker);
 _garrison set ["troops", [ceil _troopCount, _quality]];
@@ -60,6 +60,10 @@ private _vehicles = [];
 } forEach _spawnPlaceStats;
 
 _garrison set ["vehicles", _vehicles];
-A3A_garrison set [_marker, _garrison];
+
+if (!isNil "serverInitDone") then {
+    // If we're using this function after init then we need recreate the vehicle IDs
+    [_marker] call A3A_fnc_garrisonServer_initVIDs;
+};
 
 _garrison;

--- a/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_cleanup.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_cleanup.sqf
@@ -72,6 +72,7 @@ private _places = A3A_spawnPlacesHM get _marker;
 private _valid = A3A_validVehicles get _side;
 private _isAirport = _marker in airportsX;
 
+private _usedSlots = [];
 private _vehicles = _garrison get "vehicles";
 {
     _x params ["_vehType", "_slotNum", "", "_vehID"];
@@ -83,6 +84,14 @@ private _vehicles = _garrison get "vehicles";
         Debug_1("Refunding %1", _vehType);
         continue;
     };
+
+    // Temporary code to clean up 3.10.3 reinf bugs
+    if (_slotNum in _usedSlots) then {
+        _vehicles deleteAt _forEachIndex;
+        (_garrison get "supportVehicles") deleteAt _vehID;
+        Debug_2("Clearing excess vehicle %1 in slot %2", _vehType, _slotNum);
+    };
+    _usedSlots pushBack _slotNum;
 
     private _slotType = _places # _slotNum # 0;
     if !(_vehType in (_valid get _slotType)) then {

--- a/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_cleanup.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_cleanup.sqf
@@ -39,6 +39,11 @@ if ("_civ" in _marker) exitWith
         };
 
         private _slotType = if (_slotNum isEqualType []) then { "civBoat" } else { _places # _slotNum # 0 };
+        // Temporary fix for boats being mangled in 3.10.3
+        if (_slotType == "civBoat" and {_slotNum#0 isEqualType []}) then {
+            Debug_3("Fixing incorrect boat format for %1, pos %2, dir %3", _vehType, _slotNum#0, _slotNum#1);
+            _x set [2, _slotNum#1]; _x set [1, _slotNum#0];
+        };
         if !(_vehType in (_valid get _slotType)) then {
             Debug_2("%1 (slot type %2) not valid, swapping", _vehType, _slotType);
             if (_slotType == "civCar") exitWith { _x set [0, selectRandomWeighted civVehiclesWeighted] };

--- a/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_cleanup.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_cleanup.sqf
@@ -38,12 +38,13 @@ if ("_civ" in _marker) exitWith
             continue;
         };
 
-        private _slotType = if (_slotNum isEqualType []) then { "civBoat" } else { _places # _slotNum # 0 };
         // Temporary fix for boats being mangled in 3.10.3
-        if (_slotType == "civBoat" and {_slotNum#0 isEqualType []}) then {
+        if (_slotNum isEqualType [] and {_slotNum#0 isEqualType []}) then {
             Debug_3("Fixing incorrect boat format for %1, pos %2, dir %3", _vehType, _slotNum#0, _slotNum#1);
             _x set [2, _slotNum#1]; _x set [1, _slotNum#0];
         };
+
+        private _slotType = if (_slotNum isEqualType []) then { "civBoat" } else { _places # _slotNum # 0 };
         if !(_vehType in (_valid get _slotType)) then {
             Debug_2("%1 (slot type %2) not valid, swapping", _vehType, _slotType);
             if (_slotType == "civCar") exitWith { _x set [0, selectRandomWeighted civVehiclesWeighted] };

--- a/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_initVIDs.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_initVIDs.sqf
@@ -1,0 +1,33 @@
+/*
+    Server-side function for adding IDs to garrison vehicles and initializing the support data
+
+    Environment: Unscheduled, server
+
+    Arguments:
+    <STRING> Marker name of garrison.
+
+    Copyright 2025 John Jordan. All Rights Reserved.
+    Used and distributed by the Antistasi Community project with permission.
+*/
+
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+
+params ["_marker"];
+
+private _garrison = A3A_garrison get _marker;
+private _nextID = 1;
+{ _x set [3, _nextID]; _nextID = _nextID + 1 } forEach (_garrison get "vehicles");
+//{ _x set [4, _nextID]; _nextID = _nextID + 1 } forEach (_garrison getOrDefault ["buildings", []]);     // cities don't have buildings
+
+// Register support vehicles in garrison (arty, SAM etc)
+// Uses hashmap of vehicle class -> support type
+// May as well run this for rebels too? Makes airfield swaps simpler
+private _supportVehicles = createHashMap;
+{
+    private _supportType = A3A_supportVehTypes get _x#0;
+    _supportVehicles set [_x#3, ["ready", _supportType, _x]];
+} forEach (_garrison get "vehicles" select {_x#0 in A3A_supportVehTypes});
+
+_garrison set ["supportVehicles", _supportVehicles];
+_garrison set ["nextVehID", _nextID];

--- a/A3A/addons/core/functions/Save/fn_loadServer.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadServer.sqf
@@ -88,6 +88,7 @@ if (isServer) then {
 	// Convert to internal vehicle format
 	if (!_garrisonCompat) then {			// TODO: Change save format after another version  => and A3A_saveVersion < 31200
 		{
+			if ("_civ" in _x) then {continue};			// city formats unchanged
 			{
 				_x set [1, [_x#1, _x#2, _x#3]];				// pos/dir/up
 				if (count _x == 5) then { _x set [2, _x#4]; _x resize 3 } else { _x resize 2 };		// move state & cap

--- a/A3A/addons/core/functions/init/fn_initMarkerTypes.sqf
+++ b/A3A/addons/core/functions/init/fn_initMarkerTypes.sqf
@@ -30,22 +30,6 @@ A3A_garrison get "Synd_HQ" set ["type", "hq"];
 } forEach controlsX;
 
 {
-    // Add numerical ID to each garrison vehicle & building for tracking
-    private _garrison = _y;
-    private _nextID = 1;
-    { _x set [3, _nextID]; _nextID = _nextID + 1 } forEach (_garrison get "vehicles");
-    //{ _x set [4, _nextID]; _nextID = _nextID + 1 } forEach (_garrison getOrDefault ["buildings", []]);     // cities don't have buildings
-
-    // Register support vehicles in garrison (arty, SAM etc)
-    // Uses hashmap of vehicle class -> support type
-    // May as well run this for rebels too? Makes airfield swaps simpler
-    private _supportVehicles = createHashMap;
-    {
-        private _supportType = A3A_supportVehTypes get _x#0;
-        _supportVehicles set [_x#3, ["ready", _supportType, _x]];
-    } forEach (_garrison get "vehicles" select {_x#0 in A3A_supportVehTypes});
-
-    _garrison set ["supportVehicles", _supportVehicles];
-    _garrison set ["nextVehID", _nextID];
-
+    // Add numerical ID to each garrison vehicle for tracking
+    [_x] call A3A_fnc_garrisonServer_initVIDs;
 } forEach A3A_garrison;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
- Fixed civ boats being broken by loadServer.
- Fixed multiple cases of reinf using the wrong check for vehicle formats.
- Added temporary fixes for save data broken by the bugs above.
- Fixed simulated capture not updating vehicle IDs & supports.
- Fixed civ vehicle reinf not adding vehicle ID.
- Added some unscheduled safety lockouts for reinf code.
- Changed patrolReinf to use appropriate squad sizes for the call

Gonna also check a potential ATL/AGL spawning issue with garrison vehicles later.

### Please specify which Issue this PR Resolves.
closes #3831

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)
