### PR TITLE
Revert allowing loot-to-crate while carrying

### DIFF
--- a/A3A/addons/core/functions/LTC/fn_initLootToCrate.sqf
+++ b/A3A/addons/core/functions/LTC/fn_initLootToCrate.sqf
@@ -40,7 +40,7 @@ _object addAction [
     true,
     true,
     "",
-    "",
+    "isNull attachedTo _originalTarget",
     3
 ];
 
@@ -54,7 +54,7 @@ _object addAction [
     true,
     true,
     "",
-    "",
+    "isNull attachedTo _originalTarget",
     3
 ];
 


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Reverted the change that allowed loot-to-crate actions while carrying. The actions work fine but apparently addAction on an attached  object is rather busted:
1. If you're in a building or looking towards an object, the actions don't show.
2. If you're driving a car with a loot crate in the back, the actions sometimes show.

Will need to re-implement with player actions added on carry.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
