### PR TITLE
Fix buildings not being cleared from their garrison when removed

### DIFF
--- a/A3A/addons/core/functions/Builder/fn_initBuilderMonitors.sqf
+++ b/A3A/addons/core/functions/Builder/fn_initBuilderMonitors.sqf
@@ -49,10 +49,8 @@ while { true } do {
         {},
         {},
         {
-            // Just delete the thing, let server clear out the array on saving
-            private _obj = _this#0;
-            [_obj] remoteExecCall ["A3A_fnc_garrisonServer_remVehicle", 2];
-            deleteVehicle (_this#0);
+            // Tell server to delete the building after removing it from any garrison
+            [_this#0, true] remoteExecCall ["A3A_fnc_garrisonServer_remVehicle", 2];
         },
         {},
         [],

--- a/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_spawn.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_spawn.sqf
@@ -58,6 +58,7 @@ if !(_garrisonType == "hq") then {
             _building setPosWorld _posWorld;
             _building setVectorDirAndUp [_vecDir, _vecUp];
             _building setVariable ["A3A_building", true, true];
+            _building setVariable ["markerX", _marker, 2];
             _buildings pushBack _building;
         };
     } forEach (_garrisonData getOrDefault ["buildings", []]);

--- a/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_addVehicle.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_addVehicle.sqf
@@ -34,12 +34,17 @@ private _arrayType = call {
 
 private _vehID = -1;
 if (_arrayType == "buildings") then {
+    _vehicle setVariable ["markerX", _marker];        // don't need to publish for buildings
+
     if (_marker == "Synd_HQ") then {
         _garrison get "spawnedBuildings" pushBack _vehicle;
         if (_doRevealCalc) then {call A3A_fnc_calcBuildingReveal};
     };
     (_garrison get "buildings") pushBack [typeof _vehicle, getPosWorld _vehicle, vectorDir _vehicle, vectorUp _vehicle];
 } else {
+    _vehicle setVariable ["markerX", _marker, true];
+    _vehicle setVariable ["A3A_resPool", "garrison", true];
+
     // Need a global(ish) ID for this vehicle
     _vehID = _garrison get "nextVehID";
     _vehicle setVariable ["A3A_vehID", _vehID];
@@ -53,8 +58,6 @@ if (_arrayType == "buildings") then {
     };
 };
 
-_vehicle setVariable ["markerX", _marker, true];
-_vehicle setVariable ["A3A_resPool", "garrison", true];
 
 // Add to active garrison if spawned
 if (spawner getVariable _marker != 2) then {

--- a/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_clear.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_clear.sqf
@@ -75,7 +75,9 @@ if (_delete) then {
 
 if (_hqMove) then {
     // HQ is going elsewhere so need to disconnect everything
-    A3A_buildingsToSave append (_garrison get "spawnedBuildings");
+    private _hqBuildings = _garrison get "spawnedBuildings";
+    A3A_buildingsToSave append _hqBuildings;
+    { _x setVariable ["markerX", nil] } forEach _hqBuildings;
     _garrison set ["spawnedBuildings", []];
     _garrison set ["buildings", []];
     _garrison set ["vehicles", []];

--- a/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_remVehicle.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_remVehicle.sqf
@@ -6,6 +6,7 @@
 
     Arguments:
     <OBJECT> Vehicle to remove from garrison (garrison autodetected).
+    <BOOL> Optional: True to delete vehicle after removing from garrison.
 
     Copyright 2025 John Jordan. All Rights Reserved.
     Used and distributed by the Antistasi Community project with permission.
@@ -14,12 +15,15 @@
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
 
-params ["_vehicle"];
+params ["_vehicle", ["_delete", false]];
 
 Trace_1("Called with params %1", _this);
 
 private _marker = _vehicle getVariable "markerX";
-if (isNil "_marker") exitWith { Error_1("Vehicle %1 not in a garrison", _vehicle) };
+if (isNil "_marker") exitWith {
+    if (_delete) exitWith { deleteVehicle _vehicle };           // Speculative use allowed for buildings
+    Error_1("Vehicle %1 not in a garrison", _vehicle);
+};
 
 private _garrison = A3A_garrison get _marker;
 
@@ -43,8 +47,9 @@ if (_index < 0) exitWith { Error_2("Vehicle type %1 not found in garrison %2", t
 
 // Remove from server garrison data
 (_garrison get _arrayType) deleteAt _index;
-_vehicle setVariable ["markerX", nil, true];
-_garrison get "supportVehicles" deleteAt _vehID;            // Remove from support vehicles array, if it's in there
+_vehicle setVariable ["markerX", nil, _arrayType == "vehicles"];        // Only set on server for buildings
+_garrison get "supportVehicles" deleteAt _vehID;                        // Remove from support vehicles array, if it's in there
+if (_delete) then { deleteVehicle _vehicle };                           // ideally wouldn't fire the garrison op after this, but whatever
 
 // Recalculate HQ building reveal value
 // exitWith because HQ buildings are managed on the server side

--- a/A3A/addons/core/functions/Save/fn_loadServer.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadServer.sqf
@@ -153,6 +153,7 @@ if (isServer) then {
 			_veh setPosWorld _posVeh;
 			_veh setVectorDirAndUp [_vecDir, _vecUp];
 			_veh setVariable ["A3A_building", true, true];
+			_veh setVariable ["markerX", "Synd_HQ"];
 			_spawnedBuildings pushBack _veh;
 		};
 	} forEach (A3A_garrison get "Synd_HQ" get "buildings");


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Buildings lacked data required to remove them from their garrison when deleted, and the timing was busted anyway. Fixed by adding a _delete parameter to garrisonServer_remVehicle, and maintaining a markerX value for them on the server.

Tested on localhost and DS+client:
Create & destroy buildings for HQ and other garrison (slightly different systems)
Garrison spawn & despawn
Save & load
HQ move

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
