### PR TITLE
Arty/SAM support trigger and supporting reworks

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -409,6 +409,7 @@ class CfgFunctions
             class initACEUnconsciousHandler {};
             class initBases {};
             class initCivSpawnPlaces {};
+            class initCivSpawnPlaceStats {};
             class initGarrisons {};
             class initMarkerTypes {};
             class initPoliceStations {};
@@ -659,8 +660,10 @@ class CfgFunctions
         class Save {
             file = QPATHTOFOLDER(functions\Save);
             class collectSaveData {};
+            class convert310Vehicles {};
             class convertSavedGarrisons {};
             class convertSavedStatics {};
+            class convertVehiclesToInternal {};
             class deleteSave {};
             class exportSave {};
             class finalizeSave {};

--- a/A3A/addons/core/Includes/script_version.hpp
+++ b/A3A/addons/core/Includes/script_version.hpp
@@ -1,4 +1,4 @@
 #define MAJOR 3
 #define MINOR 10
-#define PATCHLVL 3
+#define PATCHLVL 4
 #define BUILD 0

--- a/A3A/addons/core/functions/CREATE/fn_reinforceSide.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_reinforceSide.sqf
@@ -23,7 +23,9 @@ private _totalReinf = 0.2 * ([A3A_resourcesDefenceOcc, A3A_resourcesDefenceInv] 
 Debug_2("%1 has %2 resources available for reinforcements", _side, _totalReinf);
 if (_totalReinf <= 0) then {continue};
 
-private _typeWeights = createHashMapFromArray [["staticMortar", 1], ["staticAT", 1], ["staticAA", 1], ["staticMG", 1], ["vehicleAA", 1], ["vehicleArty", 0.3], ["vehicleSAM", 0.5], ["vehicleTruck", 1], ["vehicle", 0.4], ["heli", 0.3], ["plane", 0.3], ["runway", 0.3], ["boat", 0.6]];
+private _typeWeights = createHashMapFromArray [["staticMortar", 0.3], ["staticAT", 0.3], ["staticAA", 0.4], ["staticMG", 0.3],
+    ["vehicleAA", 0.5], ["vehicleArty", 0.2], ["vehicleSAM", 0.2], ["vehicleTruck", 1], ["vehicle", 0.2],
+    ["heli", 0.2], ["plane", 0.2], ["runway", 0.2], ["boat", 0.4]];
 private _noPlaceTypes = _faction get "noPlaceTypes";
 
 private _enemyAirfieldPositions = airportsX select {sidesX getVariable _x != _side} apply { markerPos _x };
@@ -48,7 +50,7 @@ private _weights = [];
     private _par = A3A_garrisonSize get _marker;                                     // no variance currently?
     private _cur = _garrison get "troops" select 0;          // [count, quality]
     if (_cur < _par) then {
-        _weights pushBack (1 - _cur / _par);            // troop base weight is 1
+        _weights pushBack (_par - _cur) / 10;                           // troop base weight is 1 per 10
         _markers pushBack [_marker, "troops", _par - _cur];
     };
     if !(_marker in A3A_spawnPlaceStats) then { continue };     // roadblock/camp don't reinforce vehicles atm
@@ -62,7 +64,7 @@ private _weights = [];
 
         private _countUsed = count (_places arrayIntersect _usedPlaces);
         if (_countUsed >= _par) then { continue };
-        _weights pushBack (_typeWeights get _x) * (1 - _countUsed / _par);
+        _weights pushBack (_typeWeights get _x) * (_par - _countUsed);          // weight for vehicles is multiplied by par count
         _markers pushBack [_marker, _x, _par - _countUsed];
 
     } forEach (A3A_spawnPlaceStats get _marker);        // hashmap, place type (_x) to [placeindexes, max, par]
@@ -104,7 +106,7 @@ while {_totalReinf > 0} do
 
         // Fix up weights for next pass
         _targData set [2, _needed-1];
-        _weights set [_index, _weight * (_needed-1) / _needed];
+        _weights set [_index, _weight * (_needed-1 max 0) / _needed];
         continue;
     };
 

--- a/A3A/addons/core/functions/CREATE/fn_reinforceVehicle.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_reinforceVehicle.sqf
@@ -31,20 +31,9 @@ if (sidesX getVariable _marker != _side) exitWith {
     Info_2("Reinf of %1 type %2 blocked by side change", _marker, _slotType);
 };
 
