### PR TITLE
Fix doubled police vehicles & valid place checks

### DIFF
--- a/A3A/addons/core/functions/init/fn_initPoliceStations.sqf
+++ b/A3A/addons/core/functions/init/fn_initPoliceStations.sqf
@@ -56,15 +56,10 @@ if (_policeStationTypes isEqualTo []) exitWith {
     private _nearPlaces = _placePositions inAreaArrayIndexes [_stationPos, 50, 50] apply { _places # _x };
     if (_nearPlaces isEqualTo []) then { _garrison set ["spawnPlaces", []]; continue };
 
+    // buildEnemyGarrison will have already added the vehicle entry, just need to set up the place
     private _distances = _nearPlaces apply { _x#1 distance2d _stationPos };
     private _minPlace = _nearPlaces select (_distances find selectMin _distances);
     _garrison set ["spawnPlaces", [["vehiclePolice", _minPlace#1, _minPlace#2]] ];
-
-    private _citySide = sidesX getVariable _city;
-    if (_citySide != teamPlayer) then {
-        private _carType = selectRandom (Faction(_citySide) get "vehiclesPolice");
-        _garrison get "vehicles" pushBack [_carType, 0];
-    };
 
 } forEach citiesX;
 
@@ -85,7 +80,7 @@ A3A_cityPoliceData = createHashMap;
     private _carPlacePos = if (_spawnPlaces isEqualTo []) then {false} else {_spawnPlaces#0#1};
     if (_carPlacePos isEqualType false) then {
         A3A_spawnPlaceStats set [_city, createHashMap];
-        _garrison set ["vehicles", []];                 // probably is already, but whatever
+        _garrison set ["vehicles", []];
     };
 
     // If we're loading from a save, police station might already be destroyed

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -546,11 +546,11 @@ A3A_validVehicles = createHashMap;
 	_valid set ["vehicleSAM", _x get "vehiclesSAM"];
 	_valid set ["vehicleArty", _x get "vehiclesArtillery"];
 	_valid set ["vehiclePolice", _x get "vehiclesPolice"];
-	_valid set ["vehicleTruck", (_x get "vehiclesTrucks") + (_x get "vehiclesCargoTrucks") + (_x get "vehiclesAmmoTrucks")
-		+ (_x get "vehiclesFuelTrucks") + (_x get "vehiclesRepairTrucks")];
-	_valid set ["vehicle", (_valid get "vehicleTruck") + (_x get "vehiclesLightUnarmed") + (_x get "vehiclesLightArmed") + (_x get "vehiclesMilitiaCars")
-		+ (_x get "vehiclesLightAPCs") + (_x get "vehiclesAPCs") + (_x get "vehiclesAA") + (_x get "vehiclesArtillery") + (_x get "vehiclesIFVs")
-		+ (_x get "vehiclesLightTanks") + (_x get "vehiclesTanks") + (_x get "vehiclesHeavyTanks") + (_x get "vehiclesMilitiaLightArmed")];
+	_valid set ["vehicleTruck", (_x get "vehiclesCargo") + (_x get "vehiclesAmmoTrucks") + (_x get "vehiclesFuelTrucks") + (_x get "vehiclesRepairTrucks")];
+	_valid set ["vehicle", (_x get "vehiclesTrucks") + (_x get "vehiclesAmmoTrucks") + (_x get "vehiclesFuelTrucks") + (_x get "vehiclesRepairTrucks")
+		+ (_x get "vehiclesCargoTrucks") + (_x get "vehiclesMilitiaTrucks") + (_x get "vehiclesLightUnarmed") + (_x get "vehiclesLightArmed")
+		+ (_x get "vehiclesMilitiaCars") + (_x get "vehiclesMilitiaLightArmed") + (_x get "vehiclesLightAPCs") + (_x get "vehiclesAPCs") + (_x get "vehiclesAA") 
+		+ (_x get "vehiclesIFVs") + (_x get "vehiclesLightTanks") + (_x get "vehiclesTanks") + (_x get "vehiclesHeavyTanks")];
 
 	_valid set ["plane", (_x get "vehiclesPlanesCAS") + (_x get "vehiclesPlanesAA")];
 	_valid set ["runway", (_x get "vehiclesPlanesCAS") + (_x get "vehiclesPlanesAA") + (_x get "vehiclesPlanesTransport")];


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
- Fixed police vehicles being doubled on new and pre-3.10 saves. It gets cleaned up after a save/load cycle but kinda bad on the first run.
- Fixed slightly incorrect valid vehicle lists for vehicle and vehicleTruck place types.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
