### PR TITLE
Better version of loot-to-crate while carrying the crate

### DIFF
--- a/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_carryItem.sqf
@@ -19,13 +19,14 @@ Example:
 
 params ["_item", "_player"];         // standard addAction
 
-// Redo the checks, because this function might be delayed by script load
-if ((!isNull attachedTo _item) or (call A3A_fnc_isCarrying) or (!isNull objectParent _player)) exitWith {};
-if (_item isKindOf "StaticWeapon" and count crew _item != 0) exitWith {};
-
 // Go unscheduled to keep the state consistent
 isNil {
+    // Redo the checks, because this function might be delayed by script load
+    if ((!isNull attachedTo _item) or (call A3A_fnc_isCarrying) or (!isNull objectParent _player)) exitWith {};
+    if (_item isKindOf "StaticWeapon" and count crew _item != 0) exitWith {};
+
     if (_item isKindOf "StaticWeapon") then { _item lock true };
+    _item lockInventory true;
 
     // Prevent killing players with item
     if (isNil {_item getVariable "A3A_originalMass"}) then { _item setVariable ["A3A_originalMass", getMass _item] };
@@ -49,9 +50,24 @@ isNil {
 
     private _dropID = _player addAction [
         localize "STR_A3A_fn_UtilItem_dropOb_addact_drop",
-        { (_this#1) call A3A_fnc_dropItem }, _item, 4, true, true, "", "true"
+        { (_this#1) call A3A_fnc_dropItem }, _item, 5, true, true, "", "true"
     ];
-    _player setVariable ["A3A_actionIDdrop", _dropID];
+    private _actionIDs = [_dropID];
+
+    // Add loot actions if it's a loot crate
+    private _isUtility = typeOf _item in A3A_utilityItemHM;
+    if (_isUtility and {"loot" in (A3A_utilityItemHM get typeOf _item) # 4}) then
+    {
+        _actionIDs pushBack (_player addAction [
+            localize "STR_A3A_fn_ltc_init_addact_ltc",
+            { [_this#3, clientOwner] remoteExecCall ["A3A_fnc_canLoot", 2] }, _item, 4, true, true, "", "true"
+        ]);
+        _actionIDs pushBack (_player addAction [
+            localize "STR_A3A_fn_ltc_init_addact_ltv",
+        { [_this#3, clientOwner] remoteExecCall ["A3A_fnc_canTransfer", 2] }, _item, 3, true, true, "", "true"
+        ]);
+    };
+    _player setVariable ["A3A_carryActionIDs", _actionIDs];
 
     [_player, _item] spawn {
         params ["_player", "_item"];

--- a/A3A/addons/core/functions/UtilityItems/fn_dropItem.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_dropItem.sqf
@@ -12,15 +12,14 @@
 
 params ["_player"];
 
-// Possible to fire this off twice at high script load
-private _dropID = _player getVariable "A3A_actionIDdrop";
-if (isNil "_dropID") exitWith {};
-
 // Go unscheduled to keep the state consistent
 isNil {
-    // Clear drop action
-    _player removeAction _dropID;
-    _player setVariable ["A3A_actionIDdrop", nil];
+    // Possible to fire this off twice at high script load
+    if (_player isNil "A3A_carryActionIDs") exitWith {};
+
+    // Clear drop/loot actions
+    { _player removeAction _x } forEach (_player getVariable "A3A_carryActionIDs");
+    _player setVariable ["A3A_carryActionIDs", nil];
 
     // Clear GetInMan EH
     private _eventIDcarry = _player getVariable "A3A_eventIDcarry";
@@ -62,6 +61,7 @@ isNil {
 
     [_item, true] remoteExecCall ["enableSimulationGlobal", 2];
 
+    _item lockInventory false;
     if (_item isKindOf "StaticWeapon") then { _item lock false };
 
     _item spawn {


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Second attempt at loot-to-crate while carrying. This instead adds the LTC actions to the player while they're carrying a loot crate and removes them afterwards. Inventory is locked to make the action list a bit more stable. Seems to work pretty well.

Ideally we'd add the vehicle load action as well, but that one's trickier.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