-// Determine free places. Can't re-use reinf code due to delay
-private _garrison = A3A_garrison get _marker;
-private _faction = [A3A_faction_occ, A3A_faction_inv] select (_side == Invaders);
-private _usedPlaces = (_garrison get "vehicles") select {_x#1 isEqualType 0} apply {_x#1};
-private _possiblePlaces = A3A_spawnPlaceStats get _marker get _slotType select 0;
-private _places = _possiblePlaces - _usedPlaces;
-if (_places isEqualTo []) exitWith {
-    Info_2("Reinf of %1 type %2 cancelled because no free places", _marker, _slotType);
-};
-
-private _placeNum = if (_slotType == "vehicle") then { _places # 0 } else { selectRandom _places };
-[_marker, _vehClass, _placeNum] call A3A_fnc_garrisonServer_addVehicleType;
-Info_2("Reinforcing %1 with vehicle %2", _marker, _vehClass);
-
+private _success = [_marker, _vehClass, _slotType] call A3A_fnc_garrisonServer_addVehicleType;
+if (!_success) exitWith {};
 [-(A3A_vehicleResourceCosts get _vehClass), _side, "defence"] call A3A_fnc_addEnemyResources;
+Info_2("Reinforced %1 with vehicle %2", _marker, _vehClass);
 
 };

--- a/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_changeSide.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_changeSide.sqf
@@ -24,7 +24,7 @@ private _garrison = A3A_activeGarrison get _marker;
 
 // Terminate any active supports
 {
-    [_marker, _x#0] call A3A_garrisonLocal_vehActionEnd;
+    [_marker, _x#0] call A3A_fnc_garrisonLocal_vehActionEnd;
 } forEachReversed (_garrison get "vehActions");
 
 // In this case, marker should no longer exist in A3A_activeGarrison and we're done here

--- a/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_spawnCiv.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_spawnCiv.sqf
@@ -20,22 +20,31 @@ params ["_spawnKey", "_newGarrison"];
 
 // just a list of vehicles, or do we want other stuff?
 
+private _marker = _spawnKey select [0, _spawnKey find "_civ"];
+private _policeCarPos = A3A_cityPoliceData get _marker select 1;
+
 private _garrison = createHashMap;
+private _places = A3A_spawnPlacesHM get _spawnKey;
 private _vehicles = [];
 {
-    // Boats use special [class, pos, dir] format
-    private _class = _x#0;
-    private _vehID = _x#3;
-    private _spawnPlace = _x;
+    _x params ["_class", "_posData", "", "_vehID"];
+    private ["_pos", "_dir"];
     if (_x#1 isEqualType 0) then {
-        _spawnPlace = (A3A_spawnPlacesHM get _spawnKey) # (_x#1);
+        _spawnPlace = _places # (_x#1);
+        _pos = _spawnPlace#1; _dir = _spawnPlace#2;
+    } else {
+        // Boats use [pos, dir] posdata format
+        _pos = _posData#0; _dir = _posData#1;
     };
-    _spawnPlace params ["_type", "_pos", "_dir"];
 
     // Block if there are any near entities at all?
     private _blockers = _pos nearEntities 8;
     if (_blockers isNotEqualTo []) then {
         Error_3("Spawn of %1 in %2 blocked by %3", _class, _spawnKey, typeof (_blockers#0));
+        continue;
+    };
+    if (_policeCarPos isEqualType [] and {_policeCarPos distance2d _pos < 10}) then {
+        Debug_1("Spawn of %1 in %2 blocked by police", _class, _spawnKey);
         continue;
     };
 

--- a/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_vehAction.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_vehAction.sqf
@@ -68,7 +68,6 @@ private _group = createGroup [side group gunner _vehicle, true];            // d
 crew _vehicle joinSilent _group;
 _garrison set ["groups", (_garrison get "groups") - [grpNull]];             // prevent this growing indefinitely
 _garrison set ["troops", (_garrison get "troops") - crew _vehicle];
-_garrison get "vehActions" pushBack [_vehID, _vehicle, _group];
 
 // might need units instead for accounting? dead guys will be removed
 // But dead units get removed on server side anyway, so it mostly works...
@@ -87,7 +86,8 @@ if (_garrison get "state" == "paused") then {
 private _vehType = A3A_supportVehTypes getOrDefault [typeOf _vehicle, "none"];
 Trace_1("Running vehicle action %1", _vehType);
 
-switch (_vehType) do {
+isNil {
+private _scriptHandle = switch (_vehType) do {
     case "staticMortars": {
         [_marker, _vehID, _vehicle, _actionData, false] spawn A3A_fnc_vehActionArty;
     };
@@ -105,4 +105,7 @@ switch (_vehType) do {
             A3A_garrisonOps pushBack ["vehActionEnd", _this];
         };
     };
+};
+
+_garrison get "vehActions" pushBack [_vehID, _vehicle, _group, _scriptHandle];
 };

--- a/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_vehActionEnd.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_vehActionEnd.sqf
@@ -27,11 +27,11 @@ if (_index == -1) then {
     // Normal error because support might be terminated locally and then externally
     Trace_1("Vehicle ID %1 not found in active supports");
 };
-_vehActions deleteAt _index params ["", "_vehicle", "_crewGroup"];
+_vehActions deleteAt _index params ["", "_vehicle", "_crewGroup", "_scriptHandle"];
 
 
 // First kill function if it's running
-// TODO, no functions yet
+terminate _scriptHandle;
 
 // If garrison isn't spawned, delete the vehicle & crew
 if (_garrison get "state" == "disabled") exitWith {

--- a/A3A/addons/core/functions/GarrisonServer/fn_buildCity.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_buildCity.sqf
@@ -14,33 +14,15 @@
 
 params ["_marker"];
 
-private _spawnKey = _marker + "_civ";
-private _numCiv = 15 * sqrt (A3A_cityPop get _marker);
-
-private _spawnPlaces = A3A_spawnPlacesHM get _spawnKey;
-private _carPlaces = [];
-private _boatPlaces = [];
-{
-    if (_x#0 == "civCar") then { _carPlaces pushBack _forEachIndex; continue };
-    if (_x#0 == "civBoat") then { _boatPlaces pushBack _forEachIndex };
-} forEach _spawnPlaces;
-
-private _numParked = _numCiv * (1/50) * civTraffic;
-_numParked = (ceil _numParked) min count _carPlaces;
-
-private _numBoats = (_numCiv / 50) min count _boatPlaces;
-
-private _markerStats = createHashMap;
-_markerStats set ["civCar", [_carPlaces, count _carPlaces, _numParked]];
-_markerStats set ["civBoat", [_boatPlaces, count _boatPlaces, _numBoats]];
-
-A3A_spawnPlaceStats set [_spawnKey, _markerStats];
-
-
 // If city vehicle data was loaded from save, just bail now
-if (_spawnKey in A3A_garrison) then { continue };           
+private _spawnKey = _marker + "_civ";
+if (_spawnKey in A3A_garrison) then { continue };
 private _garrison = createHashMap;
 private _vehicles = [];
+
+private _spawnPlaces = A3A_spawnPlacesHM get _spawnKey;
+A3A_spawnPlaceStats get _spawnKey get "civCar" params ["_carPlaces", "", "_numParked"];
+A3A_spawnPlaceStats get _spawnKey get "civBoat" params ["_boatPlaces", "", "_numBoats"];
 
 for "_i" from 1 to _numParked do {
     private _type = selectRandomWeighted civVehiclesWeighted;
@@ -53,7 +35,7 @@ for "_i" from 1 to _numBoats do {
     private _type = selectRandomWeighted civBoatsWeighted;
     private _placeNum = _boatPlaces deleteAt floor random count _boatPlaces;
     (_spawnPlaces # _placeNum) params ["", "_pos", "_dir"];
-    _vehicles pushBack [_type, _pos, _dir];
+    _vehicles pushBack [_type, [_pos, _dir]];
 };
 
 _garrison set ["vehicles", _vehicles];

--- a/A3A/addons/core/functions/GarrisonServer/fn_buildEnemyGarrison.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_buildEnemyGarrison.sqf
@@ -14,7 +14,7 @@
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
 
-params ["_marker"];
+params ["_marker", ["_vehiclesOnly", false]];
 
 if !(_marker in markersX) exitWith {
     Error_1("Marker %1 is not a major marker", _marker);
@@ -26,30 +26,34 @@ if (isNil "_spawnPlaceStats") then {
     Error_1("Marker %1 not found in spawnPlaceStats", _marker);
 };
 
-private _siteType = call {
-    if (_marker in citiesX) exitWith {"city"};
-    if (_marker in airportsX) exitWith {"airport"};
-    if (_marker in outposts) exitWith {"outpost"};
-    if (_marker in seaports) exitWith {"seaport"};
-    "factory";
-};
-private _quality = [_siteType, _marker, _side] call A3A_fnc_getSiteTroopQuality;
-
 // Might be used to rebuild a garrison after a sim capture, so keep the old static info if it exists
 private _garrison = A3A_garrison getOrDefaultCall [_marker, {createHashMap}, true];
-_garrison set ["buildings", []];
-private _troopCount = (0.7 + random 0.3) * (A3A_garrisonSize get _marker);
-_garrison set ["troops", [ceil _troopCount, _quality]];
+
+if (!_vehiclesOnly) then {
+    private _siteType = call {
+        if (_marker in citiesX) exitWith {"city"};
+        if (_marker in airportsX) exitWith {"airport"};
+        if (_marker in outposts) exitWith {"outpost"};
+        if (_marker in seaports) exitWith {"seaport"};
+        "factory";
+    };
+    private _quality = [_siteType, _marker, _side] call A3A_fnc_getSiteTroopQuality;
+
+    _garrison set ["buildings", []];
+    private _troopCount = (0.7 + random 0.3) * (A3A_garrisonSize get _marker);
+    _garrison set ["troops", [ceil _troopCount, _quality]];
+};
 
 // Note: spawnPlaceStats has detailed place names (eg staticAA, vehicleTruck), garrison puts everything into vehicles
 private _vehicles = [];
 {
+    if (_x in ["vehicleArty", "vehicleSAM"]) then { continue };
     private _placeType = _x;
     _y params ["_indexes", "_max", "_par"];
 
     private _remIndexes = +_indexes;
     for "_i" from 1 to _par do {
-        private _vehType = [_faction, _placeType, _siteType == "airport"] call A3A_fnc_selectGarrisonVehicleType;
+        private _vehType = [_faction, _placeType, "airport" in _marker] call A3A_fnc_selectGarrisonVehicleType;
         if (isNil "_vehType") exitWith {};      // faction doesn't have vehicles of that type
 
         // Use places in order for vehicles, otherwise randomly

--- a/A3A/addons/core/functions/GarrisonServer/fn_buildEnemyGarrison.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_buildEnemyGarrison.sqf
@@ -47,12 +47,13 @@ if (!_vehiclesOnly) then {
 // Note: spawnPlaceStats has detailed place names (eg staticAA, vehicleTruck), garrison puts everything into vehicles
 private _vehicles = [];
 {
-    if (_x in ["vehicleArty", "vehicleSAM"]) then { continue };
     private _placeType = _x;
     _y params ["_indexes", "_max", "_par"];
+    private _vehCount = floor (random 0.99 + _par * (0.7 + random 0.3));
+    //diag_log format ["Spawning %1 of %2 type %3", _vehCount, _par, _placeType];
 
     private _remIndexes = +_indexes;
-    for "_i" from 1 to _par do {
+    for "_i" from 1 to _vehCount do {
         private _vehType = [_faction, _placeType, "airport" in _marker] call A3A_fnc_selectGarrisonVehicleType;
         if (isNil "_vehType") exitWith {};      // faction doesn't have vehicles of that type
 

--- a/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_addVehicleType.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_addVehicleType.sqf
@@ -1,13 +1,14 @@
 /*
     Server-side function to add vehicle/static of specific type to enemy garrison
-    Slot type/number selected at higher level
 
     Environment: Unscheduled, server
 
     Arguments:
     <STRING> Marker name of garrison.
     <STRING> Classname of vehicle to add to garrison.
-    <NUMBER> Slot number to place vehicle (index into spawnPlaces).
+    <NUMBER or STRING> Slot number (index into spawnPlaces) or slot type.
+
+    Returns: <BOOL> false if slot number isn't provided and there are no free places
 
     Copyright 2025 John Jordan. All Rights Reserved.
     Used and distributed by the Antistasi Community project with permission.
@@ -25,6 +26,15 @@ if (sidesX getVariable _marker == teamPlayer) exitWith {
 };
 
 private _garrison = A3A_garrison get _marker;
+
+if (_slotNum isEqualType "") then {
+    private _usedPlaces = (_garrison get "vehicles") select {_x#1 isEqualType 0} apply {_x#1};
+    private _places = (A3A_spawnPlaceStats get _marker get _slotNum select 0) - _usedPlaces;
+    if (_places isEqualTo []) exitWith {};
+    _slotNum = if (_slotNum == "vehicle") then { _places # 0 } else { selectRandom _places };
+};
+if (_slotNum isEqualType "") exitWith { Debug_2("No places found for slot type %1 in %2", _slotNum, _vehClass); false };
+
 private _vehID = _garrison get "nextVehID";
 private _vehEntry = [_vehClass, _slotNum, nil, _vehID];
 (_garrison get "vehicles") pushBack _vehEntry;
@@ -39,3 +49,5 @@ if (_vehClass in A3A_supportVehTypes) then {
 if (spawner getVariable _marker != 2) then {
     ["addVehicleType", [_marker, _vehClass, _slotNum, _vehID]] call A3A_fnc_garrisonOp;
 };
+
+true;

--- a/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_cleanup.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_cleanup.sqf
@@ -33,23 +33,26 @@ if ("_civ" in _marker) exitWith
     {
         _x params ["_vehType", "_slotNum"];
 
+        // Shouldn't trigger now that save is checked
         if (_slotNum isEqualType 0 and { _slotNum >= count _places }) then {
+            Error_1("Slot number above slot count for %1 in %2", _x, _marker);
             _vehicles deleteAt _forEachIndex;
             continue;
         };
 
         // Temporary fix for boats being mangled in 3.10.3
-        while {_slotNum isEqualType [] and {_slotNum#0 isEqualType []}} do {
-            Debug_3("Fixing incorrect boat format for %1, pos %2, dir %3", _vehType, _slotNum#0, _slotNum#1);
-            _x set [2, _slotNum#1]; _x set [1, _slotNum#0]; _slotNum = _x#1;
-        };
+        // Incorrect since boat format changed
+//        while {_slotNum isEqualType [] and {_slotNum#0 isEqualType []}} do {
+//            Error_3("Fixing incorrect boat format for %1, pos %2, dir %3", _vehType, _slotNum#0, _slotNum#1);
+//            _x set [2, _slotNum#1]; _x set [1, _slotNum#0]; _slotNum = _x#1;
+//        };
 
         private _slotType = if (_slotNum isEqualType []) then { "civBoat" } else { _places # _slotNum # 0 };
         if !(_vehType in (_valid get _slotType)) then {
             Debug_2("%1 (slot type %2) not valid, swapping", _vehType, _slotType);
             if (_slotType == "civCar") exitWith { _x set [0, selectRandomWeighted civVehiclesWeighted] };
             if (_slotType == "civBoat") exitWith { _x set [0, selectRandomWeighted civBoatsWeighted] };
-            _vehicles deleteAt _forEachIndex;
+            _vehicles deleteAt _forEachIndex;       // vehiclePolice case
         };
     } forEachReversed (_garrison get "vehicles");
 };
@@ -61,8 +64,9 @@ if (_side == teamPlayer) exitWith {};           // nothing to do here at the mom
 private _troops = _garrison get "troops";
 private _excess = (_troops#0) - (A3A_garrisonSize get _marker);
 if (_excess > 0) then {
+    Debug_2("Clearing %1 excess troops in %2", _excess, _marker);
     _troops set [0, _troops#0 - _excess];
-    [10*_excess, _side, "defence"] call A3A_fnc_addEnemyResources;
+    if (_garrison get "type" != "city") then { [10*_excess, _side, "defence"] call A3A_fnc_addEnemyResources };
 };
 
 if (_troopsOnly) exitWith { Trace("Completed") };

--- a/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_updateVehData.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_updateVehData.sqf
@@ -26,24 +26,24 @@ if (sidesX getVariable _marker != teamPlayer) exitWith {};
 
 // Can't actually tell whether garrison is spawned here... huh
 private _garrison = A3A_garrison get _marker;
+private _spawnPlaces = A3A_spawnPlacesHM get _marker;
 
-private _usedVehicles = [];
 {
-    if (_x#1 isEqualType 0) then { continue };                     // don't bother dealing with placed vehicles for now
-    private _veh = nearestObject [ASLtoATL (_x#1#0), _x#0];          // position, type
+    //if (_x#1 isEqualType 0) then { continue };                     // don't bother dealing with placed vehicles for now
+    private _posATL = if (_x#1 isEqualType 0) then { _spawnPlaces#(_x#1)#1 } else { ASLtoATL (_x#1#0) };
+    private _veh = nearestObject [_posATL, _x#0];          // position, type
     // sanity checks?
     private _reason = call {
         if (isNull _veh) exitWith { "missing" };
         if (!alive _veh) exitWith { "dead" };
-        if (_veh getVariable "markerX" != _marker) exitWith { "notMarker" };
-        if (_veh in _usedVehicles) exitWith { "used" };
+        if (_x#3 != _veh getVariable ["A3A_vehID", -1]) exitWith { "wrongVID" };
     };
     if (!isNil "_reason") then {
         Error_3("Vehicle type %1 not found in %2, reason: %3", _x#0, _marker, _reason);
         continue;
     };
     // Update pos/dir, in case it got nudged
-    _x set [1, [getPosWorld _veh, vectorDir _veh, vectorUp _veh]];
+    if (_x#1 isEqualType []) then { _x set [1, [getPosWorld _veh, vectorDir _veh, vectorUp _veh]] };
     _x set [2, _veh call HR_GRG_fnc_getState];
-    _usedVehicles pushBack _veh;
+
 } forEach (_garrison get "vehicles");

--- a/A3A/addons/core/functions/Save/fn_convert310Vehicles.sqf
+++ b/A3A/addons/core/functions/Save/fn_convert310Vehicles.sqf
@@ -1,0 +1,90 @@
+/*
+    Function to convert 3.10 saved vehicle format to new format with additional place information
+
+*/
+
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+
+private _allTypes = ["runway", "staticMG", "staticAA", "staticMortar", "vehicleAA", "vehicleArty", "vehicleSAM", "vehicleTruck", "vehicle", "heli", "plane", "boat"];
+
+// Build _validVehicles from occ+inv
+private _validVehicles = +(A3A_validVehicles get Occupants);
+private _validInv = A3A_validVehicles get Invaders;
+{ _y append (_validInv get _x) } forEach _validVehicles;
+_validVehicles get "vehicleRB" append FactionGet(reb,"vehiclesLightArmed");         // because rebel roadblocks use vehicleRB
+
+{
+    private _marker = _x;
+    private _garrison = _y;
+    private _vehicles = _garrison get "vehicles";
+    private _vehicles2 = createHashMap;
+    _garrison set ["vehicles2", _vehicles2];
+
+    // Convert free vehicles to new array format with all position info at _x#1
+    private _freeVehicles = _vehicles select { _x#1 isEqualType [] };
+    {
+        // Temporary fix for boats being mangled in 3.10.3
+        while {_x#1 isEqualType [] and {_x#1#0 isEqualType []}} do {
+            _x set [2, _x#1#1]; _x set [1, _x#1#0];
+        };
+        _x set [1, [_x#1, _x#2]];				                // pos/dir (dir may be number or vector)
+        if (count _x >= 4) then { _x#1 pushBack _x#3 };         // add in up vector, if it exists
+        if (count _x == 5) then { _x set [2, _x#4]; _x resize 3 } else { _x resize 2 };		// move state & cap
+    } forEach _freeVehicles;
+    _vehicles2 set ["free", _freeVehicles];
+
+    // If it's a city then just put everything else into civCar and we're done here
+    if ("_civ" in _marker) then {
+        _vehicles2 set ["civCar", _vehicles select { _x#1 isEqualType 0 }];
+        continue;
+    };
+
+    // If the site has saved spawn places then we have all the info required
+    if ("spawnPlaces" in _garrison) then {
+        private _places = _garrison get "spawnPlaces";
+        {
+            private _cat = _places#(_x#1)#0;                 //_catTranslate getOrDefault [_cat, _cat];
+            _vehicles2 getOrDefault [_cat, [], true] pushBack _x;
+        } forEach (_vehicles select { _x#1 isEqualType 0 });
+        continue;
+    };
+
+    private _vehPlaced = _vehicles select { _x#1 isEqualType 0 };
+    if (_vehPlaced isEqualTo []) then { continue };         // HQ, camps etc
+
+    // Should be guaranteed to exist barring changed markers
+    private _spawnPlaceStats = A3A_spawnPlaceStats getOrDefault [_marker, createHashMap];
+    private _placeTypes = _allTypes select { _x in _spawnPlaceStats };
+
+    // special case for transport planes
+    if ("runway" in _placeTypes) then {
+        private _transportPlanes = A3A_faction_all get "vehiclesPlanesTransport";
+        private _transportIndex = _vehPlaced findIf { _x#0 in _transportPlanes };
+        if (_transportIndex == -1) exitWith {};
+        _vehicles2 set ["runway", [_vehPlaced deleteAt _transportIndex]];
+        _placeTypes = _placeTypes - ["runway"];          // otherwise we'll add a normal plane below
+    };
+
+    // Find suitable place for everything else
+    {
+        private _placeType = _x;
+        private _validTypes = _validVehicles get _x;
+        {
+            private _index = _vehPlaced findIf { _x#0 in _validTypes };
+            if (_index == -1) exitWith {};                              // no vehicles left, move to next place type
+            private _vehEntry = _vehPlaced deleteAt _index;
+            _vehEntry set [1, -1];                                      // let convertVehiclesToInternal sort out the place number
+            _vehicles2 getOrDefault [_placeType, [], true] pushBack _vehEntry;
+        } forEach (_spawnPlaceStats get _placeType select 0);           // make sure we don't exceed place count (eg. for vehicleTruck)
+    } forEach _placeTypes;                                              // Type ordering matters because we want to select for vehicleAA & vehicleTruck before vehicle
+
+    // Then report & discard whatever we have left
+    if (count _vehPlaced > 0) then { Info_2("Couldn't find places at %1 for %2", _marker, _vehPlaced) };
+
+    // If it's enemy and >1 then just rebuild garrison (later)
+    if (count _vehPlaced > 1 and sidesX getVariable _marker != teamPlayer) then { _garrison deleteAt "vehicles2" };
+
+} forEach A3A_garrison;
+
+Trace("Convert310Vehicles complete");

--- a/A3A/addons/core/functions/Save/fn_convertSavedStatics.sqf
+++ b/A3A/addons/core/functions/Save/fn_convertSavedStatics.sqf
@@ -44,6 +44,7 @@ private _posHQ = if (count _varValue > 3) then {_varValue select 0} else {_varVa
 		continue;
 	};
 
+	if (_arrayType == "buildings") then { _garrisonArray pushBack [_typeVeh, _posVeh, _vecDir, _vecUp]; continue };
 	if (isNil "_state") then { _garrisonArray pushBack [_typeVeh, [_posVeh, _vecDir, _vecUp]] }
 		else { _garrisonArray pushBack [_typeVeh, [_posVeh, _vecDir, _vecUp], _state] };
 

--- a/A3A/addons/core/functions/Save/fn_convertVehiclesToInternal.sqf
+++ b/A3A/addons/core/functions/Save/fn_convertVehiclesToInternal.sqf
@@ -25,20 +25,20 @@ FIX_LINE_NUMBERS()
 
         private _places = +(A3A_spawnPlaceStats get _marker get _placeType select 0);
         {
-            if (_x#1 in _places) then { _allVehicles pushBack _x; _places deleteAt (_places find _x#1); continue };
+            private _vehEntry = +_x;
+            if (_x#1 in _places) then { _allVehicles pushBack _vehEntry; _places deleteAt (_places find _x#1); continue };
             if (_places isEqualTo []) exitWith { Error_2("No places of type %1 left in %2", _placeType, _marker) };
 
             // Saved place type mismatch, replace
             Info_3("Place mismatch for vehicle %1, place %2 in %3, moving", _x#0, _placeType, _marker);
             private _placeIndex = if (_placeType == "vehicle") then { _places deleteAt 0 }
                 else { _places deleteAt floor random count _places };
-            _x set [1, _placeIndex]; _allVehicles pushBack _x;
+            _vehEntry set [1, _placeIndex]; _allVehicles pushBack _vehEntry;
 
         } forEach _y;           // _y is the vehicle array for that place type. Guaranteed _x#1 number here
 
     } forEach (_garrison get "vehicles2");
 
     _garrison set ["vehicles", _allVehicles];
-    // TODO: remove this after testing
-    // _garrison deleteAt "vehicles2"
+    _garrison deleteAt "vehicles2"
 } forEach A3A_garrison;

--- a/A3A/addons/core/functions/Save/fn_convertVehiclesToInternal.sqf
+++ b/A3A/addons/core/functions/Save/fn_convertVehiclesToInternal.sqf
@@ -1,0 +1,44 @@
+/*
+    Convert 3.11+ saved vehicles to garrison internal format
+    Checks and replaces place indices if mismatched
+*/
+
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+
+{
+    private _marker = _x;
+    private _garrison = _y;
+    Trace_2("Processing %1 data %2", _marker, _y get "vehicles2");
+
+    if !("vehicles2" in _y) then { [_x, true] call A3A_fnc_buildEnemyGarrison; continue };		// failed conversion on occ/inv, just rebuild the vehicles
+
+    private _placeStats = A3A_spawnPlaceStats get _marker;
+    private _allVehicles = [];
+    {
+        // If there are saved spawn places then we know that the place indexes are valid
+        if ("spawnPlaces" in _garrison or _x == "free") then { _allVehicles append _y; continue };
+
+        // In theory a place type could disappear...
+        private _placeType = _x;
+        if !(_placeType in _placeStats) then { Error_2("Place type %1 not found in %2", _placeType, _marker); continue };
+
+        private _places = +(A3A_spawnPlaceStats get _marker get _placeType select 0);
+        {
+            if (_x#1 in _places) then { _allVehicles pushBack _x; _places deleteAt (_places find _x#1); continue };
+            if (_places isEqualTo []) exitWith { Error_2("No places of type %1 left in %2", _placeType, _marker) };
+
+            // Saved place type mismatch, replace
+            Info_3("Place mismatch for vehicle %1, place %2 in %3, moving", _x#0, _placeType, _marker);
+            private _placeIndex = if (_placeType == "vehicle") then { _places deleteAt 0 }
+                else { _places deleteAt floor random count _places };
+            _x set [1, _placeIndex]; _allVehicles pushBack _x;
+
+        } forEach _y;           // _y is the vehicle array for that place type. Guaranteed _x#1 number here
+
+    } forEach (_garrison get "vehicles2");
+
+    _garrison set ["vehicles", _allVehicles];
+    // TODO: remove this after testing
+    // _garrison deleteAt "vehicles2"
+} forEach A3A_garrison;

--- a/A3A/addons/core/functions/Save/fn_loadServer.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadServer.sqf
@@ -85,15 +85,19 @@ if (isServer) then {
 	private _garrisonCompat = isNil "A3A_garrison";
 	if (_garrisonCompat) then { call A3A_fnc_convertSavedGarrisons };		// Creates & fills A3A_garrison
 
-	// Convert to internal vehicle format
-	if (!_garrisonCompat) then {			// TODO: Change save format after another version  => and A3A_saveVersion < 31200
-		{
-			if ("_civ" in _x) then {continue};			// city formats unchanged
-			{
-				_x set [1, [_x#1, _x#2, _x#3]];				// pos/dir/up
-				if (count _x == 5) then { _x set [2, _x#4]; _x resize 3 } else { _x resize 2 };		// move state & cap
-			} forEach (_y get "vehicles" select { _x#1 isEqualType [] });
-		} forEach A3A_garrison;
+	if (!_garrisonCompat) then {
+		// Garrisons might become orphaned with map changes
+		private _deadGarrisons = keys A3A_garrison select { !("_civ" in _x) and markerShape _x == "" };
+		if (_deadGarrisons isNotEqualTo []) then {
+			{ A3A_garrison deleteAt _x; A3A_garrison deleteAt (_x + "_civ") } forEach _deadGarrisons;
+			Info_1("Cleared out obsolete garrisons %1", _deadGarrisons);
+		};
+
+		// If version < 031004 then convert to newer vehicle save format
+		if !("vehicles2" in (A3A_garrison get "Synd_HQ")) then { call A3A_fnc_convert310Vehicles };
+
+		// Then convert to current internal format
+		call A3A_fnc_convertVehiclesToInternal;
 	};
 
 	// Fill out any garrison that hasn't already been filled

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -145,9 +145,19 @@ private _saveGarrison = +A3A_garrison;
 	_y deleteAt "type";
 	_y deleteAt "nextVehID";
 
+	private _places = A3A_spawnPlacesHM getOrDefault [_x, []];
+	private _vehicles2 = createHashMap;
+	_y set ["vehicles2", _vehicles2];
+	{
+		private _cat = if (_x#1 isEqualType 0) then {_places#(_x#1)#0} else {"free"};
+		//_cat = _catTranslate getOrDefault [_cat, _cat];
+		private _catData = _vehicles2 getOrDefault [_cat, [], true];
+		_catData pushBack (if (isNil {_x#2}) then {_x select [0, 2]} else {_x select [0, 3]}); 
+	} forEach (_y deleteAt "vehicles");
+
 	// Convert vehicles to older storage format
 	// TODO: Simplify this to one line after another version
-	if ("_civ" in _x) then { continue };		// civ internal format didn't change
+/*	if ("_civ" in _x) then { continue };		// civ internal format didn't change
 	{
 		if (_x#1 isEqualType 0) then {
 			_x resize ([3,2] select isNil {_x#2});		// remove ID, and state if nil
@@ -157,6 +167,7 @@ private _saveGarrison = +A3A_garrison;
 			_x set [1, _pos]; _x set [2, _vecDir]; _x set [3, _vecUp];
 		};
 	} forEach (_y get "vehicles");
+*/
 } forEach _saveGarrison;
 
 ["newGarrison", _saveGarrison] call A3A_fnc_setStatVariable;

--- a/A3A/addons/core/functions/Supports/fn_SUP_SAM.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_SAM.sqf
@@ -20,37 +20,59 @@ FIX_LINE_NUMBERS()
 
 params ["_supportName", "_side", "_resPool", "_maxSpend", "_target", "_targPos", "_reveal", "_delay"];
 
+// Pass in vehicle posATL and target, returns true if reachable
+private _fnc_checkSAMPath = {
+    params ["_pos", "_target"];
+    private _targDir = _pos getDir _target;
+    private _intercept = ATLtoASL _pos vectorAdd [300*sin _targDir, 300*cos _targDir, 200];
+    if (terrainIntersectASL [_intercept, getPosASL _target]) exitWith {false};
+    _pos distance2d _target > 1500;
+};
+private _bases = airportsX inAreaArray [_target, 10000, 10000] select { sidesX getVariable _x == _side }
+    select { [markerPos _x, _target] call _fnc_checkSAMPath };
+
 private _success = false;
 isNil {
-    private _bases = airportsX inAreaArray [_target, 10000, 10000] select { sidesX getVariable _x == _side };
+    private _usedBases = [];
     private _weightedBases = [];
     {
-        private _base = _x;
-        private _pos = markerPos _x;
-        private _dist = _pos distance2D _targPos;
-        if (_dist < 1500) then {continue};
-
         // Check if there's a SAM available at that base and find vehID for it
-        private _vehID = -1;
+        private _base = _x;
         {
-            if (_y#0 == "ready" and _y#1 == "vehiclesSAM") exitWith { _vehID = _x };
+            if (_y#1 != "vehiclesSAM") then { continue };
+            if (_y#0 != "ready") exitWith { _usedBases pushBack _base };      // strictly one SAM per airport... 
+            _weightedBases pushBack [_base, _x];
+            _weightedBases pushBack (1e8 / (markerPos _base distance2d _target)^2);       // prefer more distant bases
         } forEach (A3A_garrison get _base get "supportVehicles");
-        if (_vehID == -1) then { continue };
-
-        // Check if there's a firing path from the target to the airport (proxy for SAM position)
-        private _targDir = _pos getDir _targPos;
-        private _intercept = ATLtoASL _pos vectorAdd [300*sin _targDir, 300*cos _targDir, 200];
-        if (terrainIntersectASL [_intercept, getPosASL _target]) then { continue };
-
-        _weightedBases pushBack [_base, _vehID];
-        _weightedBases pushBack (1e8 / _dist^2);       // prefer more distant bases
     } forEach _bases;
 
-    if (_weightedBases isEqualTo []) exitWith { Debug("No bases found for SAM support") };
-    selectRandomWeighted _weightedBases params ["_marker", "_vehID"];
-
+    // Extra aggro/tier based delay. Need now so we can increase it
     private _aggro = if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
-    if (_delay < 0) then { _delay = (0.5 + random 1) * (100 - _aggro + 22*A3A_enemyResponseTime) };
+    if (_delay < 0) then { _delay = (0.5 + random 1) * (150 - 5*tierWar - 0.5*_aggro) };
+
+    private _samData = [];
+    if (_weightedBases isNotEqualTo []) then {
+        _samData = selectRandomWeighted _weightedBases
+    } else {
+        // If none, then add one at a suitable airfield
+        private _vehType = selectRandom (Faction(_side) get "vehiclesSAM");
+        private _freeBases = (_bases - _usedBases) select { spawner getVariable _x == 2 };
+        if (count _freeBases == 0) exitWith { Debug("No suitable airbases to spawn SAM") };
+        private _base = selectRandom _freeBases;
+
+        if ([_base, _vehType, "vehicleSAM"] call A3A_fnc_garrisonServer_addVehicleType) then
+        {
+            // Successfully added the vehicle. It'll be on the end of the vehicle array
+            [-(A3A_vehicleResourceCosts get _vehType), _side, _resPool] call A3A_fnc_addEnemyResources;
+            private _vehEntry = A3A_garrison get _base get "vehicles" select -1;
+            _samData = [_base, _vehEntry#3];
+
+            if (_delay != 0) then { _delay = _delay + 12*A3A_enemyResponseTime };
+            [_reveal, _side, "SAM", getPosATL _target, _delay] spawn A3A_fnc_showInterceptedSetupCall;
+        };
+    };
+    if (_samData isEqualTo []) exitwith {};
+    _samData params ["_marker", "_vehID"];
 
     A3A_supportStrikes pushBack [_side, "TARGET", _target, time + 1200, 1200, 100];
 
@@ -60,8 +82,5 @@ isNil {
     _success = true;
 };
 
-//[_reveal, _side, "SAM", _targPos, _delay] spawn A3A_fnc_showInterceptedSetupCall;
-
-// Vehicle cost + extra support cost for balance
-//(A3A_vehicleResourceCosts get _launcherType) + 100;
+// Per-volley cost
 [-1, 80] select _success;

--- a/A3A/addons/core/functions/Supports/fn_SUP_artillery.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_artillery.sqf
@@ -56,7 +56,7 @@ isNil {
 
         private _artyPos = if (_posData isEqualType []) then { _posData#0 } else { A3A_spawnPlacesHM get _base select _posData select 1 };
         private _artyDist = _artyPos distance2d _targPos;
-        if ([_vehType, _artyDist, 100] call _fnc_checkArtyRange) exitWith { _artyData = [_base, _vehID] };
+        if ([_vehType, _artyDist, 400] call _fnc_checkArtyRange) exitWith { _artyData = [_base, _vehID] };
     };
 
     // Extra aggro/tier based delay. Need now so we can increase it
@@ -68,7 +68,7 @@ isNil {
     {
         private _vehType = selectRandom (Faction(_side) get "vehiclesArtillery");
         private _freeBases = (_bases - _usedBases) select { spawner getVariable _x == 2 }
-            select { [_vehType, markerPos _x distance2d _targPos, 500] call _fnc_checkArtyRange };
+            select { [_vehType, markerPos _x distance2d _targPos, 700] call _fnc_checkArtyRange };
         if (count _freeBases == 0) exitWith { Debug("No free airbases to spawn artillery") };
         private _base = selectRandom _freeBases;
 

--- a/A3A/addons/core/functions/Supports/fn_SUP_artillery.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_artillery.sqf
@@ -20,19 +20,29 @@ FIX_LINE_NUMBERS()
 
 params ["_supportName", "_side", "_resPool", "_maxSpend", "_target", "_targPos", "_reveal", "_delay"];
 
+// Pass in vehicle type and range, returns true if reachable
+private _fnc_checkArtyRange = {
+    params ["_vehType", "_dist", ["_margin", 0]];
+    private _magHM = [_vehType] call A3A_fnc_getMortarMags select 1;
+    private _magType = _magHM getOrDefault ["HE", ""];
+    [_vehType, _magType] call A3A_fnc_getArtilleryRanges params ["_minRange", "_maxRange"];
+    _minRange + _margin < _dist and _maxRange - _margin > _dist;
+};
+
 // Uses server-side garrison support vehicle data to find suitable vehicle
 // Should be done unscheduled because something else might use the selected artillery
 private _success = false;
 isNil {
-
     // First search enemy airports for artillery
     private _bases = airportsX select { sidesX getVariable _x == _side };
+    private _usedBases = [];
     private _artillery = [];          // [_marker, _vehEntry]
     {
         if (markerPos _x distance2d _targPos < 700) then { continue };      // Don't use local artillery
         private _base = _x;
         {
-            if (_y#0 != "ready" or _y#1 != "vehiclesArtillery") then { continue };
+            if (_y#1 != "vehiclesArtillery") then { continue };
+            if (_y#0 != "ready") then { _usedBases pushBack _base; continue };      // might need this later 
             _artillery pushBack [_base, _y#2];
         } forEach (A3A_garrison get _base get "supportVehicles");
     } forEach _bases;
@@ -46,29 +56,44 @@ isNil {
 
         private _artyPos = if (_posData isEqualType []) then { _posData#0 } else { A3A_spawnPlacesHM get _base select _posData select 1 };
         private _artyDist = _artyPos distance2d _targPos;
-
-        private _magHM = [_vehType] call A3A_fnc_getMortarMags select 1;
-        private _magType = _magHM getOrDefault ["HE", ""];
-
-        ([_vehType, _magType] call A3A_fnc_getArtilleryRanges) params ["_minRange", "_maxRange"];
-        if (_artyDist > _minRange and _artyDist < _maxRange) exitWith { _artyData = [_base, _vehID] };
+        if ([_vehType, _artyDist, 100] call _fnc_checkArtyRange) exitWith { _artyData = [_base, _vehID] };
     };
-    if (_artyData isEqualTo []) exitwith { Debug("No bases found for artillery support") };
 
-    // Extra aggro/tier based delay
+    // Extra aggro/tier based delay. Need now so we can increase it
     private _aggro = if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
     if (_delay < 0) then { _delay = (0.5 + random 1) * (150 - 5*tierWar - 0.5*_aggro) };
 
-    Info_5("Artillery support %1 against %2 with delay %3 will be carried out by mortar ID %4 from %5", _supportName, _targPos, _delay, _artyData#0, _artyData#1);
+    // If none, then add one at a suitable airfield
+    if (_artyData isEqualTo []) then
+    {
+        private _vehType = selectRandom (Faction(_side) get "vehiclesArtillery");
+        private _freeBases = (_bases - _usedBases) select { spawner getVariable _x == 2 }
+            select { [_vehType, markerPos _x distance2d _targPos, 500] call _fnc_checkArtyRange };
+        if (count _freeBases == 0) exitWith { Debug("No free airbases to spawn artillery") };
+        private _base = selectRandom _freeBases;
 
-    // Any point in this for single-target?
-    //[_reveal, _side, "ARTILLERY", _targPos, _delay] spawn A3A_fnc_showInterceptedSetupCall;
+        if ([_base, _vehType, "vehicleArty"] call A3A_fnc_garrisonServer_addVehicleType) then
+        {
+            // Successfully added the vehicle. It'll be on the end of the vehicle array
+            [-(A3A_vehicleResourceCosts get _vehType), _side, _resPool] call A3A_fnc_addEnemyResources;
+            private _vehEntry = A3A_garrison get _base get "vehicles" select -1;
+            _artyData = [_base, _vehEntry#3];
+
+            if (_delay != 0) then { _delay = _delay + 120 };
+            [_reveal, _side, "ARTILLERY", _targPos, _delay] spawn A3A_fnc_showInterceptedSetupCall;
+        };
+    };
+    if (_artyData isEqualTo []) exitwith {};
+    _artyData params ["_base", "_vehID"];
+
+    Info_5("Artillery support %1 against %2 with delay %3 will be carried out by vehicle ID %4 from %5", _supportName, _targPos, _delay, _vehID, _base);
 
     A3A_supportStrikes pushBack [_side, "AREA", _targPos, time + 20*60, 20*60, 200];
 
-    [_artyData#0, _artyData#1, [_targPos, _delay, _reveal]] call A3A_fnc_garrisonServer_vehAction;
+    [_base, _vehID, [_targPos, _delay, _reveal]] call A3A_fnc_garrisonServer_vehAction;
     _success = true;
 };
 
 // Per-volley cost
 [-1, 80] select _success;
+

--- a/A3A/addons/core/functions/Supports/fn_SUP_mortar.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_mortar.sqf
@@ -53,7 +53,7 @@ isNil {
         private _magType = _magHM getOrDefault ["HE", ""];
 
         ([_vehType, _magType] call A3A_fnc_getArtilleryRanges) params ["_minRange", "_maxRange"];
-        if (_mortarDist > _minRange and _mortarDist < _maxRange) exitWith { _mortarData = [_base, _vehID] };
+        if (_mortarDist > _minRange+200 and _mortarDist < _maxRange-200) exitWith { _mortarData = [_base, _vehID] };
     };
     if (_mortarData isEqualTo []) exitwith { Debug("No bases found for mortar support") };
 

--- a/A3A/addons/core/functions/init/fn_initCivSpawnPlaceStats.sqf
+++ b/A3A/addons/core/functions/init/fn_initCivSpawnPlaceStats.sqf
@@ -1,0 +1,34 @@
+/*
+    Generate spawn place stats for cities
+
+    Environment: Server, post-params init/load only
+
+    Copyright 2025 John Jordan. All Rights Reserved.
+    Used and distributed by the Antistasi Community project with permission.
+*/
+
+{
+    private _marker = _x;
+    private _spawnKey = _marker + "_civ";
+    private _numCiv = 15 * sqrt (A3A_cityPop get _marker);
+
+    private _spawnPlaces = A3A_spawnPlacesHM get _spawnKey;
+    private _carPlaces = [];
+    private _boatPlaces = [];
+    {
+        if (_x#0 == "civCar") then { _carPlaces pushBack _forEachIndex; continue };
+        if (_x#0 == "civBoat") then { _boatPlaces pushBack _forEachIndex };
+    } forEach _spawnPlaces;
+
+    private _numParked = _numCiv * (1/50) * civTraffic;
+    _numParked = (ceil _numParked) min count _carPlaces;
+
+    private _numBoats = (_numCiv / 50) min count _boatPlaces;
+
+    private _markerStats = createHashMap;
+    _markerStats set ["civCar", [_carPlaces, count _carPlaces, _numParked]];
+    _markerStats set ["civBoat", [_boatPlaces, count _boatPlaces, _numBoats]];
+
+    A3A_spawnPlaceStats set [_spawnKey, _markerStats];
+
+} forEach citiesX;

--- a/A3A/addons/core/functions/init/fn_initPoliceStations.sqf
+++ b/A3A/addons/core/functions/init/fn_initPoliceStations.sqf
@@ -58,7 +58,7 @@ if (_policeStationTypes isEqualTo []) exitWith {
 
     private _distances = _nearPlaces apply { _x#1 distance2d _stationPos };
     private _minPlace = _nearPlaces select (_distances find selectMin _distances);
-    _garrison set ["spawnPlaces", [["vehiclesPolice", _minPlace#1, _minPlace#2]] ];
+    _garrison set ["spawnPlaces", [["vehiclePolice", _minPlace#1, _minPlace#2]] ];
 
     private _citySide = sidesX getVariable _city;
     if (_citySide != teamPlayer) then {

--- a/A3A/addons/core/functions/init/fn_initPoliceStations.sqf
+++ b/A3A/addons/core/functions/init/fn_initPoliceStations.sqf
@@ -8,11 +8,9 @@
     Used and distributed by the Antistasi Community project with permission.
 */
 
-// Used if A3A_garrison doesn't have a police station entry already: Usually new campaigns or compat loading
-// A3A_garrison should exist with empty vehicles array already
-
-// Need to run this shit even if it's an old game, and civ spawns might be different
-// Already have empty spawnPlaceStats and empty vehicles (or full for saves) but not spawnPlaces
+// Need to run this shit even if it's a saved game, because police station options might improve
+// spawnPlaceStats is initialized to 1-vehicle
+// police station pos, spawnplaces and vehicles may exist in saves, should be coherent
 
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
@@ -26,117 +24,79 @@ if (_policeStationTypes isEqualTo []) exitWith {
 	Error("No police station types found in mapInfo for this map. No police stations will be generated");
 };
 
-private _minPop = getNumber (_mapInfo/"policeStationMinPop");
-
-private _policeSpawnStats = createHashMapFromArray [ ["vehiclePolice", [[0], 1, 1]] ];
-
-// netId -> city marker name for destruction detection
-A3A_policeStations = createHashMap;
-
-// Alternative: Do not save spawn places for police stations
-// Regen here and delete the vehicles if it disappeared
-// Fewer code paths, better?
+// Create police station data if there isn't one in the city
 {
 	private _city = _x;
     private _garrison = A3A_garrison get _city;
-    _garrison set ["spawnPlaces", []];                                      // not initialized elsewhere
+    if ("policeStation" in _garrison) then { continue };
     if (A3A_garrisonSize get _city < 10) then { continue };                 // don't generate for small towns
 
-    private _stationPos = _garrison get "policeStation";
-    if (isNil "_stationPos") then {
-        private _buildings = nearestTerrainObjects [markerPos _city, ["House", "Building"], 100];       // CUP needs "Building"
-        _buildings = _buildings select { typeOf _x in _policeStationTypes } select { alive _x };        // isKindOf matching would pick up abandoned buildings
-        if (_buildings isEqualTo []) then {
-            // Try again with slightly larger radius
-            Trace_1("Expanding search radius in %1", _city);
-            _buildings = nearestTerrainObjects [markerPos _city, ["House", "Building"], 150];
-            _buildings = _buildings select { typeOf _x in _policeStationTypes } select { alive _x };
-        };
-        if (_buildings isEqualTo []) then {
-            Info_1("No suitable buildings for police station in %1", _city);
-            continue;
-        };
-
-        private _types = _buildings apply { typeOf _x };
-        Trace_2("Police stations types in %1: %2", _city, _types arrayIntersect _types);
-
-        _stationPos = getPosATL selectRandom _buildings;
-        _garrison set ["policeStation", _stationPos];         // only need one entry? Hmm. LootCD & intelCD go elsewhere.
-
-        private _citySide = sidesX getVariable _city;
-        if (_citySide != teamPlayer) then {
-            private _carType = selectRandom (Faction(_citySide) get "vehiclesPolice");
-            _garrison get "vehicles" pushBack [_carType, 0];
-        };
-    };
-    // If we're loading from a save, police station might already be destroyed
-    if (_stationPos isEqualType false) then { continue };
-
-    private _station = nearestBuilding _stationPos;
-    A3A_policeStations set [netId _station, _city];          // So we can detect destruction
-
-    // Use closest city spawn place within 50m for police car
-    private _places = A3A_spawnPlacesHM get (_city + "_civ") select { _x#0 == "civCar" };
-    private _placePositions = _places apply { _x#1 };
-    private _nearPlaces = _placePositions inAreaArrayIndexes [getPosATL _station, 50, 50] apply { _places # _x };
-    if (_nearPlaces isEqualTo []) then { _garrison set ["vehicles", []]; continue };
-
-    private _distances = _nearPlaces apply { _x#1 distance2d _station };
-    private _minPlace = _nearPlaces select (_distances find selectMin _distances);
-
-    _minPlace set [0, "vehiclePolice"];                         // no longer civCar, so buildCity won't use it
-    _garrison set ["spawnPlaces", [_minPlace]];                 // need this because it's post-initZones
-    A3A_spawnPlaceStats set [_city, _policeSpawnStats];
-    A3A_garrisonSize set [_city, (A3A_garrisonSize get _city) + 4];     // need more police to fill a station
-
-} forEach citiesX;
-
-
-/*
-{
-	private _city = _x;
-    if (A3A_garrisonSize get _city < 10) then { continue };                 // don't generate for small towns
-
-    private _garrison = A3A_garrison get _city;
-    private _stationPos = 
-    if ("policeStation" in _garrison) then {
-        // Need to mark off civ spawn places if matching
-        A3A_spawnPlaceStats set [_city, _policeSpawnStats];
-        private _policePositions = (_garrison get "spawnPlaces") apply {_x#1};
-        private _civPlaces = A3A_spawnPlacesHM get (_city + "_civ") select { _x#0 == "civCar" };
-        {
-            if (_policePositions inAreaArray [_x#0, 10, 10] isEqualTo []) then { continue };
-            _x set [0, "vehiclePolice"];
-        } forEach _civPlaces;
-        continue;
-    };
-
-    private _buildings = nearestTerrainObjects [markerPos _city, ["House"], 100];
+    private _buildings = nearestTerrainObjects [markerPos _city, ["House", "Building"], 100];       // CUP needs "Building"
     _buildings = _buildings select { typeOf _x in _policeStationTypes } select { alive _x };        // isKindOf matching would pick up abandoned buildings
+    if (_buildings isEqualTo []) then {
+        // Try again with slightly larger radius
+        Trace_1("Expanding search radius in %1", _city);
+        _buildings = nearestTerrainObjects [markerPos _city, ["House", "Building"], 150];
+        _buildings = _buildings select { typeOf _x in _policeStationTypes } select { alive _x };
+    };
     if (_buildings isEqualTo []) then {
         Info_1("No suitable buildings for police station in %1", _city);
         continue;
     };
-    private _station = selectRandom _buildings;		            // or do we try to do priority order?
-    _garrison set ["policeStation", getPosATL _station];         // only need one entry? Hmm. LootCD & intelCD go elsewhere.
 
-    _station setVariable ["A3A_policeStation", _city];          // So we can detect destruction
+    private _types = _buildings apply { typeOf _x };
+    Trace_2("Police stations types in %1: %2", _city, _types arrayIntersect _types);
+
+    _stationPos = getPosATL selectRandom _buildings;
+    _garrison set ["policeStation", _stationPos];         // only need one entry? Hmm. LootCD & intelCD go elsewhere.
 
     // Use closest city spawn place within 50m for police car
     private _places = A3A_spawnPlacesHM get (_city + "_civ") select { _x#0 == "civCar" };
     private _placePositions = _places apply { _x#1 };
-    private _nearPlaces = _placePositions inAreaArrayIndexes [getPosATL _station, 50, 50] apply { _places # _x };
-    if (_nearPlaces isEqualTo []) then { continue };
+    private _nearPlaces = _placePositions inAreaArrayIndexes [_stationPos, 50, 50] apply { _places # _x };
+    if (_nearPlaces isEqualTo []) then { _garrison set ["spawnPlaces", []]; continue };
 
-    private _distances = _nearPlaces apply { _x#1 distance2d _station };
+    private _distances = _nearPlaces apply { _x#1 distance2d _stationPos };
     private _minPlace = _nearPlaces select (_distances find selectMin _distances);
+    _garrison set ["spawnPlaces", [["vehiclesPolice", _minPlace#1, _minPlace#2]] ];
 
-    _minPlace set [0, "vehiclePolice"];       // no longer civCar
-    _garrison set ["spawnPlaces", [_minPlace]];                 // need this because it's post-initZones
-    A3A_spawnPlaceStats set [_city, _policeSpawnStats];
-
-    private _carType = selectRandom (A3A_faction_occ get "vehiclesPolice");
-    _garrison set ["vehicles", [[_carType, 0]] ];
+    private _citySide = sidesX getVariable _city;
+    if (_citySide != teamPlayer) then {
+        private _carType = selectRandom (Faction(_citySide) get "vehiclesPolice");
+        _garrison get "vehicles" pushBack [_carType, 0];
+    };
 
 } forEach citiesX;
-*/
+
+
+// netId -> city marker name for destruction detection
+A3A_policeStations = createHashMap;
+
+// city marker -> [stationPos, carPos] mostly for client undercover
+A3A_cityPoliceData = createHashMap;
+
+// Then update the temporary accounting data
+{
+	private _city = _x;
+    private _garrison = A3A_garrison get _city;
+
+    // need to clear spawnPlaceStats & vehicles here if there isn't a car pos...
+    private _spawnPlaces = _garrison getOrDefault ["spawnPlaces", []];
+    private _carPlacePos = if (_spawnPlaces isEqualTo []) then {false} else {_spawnPlaces#0#1};
+    if (_carPlacePos isEqualType false) then {
+        A3A_spawnPlaceStats set [_city, createHashMap];
+        _garrison set ["vehicles", []];                 // probably is already, but whatever
+    };
+
+    // If we're loading from a save, police station might already be destroyed
+    private _stationPos = _garrison getOrDefault ["policeStation", false];
+    if (_stationPos isEqualType []) then {
+        A3A_garrisonSize set [_city, (A3A_garrisonSize get _city) + 4];             // need more police to fill a station
+        A3A_policeStations set [netId nearestBuilding _stationPos, _city];          // So we can detect destruction
+    };
+
+    A3A_cityPoliceData set [_city, [_stationPos, _carPlacePos]];
+
+} forEach citiesX;
+
+publicVariable "A3A_cityPoliceData";

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -108,6 +108,9 @@ private _savedParamsHM = createHashMapFromArray (A3A_saveData get "params");
     missionNamespace setVariable [configName _x, _val, true];                   // just publish them all, doesn't really hurt
 } forEach ("true" configClasses (configFile/"A3A"/"Params"));
 
+// Depends on civTraffic param
+call A3A_fnc_initCivSpawnPlaceStats;
+
 // Might have params dependency at some point
 if (A3A_hasACEMedical) then { call A3A_fnc_initACEUnconsciousHandler };
 

--- a/A3A/addons/core/functions/init/fn_initSpawnPlaceStats.sqf
+++ b/A3A/addons/core/functions/init/fn_initSpawnPlaceStats.sqf
@@ -15,11 +15,14 @@ FIX_LINE_NUMBERS()
 
 params ["_markers"];
 
+// Assume one police car place for now. initPoliceStations may remove it later
+private _policeSpawnStats = createHashMapFromArray [ ["vehiclePolice", [[0], 1, 1]] ];
+
 A3A_spawnPlaceStats = createHashMap;
 {
+    if (_x in citiesX) then { A3A_spawnPlaceStats set [_x, _policeSpawnStats]; continue };
     private _marker = _x;
     private _markerStats = createHashMap;
-    if (_marker in citiesX) then { A3A_spawnPlaceStats set [_x, _markerStats]; continue };
 
     private _spawnPlaces = A3A_spawnPlacesHM get _marker;
     private _isAirport = _marker in airportsX;

--- a/A3A/addons/core/functions/init/fn_initSpawnPlaceStats.sqf
+++ b/A3A/addons/core/functions/init/fn_initSpawnPlaceStats.sqf
@@ -26,6 +26,7 @@ A3A_spawnPlaceStats = createHashMap;
 
     private _spawnPlaces = A3A_spawnPlacesHM get _marker;
     private _isAirport = _marker in airportsX;
+    private _isOutpost = _marker in outposts;
     private _garrSize = A3A_garrisonSize get _marker;
     {
         private _placeType = _x;
@@ -36,13 +37,13 @@ A3A_spawnPlaceStats = createHashMap;
         private _maxPlaces = count _indexes;
         private _parPlaces = switch (_placeType) do {
             case "staticMG": { floor (_garrSize / 8) };
-            case "staticAA": { [1, 2] select _isAirport };
-            case "staticMortar": { [1, 2] select _isAirport };
-            case "vehicleAA";
-            case "vehicleArty";
-            case "vehicleSAM": { [0, 1] select _isAirport };
+            case "staticAA": { if _isAirport exitWith {2}; [0, 1] select _isOutpost };
+            case "staticMortar": { if _isAirport exitWith {2}; [0, 1] select _isOutpost };
             case "vehicleTruck": { 1 };
             case "vehicle": { [0, 6 min ceil (_maxPlaces / 2)] select _isAirport };
+            case "vehicleAA": { [0, 1] select _isAirport };
+            case "vehicleArty": { [0, 0.2] select _isAirport };
+            case "vehicleSAM": { [0, 0.3] select _isAirport };
             case "heli": { ceil (_garrSize / 15) };
             case "plane": { [0, 3] select _isAirport };         // in case outposts overlap airports
             case "runway": { [0, 1] select _isAirport };

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -541,6 +541,7 @@ A3A_validVehicles = createHashMap;
 	_valid set ["staticAT", _x get "staticAT"];
 	_valid set ["staticMortar", _x get "staticMortars"];
 
+	_valid set ["vehicleRB", _x get "vehiclesMilitiaLightArmed"];
 	_valid set ["vehicleAA", _x get "vehiclesAA"];
 	_valid set ["vehicleSAM", _x get "vehiclesSAM"];
 	_valid set ["vehicleArty", _x get "vehiclesArtillery"];
@@ -551,8 +552,8 @@ A3A_validVehicles = createHashMap;
 		+ (_x get "vehiclesLightAPCs") + (_x get "vehiclesAPCs") + (_x get "vehiclesAA") + (_x get "vehiclesArtillery") + (_x get "vehiclesIFVs")
 		+ (_x get "vehiclesLightTanks") + (_x get "vehiclesTanks") + (_x get "vehiclesHeavyTanks") + (_x get "vehiclesMilitiaLightArmed")];
 
-	_valid set ["plane", (_x get "vehiclesPlanesCAS") + (_x get "vehiclesPlanesAA") + (_x get "vehiclesPlanesTransport")];
-	_valid set ["runway", _valid get "plane"];
+	_valid set ["plane", (_x get "vehiclesPlanesCAS") + (_x get "vehiclesPlanesAA")];
+	_valid set ["runway", (_x get "vehiclesPlanesCAS") + (_x get "vehiclesPlanesAA") + (_x get "vehiclesPlanesTransport")];
 	_valid set ["heli", (_x get "vehiclesHelisLight") + (_x get "vehiclesHelisTransport") + (_x get "vehiclesHelisLightAttack") + (_x get "vehiclesHelisAttack")];
 	_valid set ["boat", (_x get "vehiclesTransportBoats") + (_x get "vehiclesGunBoats")];
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [X] Change
3. [X] Enhancement

### What have you changed and why?
Original intention was to reduce initial SAM & arty spawns and instead have them mostly generated by supports when called. While testing, I ran into an old problem with the save format where it assumes spawn places for major sites don't change. This was previously worked around by swapping to a suitable vehicle for a place, but this wasn't sufficient because it meant that sites could end up with too many of a particular vehicle type (eg every airfield ending up with SAM+arty).

Ended up rewriting the vehicle save format to preserve place type information and clear up some old inconsistencies. It's also capable of loading in 3.10.x saves and guessing which place a particular vehicle is supposed to be in. It's very accurate as long as you didn't change modsets at the same time, in which case it'll just rebuild all the enemy garrisons and delete some captured rebel vehicles. The data format is a bit larger but there's scope for optimization.
    
This then ran into issues with some other shaky shit that I did with civilian & police car spawn places. I've rewritten a lot of that code to simplify the logic and control flow. An added feature is that police station locations are now broadcast to clients, so we can sort out undercover removal.

Turns out that the reinf weighting I used initially was terrible (generally vehicles were over-weighted vs troops). Reworked that because otherwise it was difficult to control arty/SAM reinf properly.

Most of this is micro-tested so that it shouldn't need a community server run, but I may have missed a couple of bits. I shall double-check later.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

