### PR TITLE
3.11.0 testing fixes 1

### DIFF
--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_ANZAC.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_ANZAC.sqf
@@ -53,15 +53,7 @@ private _vehiclesPlanesAA = ["vn_b_air_f4c_cap"];
 ["vehiclesPlanesTransport", []] call _fnc_saveToTemplate;
 private _vehiclesAirPatrol = ["vn_b_air_uh1d_02_01"];
 
-if (isClass (configFile >> "vnx_credits")) then {
-	_vehiclesPlanesCAS = ["vnx_b_air_a4e_ran_cas", "vnx_b_air_a4e_ran_cas", "vnx_b_air_a4e_rnzaf_cas", "vnx_b_air_ov10a_aus_covey"];
-	_vehiclesPlanesAA = ["vnx_b_air_a4e_ran_cap", "vnx_b_air_a4e_ran_cap", "vnx_b_air_a4e_rnzaf_cap"];
-	_vehiclesAirPatrol append ["vnx_b_air_ov10a_aus_covey"];
-};
 
-["vehiclesAirPatrol", _vehiclesAirPatrol] call _fnc_saveToTemplate;
-["vehiclesPlanesCAS", _vehiclesPlanesCAS] call _fnc_saveToTemplate;
-["vehiclesPlanesAA", _vehiclesPlanesAA] call _fnc_saveToTemplate;
 
 ["vehiclesHelisLight", ["vn_b_air_uh1c_07_06"]] call _fnc_saveToTemplate;
 ["vehiclesHelisTransport", ["vn_b_air_uh1d_02_06"]] call _fnc_saveToTemplate;
@@ -73,8 +65,20 @@ if (isClass (configFile >> "vnx_credits")) then {
 ["vn_b_nz_army_static_m101_02", ["vn_cannon_m101_mag_he_x8", "vn_cannon_m101_mag_ab_x8", "vn_cannon_m101_mag_wp_x8"]]
 ]] call _fnc_saveToTemplate;
 
-["uavsAttack", ["vnx_b_air_ov10a_aus_covey"]] call _fnc_saveToTemplate;
+private _uavsAttack = ["vn_b_air_oh6a_01"];
 ["uavsPortable", []] call _fnc_saveToTemplate;
+
+if (isClass (configFile >> "vnx_credits")) then {
+	_vehiclesPlanesCAS = ["vnx_b_air_a4e_ran_cas", "vnx_b_air_a4e_ran_cas", "vnx_b_air_a4e_rnzaf_cas", "vnx_b_air_ov10a_aus_covey"];
+	_vehiclesPlanesAA = ["vnx_b_air_a4e_ran_cap", "vnx_b_air_a4e_ran_cap", "vnx_b_air_a4e_rnzaf_cap"];
+	_vehiclesAirPatrol append ["vnx_b_air_ov10a_aus_covey"];
+	_uavsAttack = ["vnx_b_air_ov10a_aus_covey"];
+};
+
+["vehiclesAirPatrol", _vehiclesAirPatrol] call _fnc_saveToTemplate;
+["vehiclesPlanesCAS", _vehiclesPlanesCAS] call _fnc_saveToTemplate;
+["vehiclesPlanesAA", _vehiclesPlanesAA] call _fnc_saveToTemplate;
+["uavsAttack", _uavsAttack] call _fnc_saveToTemplate;
 
 //Config special vehicles
 ["vehiclesMilitiaLightArmed", ["vn_b_wheeled_m151_mg_02_nz_army", "vn_b_wheeled_lr2a_mg_01_nz_army"]] call _fnc_saveToTemplate;
