### PR TITLE
3cb A10 loadout fix

### DIFF
--- a/A3A/addons/core/Templates/AircraftLoadouts/3CB/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/3CB/config.cpp
@@ -24,6 +24,7 @@ class A3A {
             
             class RHS_A10;
             class UK3CB_CW_US_B_EARLY_A10 : RHS_A10{};
+            class UK3CB_CW_US_B_LATE_A10 : RHS_A10{};
             
             class RHS_Su25SM_vvsc;
             class UK3CB_TKA_B_Su25SM_CAS : RHS_Su25SM_vvsc{};


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
A 3CB A10 didnt have a loadout defined. This fixes that issue.

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
