### PR TITLE
Reduce HQ detection radius back to 500-1000m typical

### DIFF
--- a/A3A/addons/core/functions/Supports/fn_requestSupport.sqf
+++ b/A3A/addons/core/functions/Supports/fn_requestSupport.sqf
@@ -33,7 +33,7 @@ A3A_activeSupports = A3A_activeSupports select { _x#4 > 0 };                // r
 // HQ knowledge update
 call {
     private _hqDist = _target distance2d markerPos "Synd_HQ";
-    private _maxSpot = 250 + A3A_HQDetectionRadius + random 500;
+    private _maxSpot = A3A_HQDetectionRadius - 250 + random 500;
     _hqSpot = (1 + random 1) * linearConversion [0, _maxSpot, _hqDist, 1, 0, true]; 
     if (_hqSpot <= 0) exitWith {};
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug?
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
In 3.10 the average HQ detection range for support calls changed from 500m (because large bunkers don't exist) to 1km, and 1.5km if the HQ had a lot of stuff built. This was probably 500m more than intended. This PR adjusts the calc accordingly.    

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
