### PR TITLE
Adds appropiate vest and backpacks from AOW and LOW

### DIFF
--- a/A3A/addons/core/Templates/Templates/Aegis/Aegis_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Aegis/Aegis_Reb_FIA.sqf
@@ -103,6 +103,13 @@ if ("rf" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["srifle_h6_tan_rf","10Rnd_556x45_AP_Stanag_red_Tan_RF","10Rnd_556x45_AP_Stanag_Tan_RF","10Rnd_556x45_AP_Stanag_green_Tan_RF"];
     _initialRebelEquipment = _initialRebelEquipment - ["SMG_02_F","30Rnd_9x21_Mag_SMG_02"];
 };
+if ("AoW" in A3A_enabledDLC) then {
+    _initialRebelEquipment append ["B_CivilianBackpack_01_Sport_Red_F", "B_CivilianBackpack_01_Sport_Green_F", "B_CivilianBackpack_01_Sport_Blue_F", "B_CivilianBackpack_01_Everyday_Vrana_F", "B_CivilianBackpack_01_Everyday_Black_F", "B_CivilianBackpack_01_Everyday_Astra_F"];
+};
+if ("Orange" in A3A_enabledDLC) then {
+    _initialRebelEquipment append ["V_Safety_blue_F", "V_Safety_orange_F", "V_Safety_yellow_F", "V_Pocketed_olive_F", "V_Pocketed_coyote_F", "V_Pocketed_black_F", "V_LegStrapBag_olive_F", "V_LegStrapBag_coyote_F", "V_LegStrapBag_black_F"];
+    _initialRebelEquipment append ["B_Messenger_Olive_F", "B_Messenger_Gray_F", "B_Messenger_Coyote_F", "B_Messenger_Black_F", "B_LegStrapBag_olive_F", "B_LegStrapBag_coyote_F", "B_LegStrapBag_black_F"];
+};
 
 if (A3A_hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
 if (A3A_hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment append ["tf_anprc155","tf_anprc155_coyote"]};

--- a/A3A/addons/core/Templates/Templates/Aegis/Aegis_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Aegis/Aegis_Reb_FIA.sqf
@@ -103,10 +103,10 @@ if ("rf" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["srifle_h6_tan_rf","10Rnd_556x45_AP_Stanag_red_Tan_RF","10Rnd_556x45_AP_Stanag_Tan_RF","10Rnd_556x45_AP_Stanag_green_Tan_RF"];
     _initialRebelEquipment = _initialRebelEquipment - ["SMG_02_F","30Rnd_9x21_Mag_SMG_02"];
 };
-if ("AoW" in A3A_enabledDLC) then {
+if ("aow" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["B_CivilianBackpack_01_Sport_Red_F", "B_CivilianBackpack_01_Sport_Green_F", "B_CivilianBackpack_01_Sport_Blue_F", "B_CivilianBackpack_01_Everyday_Vrana_F", "B_CivilianBackpack_01_Everyday_Black_F", "B_CivilianBackpack_01_Everyday_Astra_F"];
 };
-if ("Orange" in A3A_enabledDLC) then {
+if ("orange" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["V_Safety_blue_F", "V_Safety_orange_F", "V_Safety_yellow_F", "V_Pocketed_olive_F", "V_Pocketed_coyote_F", "V_Pocketed_black_F", "V_LegStrapBag_olive_F", "V_LegStrapBag_coyote_F", "V_LegStrapBag_black_F"];
     _initialRebelEquipment append ["B_Messenger_Olive_F", "B_Messenger_Gray_F", "B_Messenger_Coyote_F", "B_Messenger_Black_F", "B_LegStrapBag_olive_F", "B_LegStrapBag_coyote_F", "B_LegStrapBag_black_F"];
 };

--- a/A3A/addons/core/Templates/Templates/Aegis/Aegis_Reb_SDK.sqf
+++ b/A3A/addons/core/Templates/Templates/Aegis/Aegis_Reb_SDK.sqf
@@ -90,10 +90,10 @@ if ("rf" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["srifle_h6_oli_rf","10Rnd_556x45_AP_Stanag_red_khk_RF","10Rnd_556x45_AP_Stanag_khk_RF","10Rnd_556x45_AP_Stanag_green_khk_RF"];
     _initialRebelEquipment = _initialRebelEquipment - ["SMG_05_F", "30Rnd_9x21_Mag_SMG_02"];
 };
-if ("AoW" in A3A_enabledDLC) then {
+if ("aow" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["B_CivilianBackpack_01_Sport_Red_F", "B_CivilianBackpack_01_Sport_Green_F", "B_CivilianBackpack_01_Sport_Blue_F", "B_CivilianBackpack_01_Everyday_Vrana_F", "B_CivilianBackpack_01_Everyday_Black_F", "B_CivilianBackpack_01_Everyday_Astra_F"];
 };
-if ("Orange" in A3A_enabledDLC) then {
+if ("orange" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["V_Safety_blue_F", "V_Safety_orange_F", "V_Safety_yellow_F", "V_Pocketed_olive_F", "V_Pocketed_coyote_F", "V_Pocketed_black_F", "V_LegStrapBag_olive_F", "V_LegStrapBag_coyote_F", "V_LegStrapBag_black_F"];
     _initialRebelEquipment append ["B_Messenger_Olive_F", "B_Messenger_Gray_F", "B_Messenger_Coyote_F", "B_Messenger_Black_F", "B_LegStrapBag_olive_F", "B_LegStrapBag_coyote_F", "B_LegStrapBag_black_F"];
 };

--- a/A3A/addons/core/Templates/Templates/Aegis/Aegis_Reb_SDK.sqf
+++ b/A3A/addons/core/Templates/Templates/Aegis/Aegis_Reb_SDK.sqf
@@ -90,6 +90,13 @@ if ("rf" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["srifle_h6_oli_rf","10Rnd_556x45_AP_Stanag_red_khk_RF","10Rnd_556x45_AP_Stanag_khk_RF","10Rnd_556x45_AP_Stanag_green_khk_RF"];
     _initialRebelEquipment = _initialRebelEquipment - ["SMG_05_F", "30Rnd_9x21_Mag_SMG_02"];
 };
+if ("AoW" in A3A_enabledDLC) then {
+    _initialRebelEquipment append ["B_CivilianBackpack_01_Sport_Red_F", "B_CivilianBackpack_01_Sport_Green_F", "B_CivilianBackpack_01_Sport_Blue_F", "B_CivilianBackpack_01_Everyday_Vrana_F", "B_CivilianBackpack_01_Everyday_Black_F", "B_CivilianBackpack_01_Everyday_Astra_F"];
+};
+if ("Orange" in A3A_enabledDLC) then {
+    _initialRebelEquipment append ["V_Safety_blue_F", "V_Safety_orange_F", "V_Safety_yellow_F", "V_Pocketed_olive_F", "V_Pocketed_coyote_F", "V_Pocketed_black_F", "V_LegStrapBag_olive_F", "V_LegStrapBag_coyote_F", "V_LegStrapBag_black_F"];
+    _initialRebelEquipment append ["B_Messenger_Olive_F", "B_Messenger_Gray_F", "B_Messenger_Coyote_F", "B_Messenger_Black_F", "B_LegStrapBag_olive_F", "B_LegStrapBag_coyote_F", "B_LegStrapBag_black_F"];
+};
 
 if (A3A_hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
 if (A3A_hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment append ["tf_anprc155","tf_anprc155_coyote"]};

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
@@ -102,6 +102,13 @@ if ("rf" in A3A_enabledDLC) then {
 if ("enoch" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["sgun_HunterShotgun_01_F", "sgun_HunterShotgun_01_sawedoff_F", "2Rnd_12Gauge_Pellets", "2Rnd_12Gauge_Slug"];
 };
+if ("AoW" in A3A_enabledDLC) then {
+    _initialRebelEquipment append ["B_CivilianBackpack_01_Sport_Red_F", "B_CivilianBackpack_01_Sport_Green_F", "B_CivilianBackpack_01_Sport_Blue_F", "B_CivilianBackpack_01_Everyday_Vrana_F", "B_CivilianBackpack_01_Everyday_Black_F", "B_CivilianBackpack_01_Everyday_Astra_F"];
+};
+if ("Orange" in A3A_enabledDLC) then {
+    _initialRebelEquipment append ["V_Safety_blue_F", "V_Safety_orange_F", "V_Safety_yellow_F", "V_Pocketed_olive_F", "V_Pocketed_coyote_F", "V_Pocketed_black_F", "V_LegStrapBag_olive_F", "V_LegStrapBag_coyote_F", "V_LegStrapBag_black_F"];
+    _initialRebelEquipment append ["B_Messenger_Olive_F", "B_Messenger_Gray_F", "B_Messenger_Coyote_F", "B_Messenger_Black_F", "B_LegStrapBag_olive_F", "B_LegStrapBag_coyote_F", "B_LegStrapBag_black_F"];
+};
 
 
 if (A3A_hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
@@ -110,7 +117,7 @@ if (A3A_hasTFARBeta) then {_initialRebelEquipment append ["TFAR_microdagr","TFAR
 if (A3A_hasTFARBeta && startWithLongRangeRadio) then {_initialRebelEquipment append ["TFAR_anprc155", "TFAR_anprc155_coyote", "TFAR_anarc164", "a3a_TFAR_rt1523g_rhs", "a3a_TFAR_rt1523g_bwmod", "a3a_TFAR_rt1523g"]};
 if (A3A_hasTFARBeta && startWithLongRangeRadio) then {_initialRebelEquipment append ["TFAR_anprc155", "TFAR_anprc155_coyote", "TFAR_anarc164", "a3a_TFAR_rt1523g_rhs", "a3a_TFAR_rt1523g_bwmod", "a3a_TFAR_rt1523g"]};
 if (A3A_hasTFARBeta && startWithLongRangeRadio && ("enoch" in A3A_enabledDLC)) then {
-    _initialRebelEquipment append ["B_RadioBag_01_black_F", "B_RadioBag_01_digi_F", "a3a_B_RadioBag_01_oucamo_F", "a3a_B_RadioBag_01_wdl_F"]};
+_initialRebelEquipment append ["B_RadioBag_01_black_F", "B_RadioBag_01_digi_F", "a3a_B_RadioBag_01_oucamo_F", "a3a_B_RadioBag_01_wdl_F"]};
 _initialRebelEquipment append ["Chemlight_blue","Chemlight_green","Chemlight_red","Chemlight_yellow"];
 ["initialRebelEquipment", _initialRebelEquipment] call _fnc_saveToTemplate;
 

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
@@ -102,10 +102,10 @@ if ("rf" in A3A_enabledDLC) then {
 if ("enoch" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["sgun_HunterShotgun_01_F", "sgun_HunterShotgun_01_sawedoff_F", "2Rnd_12Gauge_Pellets", "2Rnd_12Gauge_Slug"];
 };
-if ("AoW" in A3A_enabledDLC) then {
+if ("aow" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["B_CivilianBackpack_01_Sport_Red_F", "B_CivilianBackpack_01_Sport_Green_F", "B_CivilianBackpack_01_Sport_Blue_F", "B_CivilianBackpack_01_Everyday_Vrana_F", "B_CivilianBackpack_01_Everyday_Black_F", "B_CivilianBackpack_01_Everyday_Astra_F"];
 };
-if ("Orange" in A3A_enabledDLC) then {
+if ("orange" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["V_Safety_blue_F", "V_Safety_orange_F", "V_Safety_yellow_F", "V_Pocketed_olive_F", "V_Pocketed_coyote_F", "V_Pocketed_black_F", "V_LegStrapBag_olive_F", "V_LegStrapBag_coyote_F", "V_LegStrapBag_black_F"];
     _initialRebelEquipment append ["B_Messenger_Olive_F", "B_Messenger_Gray_F", "B_Messenger_Coyote_F", "B_Messenger_Black_F", "B_LegStrapBag_olive_F", "B_LegStrapBag_coyote_F", "B_LegStrapBag_black_F"];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_LFF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_LFF.sqf
@@ -100,10 +100,10 @@ if ("expansion" in A3A_enabledDLC) then {
 if ("rf" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["srifle_h6_blk_rf","10Rnd_556x45_AP_Stanag_red_RF","10Rnd_556x45_AP_Stanag_RF","10Rnd_556x45_AP_Stanag_green_RF"];
 };
-if ("AoW" in A3A_enabledDLC) then {
+if ("aow" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["B_CivilianBackpack_01_Sport_Red_F", "B_CivilianBackpack_01_Sport_Green_F", "B_CivilianBackpack_01_Sport_Blue_F", "B_CivilianBackpack_01_Everyday_Vrana_F", "B_CivilianBackpack_01_Everyday_Black_F", "B_CivilianBackpack_01_Everyday_Astra_F"];
 };
-if ("Orange" in A3A_enabledDLC) then {
+if ("orange" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["V_Safety_blue_F", "V_Safety_orange_F", "V_Safety_yellow_F", "V_Pocketed_olive_F", "V_Pocketed_coyote_F", "V_Pocketed_black_F", "V_LegStrapBag_olive_F", "V_LegStrapBag_coyote_F", "V_LegStrapBag_black_F"];
     _initialRebelEquipment append ["B_Messenger_Olive_F", "B_Messenger_Gray_F", "B_Messenger_Coyote_F", "B_Messenger_Black_F", "B_LegStrapBag_olive_F", "B_LegStrapBag_coyote_F", "B_LegStrapBag_black_F"];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_LFF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_LFF.sqf
@@ -100,6 +100,13 @@ if ("expansion" in A3A_enabledDLC) then {
 if ("rf" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["srifle_h6_blk_rf","10Rnd_556x45_AP_Stanag_red_RF","10Rnd_556x45_AP_Stanag_RF","10Rnd_556x45_AP_Stanag_green_RF"];
 };
+if ("AoW" in A3A_enabledDLC) then {
+    _initialRebelEquipment append ["B_CivilianBackpack_01_Sport_Red_F", "B_CivilianBackpack_01_Sport_Green_F", "B_CivilianBackpack_01_Sport_Blue_F", "B_CivilianBackpack_01_Everyday_Vrana_F", "B_CivilianBackpack_01_Everyday_Black_F", "B_CivilianBackpack_01_Everyday_Astra_F"];
+};
+if ("Orange" in A3A_enabledDLC) then {
+    _initialRebelEquipment append ["V_Safety_blue_F", "V_Safety_orange_F", "V_Safety_yellow_F", "V_Pocketed_olive_F", "V_Pocketed_coyote_F", "V_Pocketed_black_F", "V_LegStrapBag_olive_F", "V_LegStrapBag_coyote_F", "V_LegStrapBag_black_F"];
+    _initialRebelEquipment append ["B_Messenger_Olive_F", "B_Messenger_Gray_F", "B_Messenger_Coyote_F", "B_Messenger_Black_F", "B_LegStrapBag_olive_F", "B_LegStrapBag_coyote_F", "B_LegStrapBag_black_F"];
+};
 
 if (A3A_hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
 if (A3A_hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment append ["tf_anprc155","tf_anprc155_coyote"]};

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
@@ -91,6 +91,13 @@ if ("rf" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["srifle_h6_oli_rf","10Rnd_556x45_AP_Stanag_red_khk_RF","10Rnd_556x45_AP_Stanag_khk_RF","10Rnd_556x45_AP_Stanag_green_khk_RF"];
     _initialRebelEquipment = _initialRebelEquipment - ["SMG_05_F","hgun_PDW2000_F","30Rnd_9x21_Mag_SMG_02"];
 };
+if ("AoW" in A3A_enabledDLC) then {
+    _initialRebelEquipment append ["B_CivilianBackpack_01_Sport_Red_F", "B_CivilianBackpack_01_Sport_Green_F", "B_CivilianBackpack_01_Sport_Blue_F", "B_CivilianBackpack_01_Everyday_Vrana_F", "B_CivilianBackpack_01_Everyday_Black_F", "B_CivilianBackpack_01_Everyday_Astra_F"];
+};
+if ("Orange" in A3A_enabledDLC) then {
+    _initialRebelEquipment append ["V_Safety_blue_F", "V_Safety_orange_F", "V_Safety_yellow_F", "V_Pocketed_olive_F", "V_Pocketed_coyote_F", "V_Pocketed_black_F", "V_LegStrapBag_olive_F", "V_LegStrapBag_coyote_F", "V_LegStrapBag_black_F"];
+    _initialRebelEquipment append ["B_Messenger_Olive_F", "B_Messenger_Gray_F", "B_Messenger_Coyote_F", "B_Messenger_Black_F", "B_LegStrapBag_olive_F", "B_LegStrapBag_coyote_F", "B_LegStrapBag_black_F"];
+};
 
 if (A3A_hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
 if (A3A_hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment append ["tf_anprc155","tf_anprc155_coyote"]};

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
@@ -91,10 +91,10 @@ if ("rf" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["srifle_h6_oli_rf","10Rnd_556x45_AP_Stanag_red_khk_RF","10Rnd_556x45_AP_Stanag_khk_RF","10Rnd_556x45_AP_Stanag_green_khk_RF"];
     _initialRebelEquipment = _initialRebelEquipment - ["SMG_05_F","hgun_PDW2000_F","30Rnd_9x21_Mag_SMG_02"];
 };
-if ("AoW" in A3A_enabledDLC) then {
+if ("aow" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["B_CivilianBackpack_01_Sport_Red_F", "B_CivilianBackpack_01_Sport_Green_F", "B_CivilianBackpack_01_Sport_Blue_F", "B_CivilianBackpack_01_Everyday_Vrana_F", "B_CivilianBackpack_01_Everyday_Black_F", "B_CivilianBackpack_01_Everyday_Astra_F"];
 };
-if ("Orange" in A3A_enabledDLC) then {
+if ("orange" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["V_Safety_blue_F", "V_Safety_orange_F", "V_Safety_yellow_F", "V_Pocketed_olive_F", "V_Pocketed_coyote_F", "V_Pocketed_black_F", "V_LegStrapBag_olive_F", "V_LegStrapBag_coyote_F", "V_LegStrapBag_black_F"];
     _initialRebelEquipment append ["B_Messenger_Olive_F", "B_Messenger_Gray_F", "B_Messenger_Coyote_F", "B_Messenger_Black_F", "B_LegStrapBag_olive_F", "B_LegStrapBag_coyote_F", "B_LegStrapBag_black_F"];
 };

--- a/A3A/addons/core/Templates/Templates/WS/WS_Reb_TURA.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_Reb_TURA.sqf
@@ -90,6 +90,13 @@ if ("rf" in A3A_enabledDLC) then {
 if ("enoch" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["sgun_HunterShotgun_01_F", "sgun_HunterShotgun_01_sawedoff_F", "2Rnd_12Gauge_Pellets", "2Rnd_12Gauge_Slug"];
 };
+if ("AoW" in A3A_enabledDLC) then {
+    _initialRebelEquipment append ["B_CivilianBackpack_01_Sport_Red_F", "B_CivilianBackpack_01_Sport_Green_F", "B_CivilianBackpack_01_Sport_Blue_F", "B_CivilianBackpack_01_Everyday_Vrana_F", "B_CivilianBackpack_01_Everyday_Black_F", "B_CivilianBackpack_01_Everyday_Astra_F"];
+};
+if ("Orange" in A3A_enabledDLC) then {
+    _initialRebelEquipment append ["V_Safety_blue_F", "V_Safety_orange_F", "V_Safety_yellow_F", "V_Pocketed_olive_F", "V_Pocketed_coyote_F", "V_Pocketed_black_F", "V_LegStrapBag_olive_F", "V_LegStrapBag_coyote_F", "V_LegStrapBag_black_F"];
+    _initialRebelEquipment append ["B_Messenger_Olive_F", "B_Messenger_Gray_F", "B_Messenger_Coyote_F", "B_Messenger_Black_F", "B_LegStrapBag_olive_F", "B_LegStrapBag_coyote_F", "B_LegStrapBag_black_F"];
+};
 
 if (A3A_hasTFAR) then {_initialRebelEquipment append ["tf_microdagr","tf_anprc154"]};
 if (A3A_hasTFAR && startWithLongRangeRadio) then {_initialRebelEquipment append ["tf_anprc155","tf_anprc155_coyote"]};

--- a/A3A/addons/core/Templates/Templates/WS/WS_Reb_TURA.sqf
+++ b/A3A/addons/core/Templates/Templates/WS/WS_Reb_TURA.sqf
@@ -90,10 +90,10 @@ if ("rf" in A3A_enabledDLC) then {
 if ("enoch" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["sgun_HunterShotgun_01_F", "sgun_HunterShotgun_01_sawedoff_F", "2Rnd_12Gauge_Pellets", "2Rnd_12Gauge_Slug"];
 };
-if ("AoW" in A3A_enabledDLC) then {
+if ("aow" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["B_CivilianBackpack_01_Sport_Red_F", "B_CivilianBackpack_01_Sport_Green_F", "B_CivilianBackpack_01_Sport_Blue_F", "B_CivilianBackpack_01_Everyday_Vrana_F", "B_CivilianBackpack_01_Everyday_Black_F", "B_CivilianBackpack_01_Everyday_Astra_F"];
 };
-if ("Orange" in A3A_enabledDLC) then {
+if ("orange" in A3A_enabledDLC) then {
     _initialRebelEquipment append ["V_Safety_blue_F", "V_Safety_orange_F", "V_Safety_yellow_F", "V_Pocketed_olive_F", "V_Pocketed_coyote_F", "V_Pocketed_black_F", "V_LegStrapBag_olive_F", "V_LegStrapBag_coyote_F", "V_LegStrapBag_black_F"];
     _initialRebelEquipment append ["B_Messenger_Olive_F", "B_Messenger_Gray_F", "B_Messenger_Coyote_F", "B_Messenger_Black_F", "B_LegStrapBag_olive_F", "B_LegStrapBag_coyote_F", "B_LegStrapBag_black_F"];
 };


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
Art of War and Laws of War adds a number backpacks and vest items that there really isn't any reason not to add to the arsenal if those check boxes have been checked

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
