### PR TITLE
Fix incorrect code for handling vehActions on paused garrisons

### DIFF
--- a/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_vehAction.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_vehAction.sqf
@@ -79,7 +79,7 @@ if (_garrison get "state" == "paused") then {
         _x enableSimulationGlobal true;
         _x allowDamage true;
         if (clientOwner == 2) then {_x hideObjectGlobal false} else {[_x, false] remoteExecCall ["hideObjectGlobal", 2]};
-    } forEach (crew _vehicle + _vehicle);
+    } forEach (crew _vehicle + [_vehicle]);
 };
 
 // Fire off vehicle action function

--- a/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_vehActionEnd.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_vehActionEnd.sqf
@@ -49,10 +49,10 @@ if (_garrison get "state" == "disabled") exitWith {
 if (_garrison get "state" == "paused") then {
     {
         if (!alive _x) then {continue};
-        _x enableSimulationGlobal true;
-        _x allowDamage true;
-        if (clientOwner == 2) then {_x hideObjectGlobal false} else {[_x, false] remoteExecCall ["hideObjectGlobal", 2]};
-    } forEach (units _crewGroup + _vehicle);
+        _x enableSimulationGlobal false;
+        _x allowDamage false;
+        if (clientOwner == 2) then {_x hideObjectGlobal true} else {[_x, true] remoteExecCall ["hideObjectGlobal", 2]};
+    } forEach (units _crewGroup + [_vehicle]);
 };
 
 // If garrison is spawned, move vehicle & crew back to active garrison data


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The code for pausing & unpausing support vehicles when vehActions were called on paused garrisons had multiple bugs. Fixed and tested.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
