### PR TITLE
Improve fast travel reliability

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -855,6 +855,7 @@ class CfgFunctions
             class deleteNamespace {};
             class filterAndWeightArray {};
             class findEmptyPos {};
+            class findEmptyPosCar {};
             class findPosNearHouse {};
             class getAdmin {};
             class isEngineer {};

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -2974,6 +2974,9 @@
         <Turkish>Yolculuk etmek istediğiniz bölgeye tıklayın.</Turkish>
         <Chinesesimp>选择你所想要前往的区域</Chinesesimp>
       </Key>
+      <Key ID="STR_A3A_fn_dialogs_ftradio_failed">
+        <Original>Failed to find an empty position in your target area. You should probably drive.</Original>
+      </Key>
       <Key ID="STR_A3A_fn_dialogs_ftradio_grp_arrived">
         <Original>Group %1 arrived to destination.</Original>
         <Italian>Gruppo %1 è arrivato a destinazione.</Italian>

--- a/A3A/addons/core/functions/Base/fn_fastTravelMove.sqf
+++ b/A3A/addons/core/functions/Base/fn_fastTravelMove.sqf
@@ -75,21 +75,50 @@ _ftUnits = _ftUnits select { _x == vehicle _x };
 
 
 // Do the actual teleport. Vehicles before units, try to place everything in proximity.
