### PR TITLE
Fix rebel roadblock/watchpost markers

### DIFF
--- a/A3A/addons/core/functions/Base/fn_mrkUpdate.sqf
+++ b/A3A/addons/core/functions/Base/fn_mrkUpdate.sqf
@@ -23,6 +23,10 @@ private _mrkText = call {
     if (_marker in resourcesX) exitWith { "Resources" };
     if (_marker in factories) exitWith { "Factory" };
     if (_marker in seaports) exitWith { "Sea Port" };
+    if (_marker in outpostsFIA) exitWith { 
+        private _strTable = ["STR_A3A_fn_base_croutpFIA_watchpost", "STR_A3A_fn_base_croutpFIA_roadblock"] select (isOnRoad markerPos _mrkD);
+        format [localize _strTable, _faction get "name"];
+    };
     ""; 		// city
 };
 

--- a/A3A/addons/core/functions/GarrisonLocal/fn_getGarrisonLimit.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_getGarrisonLimit.sqf
@@ -41,6 +41,9 @@ private _limit = switch (true) do {
     case (_marker in factories || {_marker in resourcesX}): {
         round (A3A_rebelGarrisonLimit * 0.5)
     };
+    case (_marker in outpostsFIA): {
+        round (A3A_rebelGarrisonLimit * 0.33)
+    };
     default {
         A3A_rebelGarrisonLimit
     };

--- a/A3A/addons/core/functions/MinorSites/fn_createRebelControl.sqf
+++ b/A3A/addons/core/functions/MinorSites/fn_createRebelControl.sqf
@@ -17,13 +17,11 @@ _marker setMarkerShapeLocal "ELLIPSE";
 _marker setMarkerSizeLocal [30,30];
 _marker setMarkerAlpha 0;
 
-// Visible marker
-private _strTable = ["STR_A3A_fn_base_croutpFIA_watchpost", "STR_A3A_fn_base_croutpFIA_roadblock"] select (isOnRoad _pos);
+// Visible marker (text & broadcast needs to be set after outpostsFIA)
 _iconMarker = createMarkerLocal [format ["Dum%1", _marker], _pos];
 _iconMarker setMarkerShapeLocal "ICON";
 _iconMarker setMarkerTypeLocal "loc_bunker";
 _iconMarker setMarkerColorLocal colorTeamPlayer;
-_iconMarker setMarkerText format [localize _strTable, FactionGet(reb,"name")];;
 
 private _garrison = createHashMapFromArray [ ["troops", _troopTypes], ["vehicles", []], ["buildings", []], ["type", "rebpost"] ];
 
@@ -45,8 +43,12 @@ sidesX setVariable [_marker, teamPlayer, true];
 spawner setVariable [_marker, 2, true];         // start despawned
 outpostsFIA = outpostsFIA + [_marker];
 
-// Load-from-save usage, troops are later. Don't spam publicVariable.
-if (_troopTypes isNotEqualTo []) then { publicVariable "outpostsFIA" };
+if (_troopTypes isNotEqualTo []) then {
+    // If used from a save then outpostsFIA and markers are updated later (after adding garrison)
+    // If it's live then set the text & broadcast immediately, needs outpostsFIA & side
+    publicVariable "outpostsFIA";
+    [_marker] call A3A_fnc_mrkUpdate;
+};
 
 ["RebelControlCreated", [_marker, isOnRoad _pos]] call EFUNC(Events,triggerEvent);
 

--- a/A3A/addons/core/functions/Save/fn_loadServer.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadServer.sqf
@@ -141,7 +141,7 @@ if (isServer) then {
 	// Should have garrison data for this now
 	{
 		[_x] call A3A_fnc_mrkUpdate
-	} forEach markersX;
+	} forEach (markersX + outpostsFIA);
 
 
 	// Spawn in HQ buildings before we potentially place HQ objects on them


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Rebel roadblocks were not showing the name ("FIA Roadblock" etc) after units were added, and weren't showing the unit count/max after creation or load from save. Also the maximum unit count was far too high (same as outposts). This PR fixes all those issues.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
