### PR TITLE
Fix case where high command vehicles can be stuck in paused state

### DIFF
--- a/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_remVehicle.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_remVehicle.sqf
@@ -34,3 +34,10 @@ _array deleteAt (_array find _vehicle);
 {
     if (_x getVariable ["markerX", ""] == _marker) then { unassignVehicle _x; moveOut _x };
 } forEach crew _vehicle;
+
+// Can happen with dismounted HC squad vehicles
+if (_garrison get "state" == "paused") then {
+    _vehicle enableSimulationGlobal true;
+    _vehicle allowDamage true;
+    [_vehicle, false] remoteExecCall ["hideObjectGlobal", 2];
+};


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
It was possible to semi-lock a high command vehicle in paused state (sim & damage disabled + hidden) with the following process:
1. Buy high command squad with vehicle, or assign vehicle (at HQ).
2. Dismount the squad. This adds the vehicle to the HQ garrison.
3. Move out of spawn distance so that the HQ enters paused state.
4. Order the high command squad to board the vehicle.

This PR fixes the second most obvious bug in the chain where removing the vehicle from the garrison doesn't clear the paused state from the vehicle. High command vehicles shouldn't really be added to garrisons on dismount but there's not currently much accounting for high command status and I'm not dealing with that now.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [X] Yes (Please provide further detail below.)

See above. High command vehicle assignment could do with better accounting.
