### PR TITLE
Fix camps breaking after petros death

### DIFF
--- a/A3A/addons/core/functions/Base/fn_placementselection.sqf
+++ b/A3A/addons/core/functions/Base/fn_placementselection.sqf
@@ -76,10 +76,10 @@ player allowDamage true;
 
 //If we're still in the map, we chose a place.
 if (visiblemap) then {
-	_controlsX = controlsX select {!(isOnRoad (getMarkerPos _x))};
+	_controlsX = controlsX select {!isOnRoad getMarkerPos _x};
 	{
-		if (getMarkerPos _x distance _positionClicked < distanceSPWN) then {
-			sidesX setVariable [_x,teamPlayer,true];
+		if (getMarkerPos _x distance _positionClicked < 700) then {
+			[_x, true] remoteExecCall ["A3A_fnc_garrisonServer_clear", 2]
 		};
 	} forEach _controlsX;
 	[_positionClicked] remoteExecCall ["A3A_fnc_createPetros", 2];


### PR DESCRIPTION

### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Petros death HQ relocation code was still using the old method for clearing enemy camps near the selected location, which is very bad since 3.10. Fixed.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Get Petros killed, place HQ near an enemy camp. 