### PR TITLE
Block Y menu when arsenal or vehicle arsenal is open

### DIFF
--- a/A3A/addons/core/keybinds/fn_keyActions.sqf
+++ b/A3A/addons/core/keybinds/fn_keyActions.sqf
@@ -18,6 +18,8 @@ switch (_key) do {
         if (player getVariable ["owner",player] != player) exitWith {};
         if (GVAR(keys_battleMenu)) exitWith {};         // fucking thing actually refires on closeDialog?
         if (dialog) exitWith {};
+        if (!isNull (uiNamespace getVariable ["arsanalDisplay", displayNull])) exitWith {};            // JNA open
+
         GVAR(keys_battleMenu) = true; //used to block certain actions when menu is open
 
         // So what the fuck is going on here? Let's see...


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Block Y menu opening when JNA arsenal or vehicle arsenal are open. It's a display so `dialog` returns false, apparently. Won't detect the BI arsenal or ACE arsenal (that one might be a dialog anyway. I wouldn't know).    

### Please specify which Issue this PR Resolves.
closes #3897

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
