### PR TITLE
Improve createAttackVehicle pathfinding a bit

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -70,6 +70,7 @@ class CfgFunctions
             class vehicleConvoyHeliTravel{};
             class vehicleConvoyTravel {};
             class vehicleMarkers {};
+            class waypointMonitor {};
         };
 
         class Ammunition {

--- a/A3A/addons/core/functions/AI/fn_waypointMonitor.sqf
+++ b/A3A/addons/core/functions/AI/fn_waypointMonitor.sqf
@@ -1,0 +1,46 @@
+/*
+    Help ground vehicles to follow move waypoints
+
+Parameters:
+    <OBJECT> Vehicle.
+
+*/
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+
+params ["_vehicle"];
+
+// Handle some broken input errors
+private _error = call {
+    if !(alive _vehicle) exitWith { "Dead or missing vehicle input" };
+    if !(alive driver _vehicle) exitWith { "Dead or missing driver in vehicle" };
+};
+if (!isNil "_error") exitWith { Error(_error) };
+
+private _group = group driver _vehicle;
+private _timeout = time + 20 + (_vehicle distance2d waypointPosition [_group, currentWaypoint _group]);
+private _fails = 0;
+while {_fails < 2} do
+{
+    // Terminate if we ran out of (intermediate) move waypoints or vehicle/driver broke
+    private _curWP = currentWaypoint _group;
+    if (_curWP+1 >= count waypoints _group || waypointType [_group, _curWP] != "MOVE") exitWith {};
+    if (!canMove _vehicle or !(driver _vehicle call A3A_fnc_canFight)) exitWith {};
+
+    // If next waypoint position is close then switch to next one
+    if (waypointPosition [_group, _curWP] distance2d _vehicle < 50) then {
+        _group setCurrentWaypoint [_group, _curWP + 1];
+        _timeout = time + 20 + (_vehicle distance2d waypointPosition [_group, _curWP + 1]);
+    };
+
+    // If we reached a timeout and there are no players near then attempt to bounce vehicle
+    if (time > _timeout) then {
+        _fails = _fails + 1;
+        if (units teamPlayer inAreaArray [_vehicle, 500, 500]) exitWith {};
+        private _emptyPos = [getPosATL _vehicle, _vehicle, getDir _vehicle, 10, 30, 20] call A3A_fnc_findEmptyPosCar;
+        if (_emptyPos isEqualTo []) exitWith {};
+        _vehicle setPosATL _emptyPos;
+    };
+
+    sleep 1;
+};

--- a/A3A/addons/core/functions/CREATE/fn_WPCreate.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_WPCreate.sqf
@@ -53,7 +53,7 @@ private _culledPath = [_prevPos];
 private _distToPrev = 0;
 {
     _distToPrev = _distToPrev + (_prevPos distance2d _x);
-    if (_distToPrev >= 400) then {
+    if (_distToPrev >= 200) then {
         _culledPath pushBack _x;
         _distToPrev = 0;
     };

--- a/A3A/addons/core/functions/CREATE/fn_createAttackVehicle.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAttackVehicle.sqf
@@ -44,10 +44,10 @@ ServerDebug_5("Spawn Performed: Created vehicle %1 with %2 crew (%3) and %4 carg
 if (_vehicleType isKindOf "Land") then {
 
     private _spawnPos = getPosATL _vehicle;
-    private _spawnTime = time + 10;
-    waitUntil { _spawnPos distance2d _vehicle > 10 or time > _spawnTime };
+    private _spawnTime = time + 20;
+    waitUntil { _spawnPos distance2d _vehicle > 20 or time > _spawnTime };
 
-    if (_spawnPos distance2d _vehicle < 10) then {
+    if (_spawnPos distance2d _vehicle < 20) then {
         Error_2("Vehicle %1 failed to clear spawn at %2", _vehicle, _markerOrigin);
         // teleport to first waypoint
         // arguably should just return empty array...

--- a/A3A/addons/core/functions/CREATE/fn_createVehicleQRFBehaviour.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createVehicleQRFBehaviour.sqf
@@ -132,6 +132,7 @@ else            // ground vehicle
         _attackWP setWaypointType "SAD";
         _attackWP setWaypointBehaviour "COMBAT";
 
+        [_vehicle] spawn A3A_fnc_waypointMonitor;
         [_vehicle, _typeName] spawn A3A_fnc_inmuneConvoy;
     };
 
@@ -155,6 +156,7 @@ else            // ground vehicle
         private _attackWP = _cargoGroup addWaypoint [_posDestination, 0];
         _attackWP setWaypointBehaviour "AWARE";
 
+        [_vehicle] spawn A3A_fnc_waypointMonitor;
         [_vehicle, _typeName] spawn A3A_fnc_inmuneConvoy;
     };
 
@@ -182,6 +184,7 @@ else            // ground vehicle
         //Link the dismount waypoints
         _vehWP0 synchronizeWaypoint [_cargoWP0];
 
+        [_vehicle] spawn A3A_fnc_waypointMonitor;
         [_vehicle, _typeName] spawn A3A_fnc_inmuneConvoy;
     };
 
@@ -214,6 +217,7 @@ else            // ground vehicle
         //Link the dismount waypoints
         _vehWP0 synchronizeWaypoint [_cargoWP0];
 
+        [_vehicle] spawn A3A_fnc_waypointMonitor;
         [_vehicle, _typeName] spawn A3A_fnc_inmuneConvoy;
     };
 };

--- a/A3A/addons/core/functions/Pathfinding/fn_trimPath.sqf
+++ b/A3A/addons/core/functions/Pathfinding/fn_trimPath.sqf
@@ -45,6 +45,10 @@ if(_pathCount > 5) then
     };
 };
 
+_path apply {_x#0};
+
+/*
+// Removes everything except junctions
 private _simplifiedPath = [];
 {
     if(_x select 1) then


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Various improvements to pathfinding of land vehicles created by createAttackVehicle:
1. Added a waypoint monitor routine to complete intermediate move waypoints before they're reached. Tracked vehicles still have a pause on the switch but it's better than driving past junctions and trying to go back again. This also has a bit of low-risk stuck detection/fixing. Should be pretty safe because it only affects intermediate move waypoints and quits if driver/vehicle dies or the vehicle gets stuck multiple times. All cases checked.
2. Changed trimPath to no longer remove all non-junction waypoints. Otherwise this could cause entire paths to be deleted on maps with few junctions (eg. Stubbhult), putting too much pressure on Arma's pathfinding. Only works because of 1.
3. Increased distance & timeout of spawn exit checking so that vehicles can't wiggle backwards and have another vehicle spawned in front of them.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Example of creating four attack vehicles from outpost_3 to resource_12:
```
tierWar = 8;
[Occupants, "outpost_3", markerPos "resource_12", "defence", 4, 2] call A3A_fnc_createAttackForceLand; 
```
