### PR TITLE
Fix SAMs spawning in WW2 modsets

### DIFF
--- a/A3A/addons/core/Templates/Templates/EAW/EAW_AI_IJA.sqf
+++ b/A3A/addons/core/Templates/Templates/EAW/EAW_AI_IJA.sqf
@@ -11,7 +11,6 @@
 
 ["attributeLowAir", true] call _fnc_saveToTemplate;             // Use fewer air units in general
 ["attributeMoreTrucks", true] call _fnc_saveToTemplate;         // Use more truck for transports
-["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 ["placeIntel_itemLarge", ["Land_File1_F",-155,false]] call _fnc_saveToTemplate;
 
 
@@ -39,6 +38,7 @@
 ["vehiclesLightTanks", ["EAW_ChiHa", "EAW_Type89_1937"]] call _fnc_saveToTemplate;
 ["vehiclesTanks", ["EAW_ChiHa", "EAW_ChiHa_Kai"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["LIB_Zis5v_61K"]] call _fnc_saveToTemplate;                    // ideally heavily armed with anti-ground capability and enclosed turret. Passengers will be ignored
+["vehiclesSAM", []] call _fnc_saveToTemplate;                               // do not spawn SAMs or use SAM supports
 
 
 ["vehiclesTransportBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/EAW/EAW_AI_NRA.sqf
+++ b/A3A/addons/core/Templates/Templates/EAW/EAW_AI_NRA.sqf
@@ -11,7 +11,6 @@
 
 ["attributeLowAir", true] call _fnc_saveToTemplate;             // Use fewer air units in general
 ["attributeMoreTrucks", true] call _fnc_saveToTemplate;         // Use more truck for transports
-["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 ["placeIntel_itemLarge", ["Land_File1_F",-155,false]] call _fnc_saveToTemplate;
 
 
@@ -39,6 +38,7 @@
 ["vehiclesLightTanks", ["EAW_T26_NRA", "EAW_Vickers6Ton"]] call _fnc_saveToTemplate;
 ["vehiclesTanks", ["EAW_ChiHa", "EAW_ChiHa_Kai"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["LIB_Zis5v_61K"]] call _fnc_saveToTemplate;                    // ideally heavily armed with anti-ground capability and enclosed turret. Passengers will be ignored
+["vehiclesSAM", []] call _fnc_saveToTemplate;                               // do not spawn SAMs or use SAM supports
 
 
 ["vehiclesTransportBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/EAW/EAW_AI_PLA.sqf
+++ b/A3A/addons/core/Templates/Templates/EAW/EAW_AI_PLA.sqf
@@ -11,7 +11,6 @@
 
 ["attributeLowAir", true] call _fnc_saveToTemplate;             // Use fewer air units in general
 ["attributeMoreTrucks", true] call _fnc_saveToTemplate;         // Use more truck for transports
-["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 ["placeIntel_itemLarge", ["Land_File1_F",-155,false]] call _fnc_saveToTemplate;
 
 
@@ -40,6 +39,7 @@
 ["vehiclesTanks", ["EAW_ChiHa", "EAW_ChiHa_Kai"]] call _fnc_saveToTemplate;
 ["vehiclesHeavyTanks", ["LIB_T34_76"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["LIB_Zis5v_61K"]] call _fnc_saveToTemplate;                    // ideally heavily armed with anti-ground capability and enclosed turret. Passengers will be ignored
+["vehiclesSAM", []] call _fnc_saveToTemplate;                               // do not spawn SAMs or use SAM supports
 
 
 ["vehiclesTransportBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/IFA/IFA_AI_ALLIES.sqf
+++ b/A3A/addons/core/Templates/Templates/IFA/IFA_AI_ALLIES.sqf
@@ -9,7 +9,6 @@
 ["flagTexture", "\x\A3A\addons\core\Pictures\Flags\ifa_allies.paa"] call _fnc_saveToTemplate;
 ["flagMarkerType", "a3a_flag_ALLIES"] call _fnc_saveToTemplate;
 
-["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 ["attributeLowAir", true] call _fnc_saveToTemplate;
 ["placeIntel_itemLarge", ["Land_File1_F",-155,false]] call _fnc_saveToTemplate;
 
@@ -43,6 +42,7 @@ private _vehiclesHeavyTanks = ["LIB_Churchill_Mk7","LIB_Churchill_Mk7_Crocodile"
 
 
 ["vehiclesAA", ["LIB_Zis5v_61K"]] call _fnc_saveToTemplate; //Fake "truck with bofors"
+["vehiclesSAM", []] call _fnc_saveToTemplate;                               // do not spawn SAMs or use SAM supports
 
 
 ["vehiclesTransportBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/IFA/IFA_AI_SOV.sqf
+++ b/A3A/addons/core/Templates/Templates/IFA/IFA_AI_SOV.sqf
@@ -9,7 +9,6 @@
 ["flagTexture", "\x\A3A\addons\core\Pictures\Flags\ifa_sov.paa"] call _fnc_saveToTemplate;
 ["flagMarkerType", "a3a_flag_SOV"] call _fnc_saveToTemplate;
 
-["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 ["attributeLowAir", true] call _fnc_saveToTemplate;
 ["placeIntel_itemLarge", ["Land_File1_F",-155,false]] call _fnc_saveToTemplate;
 
@@ -39,6 +38,7 @@ private _vehiclesLightTanks = ["LIB_T34_76"];
 private _vehiclesHeavyTanks = ["LIB_JS2_43"];
 
 ["vehiclesAA", ["LIB_Zis5v_61K"]] call _fnc_saveToTemplate;                    // ideally heavily armed with anti-ground capability and enclosed turret. Passengers will be ignored
+["vehiclesSAM", []] call _fnc_saveToTemplate;                               // do not spawn SAMs or use SAM supports
 
 
 ["vehiclesTransportBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/IFA/IFA_AI_UK.sqf
+++ b/A3A/addons/core/Templates/Templates/IFA/IFA_AI_UK.sqf
@@ -9,7 +9,6 @@
 ["flagTexture", "\A3\Data_F\Flags\flag_uk_co.paa"] call _fnc_saveToTemplate;
 ["flagMarkerType", "flag_UK"] call _fnc_saveToTemplate;
 
-["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 ["attributeLowAir", true] call _fnc_saveToTemplate;
 ["placeIntel_itemLarge", ["Land_File1_F",-155,false]] call _fnc_saveToTemplate;
 
@@ -40,6 +39,7 @@ private _vehiclesTanks = ["LIB_M4A4_FIREFLY","LIB_Cromwell_Mk4","LIB_Cromwell_Mk
 private _vehiclesHeavyTanks = ["LIB_Churchill_Mk7","LIB_Churchill_Mk7_Crocodile"];
 
 ["vehiclesAA", ["LIB_Zis5v_61K"]] call _fnc_saveToTemplate;                    // ideally heavily armed with anti-ground capability and enclosed turret. Passengers will be ignored
+["vehiclesSAM", []] call _fnc_saveToTemplate;                               // do not spawn SAMs or use SAM supports
 
 
 ["vehiclesTransportBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/IFA/IFA_AI_US.sqf
+++ b/A3A/addons/core/Templates/Templates/IFA/IFA_AI_US.sqf
@@ -9,7 +9,6 @@
 ["flagTexture", "a3\data_f\flags\flag_us_co.paa"] call _fnc_saveToTemplate;
 ["flagMarkerType", "flag_USA"] call _fnc_saveToTemplate;
 
-["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 ["attributeLowAir", true] call _fnc_saveToTemplate;
 ["placeIntel_itemLarge", ["Land_File1_F",-155,false]] call _fnc_saveToTemplate;
 
@@ -41,6 +40,7 @@ private _vehiclesHeavyTanks = ["LIB_M4A3_76_HVSS"];
 
 
 ["vehiclesAA", ["LIB_Zis5v_61K"]] call _fnc_saveToTemplate; //Fake "truck with bofors"
+["vehiclesSAM", []] call _fnc_saveToTemplate;                               // do not spawn SAMs or use SAM supports
 
 
 ["vehiclesTransportBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/IFA/IFA_AI_USMC.sqf
+++ b/A3A/addons/core/Templates/Templates/IFA/IFA_AI_USMC.sqf
@@ -9,7 +9,6 @@
 ["flagTexture", "\ca\data\flag_usmc_co.paa"] call _fnc_saveToTemplate;
 ["flagMarkerType", "Faction_USMC"] call _fnc_saveToTemplate;
 
-["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 ["attributeMoreTrucks", true] call _fnc_saveToTemplate;         // Use more truck for transports
 ["attributeLowAir", true] call _fnc_saveToTemplate;
 ["placeIntel_itemLarge", ["Land_File1_F",-155,false]] call _fnc_saveToTemplate;
@@ -41,6 +40,7 @@
 ["vehiclesHeavyTanks", ["LIB_M4A3_75"]] call _fnc_saveToTemplate;
 
 ["vehiclesAA", ["LIB_US_M3_Halftrack"]] call _fnc_saveToTemplate; //Fake "truck with bofors"
+["vehiclesSAM", []] call _fnc_saveToTemplate;                               // do not spawn SAMs or use SAM supports
 
 
 ["vehiclesTransportBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/IFA/IFA_AI_WEH.sqf
+++ b/A3A/addons/core/Templates/Templates/IFA/IFA_AI_WEH.sqf
@@ -9,7 +9,6 @@
 ["flagTexture", "\x\A3A\addons\core\Pictures\Flags\ifa_weh.paa"] call _fnc_saveToTemplate;
 ["flagMarkerType", "a3a_flag_WEH"] call _fnc_saveToTemplate;
 
-["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 ["attributeLowAir", true] call _fnc_saveToTemplate;
 ["placeIntel_itemLarge", ["Land_File1_F",-155,false]] call _fnc_saveToTemplate;
 
@@ -40,6 +39,7 @@ private _vehiclesLightTanks = ["a3a_lib_PzKpfwIV_noShield"];
 ["vehiclesHeavyTanks", ["LIB_PzKpfwVI_E","LIB_PzKpfwVI_E_1","LIB_PzKpfwVI_B"]] call _fnc_saveToTemplate;
 
 ["vehiclesAA", ["LIB_FlakPanzerIV_Wirbelwind", "LIB_FlakPanzerIV_Wirbelwind", "LIB_SdKfz_7_AA"]] call _fnc_saveToTemplate;                    // ideally heavily armed with anti-ground capability and enclosed turret. Passengers will be ignored
+["vehiclesSAM", []] call _fnc_saveToTemplate;                               // do not spawn SAMs or use SAM supports
 
 
 ["vehiclesTransportBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/SPEX/SPEX_AI_CW_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/SPEX/SPEX_AI_CW_Temperate.sqf
@@ -15,7 +15,6 @@
 
 ["attributeLowAir", true] call _fnc_saveToTemplate;             // Use fewer air units in general
 ["attributeMoreTrucks", true] call _fnc_saveToTemplate;         // Use more truck for transports
-["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 
 ["ammobox", "B_supplyCrate_F"] call _fnc_saveToTemplate;
 ["surrenderCrate", "SPE_Mine_AmmoBox_US"] call _fnc_saveToTemplate;
@@ -37,6 +36,7 @@
 ["vehiclesTanks", ["SPEX_CW_Cromwell_Mk5","SPEX_CW_Cromwell_Mk5","SPEX_CW_Sherman_II_late","SPEX_CW_Sherman_I"]] call _fnc_saveToTemplate;
 ["vehiclesHeavyTanks", ["SPEX_CW_Sherman_Ic_Hybrid","SPEX_CW_Sherman_Ic"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["SPE_US_M16_Halftrack"]] call _fnc_saveToTemplate;
+["vehiclesSAM", []] call _fnc_saveToTemplate;                               // do not spawn SAMs or use SAM supports
 
 ["vehiclesTransportBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/SPEX/SPEX_AI_CW_Trop.sqf
+++ b/A3A/addons/core/Templates/Templates/SPEX/SPEX_AI_CW_Trop.sqf
@@ -15,7 +15,6 @@
 
 ["attributeLowAir", true] call _fnc_saveToTemplate;             // Use fewer air units in general
 ["attributeMoreTrucks", true] call _fnc_saveToTemplate;         // Use more truck for transports
-["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 
 ["ammobox", "B_supplyCrate_F"] call _fnc_saveToTemplate;
 ["surrenderCrate", "SPE_Mine_AmmoBox_US"] call _fnc_saveToTemplate;
@@ -37,6 +36,7 @@
 ["vehiclesTanks", ["SPEX_CW_TROP_Sherman_V","SPEX_CW_TROP_Sherman_V_Early","SPEX_CW_Trop_Sherman_II","SPEX_CW_Trop_Sherman_II"]] call _fnc_saveToTemplate;
 ["vehiclesHeavyTanks", ["SPEX_CW_Sherman_Vc"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["SPE_US_M16_Halftrack"]] call _fnc_saveToTemplate;
+["vehiclesSAM", []] call _fnc_saveToTemplate;                               // do not spawn SAMs or use SAM supports
 
 ["vehiclesTransportBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/SPEX/SPEX_AI_US.sqf
+++ b/A3A/addons/core/Templates/Templates/SPEX/SPEX_AI_US.sqf
@@ -15,7 +15,6 @@
 
 ["attributeLowAir", true] call _fnc_saveToTemplate;             // Use fewer air units in general
 ["attributeMoreTrucks", true] call _fnc_saveToTemplate;         // Use more truck for transports
-["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 
 ["ammobox", "B_supplyCrate_F"] call _fnc_saveToTemplate;
 ["surrenderCrate", "SPE_Mine_AmmoBox_US"] call _fnc_saveToTemplate;
@@ -37,6 +36,7 @@
 ["vehiclesTanks", ["SPE_M4A1_75_erla","SPE_M4A1_76", "SPE_M4A1_75","SPE_M4A3_75","SPE_M4A3_76"]] call _fnc_saveToTemplate;
 ["vehiclesHeavyTanks", ["SPE_M4A1_T34_Calliope_Direct","SPE_M4A3_T34_Calliope_Direct"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["SPE_US_M16_Halftrack"]] call _fnc_saveToTemplate;
+["vehiclesSAM", []] call _fnc_saveToTemplate;                               // do not spawn SAMs or use SAM supports
 
 ["vehiclesTransportBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/SPEX/SPEX_AI_WEH.sqf
+++ b/A3A/addons/core/Templates/Templates/SPEX/SPEX_AI_WEH.sqf
@@ -15,7 +15,6 @@
 
 ["attributeLowAir", true] call _fnc_saveToTemplate;             // Use fewer air units in general
 ["attributeMoreTrucks", true] call _fnc_saveToTemplate;         // Use more truck for transports
-["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 
 ["ammobox", "B_supplyCrate_F"] call _fnc_saveToTemplate;
 ["surrenderCrate", "SPE_Weaponcrate_MP40_GER"] call _fnc_saveToTemplate;
@@ -37,6 +36,7 @@
 ["vehiclesTanks", ["SPE_PzKpfwIII_M", "SPE_PzKpfwIV_G", "SPE_PzKpfwIV_G", "SPE_PzKpfwV_G"]] call _fnc_saveToTemplate;
 ["vehiclesHeavyTanks", ["SPE_Jagdpanther_G1","SPE_PzKpfwVI_H1", "SPE_PzKpfwVI_H1", "SPE_PzKpfwV_G", "SPE_PzKpfwV_G", "SPE_PzKpfwV_G","SPEX_GER_Sherman_I","SPEX_GER_Sherman_Vc"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["SPE_ST_OpelBlitz_Flak38"]] call _fnc_saveToTemplate;
+["vehiclesSAM", []] call _fnc_saveToTemplate;                               // do not spawn SAMs or use SAM supports
 
 ["vehiclesTransportBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/SPEX/SPEX_AI_WEH_Trop.sqf
+++ b/A3A/addons/core/Templates/Templates/SPEX/SPEX_AI_WEH_Trop.sqf
@@ -15,7 +15,6 @@
 
 ["attributeLowAir", true] call _fnc_saveToTemplate;             // Use fewer air units in general
 ["attributeMoreTrucks", true] call _fnc_saveToTemplate;         // Use more truck for transports
-["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 
 ["ammobox", "B_supplyCrate_F"] call _fnc_saveToTemplate;
 ["surrenderCrate", "SPE_Weaponcrate_MP40_GER"] call _fnc_saveToTemplate;
@@ -37,6 +36,7 @@
 ["vehiclesTanks", ["SPEX_DAK_PzKpfwIII_L", "SPEX_DAK_PzKpfwIII_L", "SPEX_DAK_PzKpfwIV_G"]] call _fnc_saveToTemplate;
 ["vehiclesHeavyTanks", ["SPEX_DAK_PzKpfwVI_H1"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["SPEX_DAK_OpelBlitz_Flak38"]] call _fnc_saveToTemplate;
+["vehiclesSAM", []] call _fnc_saveToTemplate;                               // do not spawn SAMs or use SAM supports
 
 ["vehiclesTransportBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_US.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_US.sqf
@@ -15,7 +15,6 @@
 
 ["attributeLowAir", true] call _fnc_saveToTemplate;             // Use fewer air units in general
 ["attributeMoreTrucks", true] call _fnc_saveToTemplate;         // Use more truck for transports
-["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 
 ["ammobox", "B_supplyCrate_F"] call _fnc_saveToTemplate;
 ["surrenderCrate", "SPE_Mine_AmmoBox_US"] call _fnc_saveToTemplate;
@@ -37,6 +36,7 @@
 ["vehiclesTanks", ["SPE_M4A1_75_erla","SPE_M4A1_76", "SPE_M4A1_75","SPE_M4A3_75","SPE_M4A3_76"]] call _fnc_saveToTemplate;
 ["vehiclesHeavyTanks", ["SPE_M4A1_T34_Calliope_Direct","SPE_M4A3_T34_Calliope_Direct"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["SPE_US_M16_Halftrack"]] call _fnc_saveToTemplate;
+["vehiclesSAM", []] call _fnc_saveToTemplate;                               // do not spawn SAMs or use SAM supports
 
 ["vehiclesTransportBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_WEH.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_IFA/SPE_IFA_AI_WEH.sqf
@@ -15,7 +15,6 @@
 
 ["attributeLowAir", true] call _fnc_saveToTemplate;             // Use fewer air units in general
 ["attributeMoreTrucks", true] call _fnc_saveToTemplate;         // Use more truck for transports
-["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 
 ["ammobox", "B_supplyCrate_F"] call _fnc_saveToTemplate;
 ["surrenderCrate", "SPE_Weaponcrate_MP40_GER"] call _fnc_saveToTemplate;
@@ -37,6 +36,7 @@
 ["vehiclesTanks", ["SPE_PzKpfwIII_M", "SPE_PzKpfwIV_G", "SPE_PzKpfwIV_G", "SPE_PzKpfwV_G"]] call _fnc_saveToTemplate;
 ["vehiclesHeavyTanks", ["SPE_Jagdpanther_G1","SPE_PzKpfwVI_H1", "SPE_PzKpfwVI_H1", "SPE_PzKpfwV_G", "SPE_PzKpfwV_G", "SPE_PzKpfwV_G"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["SPE_ST_OpelBlitz_Flak38"]] call _fnc_saveToTemplate;
+["vehiclesSAM", []] call _fnc_saveToTemplate;                               // do not spawn SAMs or use SAM supports
 
 ["vehiclesTransportBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/SPE_SEP/SEP_AI_ACAF.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_SEP/SEP_AI_ACAF.sqf
@@ -15,7 +15,6 @@
 
 ["attributeLowAir", true] call _fnc_saveToTemplate;             // Use fewer air units in general
 ["attributeMoreTrucks", true] call _fnc_saveToTemplate;         // Use more truck for transports
-["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 
 ["ammobox", "B_supplyCrate_F"] call _fnc_saveToTemplate;
 ["surrenderCrate", "SPE_Mine_AmmoBox_US"] call _fnc_saveToTemplate;
@@ -37,6 +36,7 @@
 ["vehiclesTanks", ["SPEX_CW_Cromwell_Mk5"]] call _fnc_saveToTemplate;
 ["vehiclesHeavyTanks", []] call _fnc_saveToTemplate;
 ["vehiclesAA", ["SPE_US_M16_Halftrack"]] call _fnc_saveToTemplate;
+["vehiclesSAM", []] call _fnc_saveToTemplate;                               // do not spawn SAMs or use SAM supports
 
 ["vehiclesTransportBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/SPE_SEP/SEP_AI_IHAC.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_SEP/SEP_AI_IHAC.sqf
@@ -15,7 +15,6 @@
 
 ["attributeLowAir", true] call _fnc_saveToTemplate;             // Use fewer air units in general
 ["attributeMoreTrucks", true] call _fnc_saveToTemplate;         // Use more truck for transports
-["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 
 ["ammobox", "B_supplyCrate_F"] call _fnc_saveToTemplate;
 ["surrenderCrate", "SPE_Mine_AmmoBox_US"] call _fnc_saveToTemplate;
@@ -37,6 +36,7 @@
 ["vehiclesTanks", ["SEP_I_IHTC_M4A1_75"]] call _fnc_saveToTemplate;
 ["vehiclesHeavyTanks", []] call _fnc_saveToTemplate;
 ["vehiclesAA", ["SPE_US_M16_Halftrack"]] call _fnc_saveToTemplate;
+["vehiclesSAM", []] call _fnc_saveToTemplate;                               // do not spawn SAMs or use SAM supports
 
 ["vehiclesTransportBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/SPE_SEP/SEP_AI_US_Winter.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_SEP/SEP_AI_US_Winter.sqf
@@ -15,7 +15,6 @@
 
 ["attributeLowAir", true] call _fnc_saveToTemplate;             // Use fewer air units in general
 ["attributeMoreTrucks", true] call _fnc_saveToTemplate;         // Use more truck for transports
-["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 
 ["ammobox", "B_supplyCrate_F"] call _fnc_saveToTemplate;
 ["surrenderCrate", "SPE_Mine_AmmoBox_US"] call _fnc_saveToTemplate;
@@ -37,6 +36,7 @@
 ["vehiclesTanks", ["SEP_I_US_WIN_M4A0_75","SEP_I_US_WIN_M4A3_75","SEP_I_US_WIN_M4A3_75", "SEP_I_US_WIN_M4A1_76","SEP_I_US_WIN_M4A3_76"]] call _fnc_saveToTemplate;
 ["vehiclesHeavyTanks", ["SEP_I_US_WIN_M4A1_T34_Calliope_Direct","SEP_I_US_WIN_M4A3_T34_Calliope_Direct"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["SEP_I_US_WIN_M16_Halftrack"]] call _fnc_saveToTemplate;
+["vehiclesSAM", []] call _fnc_saveToTemplate;                               // do not spawn SAMs or use SAM supports
 
 ["vehiclesTransportBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/SPE_SEP/SEP_AI_WEH_Core.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_SEP/SEP_AI_WEH_Core.sqf
@@ -15,7 +15,6 @@
 
 ["attributeLowAir", true] call _fnc_saveToTemplate;             // Use fewer air units in general
 ["attributeMoreTrucks", true] call _fnc_saveToTemplate;         // Use more truck for transports
-["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 
 ["ammobox", "B_supplyCrate_F"] call _fnc_saveToTemplate;
 ["surrenderCrate", "SPE_Weaponcrate_MP40_GER"] call _fnc_saveToTemplate;
@@ -37,6 +36,7 @@
 ["vehiclesTanks", ["SPE_ST_PzKpfwIII_N", "SPE_ST_PzKpfwIII_M", "SPE_ST_PzKpfwIII_M", "SPE_ST_PzKpfwIV_G", "SPE_ST_PzKpfwIV_G", "SPE_ST_PzKpfwV_G"]] call _fnc_saveToTemplate;
 ["vehiclesHeavyTanks", ["SPE_ST_Jagdpanther_G1","SPE_ST_PzKpfwVI_H1", "SPE_ST_PzKpfwVI_H1", "SPE_ST_PzKpfwV_G", "SPE_ST_PzKpfwV_G", "SPE_ST_PzKpfwV_G"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["SPE_ST_OpelBlitz_Flak38"]] call _fnc_saveToTemplate;
+["vehiclesSAM", []] call _fnc_saveToTemplate;                               // do not spawn SAMs or use SAM supports
 
 ["vehiclesTransportBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/SPE_SEP/SEP_AI_WEH_Winter.sqf
+++ b/A3A/addons/core/Templates/Templates/SPE_SEP/SEP_AI_WEH_Winter.sqf
@@ -15,7 +15,6 @@
 
 ["attributeLowAir", true] call _fnc_saveToTemplate;             // Use fewer air units in general
 ["attributeMoreTrucks", true] call _fnc_saveToTemplate;         // Use more truck for transports
-["attributeNoSAM", true] call _fnc_saveToTemplate;              // Don't use SAM supports
 
 ["ammobox", "B_supplyCrate_F"] call _fnc_saveToTemplate;
 ["surrenderCrate", "SPE_Weaponcrate_MP40_GER"] call _fnc_saveToTemplate;
@@ -37,6 +36,7 @@
 ["vehiclesTanks", ["SEP_B_GER_WIN_PzKpfw_III_M", "SEP_B_GER_WIN_PzKpfw_III_M", "SEP_B_GER_WIN_PzKpfw_IV_G", "SEP_B_GER_WIN_PzKpfw_IV_G", "SEP_B_GER_WIN_PzKpfw_V_G"]] call _fnc_saveToTemplate;
 ["vehiclesHeavyTanks", ["SEP_B_GER_WIN_Jagdpanther_G1","SEP_B_GER_WIN_PzKpfw_VI_H1", "SEP_B_GER_WIN_PzKpfw_VI_H1", "SEP_B_GER_WIN_PzKpfw_V_G", "SEP_B_GER_WIN_PzKpfw_V_G", "SEP_B_GER_WIN_PzKpfw_V_G"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["SEP_B_GER_WIN_OpelBlitz_Flak38"]] call _fnc_saveToTemplate;
+["vehiclesSAM", []] call _fnc_saveToTemplate;                               // do not spawn SAMs or use SAM supports
 
 ["vehiclesTransportBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["I_C_Boat_Transport_02_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/functions/Supports/fn_initSupports.sqf
+++ b/A3A/addons/core/functions/Supports/fn_initSupports.sqf
@@ -45,7 +45,7 @@ private _initData = [
     ["QRFLAND",       "TROOPS", 1.0, 1.4,   0,   0,  "", ""],
     ["QRFAIR",        "TROOPS", 0.5, 0.1,   0,   0,  "", ""],
     ["CARPETBOMBS",     "AREA", 0.5, 0.1, 200,   0, "u", "vehiclesPlanesCAS"],            // balanced against airstrikes
-    ["SAM",           "TARGET", 1.0, 1.0,   0, 100,  "", ""],                             // balanced against ASF
+    ["SAM",           "TARGET", 1.0, 1.0,   0, 100,  "", "vehiclesSAM"],                  // balanced against ASF
     ["ORBITALSTRIKE",   "AREA", 0.2, 0.0, 300,   0, "f", ""],
     ["SEAD",          "TARGET", 0.5, 0.5,   0, 100,  "", "vehiclesPlanesAA"],
     ["UAV",             "AREA", 0.0, 0.0,   0,   0,  "", "uavsAttack"]                    // Not used for support calls 
@@ -57,7 +57,7 @@ private _fnc_buildSupportHM =
 {
     params ["_faction"];
     private _lowAir = _faction getOrDefault ["attributeLowAir", false];
-    private _noSAM = _faction getOrDefault ["attributeNoSAM", false];
+    private _noSAM = _faction getOrDefault ["attributeNoSAM", false];               // backwards compat
     private _suppHM = createHashMap;
     {
         _x params ["_suppType", "_baseType", "_weight", "_lowAirWeight", "_effRadius", "_strikepower", "_flags", "_reqType"];

--- a/A3A/addons/core/functions/Templates/fn_compatibilityLoadFaction.sqf
+++ b/A3A/addons/core/functions/Templates/fn_compatibilityLoadFaction.sqf
@@ -89,6 +89,7 @@ if (_side in [Occupants, Invaders]) then {
     if (_faction get "vehiclesGunBoats" isEqualTo []) then { _noType pushBack "boat" };
     if ((_faction get "vehiclesPlanesAA") + (_faction get "vehiclesPlanesCAS") isEqualTo []) then { _noType append ["plane", "runway"] };
     if (_faction get "vehiclesArtillery" isEqualTo []) then { _noType pushBack "vehicleArty" };
+    if (_faction get "vehiclesSAM" isEqualTo []) then { _noType pushBack "vehicleSAM" };
     _faction set ["noPlaceTypes", _noType];
 };
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed SAMs spawning at campaign start or as reinforcements in no-SAM factions:
- Switched attribute for array blanking in factions.
- Added vehicleSAM to noPlaceTypes array so that reinf doesn't attempt.
- Added SAM vehicle type to initSupports array.

I left the no-SAM attribute switch in initSupports for limited backwards compat with extensions, but it's not needed for the main mod anymore.

### Please specify which Issue this PR Resolves.
closes #3890

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
