### PR TITLE
Fix SP playableUnits and playerScoreAdd

### DIFF
--- a/A3A/addons/core/functions/OrgPlayers/fn_playerScoreAdd.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_playerScoreAdd.sqf
@@ -7,30 +7,23 @@ if (!isPlayer _playerX) exitWith {};
 
 //if (rank _playerX == "COLONEL") exitWith {};
 _playerX = _playerX getVariable ["owner",_playerX];
-if (isMultiplayer) exitWith
-	{
-	_pointsXJ = _playerX getVariable ["score",0];
-	_moneyJ = _playerX getVariable ["moneyX",0];
-	if (_pointsX > 0) then
-		{
-		_moneyJ = _moneyJ + (_pointsX * 10);
-		_playerX setVariable ["moneyX",_moneyJ,true];
-		if (_pointsX > 1) then
-			{
-			_textX = format ["<br/><br/><br/><br/><br/><br/>" + localize "STR_A3A_fn_orgp_playerScoreAdd_money" + " €",_pointsX*10];
-			[petros,"income",_textX] remoteExec ["A3A_fnc_commsMP",_playerX];
-			//[] remoteExec ["A3A_fnc_statistics",_playerX];
-			if (_pointsX >= 10) then { // Dumb way to track mission completion without changing every mission file
-				private _missions = _playerX getVariable ["missionsCompleted",0];
-				_playerX setVariable ["missionsCompleted",_missions + 1];
-			}
-			};
-		};
-	_pointsX = _pointsX + _pointsXJ;
-	_playerX setVariable ["score",_pointsX,true];
-	};
 
+_pointsXJ = _playerX getVariable ["score",0];
+_moneyJ = _playerX getVariable ["moneyX",0];
 if (_pointsX > 0) then
+{
+	_moneyJ = _moneyJ + (_pointsX * 10);
+	_playerX setVariable ["moneyX",_moneyJ,true];
+	if (_pointsX > 1) then
 	{
-	if (_pointsX != 1) then {[0,(_pointsX * 5)] remoteExec ["A3A_fnc_resourcesFIA",2]} else {[0,20-(tierWar * 2)] remoteExec ["A3A_fnc_resourcesFIA",2]};
+		_textX = format ["<br/><br/><br/><br/><br/><br/>" + localize "STR_A3A_fn_orgp_playerScoreAdd_money" + " €",_pointsX*10];
+		[petros,"income",_textX] remoteExec ["A3A_fnc_commsMP",_playerX];
+		//[] remoteExec ["A3A_fnc_statistics",_playerX];
+		if (_pointsX >= 10) then { // Dumb way to track mission completion without changing every mission file
+			private _missions = _playerX getVariable ["missionsCompleted",0];
+			_playerX setVariable ["missionsCompleted",_missions + 1];
+		}
 	};
+};
+_pointsX = _pointsX + _pointsXJ;
+_playerX setVariable ["score",_pointsX,true];

--- a/A3A/addons/core/functions/Revive/fn_unconsciousAAF.sqf
+++ b/A3A/addons/core/functions/Revive/fn_unconsciousAAF.sqf
@@ -10,7 +10,7 @@ private _playerNear = false;
 private _group = group _unit;
 private _side = side _group;
 
-if (playableUnits inAreaArray [getPosATL _unit, distanceSPWN2, distanceSPWN2] isNotEqualTo []) then
+if (call A3A_fnc_playableUnits inAreaArray [getPosATL _unit, distanceSPWN2, distanceSPWN2] isNotEqualTo []) then
 {
 	_playerNear = true;
 	[_unit,"heal"] remoteExec ["A3A_fnc_flagaction",0,_unit];

--- a/A3A/addons/tasks/Helpers/fn_hintNear.sqf
+++ b/A3A/addons/tasks/Helpers/fn_hintNear.sqf
@@ -9,6 +9,6 @@ FIX_LINE_NUMBERS()
 
 params ["_title", "_bodyText", "_center", "_radius"];
 
-private _nearPlayers = playableUnits inAreaArray [_center, _radius, _radius];
+private _nearPlayers = call A3A_fnc_playableUnits inAreaArray [_center, _radius, _radius];
 if (_nearPlayers isEqualTo []) exitWith {};
 [_title, _bodyText] remoteExecCall ["A3A_fnc_customHint", _nearPlayers];

--- a/A3A/addons/tasks/Helpers/fn_rewardPlayers.sqf
+++ b/A3A/addons/tasks/Helpers/fn_rewardPlayers.sqf
@@ -17,7 +17,7 @@ private _rewardPlayers = call {
     if (_group isEqualType grpNull) exitWith {
         units _group inAreaArray [_position, _radius, _radius] select { isPlayer _x };
     };
-    private _allPlayers = playableUnits;        // probably don't want to reward corpses
+    private _allPlayers = call A3A_fnc_playableUnits;        // probably don't want to reward corpses
     if (!_group) exitWith {
         _allPlayers inAreaArray [_position, _radius, _radius];
     };

--- a/A3A/addons/tasks/Helpers/fn_taskNotifyNear.sqf
+++ b/A3A/addons/tasks/Helpers/fn_taskNotifyNear.sqf
@@ -6,6 +6,6 @@ private _notifyType = if (_state == "CREATED") then { "taskUnassignedIcon" } els
 private _typeTexture = [[_taskId] call BIS_fnc_taskType] call BIS_fnc_taskTypeIcon;
 private _title = [_taskId] call BIS_fnc_taskDescription select 1 select 0;      // For some reason this is an array of arrays of strings...
 
-private _nearPlayers = playableUnits inAreaArray [_center, _radius, _radius];
+private _nearPlayers = call A3A_fnc_playableUnits inAreaArray [_center, _radius, _radius];
 if (_nearPlayers isEqualTo []) exitWith {};
 [_notifyType, [_typeTexture, _title]] remoteExecCall ["BIS_fnc_showNotification", _nearPlayers];

--- a/A3A/addons/tasks/Tasks/fn_SUP_Supplies.sqf
+++ b/A3A/addons/tasks/Tasks/fn_SUP_Supplies.sqf
@@ -166,7 +166,7 @@ _task set ["s_boxPlaced",
 
 	// Show the countdown if blocked on last check
 	if ("_blockTime" in _this) then {
-		private _nearPlayers = playableUnits inAreaArray [getPosATL _box, 300, 300];
+		private _nearPlayers = call A3A_fnc_playableUnits inAreaArray [getPosATL _box, 300, 300];
 		private _endTime = serverTime + _countdown;
 		[_this get "_hintTitle", localize "STR_A3A_Tasks_LOG_Supplies_countdown", _endTime, _box, 50] remoteExec ["A3A_fnc_customHintCountdown", _nearPlayers];
 		_this deleteAt "_blockTime";


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
playableUnits was used in new mission notification code and an old enemy revive check. It returns empty array in SP so we need to use the wrapper function instead.

playerScoreAdd had an old/weird SP branch. Removed.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
