### PR TITLE
Fix RRR clamp issue

### DIFF
--- a/A3A/addons/gui/functions/RRR/fn_vehServiceDialog.sqf
+++ b/A3A/addons/gui/functions/RRR/fn_vehServiceDialog.sqf
@@ -138,20 +138,14 @@ switch (_mode) do
                     if (_mag in BLACKLISTED_MAGS) then {continue};
                     // check for laser
                     private _ammo = getText(configFile >> "CfgMagazines" >> _mag >> "ammo");
+                    private _count = getNumber (configFile >> "CfgMagazines" >> _mag >> "count");
                     private _sim = getText(configFile >> "CfgAmmo" >> _ammo >> "simulation");
                     if (_sim in BLACKLISTED_SIMS) then {continue};
 
                     private _key = tolower _mag + str _turret;        // RHS lol
                     private _val = _magsCombinedHM getOrDefault [_key, [_mag, _turret, 0, 0], true];
-                    _val set [3, (_val#3) + _bullets];
-                } forEach _originalMags;
-
-                {
-                    _x params ["_mag", "_turret", "_bullets"];
-                    private _key = tolower _mag + str _turret;
-                    if !(_key in _magsCombinedHM) then {continue};          // Ignore anything that isn't in original loadout (could be pylon, blacklist, whatever)
-                    private _val = _magsCombinedHM get _key;
                     _val set [2, (_val#2) + _bullets];
+                    _val set [3, (_val#3) + _count];
                 } forEach magazinesAllTurrets cursorObject;
 
                 private _magsCombined = values _magsCombinedHM;

--- a/A3A/addons/gui/functions/RRR/fn_vehServiceDialog.sqf
+++ b/A3A/addons/gui/functions/RRR/fn_vehServiceDialog.sqf
@@ -132,8 +132,11 @@ switch (_mode) do
                 // new format? [magclass, turret, bulletCount, origCount]
                 private _originalMags = typeOf cursorObject call HR_GRG_fnc_getDefaultMags;
                 private _magsCombinedHM = createHashMap;
+                private _pylonMags = getAllPylonsInfo _veh apply {_x#3};
                 {
                     _x params ["_mag", "_turret", "_bullets"];
+                    // check for pylon
+                    if (_mag in _pylonMags) then {continue};
                     // blacklist
                     if (_mag in BLACKLISTED_MAGS) then {continue};
                     // check for laser

--- a/A3A/addons/gui/functions/RRR/fn_vehServiceDialog.sqf
+++ b/A3A/addons/gui/functions/RRR/fn_vehServiceDialog.sqf
@@ -132,11 +132,11 @@ switch (_mode) do
                 // new format? [magclass, turret, bulletCount, origCount]
                 private _originalMags = typeOf cursorObject call HR_GRG_fnc_getDefaultMags;
                 private _magsCombinedHM = createHashMap;
-                private _pylonMags = getAllPylonsInfo _veh apply {_x#3};
+                private _pylonMags = getAllPylonsInfo _veh select {_x#3 != ""} apply {[_x#3, _x#2, _x#4]};      // [magName, path, ammo]
+                private _allMags = magazinesAllTurrets _veh apply {_x select [0,3]};        // matched formats
+                _pylonMags apply {_allMags deleteAt (_allMags find _x)};
                 {
                     _x params ["_mag", "_turret", "_bullets"];
-                    // check for pylon
-                    if (_mag in _pylonMags) then {continue};
                     // blacklist
                     if (_mag in BLACKLISTED_MAGS) then {continue};
                     // check for laser
@@ -149,7 +149,7 @@ switch (_mode) do
                     private _val = _magsCombinedHM getOrDefault [_key, [_mag, _turret, 0, 0], true];
                     _val set [2, (_val#2) + _bullets];
                     _val set [3, (_val#3) + _count];
-                } forEach magazinesAllTurrets cursorObject;
+                } forEach _allMags;
 
                 private _magsCombined = values _magsCombinedHM;
                 _magsCombined sort true;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
When vehicles had their ammo clamped, the extra mags would show up in the UI but not be usable in the actual action function. This PR changes the UI to use magazinesAllTurrets. Not perfect, partial mags will still show, so ammo prices that arent perfect (most of them) will have close to, >90% ammo counts but not be exactly full.

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