@@ -268,7 +272,6 @@ _militaryLoadoutData set ["binoculars", ["vn_mk21_binocs"]];
 
 _militaryLoadoutData set ["rifles", [
 ["vn_m16", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
-["vn_m16_camo", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
 ["vn_l1a1_01", "", "vn_b_l1a1", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], [], ""],
 ["vn_l1a1_01", "", "vn_b_l1a1", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], [], ""],
 ["vn_l1a1_01_camo", "", "vn_b_l1a1", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], [], ""],
@@ -276,7 +279,6 @@ _militaryLoadoutData set ["rifles", [
 ]];
 _militaryLoadoutData set ["slRifles", [
 ["vn_m16", "", "", "vn_o_4x_m16", ["vn_m16_30_mag", "vn_m16_30_mag", "vn_m16_30_t_mag"], [], ""],
-["vn_m16_camo", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
 ["vn_m16_camo", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
 ["vn_l34a1", "", "", "", ["vn_f1_smg_mag", "vn_f1_smg_mag", "vn_f1_smg_t_mag"], [], ""],
 ["vn_l1a1_03", "", "", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], [], ""]
@@ -289,7 +291,7 @@ _militaryLoadoutData set ["SMGs", [
 ]];
 _militaryLoadoutData set ["grenadeLaunchers", [
 ["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ["vn_40mm_m576_buck_mag"], ""],
-["vn_l1a1_01_gl", "", "", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], ["vn_22mm_m61_frag_mag", "vn_22mm_m61_frag_mag", "vn_22mm_n94_heat_mag"], ""],
+["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ["vn_40mm_m576_buck_mag"], ""],
 ["vn_l1a1_01_gl", "", "", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], ["vn_22mm_m61_frag_mag", "vn_22mm_m61_frag_mag", "vn_22mm_n94_heat_mag"], ""],
 ["vn_l1a1_01_gl", "", "", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], ["vn_22mm_m61_frag_mag", "vn_22mm_m61_frag_mag", "vn_22mm_n94_heat_mag"], ""],
 ["vn_l1a1_xm148", "", "", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""]
@@ -457,6 +459,8 @@ private _squadLeaderTemplate = {
 	[selectRandom ["grenadeLaunchers", "slRifles"]] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 	["primary", 4] call _fnc_addAdditionalMuzzleMagazines;
+
+	["lightATLaunchers"] call _fnc_setLauncher;
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 4] call _fnc_addMagazines;

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_MACV.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_MACV.sqf
@@ -65,7 +65,7 @@ private _vehiclesAirPatrol = ["vn_b_air_oh6a_07", "vn_b_air_uh1d_02_01"];
 ["vn_b_army_static_m101_02", ["vn_cannon_m101_mag_he_x8", "vn_cannon_m101_mag_ab_x8", "vn_cannon_m101_mag_wp_x8"]]
 ]] call _fnc_saveToTemplate;
 
-["uavsAttack", ["vn_b_air_oh6a_01"]] call _fnc_saveToTemplate;				// scout helis are fine for this
+private _uavsAttack = ["vn_b_air_oh6a_01"]; // scout helis are fine for this
 ["uavsPortable", []] call _fnc_saveToTemplate;
 
 //Config special vehicles
@@ -90,6 +90,7 @@ if (isClass (configFile >> "vnx_credits")) then {
 	_vehiclesAirPatrol append ["vn_b_air_oh6a_07", "vn_b_air_uh1d_02_01", "vnx_b_air_ov10a_covey", "vnx_b_air_hh1h_01_01", "vnx_b_air_hh1h_02_01"];
 	_vehiclesPlanesCAS append ["vnx_b_air_ov10a_mr"];
 	_vehiclesPlanesTransport append ["vnx_b_air_ac119_02_01"];
+	_uavsAttack append ["vnx_b_air_ov10a_covey", "vnx_b_air_ov10a_covey"];
 };
 
 ["vehiclesLightArmed", _vehiclesLightArmed] call _fnc_saveToTemplate;
@@ -97,6 +98,7 @@ if (isClass (configFile >> "vnx_credits")) then {
 ["vehiclesAirPatrol", _vehiclesAirPatrol] call _fnc_saveToTemplate;
 ["vehiclesPlanesCAS", _vehiclesPlanesCAS] call _fnc_saveToTemplate;
 ["vehiclesPlanesTransport", _vehiclesPlanesTransport] call _fnc_saveToTemplate;
+["uavsAttack", _uavsAttack] call _fnc_saveToTemplate;
 
 //Minefield definition
 //CFGVehicles variant of Mines are needed "ATMine", "APERSTripMine", "APERSMine"
@@ -497,6 +499,8 @@ private _squadLeaderTemplate = {
 	[selectRandom ["grenadeLaunchers", "slRifles"]] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 	["primary", 4] call _fnc_addAdditionalMuzzleMagazines;
+
+	["lightATLaunchers"] call _fnc_setLauncher;
 
 	[["slSidearms", "sidearms"] call _fnc_fallback] call _fnc_setHandgun;
 	["handgun", 4] call _fnc_addMagazines;

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_USMC.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_USMC.sqf
@@ -65,7 +65,7 @@ private _vehiclesAirPatrol = ["vn_b_air_uh1c_07_05", "vn_b_air_uh1b_01_04"];
 ["vn_b_army_static_m101_02", ["vn_cannon_m101_mag_he_x8", "vn_cannon_m101_mag_ab_x8", "vn_cannon_m101_mag_wp_x8"]]
 ]] call _fnc_saveToTemplate;
 
-["uavsAttack", ["vn_b_air_oh6a_01"]] call _fnc_saveToTemplate;				// scout helis are fine for this
+private _uavsAttack = ["vn_b_air_oh6a_01"]; // scout helis are fine for this
 ["uavsPortable", []] call _fnc_saveToTemplate;
 
 //Config special vehicles
@@ -94,6 +94,7 @@ if (isClass (configFile >> "vnx_credits")) then {
 	_vehiclesPlanesCAS append ["vnx_b_air_a4e_usmc_cas", "vnx_b_air_a4e_usmc_cas", "vnx_b_air_a4e_usmc_cas", "vnx_b_air_ov10a_mr"];
 	_vehiclesPlanesTransport append ["vnx_b_air_ac119_02_01"];
 	_vehiclesAirPatrol append ["vnx_b_air_ov10a_covey"];
+	_uavsAttack append ["vnx_b_air_ov10a_covey", "vnx_b_air_ov10a_covey"];
 };
 
 ["vehiclesLightArmed", _vehiclesLightArmed] call _fnc_saveToTemplate;
@@ -105,6 +106,7 @@ if (isClass (configFile >> "vnx_credits")) then {
 ["vehiclesPlanesCAS", _vehiclesPlanesCAS] call _fnc_saveToTemplate;
 ["vehiclesPlanesTransport", _vehiclesPlanesTransport] call _fnc_saveToTemplate;
 ["vehiclesLightAPCs", _vehiclesLightAPCs] call _fnc_saveToTemplate;
+["uavsAttack", _uavsAttack] call _fnc_saveToTemplate;
 
 //Minefield definition
 //CFGVehicles variant of Mines are needed "ATMine", "APERSTripMine", "APERSMine"
@@ -302,10 +304,10 @@ _sfLoadoutData set ["sidearms", [
 
 private _militaryLoadoutData = _loadoutData call _fnc_copyLoadoutData;
 _militaryLoadoutData set ["uniforms", ["vn_b_uniform_macv_02_15","vn_b_uniform_macv_03_15","vn_b_uniform_macv_04_15","vn_b_uniform_macv_05_15","vn_b_uniform_macv_06_15"]];
-_militaryLoadoutData set ["vests", ["vn_b_vest_usmc_01","vn_b_vest_usmc_02"]];
-_militaryLoadoutData set ["glVests", ["vn_b_vest_usmc_04"]];
+_militaryLoadoutData set ["vests", ["vn_b_vest_usmc_01","vn_b_vest_usmc_02", "vn_b_vest_usmc_09", "vn_b_vest_usmc_09", "vn_b_vest_usmc_07"]];
+_militaryLoadoutData set ["glVests", ["vn_b_vest_usmc_04", "vn_b_vest_usmc_09"]];
 _militaryLoadoutData set ["medVests", ["vn_b_vest_usmc_05"]];
-_militaryLoadoutData set ["mgVests", ["vn_b_vest_usmc_03"]];
+_militaryLoadoutData set ["mgVests", ["vn_b_vest_usmc_03", "vn_b_vest_usmc_08"]];
 _militaryLoadoutData set ["slVests", ["vn_b_vest_usmc_06"]];
 _militaryLoadoutData set ["backpacks", ["vn_b_pack_m41_01","vn_b_pack_m41_02","vn_b_pack_m41_03","vn_b_pack_m41_04"]];
 _militaryLoadoutData set ["slBackpacks", ["vn_b_pack_m41_05"]];
@@ -314,13 +316,12 @@ _militaryLoadoutData set ["binoculars", ["vn_anpvs2_binoc"]];
 
 _militaryLoadoutData set ["rifles", [
 ["vn_m16", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
-["vn_m16", "", "vn_b_m16", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
 ["vn_m14", "", "vn_b_m14", "", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], ""],
-["vn_m14_camo", "", "vn_b_m14", "", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], ""]
+["vn_m14_camo", "", "vn_b_m14", "", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], ""],
+["vn_m1_garand", "", "vn_b_m1_garand", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], [], ""]
 ]];
 _militaryLoadoutData set ["slRifles", [
 ["vn_m16", "", "", "vn_o_4x_m16", ["vn_m16_30_mag", "vn_m16_30_mag", "vn_m16_30_t_mag"], [], ""],
-["vn_xm177", "", "", "vn_o_4x_m16", ["vn_m16_30_mag", "vn_m16_30_mag", "vn_m16_30_t_mag"], [], ""],
 ["vn_xm177", "", "", "", ["vn_m16_30_mag", "vn_m16_30_mag", "vn_m16_30_t_mag"], [], ""],
 ["vn_m63a", "", "", "", ["vn_m63a_30_mag", "vn_m63a_30_mag", "vn_m63a_30_t_mag"], [], ""],
 ["vn_m14a1_shorty", "", "", "vn_o_m14_front", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], ""]
@@ -341,10 +342,10 @@ _militaryLoadoutData set ["carbines", [
 ["vn_m2carbine", "", "", "", ["vn_carbine_30_mag", "vn_carbine_30_mag", "vn_carbine_30_t_mag"], [], ""]
 ]];
 _militaryLoadoutData set ["grenadeLaunchers", [
-["vn_m16_xm148", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ""],
 ["vn_m16_xm148", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""],
 ["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ["vn_40mm_m576_buck_mag"], ""],
-["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ["vn_40mm_m576_buck_mag"], ""]
+["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ["vn_40mm_m576_buck_mag"], ""],
+["vn_m1_garand_gl", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m1a2_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_lume_mag"], ""]
 ]];
 _militaryLoadoutData set ["SMGs", [
 ["vn_m3a1", "", "", "", ["vn_m3a1_mag", "vn_m3a1_mag", "vn_m3a1_t_mag"], [], ""]
@@ -396,10 +397,10 @@ _policeLoadoutData set ["sidearms", [
 
 private _militiaLoadoutData = _loadoutData call _fnc_copyLoadoutData;
 _militiaLoadoutData set ["uniforms", ["vn_b_uniform_macv_02_01","vn_b_uniform_macv_05_01","vn_b_uniform_macv_04_01","vn_b_uniform_macv_06_01","vn_b_uniform_macv_03_01"]];
-_militiaLoadoutData set ["vests", ["vn_b_vest_usmc_01","vn_b_vest_usmc_02"]];
-_militiaLoadoutData set ["glVests", ["vn_b_vest_usmc_04"]];
-_militiaLoadoutData set ["medVests", ["vn_b_vest_usmc_05"]];
-_militiaLoadoutData set ["mgVests", ["vn_b_vest_usmc_03"]];
+_militiaLoadoutData set ["vests", ["vn_b_vest_usmc_07","vn_b_vest_usmc_09"]];
+_militiaLoadoutData set ["glVests", ["vn_b_vest_usmc_09"]];
+_militiaLoadoutData set ["medVests", ["vn_b_vest_usmc_07"]];
+_militiaLoadoutData set ["mgVests", ["vn_b_vest_usmc_08"]];
 _militiaLoadoutData set ["slVests", ["vn_b_vest_usmc_06"]];
 _militiaLoadoutData set ["backpacks", ["vn_b_pack_m41_01"]]; // "vn_b_pack_m41_02","vn_b_pack_m41_03","vn_b_pack_m41_04"
 _militiaLoadoutData set ["slBackpacks", ["vn_b_pack_m41_05"]];
@@ -500,6 +501,8 @@ private _squadLeaderTemplate = {
 	[selectRandom ["grenadeLaunchers", "slRifles"]] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 	["primary", 4] call _fnc_addAdditionalMuzzleMagazines;
+
+	["lightATLaunchers"] call _fnc_setLauncher;
 
 	[["slSidearms", "sidearms"] call _fnc_fallback] call _fnc_setHandgun;
 	["handgun", 4] call _fnc_addMagazines;

--- a/A3A/addons/core/Templates/Templates/VN/VN_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_Vehicle_Attributes.sqf
@@ -20,18 +20,22 @@
     ["vn_b_air_f100d_cap", ["cost", 200]],
     
     // PT76 with slightly better armor and gunner
-    ["vn_o_armor_type63_01", ["cost", 180]],
-
-    // skyhawks, worse across the board than either of the real planes + restricted to aim9ds
-    ["vnx_b_air_a4e_usmc_cas", ["cost", 180]],
-    ["vnx_b_air_a4e_ran_cas", ["cost", 180]],
-    ["vnx_b_air_a4e_rnzaf_cas", ["cost", 180]],
-    ["vnx_b_air_a4e_ran_cap", ["cost", 200]],
-    ["vnx_b_air_a4e_rnzaf_cap", ["cost", 200]],
-
-    // silly COIN plane with MMG main guns, no guided munitions
-    ["vnx_b_air_ov10a_mr", ["cost", 140]],
-    ["vnx_b_air_ov10a_usmc_mr", ["cost", 140]],
-    ["vnx_b_air_ov10a_aus_covey", ["cost", 140]]
-
+    ["vn_o_armor_type63_01", ["cost", 180]]
 ]] call _fnc_saveToTemplate;
+
+// S.O.G. Nickel Steel
+if (isClass (configFile >> "CfgPatches" >> "vnx_credits")) then {
+    (["attributesVehicles"] call _fnc_getFromTemplate) append [
+        // skyhawks, worse across the board than either of the real planes + restricted to aim9ds
+        ["vnx_b_air_a4e_usmc_cas", ["cost", 180]],
+        ["vnx_b_air_a4e_ran_cas", ["cost", 180]],
+        ["vnx_b_air_a4e_rnzaf_cas", ["cost", 180]],
+        ["vnx_b_air_a4e_ran_cap", ["cost", 200]],
+        ["vnx_b_air_a4e_rnzaf_cap", ["cost", 200]],
+
+        // silly COIN plane with MMG main guns, no guided munitions
+        ["vnx_b_air_ov10a_mr", ["cost", 140]],
+        ["vnx_b_air_ov10a_usmc_mr", ["cost", 140]],
+        ["vnx_b_air_ov10a_aus_covey", ["cost", 140]]     
+    ];
+};

--- a/A3A/addons/gui/functions/RRR/fn_vehServiceDialog.sqf
+++ b/A3A/addons/gui/functions/RRR/fn_vehServiceDialog.sqf
@@ -228,7 +228,7 @@ switch (_mode) do
                     _resVehicle ctrlSetText "None found";
                 } else {
                     private _vehicleName = [typeOf _selSupplyVehicle, "CfgVehicles"] call _fnc_getName;
-                    _resVehicle ctrlSetText format ["%1 (%2 points)", _vehicleName, _remCargo];
+                    _resVehicle ctrlSetText format ["%1 (%2 points)", _vehicleName, round _remCargo];
                 };
 
                 _pylonPicture ctrlSetText getText (_pylonConfig >> "uiPicture");
@@ -297,6 +297,7 @@ switch (_mode) do
                     // Create turret button if aircraft has a gunner position
                     private _ctrlTurret = controlNull;
 
+                    /*
                     if (_hasGunner) then {
                         _ctrlTurret = _display ctrlCreate ["ctrlButtonPictureKeepAspect", -1, _globalControlGroup];
                         _ctrlTurret ctrlSetPosition [_posX - (5 * GRID_W), _posY, 5 * GRID_W, 5 * GRID_H];
@@ -305,7 +306,6 @@ switch (_mode) do
                         private _turretPath = [_veh, _forEachIndex] call EFUNC(common,getPylonTurret);
                         _ctrlTurret setVariable ["turretPath", _turretPath];
                         _ctrlTurret setVariable ["index", _forEachIndex];
-                        /*
                         _ctrlTurret call FUNC(handleTurretButton);
 
                         // Toggle the pylon's turret when the button is clicked
@@ -314,8 +314,8 @@ switch (_mode) do
 
                             [_ctrlTurret, true] call FUNC(handleTurretButton);
                         }];
-                        */
                     };
+                    */
                     ctrlSetFocus _ctrlCombo;
 
                     _pylonControls pushBack [_ctrlCombo, _ctrlTurret, _mirroredIndex, _defaultTurretPath];


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Just the small fixes and stuff required to keep testing working. More fixes to come later.
round point number on pylon display
temporarily removed pylon ownership UI elements
added conditional code for VNX to VN vehicle attributes removed a VNX only aircraft from ANZAC air patrol
made ANZAC use more L1A1s and less rifle grenades
slightly increased LAT availability in all templates gave MACV and USMC ov-10a attack UAVs
majorly lowered the armored vest availability for USMC reduced USMC gear quality for military

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
