### PR TITLE
Fix incorrect units being placed in radio tower sniper spots

### DIFF
--- a/A3A/addons/core/functions/GarrisonLocal/fn_spawnGarrisonSquads.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_spawnGarrisonSquads.sqf
@@ -114,7 +114,7 @@ else
 
     // Replace garrison squad with snipers for high positions
     for "_i" from 1 to (_sniperCount min count _garrSquad) do {
-        _garrSquad set [_i, _faction get "unitMarksman"];
+        _garrSquad set [_i-1, _faction get "unitMarksman"];
     };
 };
 Debug_1("Squads: %1", _squads);

--- a/A3A/addons/core/functions/init/fn_initVarCommon.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarCommon.sqf
@@ -159,7 +159,7 @@ A3A_buildingBlacklist = [
 	"Land_vn_quonset_02_01","Land_vn_quonset_02","Land_vn_quonset_01","Land_vn_hootch_01","Land_vn_hootch_02","Land_vn_barracks_02","Land_vn_barracks_02_01","Land_vn_barracks_04","Land_vn_b_trench_bunker_03_03","Land_vn_tent_mash_01_01","Land_vn_tent_mash_01_02","Land_vn_tent_01_03","Land_vn_tent_01_01","Land_vn_tent_01_02","Land_vn_tent_01_04",
 	"Land_vn_barracks_04_01","Land_vn_barracks_04_02","Land_vn_b_trench_bunker_01_03","Land_vn_b_trench_bunker_03_04","Land_vn_tent_mash_01_04","Land_vn_tent_02_01","Land_vn_tent_02_02","Land_vn_tent_mash_01","Land_vn_tent_mash_02_03","Land_vn_tent_mash_02_04","Land_vn_hut_old02","Land_vn_tent_02_04","Land_vn_tent_02_03","Land_vn_tent_mash_02_02",
 	"Land_vn_tent_mash_02_01","Land_vn_tent_mash_01_03","Land_vn_army_hut_storrage","Land_vn_army_hut_int","Land_vn_wf_field_hospital_east","Land_vn_army_hut2_int","Land_vn_army_hut3_long_int", "Land_vn_o_prop_cong_cage_01", "Land_vn_o_prop_cong_cage_02", "Land_vn_o_prop_cong_cage_03",
-	"Land_SPE_bocage_long_mound", "Land_SPE_bocage_short_mound", "Land_SPE_bocage_short_mound_lc", "Land_SPE_bocage_long_mound_lc"
+	"Land_SPE_bocage_long_mound", "Land_SPE_bocage_short_mound", "Land_SPE_bocage_short_mound_lc", "Land_SPE_bocage_long_mound_lc", "Land_TTowerBig_1_F", "Land_TTowerBig_2_F"
 ];
 //Lights and Lamps array used for 'Blackout'
 A3A_lampTypes = [


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
- Fixed off-by-one error that caused radio tower marksmen to be placed in the wrong spots.
- Added radio towers to blacklist so that it doesn't place normal building garrison there.

Didn't handle the case where multiple garrisons overlap the same radio tower (see central Altis). That one is a pain.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
