### PR TITLE
Fix SP mission end if player is killed while down

### DIFF
--- a/A3A/addons/core/functions/Revive/fn_handleDamage.sqf
+++ b/A3A/addons/core/functions/Revive/fn_handleDamage.sqf
@@ -92,6 +92,11 @@ if (_part == "") then
 
         if (_overall > 1) exitWith
         {
+            // SP case, player cannot be allowed to die
+            if (!isMultiplayer and _unit == player) exitWith {
+                [player] spawn A3A_fnc_respawn;
+                _damage = 0.9;
+            };
             _unit setDamage 1;
             // Don't remove for players because it's transferred on respawn
             if (!isPlayer _unit) then { _unit removeAllEventHandlers "HandleDamage" };


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
In SP mode, if the player was killed while down then it would end the mission. This PR changes the case to run the respawn logic instead.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Run this four times:
`player setPosATL (getPosATL player vectorAdd [0,0,50]);`
