### PR TITLE
Fix enemy roadblocks & camps placed near HQ for new games

### DIFF
--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -149,6 +149,14 @@ if (_startType != "new") then
 }
 else
 {
+    // HQ placement setup, done before initGarrisons so that roadblocks aren't created nearby
+    private _posHQ = A3A_saveData get "startPos";
+    respawnTeamPlayer setMarkerPos _posHQ;
+    "Synd_HQ" setMarkerPos _posHQ;
+    posHQ = _posHQ; publicVariable "posHQ";     // hmm, remove this at some point
+    petros setPos _posHQ;
+    [_posHQ] call A3A_fnc_relocateHQObjects;
+
     // Fill out garrisons, set sides/names as appropriate
     call A3A_fnc_initGarrisons;
 
@@ -177,14 +185,6 @@ else
     Info("Initial arsenal unlocks completed");
     call A3A_fnc_checkRadiosUnlocked;
     [] call A3A_fnc_arsenalManage;
-
-    // HQ placement setup
-    private _posHQ = A3A_saveData get "startPos";
-    respawnTeamPlayer setMarkerPos _posHQ;
-    "Synd_HQ" setMarkerPos _posHQ;
-    posHQ = _posHQ; publicVariable "posHQ";     // hmm, remove this at some point
-    petros setPos _posHQ;
-    [_posHQ] call A3A_fnc_relocateHQObjects;
 };
 
 if (_startType != "load") then {


### PR DESCRIPTION


### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed enemy roadblocks & camps potentially being placed near HQ on init for new games with non-default HQ position. Should be safe.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
