### PR TITLE
Mostly rebel roadblock fixes

### DIFF
--- a/A3A/addons/core/functions/Base/fn_createOutpostsFIA.sqf
+++ b/A3A/addons/core/functions/Base/fn_createOutpostsFIA.sqf
@@ -2,27 +2,19 @@
 FIX_LINE_NUMBERS()
 if (!isServer) exitWith {};
 
-private ["_groupX","_unit","_radiusX","_roads","_road","_pos","_truckX","_textX","_mrk","_unitsX","_formatX"];
+private ["_typeX","_costs","_groupX","_unit","_radiusX","_roads","_road","_pos","_truckX","_textX","_mrk","_hr","_unitsX","_formatX"];
 
-params ["_positionTel"];
+_typeX = _this select 0;
+_positionTel = _this select 1;
 
-private _titleStr = localize "STR_A3A_fn_base_outpdiag_title";
+_isRoad = isOnRoad _positionTel;
 
-// Check for both marker name collision and nearby rebel posts
-// Moved from outpostDialog because we need server data
-private _nearPosts = outpostsFIA inAreaArrayIndexes [_positionTel, 300, 300];
-private _mrkName = format ["RebPost%1", mapGridPosition _positionTel];
-private _isNearMrk = markerShape _mrkName != "" and !(_mrkName in A3A_markersToDelete);
-if (count _nearPosts > 0 or _isNearMrk) exitWith {
-	[_titleStr, localize "STR_A3A_fn_base_createoutpfia_alreadynear"] remoteExecCall ["A3A_fnc_customHint", theBoss];
-};
+_typeGroup = FactionGet(reb,"groupSniper");
+_typeVehX = (FactionGet(reb,"vehiclesBasic")) # 0;
+_taskData = localize "STR_A3A_fn_createOutpostsFIA_OP_data";
+_taskTitle = localize "STR_A3A_fn_createOutpostsFIA_OP_title";
+private _tsk = "";
 
