### PR TITLE
Fix garage refuel handling of bad/old state data

### DIFF
--- a/A3A/addons/garage/Refuel/fn_getTotalFuelCargo.sqf
+++ b/A3A/addons/garage/Refuel/fn_getTotalFuelCargo.sqf
@@ -17,18 +17,25 @@ Example:
 
 License: APL-ND
 */
+
+#include "defines.inc"
+FIX_LINE_NUMBERS()
+
 private _totalFuelCargo = 0;
 {
-    private _fuelSource = _x;
-    private "_vehData";
-    {_vehData = _x get _fuelSource; if (!isNil "_vehdata") exitWith {}; } forEach HR_GRG_Vehicles; //find vehicles in categorys, typically cat 0 "cars"
+    private _sourceUID = _x;
+    private _vehData = (HR_GRG_Vehicles#HR_GRG_SOURCEINDEX) get _sourceUID;
+    if (isNil "_vehData") exitWith {
+        Error_1("Fuel source vehicle %1 not found in source category", _sourceUID);
+    };
+
     private _fuelData = _vehData#4#0;
     _totalFuelCargo = _totalFuelCargo + (if (A3A_hasAce) then {
         private _aceFuelCargo = _fuelData#2;
-        if (isNil "_aceFuelCargo") then {0} else {_aceFuelCargo}
+        if (isNil "_aceFuelCargo") then {0} else {0 max _aceFuelCargo}
     } else {
         private _transportFuel = getNumber (configFile/"CfgVehicles"/_vehData#1/"transportFuel");
-        (_fuelData#1) * _transportFuel
+        (0 max _fuelData#1) * _transportFuel
     });
 } forEach (HR_GRG_Sources#1);
 

--- a/A3A/addons/garage/Refuel/fn_refuelVehicleFromSources.sqf
+++ b/A3A/addons/garage/Refuel/fn_refuelVehicleFromSources.sqf
@@ -50,9 +50,9 @@ while {count (HR_GRG_Sources#1) > 0} do {
     private _fuelData = _sourceData#4#0; //vehicle data >> statePreservation data >> Fuel data
     private _transportFuel = getNumber (configFile/"CfgVehicles"/_sourceData#1/"transportFuel");
     private _fuelCargo = if (A3A_hasAce) then {
-        _fuelData # 2;
+        if (isNil {_fuelData#2}) then {0} else {0 max _fuelData#2}
     } else {
-        (_fuelData # 1) * _transportFuel;
+        (0 max _fuelData#1) * _transportFuel
     };
     Trace_1("Fuel cargo: %1", _fuelCargo);
 


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
1. If you put a fuel vehicle into the garage with ACE loaded, it'll write the vanilla fuel cargo as -1. This was then used for calculations of available fuel, causing ACE + non-ACE garaged tankers to report 0 fuel total. It also broke the actual refuel function. Fixed with a scattering of `0 max`.

2. At some point the garage was capable of writing nil as the ACE fuel cargo. If then used with ACE, the refuel function would do its crackheaded infinite loop and then fail to refuel anything. Fixed with a nil check.

Also sanitized some related code. Should really rework the refuel function to be less dangerous but maybe later.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)
