### PR TITLE
Fix city support proximity and improve mission texts

### DIFF
--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -4861,7 +4861,7 @@
         <Chinesesimp>肃清区域</Chinesesimp>
       </Key>
       <Key ID="STR_A3A_fn_mission_conq_police_text">
-        <Original>A police station is disturbing our operations in %1. Go there and destroy it before %2. You can ransack it for loot and intel first.</Original>
+        <Original>A police station in %1 is disrupting our efforts to convert the population. Go there and destroy it before %2 for an extra reward. You can ransack it for loot and intel first.</Original>
       </Key>
       <Key ID="STR_A3A_fn_mission_conq_police_title">
         <Original>Destroy the police station</Original>
@@ -5031,7 +5031,7 @@
         <Original>An enemy plane is airdropping supplies on this position. Get there with a truck and recover the crate. Be careful not to shoot down the plane!</Original>
       </Key>
       <Key ID="STR_A3A_fn_mission_des_ante_text">
-        <Original>We need to destroy or take a Radio Tower in %1. This will interrupt the coverage of %3 radio propaganda. Do it before %2.</Original>
+        <Original>We need to destroy or capture a Radio Tower in %1. This will interrupt the coverage of %3 radio propaganda and assist our efforts to convert nearby towns to the rebel cause. Do it before %2 for an extra reward.</Original>
         <Italian>Dobbiamo distruggere o catturare la Torre Radio a %1. Ciò interromperà la Rete di Propaganda %3. Falla entro %2.</Italian>
         <French>Nous devons détruire ou capturer une Tour Radio dans %1. Cela va interrompre le reseau de propagande de %3. Faites le avant %2.</French>
         <Korean>%1에 있는 파괴하거나 점령해야 합니다. 그러면 %3의 프로파간다 네트워크 송신이 중단됩니다. %2 전까지 수행하십시오.</Korean>

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -4848,7 +4848,7 @@
         <Chinesesimp>夺取哨站</Chinesesimp>
       </Key>
       <Key ID="STR_A3A_fn_mission_conq_outp_titel3">
-        <Original>Destroy Roadblock</Original>
+        <Original>Clear Roadblock</Original>
         <Korean>검문소 파괴</Korean>
         <Russian>Уничтожить блокпост</Russian>
         <Chinesesimp>摧毁路障</Chinesesimp>

--- a/A3A/addons/core/functions/Base/fn_citySupportChange.sqf
+++ b/A3A/addons/core/functions/Base/fn_citySupportChange.sqf
@@ -15,8 +15,8 @@ if (_pos isEqualTo "") exitWith {Error("The second parameter, the position, must
 private _city = if (_pos in citiesX) then {_pos} else {
 	// Other enemies still count if within city marker for now
 	if (_pos isEqualType "") then { _pos = markerPos _pos };			// could be passed non-city marker
-	private _nearCities = citiesX inAreaArrayIndexes [_pos, 500, 500] apply { citiesX#_x };
-	private _nearCities = _nearCities select { _pos inArea _x };
+	private _nearCities = citiesX inAreaArray [_pos, 700, 700];
+	private _nearCities = _nearCities select { (markerSize _x # 0) + 200 > (markerPos _x distance2d _pos) };
 	selectRandom _nearCities;
 };
 if (isNil "_city") exitWith {};			// Unit not in city


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Enemy deaths only contributed to city support when they occurred within city radius. In 3.11 the city radius was substantially reduced for most towns, so if you shot QRF units after they were dropped by a heli they probably wouldn't count. This might be making cities more difficult to flip than intended, so I've added a 200m buffer.

Also made an attempt to document support mechanics in destroy radio tower & police station missions. Probably won't help much, but it's something.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
City support radius changes can be micro-tested like this:
```
private _pos = getPosATL player;
private _nearCities = citiesX inAreaArray [_pos, 700, 700];
private _nearCities = _nearCities select { (markerSize _x # 0) + 200 > (markerPos _x distance2d _pos) };
_nearCities;
```