### PR TITLE
Refactored cosmetic headgear blacklists, blacklisted lot of WW2 hats

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_equipmentSort.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_equipmentSort.sqf
@@ -60,23 +60,41 @@ allCivilianVests deleteAt (allCivilianVests find "vn_b_vest_seal_01");
 //WHY is there no clean list?
 //allArmoredHeadgear = allHeadgear select {getNumber (configfile >> "CfgWeapons" >> _x >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Head" >> "armor") > 0};
 allCosmeticHeadgear = allHeadgear - allArmoredHeadgear;
-{allCosmeticHeadgear deleteAt (allCosmeticHeadgear find _x)} forEach [
-	"H_SPE_GER_ST_M40_cap",
-	"H_SPE_GER_ST_M40_cap_hp",
-	"H_SPE_GER_ST_M40_cap_Offz",
-	"H_SPE_GER_ST_M40_cap_Offz_hp",
-	"H_SPE_GER_ST_M40_cap_Offz_2",
-	"H_SPE_GER_ST_M40_Pz_cap",
-	"H_SPE_GER_ST_M40_Pz_cap_headset",
-	'H_SPE_GER_ST_M40_Pz_cap_Offz',
-	"H_SPE_GER_ST_M40_Pz_cap_Offz_headset",
-	"H_SPE_GER_ST_M40_Pz_cap_Offz_2",
-	"H_SPE_GER_ST_M40_Pz_cap_2",
-	"H_SPE_GER_ST_M40_cap_2",
-	"rhs_fieldcap_helm",
-	"rhs_fieldcap_helm_ml",
-	"rhs_fieldcap_helm_digi"
+
+private _costmeticHeadgearBlacklist = [
+	"H_Cap_Black_IDAP_F",
+	"H_Cap_Orange_IDAP_F",
+	"H_Cap_White_IDAP_F"
 ];
+
+if ((isClass (configFile >> "CfgPatches" >> "IFA3_Core")) or (isClass (configFile >> "CfgPatches" >> "ww2_spe_assets_c_characters_germans_c"))) then {
+	_costmeticHeadgearBlacklist append [
+		//SPE
+		"H_SPE_Milice_beret_1",
+		"H_SPE_Milice_beret_2"
+	];
+	{
+		private _hatClass = _x; 
+		{
+			if (_x in _hatClass) then {
+				_costmeticHeadgearBlacklist pushBackUnique _hatClass;
+			};
+		} forEach ["_DAK_", "_GER_", "_US_", "_NKVD_", "_SOV_", "_UK_", "_CW_", "_CAN_", "_PL_HSAT_"]; //HSAT has no armour for some reason
+		
+	} forEach allCosmeticHeadgear;
+	//Doing IFA and SPE at the same time because of the keyword overlap between the two
+};
+
+if (isClass (configFile >> "CfgPatches" >> "rhsgref_main")) then {
+	_costmeticHeadgearBlacklist append [
+		"rhs_fieldcap_helm",
+		"rhs_fieldcap_helm_ml",
+		"rhs_fieldcap_helm_digi"
+	];
+};
+
+{allCosmeticHeadgear deleteAt (allCosmeticHeadgear find _x)} forEach _costmeticHeadgearBlacklist;
+
 
 //////////////////
 //   Glasses   ///

--- a/A3A/addons/core/functions/Ammunition/fn_equipmentSort.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_equipmentSort.sqf
@@ -79,7 +79,7 @@ if ((isClass (configFile >> "CfgPatches" >> "IFA3_Core")) or (isClass (configFil
 			if (_x in _hatClass) then {
 				_costmeticHeadgearBlacklist pushBackUnique _hatClass;
 			};
-		} forEach ["_DAK_", "_GER_", "_US_", "_NKVD_", "_SOV_", "_UK_", "_CW_", "_CAN_", "_PL_HSAT_"]; //HSAT has no armour for some reason
+		} forEach ["_DAK_", "_GER_", "_NKVD_", "_SOV_", "_PL_HSAT_"]; //PL HSAT's have no armour for some reason
 		
 	} forEach allCosmeticHeadgear;
 	//Doing IFA and SPE at the same time because of the keyword overlap between the two


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    Added a cosmetic headgear blacklist array, adds to it if mods are loaded which contains stuffs we want to blacklist.
    Generates the blacklist required for IFA, SPE, SPEX, SEP headgear.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
its only cosmetics so i did not check too hard for false positives