### PR TITLE
Various pylon fixes involving use of getAllPylonsInfo

### DIFF
--- a/A3A/addons/garage/Pylons/fn_getPylonTurret.sqf
+++ b/A3A/addons/garage/Pylons/fn_getPylonTurret.sqf
@@ -7,7 +7,7 @@
  * 1: Pylon Index (starting at 0) <NUMBER>
  *
  * Return Value:
- * * Turret index (either [-1] or [0]) <ARRAY>
+ * * Turret index (either [] or [0]) <ARRAY>
  *
  * Scope: Any
  * Environment: Any
@@ -19,36 +19,8 @@
 
 params ["_vehicle", "_pylonIndex"];
 
-// See if index is in ace_pylonTurrets setVar on vehicle
-private _pylonTurrets = _vehicle getVariable ["ace_pylonTurrets", []];
-private _returnValue = _pylonTurrets param [_pylonIndex, []];
-
-if (_returnValue isEqualTo []) then {
-    // Attempt to determine turret owner based on magazines in the vehicle
-    private _pyMags = getPylonMagazines _vehicle;
-    private _pylonConfigs = configProperties [configFile >> "CfgVehicles" >> typeOf _vehicle >> "Components" >> "TransportPylonsComponent" >> "Pylons", "isClass _x"];
-    if (_pylonIndex >= (count _pyMags)) exitWith {};
-    if (_pylonIndex >= (count _pylonConfigs)) exitWith {};
-
-    private _targetMag = _pyMags select _pylonIndex;
-    private _inPilot = _targetMag in (_vehicle magazinesTurret [-1]);
-    private _inGunner = _targetMag in (_vehicle magazinesTurret [0]);
-
-    if (_inPilot) then {
-        if !(_inGunner) then {
-            _returnValue = [];
-        };
-    } else {
-        if (_inGunner) then {
-            _returnValue = [0];
-        };
-    };
-
-    if (_returnValue isEqualTo []) then { // If not sure, just use config value
-        _returnValue = getArray ((_pylonConfigs select _pylonIndex) >> "turret");
-    };
-} else {
-    if (_returnValue isEqualTo [-1]) then { _returnValue = [] };
-};
-
-_returnValue
+// This is trivial with getAllPylonsInfo
+private _pylonInfo = getAllPylonsInfo _vehicle;
+if (_pylonIndex >= count _pylonInfo) exitWith { [] };       // shouldn't happen but whatever
+private _turret = _pylonInfo#_pylonIndex#2;
+[_turret, []] select (_turret isEqualTo [-1]);           // translate to dumbass pylon command driver turret format

--- a/A3A/addons/garage/StatePreservation/fn_getAmmoData.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_getAmmoData.sqf
@@ -63,22 +63,12 @@ if (!isClass _pylonsCfg and HR_GRG_reduceState) then {
     };
 };
 
-private _nonPylon = magazinesAllTurrets _veh select {!("pylon" in toLower (_x#0))} apply { [false, [_x#0,_x#1,_x#2]] }; //[is Pylon, [magName, path, ammo]]
+// Ok do this properly for a change
+private _pylonMags = getAllPylonsInfo _veh select {_x#3 != ""} apply {[_x#3, _x#2, _x#4]};      // [magName, path, ammo]
+private _allMags = magazinesAllTurrets _veh apply {_x select [0,3]};        // matched formats
+_pylonMags apply {_allMags deleteAt (_allMags find _x)};
+private _nonPylon = _allMags apply {[false, _x]};       // [isPylon, [magname, path, ammo]]
 
-private _pylonAmmo = [];
-private _magName = getPylonMagazines _veh;
-{
-    private _pylonIndex = _forEachIndex + 1;
-    _pylonAmmo pushBack [
-        true
-        , [
-            _pylonIndex
-            , configName _x
-            , [_veh, _forEachIndex] call HR_GRG_fnc_getPylonTurret
-            , _magName#_forEachIndex
-            , _veh ammoOnPylon _pylonIndex
-        ]
-    ];
-} forEach ("true" configClasses (_pylonsCfg >> "Pylons"));
-
+private _pylonAmmo = getAllPylonsInfo _veh apply {[true, _x select [0, 5]]};            // lol code reduction
+{ if (_x#1#2 isEqualTo [-1]) then {_x#1 set [2, []]} } forEach _pylonAmmo;                  // maintain previous behaviour, but it doesn't seem to matter now
 _nonPylon + _pylonAmmo


### PR DESCRIPTION

### What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
BI added a good pylon command in 2.02:
- Replaced getPylonTurret with trivial code.
- Fixed getPylonTurret spamming "Invalid turret path" errors.
- Non-pylon magazine save code no longer stores non-vanilla pylon magazines.
- Pylon magazine save code heavily simplified.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
