### PR TITLE
Make towing code co-operate with the garrison logic

### DIFF
--- a/A3A/addons/core/Scripts/fn_advancedTowingInit.sqf
+++ b/A3A/addons/core/Scripts/fn_advancedTowingInit.sqf
@@ -378,9 +378,10 @@ SA_Attach_Tow_Ropes = {
 					[_helper, [0,0,0], [0,0,-1]] ropeAttachTo (_towRopes select 0);
 					[_vehicle,_vehicleHitch,_cargo,_cargoHitch,_ropeLength] spawn SA_Simulate_Towing;
 
-					// capture empty vehicles when attached
+					// Capture and ungarrison empty vehicles when attached
 					if (count crew _cargo == 0) then {
 						[_cargo, side group _player, true] remoteExec ["A3A_fnc_vehKilledOrCaptured", 2];
+						if !(_cargo isNil "markerX") then { [_cargo] remoteExecCall ["A3A_fnc_garrisonServer_remVehicle", 2] };
 					};
 				};
 			};
@@ -412,6 +413,10 @@ SA_Pickup_Tow_Ropes = {
 	if(local _vehicle) then {
 		private ["_attachedObj","_helper"];
 		{
+			// When helper is deleted, check for adding to HQ garrison
+			private _cargo = _x getVariable "SA_Cargo";
+			if (alive _cargo) then { [_cargo] remoteExec ["A3A_fnc_rebelVehPlacedWorker", 2] };
+
 			_attachedObj = _x;
 			{
 				_attachedObj ropeDetach _x;
@@ -436,8 +441,7 @@ SA_Pickup_Tow_Ropes = {
 SA_Drop_Tow_Ropes = {
 	params ["_vehicle","_player"];
 	if(local _vehicle) then {
-		private ["_helper"];
-		_helper = (_player getVariable ["SA_Tow_Ropes_Pick_Up_Helper", objNull]);
+		private _helper = (_player getVariable ["SA_Tow_Ropes_Pick_Up_Helper", objNull]);
 		if(!isNull _helper) then {
 			{
 				_helper ropeDetach _x;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The towing logic did not have any additions for the new garrison code in 3.10, so towed vehicles could disappear or be despawned while driving, and wouldn't be added to HQ when unhooked there.

Changes:
- Vehicles are now removed from their garrison when towed.
- Vehicles may now be added to HQ garrison (if in radius) when the tow rope is detached.

This isn't quite ideal. Hooking up a crewed enemy vehicle will not remove it from the original garrison, even if it becomes uncrewed later and isn't boarded by rebels. Hooking up an uncrewed vehicle and leaving it there will permanently cost the enemy, but then boarding the vehicle does the same thing. Should probably check that sort of thing on despawn but it's fiddly.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
