### PR TITLE
Improve bank vehicle spawn safety

### DIFF
--- a/A3A/addons/core/functions/Missions/fn_LOG_Bank.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Bank.sqf
@@ -36,10 +36,21 @@ _mrkFinal setMarkerShape "ICON";
 //_mrkFinal setMarkerText "Bank";
 
 private _bankVehicleClass = selectRandom (FactionGet(reb, "vehiclesCivSupply"));
+private _truckX = createVehicle [_bankVehicleClass, markerPos "Synd_HQ" vectorAdd [0,0,-1000], [], 0, "CAN_COLLIDE"];
+_truckX enableSimulation false;
+call {
+	private _testDir = random 360;
+	private _pos = [markerPos "Synd_HQ", _truckX, _testDir, 0, 50, 50] call A3A_fnc_findEmptyPosCar;
+	if (_pos isEqualTo []) then { _pos = markerPos "Synd_HQ" findEmptyPosition [1,50,_bankVehicleClass] };
+	isNil {
+		_truckX setPosATL _pos;
+		_truckX setDir _testDir;
+		_truckX allowDamage false;
+		_truckX enableSimulation true;
+	};
+	_truckX spawn { sleep 3; _this allowDamage true };
+};
 
-_pos = (getMarkerPos respawnTeamPlayer) findEmptyPosition [1,50,_bankVehicleClass];
-
-_truckX = _bankVehicleClass createVehicle _pos;
 {_x reveal _truckX} forEach (allPlayers - (entities "HeadlessClient_F"));
 [_truckX, teamPlayer] call A3A_fnc_AIVEHinit;
 _truckX setVariable ["destinationX",_nameDest,true];


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
Used code from the fast travel logic to spawn the vehicle for the bank mission. The placement isn't ideal but it explodes at least 10x less often than findEmptyPosition.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
