### PR TITLE
Remove looting block when carrying

### DIFF
--- a/A3A/addons/core/functions/LTC/fn_initLootToCrate.sqf
+++ b/A3A/addons/core/functions/LTC/fn_initLootToCrate.sqf
@@ -40,9 +40,7 @@ _object addAction [
     true,
     true,
     "",
-    "(
-        (attachedTo _originalTarget isEqualTo objNull)
-    )",
+    "",
     3
 ];
 
@@ -56,9 +54,7 @@ _object addAction [
     true,
     true,
     "",
-    "(
-        (attachedTo _originalTarget isEqualTo objNull)
-    )",
+    "",
     3
 ];
 


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Archaic limitation: for no apparent reason, looting while carrying the crate was blocked. Fixed now. In the future could maybe move the "drop" action below the looting functions but I think that's just the generic utility code running first

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