-private _destPos = markerPos _base getPos [10, random 360];
+private _destPos = markerPos _base getPos [30, random 360];
 {
-	private _radiusX = 10;
-	while {true} do {
-		private _roads = _destPos nearRoads _radiusX;
-		if (count _roads > 0) exitWith { _destPos = getPosATL (_roads select 0) };
-		_radiusX = _radiusX + 10;
-		if (_radiusX > 100) exitWith {};
+	private _vehPlace = false;
+	if !(_x isKindOf "StaticWeapon") then {
+		// attempt to place on a road section
+		private _emptyRoads = _destPos nearRoads 20 select { _x nearEntities 10 isEqualTo [] };
+		if (_emptyRoads isEqualTo []) then { _emptyRoads = _destPos nearRoads 50 select { _x nearEntities 10 isEqualTo [] } };
+		if (_emptyRoads isEqualTo []) then { _emptyRoads = _destPos nearRoads 100 select { _x nearEntities 10 isEqualTo [] } };
+		if (_emptyRoads isNotEqualTo []) then {
+			private _road = selectRandom _emptyRoads;
+			private _pos1 = getRoadInfo _road # 6;
+			private _pos2 = getRoadInfo _road # 7;
+			private _dir = if (_pos1 distance2d _destPos < _pos2 distance2d _destPos) then { _pos2 getDir _pos1 } else { _pos1 getDir _pos2 };
+			_vehPlace = [getPosATL _road, _dir];
+		};
 	};
-	private _vehPos = _destPos findEmptyPosition [0,100,typeOf _x];
-	_x setVehiclePosition [_vehPos, [], 5, "NONE"];
+	if (_vehPlace isEqualType false) then {
+		// go find a random empty position instead
+		private _testDir = random 360;
+		private _pos = [_destPos, _x, _testDir, 5, 20, 20] call A3A_fnc_findEmptyPosCar;
+		if (_pos isNotEqualTo []) exitWith { _vehPlace = [_pos, _testDir] };
+		_pos = [_destPos, _x, _testDir, 20, 30, 30] call A3A_fnc_findEmptyPosCar;
+		if (_pos isNotEqualTo []) exitWith { _vehPlace = [_pos, _testDir] };
+		_pos = [_destPos, _x, _testDir, 50, 100, 50] call A3A_fnc_findEmptyPosCar;
+		if (_pos isNotEqualTo []) exitWith { _vehPlace = [_pos, _testDir] };
+	};
+	if (_vehPlace isEqualType false) then {
+		[_titleStr, localize "STR_A3A_fn_dialogs_ftradio_fail"] call A3A_fnc_customHint;
+		continue;
+	};
+	isNil {
+		// Actually move vehicle
+		_x setPosATL _vehPlace#0;
+		_x setDir _vehPlace#1;
+		_x allowDamage false;
+	};
+	// Update destPos to last non-static vehicle
+	if !(_x isKindOf "StaticWeapon") then { _destPos = _vehPlace # 0 }; 
+
 } forEach _ftVehicles;
 
 {
-	private _unitPos = _destPos findEmptyPosition [1,50,typeOf _x];
+	private _unitPos = _destPos findEmptyPosition [5,50,typeOf _x];
+	if (_unitPos isEqualTo []) then { _unitPos = _destPos getPos [5 + 45 * sqrt random 1, random 360] };		// whatever, units are pretty safe
 	_x setPosATL _unitPos;
 	if (!isPlayer _x and !(_x getVariable ["incapacitated",false])) then {
 		_x setVariable ["rearming",false];
@@ -98,7 +127,6 @@ private _destPos = markerPos _base getPos [10, random 360];
 	};
 } forEach _ftUnits;
 
-
 if (!_isHC) then {
 	disableUserInput false;
 	cutText [localize "STR_A3A_fn_dialogs_fastTravelRadio_end","BLACK IN",1]
@@ -106,3 +134,6 @@ if (!_isHC) then {
 	[_titleStr, format [localize "STR_A3A_fn_dialogs_ftradio_grp_arrived", groupID _groupX]] call A3A_fnc_customHint;
 };
 [] call A3A_fnc_playerLeashRefresh;
+
+sleep 5;
+{ _x allowDamage true } forEach _ftVehicles;

--- a/A3A/addons/core/functions/Utility/fn_findEmptyPos.sqf
+++ b/A3A/addons/core/functions/Utility/fn_findEmptyPos.sqf
@@ -25,7 +25,7 @@ params ["_center", "_minDist", "_maxDist", "_checkRad", "_attempts", ["_checkFnc
 private _minDist2 = _minDist^2;
 private _rDist = _maxDist^2 - _minDist^2;
 private _objRad = _checkRad + 1;        // use slightly larger radius for terrain objects because their center isn't great
-private _diag = _checkRad * sqrt 2;
+private _diag = _checkRad / sqrt 2;
 private _lOff = [[-_checkRad,0,1], [_checkRad,0,1], [0,-_checkRad,1], [0,_checkRad,1]];
 private _dOff = [[_diag,_diag,1], [-_diag,-_diag,1], [-_diag,_diag,1], [_diag,-_diag,1]];
 
@@ -36,14 +36,24 @@ for "_i" from 1 to _attempts do {
     if (surfaceIsWater _tpos) then { continue };            // could do gradient check too?
     if (nearestTerrainObjects [_tpos, [], _objRad, false, true] - (_tpos nearRoads _objRad) isNotEqualTo []) then { continue };
     if (_tpos nearEntities _checkRad isNotEqualTo []) then { continue };
+    if (_tpos nearObjects ["building", _checkRad] isNotEqualTo []) then { continue };        // rebel constructions mostly
 
     if (call _checkFnc) then {continue};
 
-    // 45-degree ray checks for larger objects
+    // 45-degree ray & diamond checks for larger objects
+/*    private _lOffT = _lOff apply {ATLtoASL (_tpos vectorAdd _x)};
+    private _dOffT = _dOff apply {ATLtoASL (_tpos vectorAdd _x)};
+    if (lineIntersectsSurfaces [[
+        [_lOffT#0, _lOffT#1], [_lOffT#2, _lOffT#3], [_dOffT#0, _dOffT#1], [_dOffT#2, _dOffT#3],         // radial
+        [_lOffT#0, _dOffT#2], [_dOffT#2, _lOffT#3], [_lOffT#3, _dOffT#0], [_dOffT#0, _lOffT#1],          // high octagon
+        [_lOffT#1, _dOffT#3], [_dOffT#3, _lOffT#2], [_lOffT#2, _dOffT#1], [_dOffT#1, _lOffT#0]          // low octagon
+    ]] findIf { _x isNotEqualTo [] } == -1) exitWith {_pos = _tpos};
+*/
     if (lineIntersectsSurfaces [ATLtoASL (_tpos vectorAdd _lOff#0), ATLtoASL (_tpos vectorAdd _lOff#1)] isNotEqualTo []) then {continue};
     if (lineIntersectsSurfaces [ATLtoASL (_tpos vectorAdd _lOff#2), ATLtoASL (_tpos vectorAdd _lOff#3)] isNotEqualTo []) then {continue};
     if (lineIntersectsSurfaces [ATLtoASL (_tpos vectorAdd _dOff#0), ATLtoASL (_tpos vectorAdd _dOff#1)] isNotEqualTo []) then {continue};
     if (lineIntersectsSurfaces [ATLtoASL (_tpos vectorAdd _dOff#2), ATLtoASL (_tpos vectorAdd _dOff#3)] isEqualTo []) exitWith {_pos = _tpos};
+
 };
 
 _pos;

--- a/A3A/addons/core/functions/Utility/fn_findEmptyPosCar.sqf
+++ b/A3A/addons/core/functions/Utility/fn_findEmptyPosCar.sqf
@@ -1,0 +1,65 @@
+/*
+    Function to find empty-ish position on land within min/max radius
+    Combines distance check for small objects and raycast for large objects
+    Includes annular distribution adjustment
+    Optimized for car shaped objects. Needs created vehicle for bounding box.
+
+    Arguments:
+    <POSITION> ATL search position
+    <OBJECT> Object to use for bounding box size
+    <NUMBER> Direction of object to test
+    <NUMBER> Minimum search radius
+    <NUMBER> Maximum search radius
+    <NUMBER> Maximum number of attempts 
+    <CODE> Optional: Additional code to run when checking positions. _tpos passed in as ATL. Return true for rejected, false for accepted
+
+    Returns:
+    <POSITION> ATL empty position, or empty array 
+
+    Copyright 2025 John Jordan. All Rights Reserved.
+    Used and distributed by the Antistasi Community project with permission.
+*/
+
+params ["_center", "_vehicle", "_dir", "_minDist", "_maxDist",  "_attempts", ["_checkFnc", {false}]];
+
+private _minDist2 = _minDist^2;
+private _rDist = _maxDist^2 - _minDist^2;
+private _bb = boundingBoxReal [_vehicle, "Geometry"];
+private _bbHeight = _bb#1#2 - _bb#0#2 + 1;        // offset from mid
+private _checkRad = _bb#2 + 2;
+_bb = [_bb#0 vectorAdd [-1,-1,0], _bb#1 vectorAdd [1,1,0]];
+
+// Corner offset prep
+private _bbC = [[_bb#0#0, _bb#0#1], [_bb#0#0, _bb#1#1], [_bb#1#0, _bb#1#1], [_bb#1#0, _bb#0#1]];
+private _cost = cos _dir; private _sint = sin _dir;
+private _lowC = _bbC apply { [_cost*_x#0 + _sint*_x#1, -_sint*_x#0 + _cost*_x#1, 0.7] };
+private _midZvec = [0,0,0.8];
+private _highZvec = [0,0,_bbHeight-1.5];
+
+private _pos = [];
+
+for "_i" from 1 to _attempts do {
+    private _tpos = _center getPos [sqrt (_minDist2 + random _rDist), random 360];
+    if (surfaceIsWater _tpos) then { continue };
+    if (surfaceNormal _tpos # 2 < 0.94) then { continue };      // 20 degrees maximum gradient
+    if (nearestTerrainObjects [_tpos, [], _checkRad, false, true] - (_tpos nearRoads _checkRad) isNotEqualTo []) then { continue };
+    if (_tpos nearEntities _checkRad isNotEqualTo []) then { continue };
+    if (_tpos nearObjects ["building", _checkRad] isNotEqualTo []) then { continue };        // rebel constructions mostly
+
+    // Quick low diagonals
+    private _lowCT = _lowC apply {ATLtoASL (_tpos vectorAdd _x)};
+    if (lineIntersectsSurfaces [_lowCT#0, _lowCT#2] isNotEqualTo []) then {continue};
+    if (lineIntersectsSurfaces [_lowCT#1, _lowCT#3] isNotEqualTo []) then {continue};
+
+    if (call _checkFnc) then {continue};
+
+    private _midCT = _lowCT apply { _x vectorAdd _midZvec };
+    private _highCT = _midCT apply { _x vectorAdd _highZvec };
+    if (lineIntersectsSurfaces [[
+        [_lowCT#0, _lowCT#1], [_lowCT#1, _lowCT#2], [_lowCT#2, _lowCT#3], [_lowCT#3, _lowCT#0],         // low rectangle
+        [_midCT#0, _midCT#1], [_midCT#1, _midCT#2], [_midCT#2, _midCT#3], [_midCT#3, _midCT#0],         // mid rectangle
+        [_lowCT#0, _highCT#0], [_lowCT#1, _highCT#1], [_lowCT#2, _highCT#2], [_lowCT#3, _highCT#3]      // roof checks
+    ]] findIf { _x isNotEqualTo [] } == -1) exitWith {_pos = _tpos};
+};
+
+_pos;


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
The fast travel placement selection logic in 3.10 turned out to be worse than the earlier code. I have extensively reworked it to remove dependence on shitty Arma 3 commands and it's now pretty difficult to kill yourself. Three layers:
1. First it tries to put you in the middle of a nearby road. More like the old FT but with a bit more protection.
2. Then it searches for a nearby space that fits your vehicle, mostly using raycasts. This is so reliable that I didn't manage to kill a vehicle yet after spawning hundreds of them.
3. If that fails then it simply refuses to FT you. This is pretty unlikely to ever happen but I force-tested the code path.

Worst case is that two players fast travel within a couple of hundred milliseconds and it picks the same spot, but this is less likely than the old code because the road selection is more randomised. There is also five seconds of vehicle damage protection, but if two vehicles teleport to the same spot then they'll probably end up a couple of kilometers away upside down. Oh well.

Also fixed a couple of minor bugs in findEmptyPos (mostly used for spawning patrols).

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
