### PR TITLE
Various AI fixes from 3.11 testing feedback

### DIFF
--- a/A3A/addons/core/functions/AI/fn_askHelp.sqf
+++ b/A3A/addons/core/functions/AI/fn_askHelp.sqf
@@ -24,7 +24,7 @@ private _fnc_canHelp = {
     params ["_unit"];
     if ((isPlayer _unit) or (vehicle _unit != _unit) or (_unit distance _target > 100)) exitWith { false };
     if !([_unit] call A3A_fnc_canFight) exitWith { false };
-    if (currentCommand _unit == "STOP") exitWith { false };
+    if (currentCommand _unit == "STOP" and _unit isNil "A3A_forcedStance") exitWith { false };          // unit probably stopped by player, won't respond to doMove
     if ((_unit getVariable ["maneuvering", false]) or (_unit getVariable ["helping", false]) or (_unit getVariable ["rearming", false])) exitWith { false };
     if (_unitNeedsFAK and {count (_firstAidKits arrayIntersect items _unit) == 0}) exitWith { false };
     true;

--- a/A3A/addons/core/functions/CREATE/fn_AAFroadPatrol.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AAFroadPatrol.sqf
@@ -67,7 +67,7 @@ _posbase = getMarkerPos _base;
 
 if (_typePatrol == "AIR") then
 {
-	_arrayDestinations = markersX select {sidesX getVariable [_x,sideUnknown] == _sideX};
+	_arrayDestinations = markersX inAreaArray ["Synd_HQ", 4000, 4000] select {sidesX getVariable _x == _sideX};
 	_distanceX = 200;
 }
 else
@@ -134,6 +134,7 @@ if (_typeCar in (_faction get "vehiclesLightUnarmed")) then
 
 //if (_typePatrol == "LAND") then {_veh forceFollowRoad true};
 
+private _startTime = time;
 while {alive _veh} do
 {
 	if (count _arrayDestinations < 2) exitWith {};
@@ -154,9 +155,10 @@ while {alive _veh} do
 	private _timeout = time + (_veh distance2d _posDestination) / 6 + 300;			// stuck detection
 	waitUntil {sleep 60; (_veh distance _posDestination < _distanceX) or (time > _timeout) or ({[_x] call A3A_fnc_canFight} count _soldiers == 0) or (!canMove _veh)};
 	if !(_veh distance _posDestination < _distanceX) exitWith {};
+	if (time - _startTime - 1800 > random 3600) exitWith {};				// random 30 to 90 minute max patrol time
 	if (_typePatrol == "AIR") then
 	{
-		_arrayDestinations = markersX select {sidesX getVariable [_x,sideUnknown] == _sideX};
+		_arrayDestinations = markersX inAreaArray ["Synd_HQ", 4000, 4000] select {sidesX getVariable _x == _sideX};
 	}
 	else
 	{

--- a/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_cityReinf.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_cityReinf.sqf
@@ -98,8 +98,8 @@ if ((random 10 < 2.5) and !("Sniper" in _unitTypes#0)) then {
     [_dog] spawn A3A_fnc_guardDog;
 };
 
-// TODO: should probably store the city radius
-[_group, "Patrol_Area", 0, 250, -1, false, markerPos _marker, false, false] call A3A_fnc_patrolLoop;
+private _cityRad = selectMax markerSize _marker;
+[_group, "Patrol_Area", 0, _cityRad, -1, true, markerPos _marker, true, false] call A3A_fnc_patrolLoop;
 
 
 // Next, attempt to spawn in a building somewhere in the town

--- a/A3A/addons/core/functions/GarrisonLocal/fn_spawnGarrisonPatrols.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_spawnGarrisonPatrols.sqf
@@ -50,8 +50,9 @@ private _highGroupTypes = _faction get (_patrolGroupTypes # (ceil _quality));
 private _highPatrols = round (_numPatrols * (_quality%1));
 
 private _minRad = 0;
-private _maxRad = markerSize _marker # 0 min markerSize _marker # 1;
-if (_type != "city") then { _minRad = _maxRad; _maxRad = _maxRad + 200 };
+private _maxRad = selectMax markerSize _marker;
+private _isCity = _type == "city";
+if (!_isCity) then { _minRad = _maxRad; _maxRad = _maxRad + 200 };
 private _station = _activeGarrison getOrDefault ["policeStation", objNull];     // in local garrison data it's an object
 
 for "_i" from 1 to _numPatrols do
@@ -77,7 +78,7 @@ for "_i" from 1 to _numPatrols do
         sleep 0.1;
     };
 
-    [_group, "Patrol_Area", _minRad, _maxRad, -1, true, _markerPos, false, false] call A3A_fnc_patrolLoop;
+    [_group, "Patrol_Area", _minRad, _maxRad, -1, true, _markerPos, _isCity, false] call A3A_fnc_patrolLoop;
 };
 
 _storedTroops set [0, (_troopCount) - 2*_numPatrols];

--- a/A3A/addons/core/functions/GarrisonLocal/fn_spawnPoliceStation.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_spawnPoliceStation.sqf
@@ -111,6 +111,7 @@ for "_i" from 1 to _numUnits do
     [_unit, _marker] call A3A_fnc_NATOinit;
     _unit setUnitPos "UP";
     _unit setVariable ["A3A_forcedStance", "UP"];
+    _unit disableAI "TARGET";           // should stop them being ordered to search 300m away...
     dostop _unit;
 
     sleep 0.1;

--- a/A3A/addons/core/functions/Missions/fn_LOG_Gunshop.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Gunshop.sqf
@@ -102,7 +102,7 @@ private _spawnPosition = [markerPos _city, 0, 200, 2] call A3A_fnc_findPatrolPos
 private _patrolTypes = Faction(_enemySide) get (["groupsSmall", "groupSpecOpsRandom"] select (tierWar > random 12));
 private _patrolGroup = [_spawnPosition, _enemySide, selectRandom _patrolTypes, false, true] call A3A_fnc_spawnGroup;
 {[_x, ""] call A3A_fnc_NATOinit} forEach units _patrolGroup;
-[_patrolGroup, "Patrol_Area", 0, 200, 200, true, markerPos _city] call A3A_fnc_patrolLoop;
+[_patrolGroup, "Patrol_Area", 0, 200, -1, true, markerPos _city] call A3A_fnc_patrolLoop;
 
 
 private _timeout = time + 3600;

--- a/A3A/addons/core/functions/Missions/fn_supplyDrop.sqf
+++ b/A3A/addons/core/functions/Missions/fn_supplyDrop.sqf
@@ -97,7 +97,7 @@ if (currentWaypoint _group > 0) then
     _crate attachTo [_parachute, [0, 0, 0]];
 
     // Now the patrol can see the parachute, send them in the right direction
-    [_patrolGroup, "Patrol_Area", 0, 200, 200, true, _targPos] call A3A_fnc_patrolLoop;
+    [_patrolGroup, "Patrol_Area", 0, 200, -1, true, _targPos] call A3A_fnc_patrolLoop;
 
     // Now wait for the crate to hit the ground
     waitUntil {sleep 1; diag_log velocity _parachute; getPosATL _crate#2 < 1};

--- a/A3A/addons/patcom/functions/Patcom/fn_patrolArea.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolArea.sqf
@@ -46,8 +46,14 @@ private _patrolParams = _group getVariable "PATCOM_Patrol_Params";
 if ((side leader _group) == civilian) then {
     [_group, "CARELESS", "NORMAL", "LINE", "BLUE", "AUTO"] call A3A_fnc_patrolSetCombatModes;
 } else {
-    [_group, "SAFE", "LIMITED", "COLUMN", "WHITE", "AUTO"] call A3A_fnc_patrolSetCombatModes;
-    _group setVariable ["PATCOM_Group_State", "CALM"];
+    private _knownEnemies = _group targets [true, 0, [], PATCOM_TARGET_TIME];
+    if (_knownEnemies isEqualTo []) then {
+        [_group, "SAFE", "LIMITED", "COLUMN", "YELLOW", "AUTO"] call A3A_fnc_patrolSetCombatModes;
+        _group setVariable ["PATCOM_Group_State", "CALM"];
+    } else {
+        [_group, "COMBAT", "NORMAL", "WEDGE", "RED", "AUTO"] call A3A_fnc_patrolSetCombatModes;
+        _group setVariable ["PATCOM_Group_State", "COMBAT"];
+    };
 };
 
 if (PATCOM_DEBUG) then {
@@ -58,14 +64,9 @@ if (PATCOM_DEBUG) then {
     };
 };
 
-// We check to see if the waypoint is still active after 3 minutes. If waypoint isn't complete the unit is likely stuck.
-if (_group getVariable "PATCOM_WaypointTime" < serverTime) exitWith {
-    // Return home
-    [_group, _groupHomePosition, "MOVE", "PATCOM_PATROL_AREA", -1, _patrolParams # 1] call A3A_fnc_patrolCreateWaypoint;
-};
 
-// Check for current waypoints and make sure they are type MOVE for patrol
-if (currentWaypoint _group == count waypoints _group || waypointType [_group, currentWaypoint _group] != "MOVE") then {
+// Check if waypoint was reached, wasn't MOVE (from previous attack order) or timed out
+if (currentWaypoint _group == count waypoints _group || waypointType [_group, currentWaypoint _group] != "MOVE" || time > _group getVariable ["PATCOM_WaypointTime", 0]) then {
     if (_searchBuildings) then {
         // Percentage chance on searching a nearby building.
         if (15 > random 100) exitWith {

--- a/A3A/addons/patcom/functions/Patcom/fn_patrolCommander.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolCommander.sqf
@@ -65,16 +65,16 @@ If (PATCOM_DEBUG) then {
     ServerDebug_3("PATCOM | Group: %1 | Current Orders: %2 | Group State: %3", _group, _currentOrders, _group getVariable "PATCOM_Group_State");
 };
 
+if (_currentOrders == "Patrol_Area") exitWith {
+    [_group, _patrolParams#1, _patrolParams#2, _patrolParams#3, _patrolParams#4, _patrolParams#5, _patrolParams#6] call A3A_fnc_patrolArea;
+};
+
 if (_currentOrders == "Patrol_Attack") exitWith {
     [_group, _patrolParams#2, _patrolParams#5] call A3A_fnc_patrolAttack;
 };
 
 if (_currentOrders == "Patrol_Defend") exitWith {
     [_group, _patrolParams#1, _patrolParams#2, _patrolParams#4, _patrolParams#5] call A3A_fnc_patrolDefend;
-};
-
-if (_currentOrders == "Patrol_Area") exitWith {
-    [_group, _patrolParams#1, _patrolParams#2, _patrolParams#3, _patrolParams#4, _patrolParams#5, _patrolParams#6] call A3A_fnc_patrolArea;
 };
 
 if (_currentOrders == "Patrol_Water") exitWith {

--- a/A3A/addons/patcom/functions/Patcom/fn_patrolCreateWaypoint.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolCreateWaypoint.sqf
@@ -76,6 +76,6 @@ if (waypointType _waypoint != _waypointType) then {
     _waypoint setWaypointType _waypointType;
 };
 
-// Set Waypoint time 5 minutes into the future.
-private _waypointTime = serverTime + 300;
+// Allow enough time to reach the next waypoint
+private _waypointTime = time + 30 + (_position distance leader _group);
 _group setVariable ["PATCOM_WaypointTime", _waypointTime];

--- a/A3A/addons/patcom/functions/Patcom/fn_patrolWater.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolWater.sqf
@@ -40,21 +40,15 @@ params [
 private _groupHomePosition = _group getVariable "PATCOM_Patrol_Home";
 private _patrolParams = _group getVariable "PATCOM_Patrol_Params";
 
-[_group, "SAFE", "LIMITED", "COLUMN", "WHITE", "AUTO"] call A3A_fnc_patrolSetCombatModes;
+[_group, "SAFE", "LIMITED", "COLUMN", "YELLOW", "AUTO"] call A3A_fnc_patrolSetCombatModes;
 _group setVariable ["PATCOM_Group_State", "CALM"];
 
 if (PATCOM_DEBUG) then {
     [leader _group, "PATROL WATER", 10, "White"] call A3A_fnc_debugText3D;
 };
 
-// We check to see if the waypoint is still active after 3 minutes. If waypoint isn't complete the unit is likely stuck.
-if (_group getVariable "PATCOM_WaypointTime" < serverTime) exitWith {
-    // Return home
-    [_group, _groupHomePosition, "MOVE", "PATCOM_PATROL_WATER", -1, _patrolParams # 1] call A3A_fnc_patrolCreateWaypoint;
-};
-
-// Check for current waypoints and make sure they are type MOVE for patrol
-if (currentWaypoint _group == count waypoints _group || waypointType [_group, currentWaypoint _group] != "MOVE") then {
+// Check if waypoint is reached or timeout has expired
+if (currentWaypoint _group == count waypoints _group || waypointType [_group, currentWaypoint _group] != "MOVE" || time > _group getVariable ["PATCOM_WaypointTime", 0]) then {
     if (_maxPatrolDistance != -1) then {
         if ((leader _group) distance _groupHomePosition > _maxPatrolDistance) exitWith {
             // Return home


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
- Added a timeout to AAFRoadPatrol so that air & sea patrols don't wander around forever preventing new patrol spawns.
- Restricted air patrol destinations to 4km from HQ.
- Changed "safe" patcom area patrol parameters to yellow combat mode, so that they can shoot back more quickly.
- Added combat switch to patcom area patrol so that they act less weird when not on an attack order.
- Fixed the patcom stuck timeout so that it depends on waypoint distance and doesn't automatically return to home.
- Fixed patrol parameters for city reinforcements.
- Fixed city patrols not being allowed to search buildings.
- Fixed police station garrison heading out on a magical mystery tour.
- Fixed gun shop patrol returning to original location instead of the crate.
- Fixed building garrisons not attempting to heal each other.

### Please specify which Issue this PR Resolves.
closes #3732

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
