### PR TITLE
Fix Patcom using side leader _group

### DIFF
--- a/A3A/addons/patcom/functions/Patcom/fn_patrolArea.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolArea.sqf
@@ -43,7 +43,7 @@ private _groupHomePosition = _group getVariable "PATCOM_Patrol_Home";
 private _patrolParams = _group getVariable "PATCOM_Patrol_Params";
 
 // This is the only place we handle civilians in this Commander.
-if ((side leader _group) == civilian) then {
+if ((side _group) == civilian) then {
     [_group, "CARELESS", "NORMAL", "LINE", "BLUE", "AUTO"] call A3A_fnc_patrolSetCombatModes;
 } else {
     private _knownEnemies = _group targets [true, 0, [], PATCOM_TARGET_TIME];
@@ -57,7 +57,7 @@ if ((side leader _group) == civilian) then {
 };
 
 if (PATCOM_DEBUG) then {
-    if ((side leader _group) == civilian) then {
+    if ((side _group) == civilian) then {
         [leader _group, "CIVILIAN THINGS", 10, "White"] call A3A_fnc_debugText3D;
     } else {
         [leader _group, "PATROL AREA", 10, "White"] call A3A_fnc_debugText3D;

--- a/A3A/addons/patcom/functions/Patcom/fn_patrolCivilianCommander.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolCivilianCommander.sqf
@@ -30,6 +30,4 @@ private _patrolParams = _group getVariable "PATCOM_Patrol_Params";
 // We exit here if the group is empty. It's a waste of performance to handle empty groups.
 if (count units _group <= 0) exitWith {};
 
-if ((side leader _group) == civilian) then {
-    [_group, _patrolParams#1, _patrolParams#2, _patrolParams#3,_patrolParams#4,_patrolParams#5,_patrolParams#6,_patrolParams#7] call A3A_fnc_patrolArea;
-};
+[_group, _patrolParams#1, _patrolParams#2, _patrolParams#3,_patrolParams#4,_patrolParams#5,_patrolParams#6,_patrolParams#7] call A3A_fnc_patrolArea;

--- a/A3A/addons/patcom/functions/Patcom/fn_patrolGroupVariables.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolGroupVariables.sqf
@@ -42,7 +42,7 @@ If (PATCOM_DEBUG) then {
     ServerDebug_2("PATCOM | Setting up Variables on group: %1 - side: %2", _group, side (leader _group));
 };
 
-if ((side leader _group) == civilian) then {
+if ((side _group) == civilian) then {
     // Patrol Type, Min Patrol, Max Patrol, Max Distance, From Center, Center Pos, Search Buildings
     if ((count (_group getVariable ["PATCOM_Patrol_Params", []])) == 0) then {
         _group setVariable ["PATCOM_Patrol_Params", ["Civilian", 10, 50 + (random 50), -1, true, getPosATL (leader _group), true]];

--- a/A3A/addons/patcom/functions/Patcom/fn_patrolLoop.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolLoop.sqf
@@ -70,7 +70,7 @@ private _scriptHandle = [_group] spawn {
     while {true} do {
         if ((isNull _group) || (({alive _x} count units _group) < 1)) exitWith {};
 
-        if ((side leader _group) == civilian) then {                // causes this to run on military groups after they're all downed. Bad?
+        if ((side _group) == civilian) then {
             [_group] call A3A_fnc_patrolCivilianCommander;
         } else {
             [_group] call A3A_fnc_patrolCommander;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Patcom was using `side leader _group` for some reason, which seems to have broken on rare occasions, potentially if the patcom command ran while the commander was halfway through surrenderAction. Changed to side _group which is at least consistent.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