-private _typeGroup = FactionGet(reb,"groupSniper");
-private _typeVehX = (FactionGet(reb,"vehiclesBasic")) # 0;
-private _taskData = localize "STR_A3A_fn_createOutpostsFIA_OP_data";
-private _taskTitle = localize "STR_A3A_fn_createOutpostsFIA_OP_title";
-
-private _isRoad = isOnRoad _positionTel;
 if (_isRoad) then {
 	_typeGroup = FactionGet(reb,"groupAT") + [FactionGet(reb,"unitCrew")];
 	_typeVehX = (FactionGet(reb,"vehiclesTruck")) # 0;
@@ -30,17 +22,8 @@ if (_isRoad) then {
 	_taskTitle = localize "STR_A3A_fn_createOutpostsFIA_RB_title";
 };
 
-private _hr = 0;
-private _cost = if (_isRoad) then { [FactionGet(reb,"vehiclesLightArmed") # 0] call A3A_fnc_vehiclePrice } else { 0 };
-{_cost = _cost + (server getVariable _x); _hr = _hr + 1} forEach _typeGroup;
-if (server getVariable "resourcesFIA" < _cost or server getVariable "hr" < _hr) exitWith {
-	[_titleStr, format [localize "STR_A3A_fn_base_outpdiag_no_resources",_hr,_cost]] remoteExecCall ["A3A_fnc_customHint", theBoss];
-};
-[-_hr, -_cost] spawn A3A_fnc_resourcesFIA;
-
-
-private _dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + 60];
-private _dateLimitNum = dateToNumber _dateLimit;
+_dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + 60];
+_dateLimitNum = dateToNumber _dateLimit;
 private _taskId = "outpostsFIA" + str A3A_taskCount;
 [[teamPlayer,civilian],_taskId,[_taskData,_taskTitle],_positionTel,false,0,true,"Move",true] call BIS_fnc_taskCreate;
 [_taskId, "outpostsFIA", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];

--- a/A3A/addons/core/functions/Base/fn_createOutpostsFIA.sqf
+++ b/A3A/addons/core/functions/Base/fn_createOutpostsFIA.sqf
@@ -2,19 +2,27 @@
 FIX_LINE_NUMBERS()
 if (!isServer) exitWith {};
 
-private ["_typeX","_costs","_groupX","_unit","_radiusX","_roads","_road","_pos","_truckX","_textX","_mrk","_hr","_unitsX","_formatX"];
+private ["_groupX","_unit","_radiusX","_roads","_road","_pos","_truckX","_textX","_mrk","_unitsX","_formatX"];
 
-_typeX = _this select 0;
-_positionTel = _this select 1;
+params ["_positionTel"];
 
-_isRoad = isOnRoad _positionTel;
+private _titleStr = localize "STR_A3A_fn_base_outpdiag_title";
 
-_typeGroup = FactionGet(reb,"groupSniper");
-_typeVehX = (FactionGet(reb,"vehiclesBasic")) # 0;
-_taskData = localize "STR_A3A_fn_createOutpostsFIA_OP_data";
-_taskTitle = localize "STR_A3A_fn_createOutpostsFIA_OP_title";
-private _tsk = "";
+// Check for both marker name collision and nearby rebel posts
+// Moved from outpostDialog because we need server data
+private _nearPosts = outpostsFIA inAreaArrayIndexes [_positionTel, 300, 300];
+private _mrkName = format ["RebPost%1", mapGridPosition _positionTel];
+private _isNearMrk = markerShape _mrkName != "" and !(_mrkName in A3A_markersToDelete);
+if (count _nearPosts > 0 or _isNearMrk) exitWith {
+	[_titleStr, localize "STR_A3A_fn_base_createoutpfia_alreadynear"] remoteExecCall ["A3A_fnc_customHint", theBoss];
+};
 
+private _typeGroup = FactionGet(reb,"groupSniper");
+private _typeVehX = (FactionGet(reb,"vehiclesBasic")) # 0;
+private _taskData = localize "STR_A3A_fn_createOutpostsFIA_OP_data";
+private _taskTitle = localize "STR_A3A_fn_createOutpostsFIA_OP_title";
+
+private _isRoad = isOnRoad _positionTel;
 if (_isRoad) then {
 	_typeGroup = FactionGet(reb,"groupAT") + [FactionGet(reb,"unitCrew")];
 	_typeVehX = (FactionGet(reb,"vehiclesTruck")) # 0;
@@ -22,8 +30,17 @@ if (_isRoad) then {
 	_taskTitle = localize "STR_A3A_fn_createOutpostsFIA_RB_title";
 };
 
-_dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + 60];
-_dateLimitNum = dateToNumber _dateLimit;
+private _hr = 0;
+private _cost = if (_isRoad) then { [FactionGet(reb,"vehiclesLightArmed") # 0] call A3A_fnc_vehiclePrice } else { 0 };
+{_cost = _cost + (server getVariable _x); _hr = _hr + 1} forEach _typeGroup;
+if (server getVariable "resourcesFIA" < _cost or server getVariable "hr" < _hr) exitWith {
+	[_titleStr, format [localize "STR_A3A_fn_base_outpdiag_no_resources",_hr,_cost]] remoteExecCall ["A3A_fnc_customHint", theBoss];
+};
+[-_hr, -_cost] spawn A3A_fnc_resourcesFIA;
+
+
+private _dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + 60];
+private _dateLimitNum = dateToNumber _dateLimit;
 private _taskId = "outpostsFIA" + str A3A_taskCount;
 [[teamPlayer,civilian],_taskId,[_taskData,_taskTitle],_positionTel,false,0,true,"Move",true] call BIS_fnc_taskCreate;
 [_taskId, "outpostsFIA", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];

--- a/A3A/addons/core/functions/Base/fn_outpostDialog.sqf
+++ b/A3A/addons/core/functions/Base/fn_outpostDialog.sqf
@@ -44,7 +44,7 @@ if (_typeX != "delete") then
 		};
 
 	{_costs = _costs + (server getVariable _x); _hr = _hr +1} forEach _typeGroup;
-	}
+	};
 
 
 // Check for both marker name collision and nearby rebel posts

