### PR TITLE
Sort out deletion times for supplies & police station tasks

### DIFF
--- a/A3A/addons/core/functions/Missions/fn_SUP_PoliceStation.sqf
+++ b/A3A/addons/core/functions/Missions/fn_SUP_PoliceStation.sqf
@@ -39,5 +39,5 @@ else
     [20, true, _policeStation, 500] call A3A_tasks_fnc_rewardPlayers;           // players in nearest group within 500m
 };
 
-private _delay = 60 max (_startTime + 1200 - time);
+private _delay = 120 max (_startTime + 1200 - time);
 [_taskId, "SUPP", _delay] spawn A3A_fnc_taskDelete;

--- a/A3A/addons/core/functions/Missions/fn_SUP_PoliceStation.sqf
+++ b/A3A/addons/core/functions/Missions/fn_SUP_PoliceStation.sqf
@@ -39,5 +39,5 @@ else
     [20, true, _policeStation, 500] call A3A_tasks_fnc_rewardPlayers;           // players in nearest group within 500m
 };
 
-private _delay = 0 min (_startTime + 1200 - time);
+private _delay = 60 max (_startTime + 1200 - time);
 [_taskId, "SUPP", _delay] spawn A3A_fnc_taskDelete;

--- a/A3A/addons/tasks/Tasks/fn_SUP_Supplies.sqf
+++ b/A3A/addons/tasks/Tasks/fn_SUP_Supplies.sqf
@@ -210,18 +210,16 @@ _task set ["s_cleanup", {
 
 	// reverse-engineer task start time
 	private _startTime = (_this get "_endTime") - 60 * (15 + 30*(_this get "_difficulty"));
-	private _clearTime = 60 max ((_startTime + 1200) - time);
+	private _clearTime = 120 max ((_startTime + 1200) - time);
 	Trace_3("Start time %1; time %2; clearTime %3", _startTime, time, _clearTime);
-	_clearTime spawn {
-		sleep _this;
+	[_clearTime, _this get "_taskId"] spawn {
+		params ["_delay", "_taskId"];
+		sleep _delay;
 		A3A_activeTasks deleteAt (A3A_activeTasks find "SUPP");
 		publicVariable "A3A_activeTasks";
+		[_taskId, true, true] call BIS_fnc_deleteTask;
 	};
 
-	(_this get "_taskId") spawn {
-		sleep 120;
-		[_this, true, true] call BIS_fnc_deleteTask;
-	};
 	true;		// delete the damned task
 }];
 

--- a/A3A/addons/tasks/Tasks/fn_SUP_Supplies.sqf
+++ b/A3A/addons/tasks/Tasks/fn_SUP_Supplies.sqf
@@ -210,7 +210,7 @@ _task set ["s_cleanup", {
 
 	// reverse-engineer task start time
 	private _startTime = (_this get "_endTime") - 60 * (15 + 30*(_this get "_difficulty"));
-	private _clearTime = 0 max ((_startTime + 1200) - time);
+	private _clearTime = 60 max ((_startTime + 1200) - time);
 	Trace_3("Start time %1; time %2; clearTime %3", _startTime, time, _clearTime);
 	_clearTime spawn {
 		sleep _this;


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Sanitized the deletion & lockout times for city supplies and police station tasks so that they match. Changed the minimum deletion time from zero to two minutes.    

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
