### PR TITLE
Update fn_AAFroadPatrol.sqf to spawn patrols further from airbases

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_AAFroadPatrol.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AAFroadPatrol.sqf
@@ -14,8 +14,11 @@ _roads = [];
 private _players = allPlayers - entities "HeadlessClient_F";
 private _bases = (seaports + airportsX + outposts) select {
 	call {
-		if ((_players inAreaArray [markerPos _x, 2000, 2000] isEqualTo [])) exitWith {false};
-		if (!(_players inAreaArray [markerPos _x, 350, 350] isEqualTo [])) exitWith {false};
+		private _maxRange = distanceMission / 2;  //Former max distance 2000, with default mission radius is now 2000
+		private _minRange = distanceMission / 10; //Former min distance 350, with default mission radius is now 400
+		if(_x in airportsX) then {_maxRange = _maxRange * 2; _minRange = _minRange * 2; }; //double max and min for airbases, helicopters are seen & heard from further and travel faster
+		if ((_players inAreaArray [markerPos _x, _maxRange, _maxRange] isEqualTo [])) exitWith {false};
+		if (!(_players inAreaArray [markerPos _x, _minRange, _minRange] isEqualTo [])) exitWith {false};
 		private _side = sidesX getVariable [_x, sideUnknown];
 		if (_side == teamPlayer) exitWith {false};
 		if (_x in seaports and Faction(_side) get "vehiclesGunBoats" isEqualTo []) exitWith {false};
@@ -67,7 +70,7 @@ _posbase = getMarkerPos _base;
 
 if (_typePatrol == "AIR") then
 {
-	_arrayDestinations = markersX inAreaArray ["Synd_HQ", 4000, 4000] select {sidesX getVariable _x == _sideX};
+	_arrayDestinations = markersX inAreaArray ["Synd_HQ", distanceMission * 1.25, distanceMission * 1.25] select {sidesX getVariable _x == _sideX};
 	_distanceX = 200;
 }
 else
@@ -158,7 +161,7 @@ while {alive _veh} do
 	if (time - _startTime - 1800 > random 3600) exitWith {};				// random 30 to 90 minute max patrol time
 	if (_typePatrol == "AIR") then
 	{
-		_arrayDestinations = markersX inAreaArray ["Synd_HQ", 4000, 4000] select {sidesX getVariable _x == _sideX};
+		_arrayDestinations = markersX inAreaArray ["Synd_HQ", distanceMission * 1.25, distanceMission * 1.25] select {sidesX getVariable _x == _sideX};
 	}
 	else
 	{


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    Air patrols now pick destinations from 1.25 * mission distance, by default up to 5km from HQ.
    Patrol spawn distance overall is now derived from mission distance, half mission distance is the max distance patrols will spawn, and they will not spawn if a player is closer than one tenth of mission distance, with the default mission distance that is 2000 and 400 meters respectively 
     Air patrols check twice the distance compared to ground and sea patrols as they are limited to spawning at airbases

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
