### PR TITLE
Fix Refugee mission breaking on towns with bad buildings

### DIFF
--- a/A3A/addons/core/functions/Missions/fn_RES_Refugees.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RES_Refugees.sqf
@@ -17,17 +17,17 @@ _positionX = getMarkerPos _markerX;
 _POWs = [];
 
 _radiusX = [_markerX] call A3A_fnc_sizeMarker;
-//_houses = nearestObjects [_positionX, ["house"], _radiusX];
-_houses = (nearestObjects [_positionX, ["house"], _radiusX]) select {!((typeOf _x) in A3A_buildingBlacklist)};
+_houses = nearestObjects [_positionX, ["house"], _radiusX] select {!((typeOf _x) in A3A_buildingBlacklist)};
+if (_houses isEqualTo []) exitWith { Error_1("%1 has no houses?", _markerX) };
 _posHouse = [];
 _houseX = _houses select 0;
-while {count _posHouse < 4} do
-	{
-	_houseX = selectRandom _houses;
-	_posHouse = _houseX buildingPos -1;
-	if (count _posHouse < 4) then {_houses = _houses - [_houseX]};
-	};
-
+while {count _posHouse < 4 and _houses isNotEqualTo []} do
+{
+	// Find first house with 4+ positions, or best one as fallback
+	private _testHouse = _houses deleteAt (floor random count _houses);
+	private _positions = _testHouse buildingPos -1;
+	if (count _positions > count _posHouse) then { _posHouse = _positions; _houseX = _testHouse };
+};
 
 _nameDest = [_markerX] call A3A_fnc_localizar;
 _timeLimit = if (_difficultX) then {30} else {60};


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
In 3.11 the refugee mission was changed to only use houses with 4+ building places. This breaks in Gvozdno on Chernarus because there are no buildings there with more than 3 building positions.

Rewrote to *prefer* buildings with 4+ building positions. Tested both cases.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
