### PR TITLE
Misc fixes 20-03-2026

### DIFF
--- a/A3A/addons/core/functions/Base/fn_findAttackTargets.sqf
+++ b/A3A/addons/core/functions/Base/fn_findAttackTargets.sqf
@@ -133,7 +133,7 @@ private _finalWeights = [];
     _localThreat = _localThreat + 10 * count (_rebelAISpawners inAreaArray [_targpos, 500, 500]);
 
     // Supply convoys shortcut
-    if (_x in citiesX and _side == Occupants) then {
+    if (_x in citiesX and _side == Occupants and _targetSide == teamPlayer) then {
         private _landBase = [_x] call A3A_fnc_findBasesForConvoy;
         if (_landBase == "") then { continue };             // no suitable base found 
         _finalTargets pushBack [_target, _landBase, _value, _localThreat, 0, 1];

--- a/A3A/addons/core/functions/GarrisonServer/fn_selectGarrisonVehicleType.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_selectGarrisonVehicleType.sqf
@@ -62,6 +62,7 @@ if (_placeType == "plane") exitWith {
     [["vehiclesPlanesAA", "vehiclesPlanesCAS"], [1,2]] call _fnc_selectFromLists;
 };
 if (_placeType == "vehiclePolice") exitWith { selectRandom (_faction get "vehiclesPolice") };
+if (_placeType == "vehicleRB") exitWith { selectRandom (_faction get "vehiclesMilitiaLightArmed") };
 if (_placeType == "vehicleAA") exitWith { selectRandom (_faction get "vehiclesAA") };
 if (_placeType == "vehicleArty") exitWith { selectRandom (_faction get "vehiclesArtillery") };
 if (_placeType == "vehicleSAM") exitWith { selectRandom (_faction get "vehiclesSAM") };

--- a/A3A/addons/core/functions/Missions/fn_DES_Antenna.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Antenna.sqf
@@ -2,10 +2,9 @@
 if (!isServer and hasInterface) exitWith{};
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
-private ["_antenna","_positionX","_timeLimit","_markerX","_nameDest","_mrkFinal","_tsk"];
+private ["_positionX","_timeLimit","_nameDest","_mrkFinal","_tsk"];
 
-_antenna = _this select 0;
-_markerX = [markersX,_antenna] call BIS_fnc_nearestPosition;
+params ["_markerX", "_antenna"];
 
 _difficultX = if (random 10 < tierWar) then {true} else {false};
 _leave = false;
@@ -30,7 +29,7 @@ _mrkFinal setMarkerShape "ICON";
 private _taskId = "DES" + str A3A_taskCount;
 [[teamPlayer,civilian],_taskId,[format [localize "STR_A3A_fn_mission_des_ante_text",_nameDest,_displayTime,FactionGet(occ,"name")],localize "STR_A3A_fn_mission_des_ante_titel",_mrkFinal],_positionX,false,0,true,"Destroy",true] call BIS_fnc_taskCreate;
 [_taskId, "DES", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
-waitUntil {sleep 1;(dateToNumber date > _dateLimitNum) or (not alive _antenna) or (not(sidesX getVariable [_markerX,sideUnknown] == Occupants))};
+waitUntil {sleep 1;(dateToNumber date > _dateLimitNum) or (not alive _antenna) or (sidesX getVariable _markerX == teamPlayer)};
 
 _bonus = if (_difficultX) then {2} else {1};
 

--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal.sqf
@@ -1813,9 +1813,9 @@ switch _mode do {
 					[_index, _oldItem] call jn_fnc_arsenal_addItem;
 
 					//add new weapon
-					if (_item != "") then {
+					if (_item != "" and isClass (configFile >> "CfgWeapons" >> _item)) then {
 						//give player new weapon
-						[player,_item,0] call bis_fnc_addweapon;
+						player addWeapon _item;
 						[_index, _item]call jn_fnc_arsenal_removeItem;
 
 						//Remove any attachments that spawn *with* the weapon.

--- a/A3A/addons/tasks/Params/fn_DES_Antenna_p.sqf
+++ b/A3A/addons/tasks/Params/fn_DES_Antenna_p.sqf
@@ -6,8 +6,8 @@ private _possible = [];
 {
     private _nearbyMarker = A3A_antennaMap get netId _x;
     if (sidesX getVariable _nearbyMarker == teamPlayer) then {continue};
-    _possible pushBack _x;
+    _possible pushBack [_nearbyMarker, _x];
 } forEach _nearAntennas;
 
 if (_possible isEqualTo []) exitWith {false};
-[1, [selectRandom _possible]];
+[1, selectRandom _possible];

--- a/A3A/addons/tasks/Tasks.hpp
+++ b/A3A/addons/tasks/Tasks.hpp
@@ -110,8 +110,8 @@ class Tasks {
     };
     class RES_Prisoners {
         category = "RES";
-        func = QFUNCMAIN(SUP_Prisoners);
-        params = QFUNC(SUP_Prisoners_p);
+        func = QFUNCMAIN(RES_Prisoners);
+        params = QFUNC(RES_Prisoners_p);
         version = 1;
         weight = 1;
         isLegacy = 1;


### PR DESCRIPTION

### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
- Fix occupants being unable to attack invader towns (3.11).
- Fix enemy roadblock vehicles not being reinforced correctly after destruction (3.10). Probably the only 3.10 or older bug here.
- Fix destroy antenna mission autocompleting when called on invader antennas. Not sure if this was in older versions. I suspect it simply ignored radio towers owned by invaders for most purposes. In 3.11 they matter.
- Fix prisoner rescue mission incorrectly linked (3.11).

Roadblock vehicle reinf fix is theoretical because it's tricky to replicate. Others are tested in detail.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