--- a/A3A/addons/core/functions/Base/fn_outpostDialog.sqf
+++ b/A3A/addons/core/functions/Base/fn_outpostDialog.sqf
@@ -23,53 +23,6 @@ onMapSingleClick "";
 
 if (!visibleMap) exitWith {};
 
-_positionTel = positionTel;
-_pos = [];
-
-if ((_typeX == "delete") and (count outpostsFIA < 1)) exitWith {[_titleStr, localize "STR_A3A_fn_base_outpdiag_no_delete"] call A3A_fnc_customHint;};
-if ((_typeX == "delete") and ({(alive _x) and (!captive _x) and ((side _x == Occupants) or (side _x == Invaders)) and (_x distance _positionTel < 500)} count allUnits > 0)) exitWith {[_titleStr, localize "STR_A3A_fn_base_outpdiag_no_enemies"] call A3A_fnc_customHint;};
-
-_costs = 0;
-_hr = 0;
-
-if (_typeX != "delete") then
-	{
-	_isRoad = isOnRoad _positionTel;
-
-	_typeGroup = FactionGet(reb,"groupSniper");
-
-	if (_isRoad) then
-		{
-		_typeGroup = FactionGet(reb,"groupAT");
-		_costs = _costs + ([(FactionGet(reb,"vehiclesLightArmed")) # 0] call A3A_fnc_vehiclePrice) + (server getVariable FactionGet(reb,"unitCrew"));
-		_hr = _hr + 1;
-		};
-
-	//_formatX = (configfile >> "CfgGroups" >> "teamPlayer" >> "Guerilla" >> "Infantry" >> _typeGroup);
-	//_unitsX = [_formatX] call groupComposition;
-	{_costs = _costs + (server getVariable _x); _hr = _hr +1} forEach _typeGroup;
-	}
-else
-	{
-	_mrk = [outpostsFIA,_positionTel] call BIS_fnc_nearestPosition;
-	_pos = getMarkerPos _mrk;
-	if (_positionTel distance _pos >10) exitWith {[_titleStr, localize "STR_A3A_fn_base_outpdiag_no_post"] call A3A_fnc_customHint;};
-	};
-//if ((_typeX == "delete") and (_positionTel distance _pos >10)) exitWith {hint "No post nearby"};
-
-
 if (_typeX == "delete") exitWith {[_titleStr, localize "STR_A3A_fn_base_createoutpfia_outdated"] call A3A_fnc_customHint;};
 
-// Check for both marker name collision and nearby rebel posts
-private _nearPosts = outpostsFIA inAreaArrayIndexes [_positionTel, 300, 300];
-private _isNearMrk = markerShape format ["RebPost%1", mapGridPosition _positionTel] != "";
-if (count _nearPosts > 0 or _isNearMrk) exitWith {
-	[_titleStr, localize "STR_A3A_fn_base_createoutpfia_alreadynear"] call A3A_fnc_customHint;
-};
-
-_resourcesFIA = server getVariable "resourcesFIA";
-_hrFIA = server getVariable "hr";
-if (_resourcesFIA < _costs or _hrFIA < _hr) exitWith {[_titleStr, format [localize "STR_A3A_fn_base_outpdiag_no_resources",_hr,_costs]] call A3A_fnc_customHint;};
-[-_hr,-_costs] remoteExec ["A3A_fnc_resourcesFIA",2];
-
-[_typeX,_positionTel] remoteExec ["A3A_fnc_createOutpostsFIA", 2];
+[positionTel] remoteExec ["A3A_fnc_createOutpostsFIA", 2];

--- a/A3A/addons/core/functions/Base/fn_outpostDialog.sqf
+++ b/A3A/addons/core/functions/Base/fn_outpostDialog.sqf
@@ -10,6 +10,7 @@ if (!([player] call A3A_fnc_hasRadio)) exitWith {if !(A3A_hasIFA) then {[localiz
 else {[localize "STR_A3A_fn_base_outpdiag_radioman", localize "STR_A3A_fn_base_outpdiag_no_radioman"] call A3A_fnc_customHint;}};
 
 _typeX = _this select 0;
+if (_typeX == "delete") exitWith {[_titleStr, localize "STR_A3A_fn_base_createoutpfia_outdated"] call A3A_fnc_customHint;};
 
 if (!visibleMap) then {openMap true};
 positionTel = [];
@@ -23,6 +24,39 @@ onMapSingleClick "";
 
 if (!visibleMap) exitWith {};
 
-if (_typeX == "delete") exitWith {[_titleStr, localize "STR_A3A_fn_base_createoutpfia_outdated"] call A3A_fnc_customHint;};
+_positionTel = positionTel;
+_pos = [];
 
-[positionTel] remoteExec ["A3A_fnc_createOutpostsFIA", 2];
+_costs = 0;
+_hr = 0;
+
+if (_typeX != "delete") then
+	{
+	_isRoad = isOnRoad _positionTel;
+
+	_typeGroup = FactionGet(reb,"groupSniper");
+
+	if (_isRoad) then
+		{
+		_typeGroup = FactionGet(reb,"groupAT");
+		_costs = _costs + ([(FactionGet(reb,"vehiclesLightArmed")) # 0] call A3A_fnc_vehiclePrice) + (server getVariable FactionGet(reb,"unitCrew"));
+		_hr = _hr + 1;
+		};
+
+	{_costs = _costs + (server getVariable _x); _hr = _hr +1} forEach _typeGroup;
+	}
+
+
+// Check for both marker name collision and nearby rebel posts
+private _nearPosts = outpostsFIA inAreaArrayIndexes [_positionTel, 300, 300];
+private _isNearMrk = format ["RebPost%1", mapGridPosition _positionTel] in outpostsFIA;
+if (count _nearPosts > 0 or _isNearMrk) exitWith {
+	[_titleStr, localize "STR_A3A_fn_base_createoutpfia_alreadynear"] call A3A_fnc_customHint;
+};
+
+_resourcesFIA = server getVariable "resourcesFIA";
+_hrFIA = server getVariable "hr";
+if (_resourcesFIA < _costs or _hrFIA < _hr) exitWith {[_titleStr, format [localize "STR_A3A_fn_base_outpdiag_no_resources",_hr,_costs]] call A3A_fnc_customHint;};
+[-_hr,-_costs] remoteExec ["A3A_fnc_resourcesFIA",2];
+
+[_typeX,_positionTel] remoteExec ["A3A_fnc_createOutpostsFIA", 2];

--- a/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_zoneCheck.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_zoneCheck.sqf
@@ -24,8 +24,8 @@ private _markerPos = markerPos _marker;
 private _type = _garrison get "type";
 private _side = _garrison get "side";
 
-if (_type in ["hq", "city"]) exitWith {};          // No action required
-if (_type in ["camp", "roadblock", "rebpost"]) exitWith
+if (_type in ["hq", "city", "rebpost"]) exitWith {};          // No action required
+if (_type in ["camp", "roadblock"]) exitWith
 {
     // Minor site case, remove if empty
     private _remTroops = _troops select { _x call A3A_fnc_canFight };

--- a/A3A/addons/core/functions/MinorSites/fn_createRebelControl.sqf
+++ b/A3A/addons/core/functions/MinorSites/fn_createRebelControl.sqf
@@ -10,12 +10,18 @@ params ["_pos", "_troopTypes", "_vehTypes"];
 // Adjust position to road if there is one
 if (isOnRoad _pos) then { _pos = getPosATL roadAt _pos };
 
-// Create underlying shape marker
-_marker = createMarkerLocal [format ["RebPost%1", mapGridPosition _pos], _pos];
-if (_marker == "") exitWith { Error_1("Already a rebel post at %1", _pos) };            // should be impossible
-_marker setMarkerShapeLocal "ELLIPSE";
-_marker setMarkerSizeLocal [30,30];
-_marker setMarkerAlpha 0;
+// If previous marker with the same name was deleted, clear that and move the old one
+private _marker = format ["RebPost%1", mapGridPosition _pos];
+if (markerShape _marker != "") then {
+    A3A_markersToDelete = A3A_markersToDelete - [_marker];
+    _marker setMarkerPos _pos;
+} else {
+    // Create underlying shape marker
+    createMarkerLocal [_marker, _pos];
+    _marker setMarkerShapeLocal "ELLIPSE";
+    _marker setMarkerSizeLocal [30,30];
+    _marker setMarkerAlpha 0;
+};
 
 // Visible marker (text & broadcast needs to be set after outpostsFIA)
 _iconMarker = createMarkerLocal [format ["Dum%1", _marker], _pos];
@@ -46,6 +52,7 @@ outpostsFIA = outpostsFIA + [_marker];
 if (_troopTypes isNotEqualTo []) then {
     // If used from a save then outpostsFIA and markers are updated later (after adding garrison)
     // If it's live then set the text & broadcast immediately, needs outpostsFIA & side
+    [_marker] call A3A_fnc_garrisonServer_initVIDs;
     publicVariable "outpostsFIA";
     [_marker] call A3A_fnc_mrkUpdate;
 };

--- a/A3A/addons/core/functions/Save/fn_convertSavedStatics.sqf
+++ b/A3A/addons/core/functions/Save/fn_convertSavedStatics.sqf
@@ -9,11 +9,6 @@ if (A3A_saveVersion < 20401) exitWith {};
 // Nothing to do for new saves
 if (A3A_saveVersion >= 31000) exitWith {};
 
-// Need to get Synd_HQ position now, otherwise this stuff won't go into the garrison
-private _varValue = ["posHQ"] call A3A_fnc_returnSavedStat;
-private _posHQ = if (count _varValue > 3) then {_varValue select 0} else {_varValue};
-"Synd_HQ" setMarkerPos _posHQ;
-
 {
 	_x params ["_typeVeh", "_posVeh", "_vecUp", "_vecDir", "_state"];
 

--- a/A3A/addons/core/functions/Save/fn_loadServer.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadServer.sqf
@@ -112,6 +112,11 @@ if (isServer) then {
 
 	// outpostsFIA should be fully handled by convertSavedGarrisons
 
+	// Need to get Synd_HQ position now, so roadblocks aren't generated nearby and compat statics go into the right garrison
+	private _posHQ = ["posHQ"] call A3A_fnc_returnSavedStat;
+	if (count _posHQ > 3) then { _posHQ = _posHQ select 0 };
+	"Synd_HQ" setMarkerPos _posHQ;
+
 	// Sync minor site data & generate if missing
 	call A3A_fnc_initMinorSites;
 


### PR DESCRIPTION

### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
- Enable creation of new roadblock/watchpost where one was deleted in that session. Used to generate a "There's already a roadblock near that position" message.
- Block destruction of rebel roadblocks/watchposts by kills. This one's a bit arguable but otherwise I'd need to implement dragging nearby buildings & statics into roadblocks & watchposts on creation.
- Fix rebel roadblock vehicle IDs not being generated on creation (RPT error + state preservation issue).
- Fix enemy roadblocks & camps potentially being created within 500m of HQ on pre-3.10 saves. Not really related but I ran into it while testing.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Create a new roadblock. Send the vehicle there so it builds. Dismiss the roadblock. Create it again in the same position.
