### PR TITLE
Fix item price for some weird/broken CUP missiles

### DIFF
--- a/A3A/addons/config_fixes/CUP/CfgAmmo.hpp
+++ b/A3A/addons/config_fixes/CUP/CfgAmmo.hpp
@@ -1,7 +1,7 @@
 class CfgAmmo {
-    // Long range missile with crap payload, comes out a bit low
+    // Missing lock params on this one. Easier to fix directly than try to figure out Arma's defaults
     class MissileBase;
-    class CUP_M_47_AT_EP1 : MissileBase {
-        A3A_price = 500;
+    class CUP_M_AGM_114L_Hellfire_II_AT : MissileBase {
+        missileLockMaxDistance = 8000;
     };
 };

--- a/A3A/addons/gui/functions/gunShop/fn_calculateItemPrice.sqf
+++ b/A3A/addons/gui/functions/gunShop/fn_calculateItemPrice.sqf
@@ -74,10 +74,12 @@ private _fnc_ammoPriceCalculator = {
     };
 
     // Add in thrust for rockets and maneuvrability for guided missiles (iron bombs are missile sim, so need to check guidance)
-    private _velocity = A3A_ammoInitSpeed getOrDefault [_className, 0];
+    private _muzzVelocity = A3A_ammoInitSpeed getOrDefault [_className, 0];
+    private _subVelocity = _muzzVelocity;
     private _totThrust = 0;
     if (_simType in _rocketSims) then {
         _totThrust = getNumber (_cfgAmmo >> "thrust") * getNumber (_cfgAmmo >> "thrustTime");
+        _subVelocity = _subVelocity + _totThrust;           // need this for some retarded KEP ammo
         if (_guidanceMod > 0) then {
             private _manHigh = getNumber (_cfgAmmo >> "maxSpeed")^1.8 * getNumber (_cfgAmmo >> "maneuvrability") / 175;
             private _manLow = getNumber (_cfgAmmo >> "maxSpeed") * getNumber (_cfgAmmo >> "maneuvrability") / 2;
@@ -85,13 +87,12 @@ private _fnc_ammoPriceCalculator = {
             _totThrust = _totThrust + (_manHigh max _manLow);
         };
     };
-    //if (_log) then {diag_log format ["Sim %1, velocity %2, thrust %3, guidanceMod %4", _simType, _velocity, _totThrust, _guidanceMod]};
+    //if (_log) then {diag_log format ["Sim %1, velocity %2, thrust %3, guidanceMod %4", _simType, _muzzVelocity, _totThrust, _guidanceMod]};
 
     // submunitionAmmo can be either [type, prob, type2, prob2] array or just type string
     private _subAmmoType = getText (_cfgAmmo >> "submunitionAmmo");
     if (isArray (_cfgAmmo >> "submunitionAmmo")) then { _subAmmoType = getArray (_cfgAmmo >> "submunitionAmmo") # 0 };
 
-    private _subVelocity = _velocity;	   // used for payload value later
     private _subCount = 1;
     private _probablyHEAT = false;
     while {_subAmmoType != ""} do
@@ -102,10 +103,9 @@ private _fnc_ammoPriceCalculator = {
             _subCount = _subCount * _thisSubCount;
         };
         _probablyHEAT = count _subConeType < 2;										// single projectile so treat as HEAT warhead later
-        if (getNumber (_cfgAmmo >> "submunitionInitSpeed") > 0) then {				// _simType != "shotdeploy" ? Not sure which is correct
-            _subVelocity = getNumber (_cfgAmmo >> "submunitionInitSpeed");
-            _totThrust = _totThrust + (_subVelocity - _velocity);
-        };
+        private _subVelDiff = 0 max (getNumber (_cfgAmmo >> "submunitionInitSpeed") - _subVelocity);
+        _subVelocity = _subVelocity + _subVelDiff;                      // Tested with CUP CRV7 and Rocket_04_AP
+        _totThrust = _totThrust + _subVelDiff;
 
         // Submunitions can have thrust/guidance/maneuver too. Add that in.
         _cfgAmmo = configFile >> "CfgAmmo" >> _subAmmoType;			// replace main ammo
@@ -129,11 +129,11 @@ private _fnc_ammoPriceCalculator = {
     // hit & indirHit for final projectile (assuming original doesn't matter for subProjectile)
     [_cfgAmmo, _probablyHEAT, _log] call _fnc_payloadValue params ["_varPayload", "_fixedPayload"];
     private _varTotal = _varPayload * _subCount^0.8 + _guidanceMod;
-    private _varCost = 0.000175 * (600 + _velocity + _totThrust) * _varTotal;
+    private _varCost = 0.000175 * (600 + _muzzVelocity + _totThrust) * _varTotal;
 
     // guidance applies twice, once as payload weight and then as direct expense
     private _price = _varCost + (_fixedPayload * _subCount^0.8) + _guidanceMod;
-    //if (_log) then {diag_log format ["VCost %1, FCost %2, Vmul %3, Price %4, end", _varCost, _fixedPayload*_subCount^0.8, 1 + (_velocity + _totThrust) / 500, _price]};
+    //if (_log) then {diag_log format ["VCost %1, FCost %2, Vmul %3, Price %4, end", _varCost, _fixedPayload*_subCount^0.8, 1 + (_muzzVelocity + _totThrust) / 600, _price]};
     _price;
 };
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement
4. [X] CUP bug

### What have you changed and why?
- Rejigged velocity vars so that submunition velocity is inherited roughly the way Arma does it in the case that initSubmunitionSpeed is low-valued. Only affects some weird and probably broken CUP rounds, but it's a valid general change.
- Config-fixed CUP's AGM-114L because it's missing some values that exist on every other missile. It worked anyway but that's probably due to Arma defaults and coincidences that I'm not going to reverse-engineer. I did check that the missile also worked afterwards.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
