### PR TITLE
Fix mis-cased markers not working correctly

### DIFF
--- a/A3A/addons/core/functions/init/fn_initVarCommon.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarCommon.sqf
@@ -305,7 +305,9 @@ medicAnims = ["AinvPknlMstpSnonWnonDnon_medic_1","AinvPknlMstpSnonWnonDnon_medic
 //      OTHER LOOKUP TABLES      ///
 ////////////////////////////////////
 
-A3A_markerPrefixHM = createHashMapFromArray [["airport", "airp_"], ["outpost", "outp_"], ["resource", "reso_"], ["factory", "fact_"], ["seaport", "seap_"]];
+// Cherno 2020 has one miscased factory, VT7 has all outposts and seaports. Provide both cases to preserve original behaviour
+A3A_markerPrefixHM = createHashMapFromArray [["airport", "airp_"], ["outpost", "outp_"], ["resource", "reso_"], ["factory", "fact_"], ["seaport", "seap_"],
+    ["Airport", "airp_"], ["Outpost", "outp_"], ["Resource", "reso_"], ["Factory", "fact_"], ["Seaport", "seap_"]];
 
 
 Info("initVarCommon completed");

--- a/A3A/addons/core/functions/init/fn_prepareMarkerArrays.sqf
+++ b/A3A/addons/core/functions/init/fn_prepareMarkerArrays.sqf
@@ -103,7 +103,8 @@ private _majorMarkers = (airportsX + resourcesX + factories + outposts + seaport
 // Autogenerate stuff like helipad placements for markers that don't have any defined spawn places
 A3A_spawnPlacesHM = createHashMap;
 {
-    [_x, _placeMarkers getOrDefault [_x, []]] call A3A_fnc_initSpawnPlaces;
+    // Need the tolower here to preserve original behaviour matching Outpost_1 to outp_1_vehicle
+    [_x, _placeMarkers getOrDefault [toLower _x, []]] call A3A_fnc_initSpawnPlaces;
 } forEach _majorMarkers;
 
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Apparently all the outposts and seaports on VT7 have incorrect case (Outpost_1 instead of outpost_1) but the older code accidentally handled that.
- Fixed 3.10.3+ issue where marker prefix lookup would throw SQF errors.
- Fixed 3.10+ issue where related markers (eg. outp_1_vehicle) wouldn't be detected if the main marker was miscased. This would have made outposts on VT7 incapable of sending land QRFs.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Load VT7, check that there aren't any green rectangles on outposts.