### PR TITLE
Fix gunshop & supply convoys running on server

### DIFF
--- a/A3A/addons/core/functions/Base/fn_chooseAttack.sqf
+++ b/A3A/addons/core/functions/Base/fn_chooseAttack.sqf
@@ -103,7 +103,7 @@ if (_isCity and sidesX getVariable _targetMrk == teamPlayer) exitWith {
         // Do we allow these even if there's already a convoy? Probably not harmful.
         Info_2("Sending supply convoy from %1 to %2", _originMrk, _targetMrk);
         [-200, _side, "attack"] call A3A_fnc_addEnemyResources;
-        [[_targetMrk, _originMrk, "Supplies", "attack"],"A3A_fnc_convoy"] call A3A_fnc_scheduler;
+        [_targetMrk, _originMrk, "Supplies", "attack"] spawn A3A_fnc_convoy;
     };
     true;
 };

--- a/A3A/addons/core/functions/Missions/fn_LOG_Gunshop.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Gunshop.sqf
@@ -164,8 +164,7 @@ if (_noCrate and _convoyPair isNotEqualTo []) exitWith
     [_coolerPetros, localize "STR_A3A_fn_mission_gunshop_intercept"] remoteExec ["globalChat", _nearPlayers];
     
     sleep 5;
-    private _args = _convoyPair + ["GunShop","legacy",-1, _gunshopList];
-    [_args, "A3A_fnc_convoy"] remoteExec ["A3A_fnc_scheduler", 2];
+    (_convoyPair + ["GunShop", "legacy", -1, _gunshopList]) spawn A3A_fnc_convoy;
 
     [_patrolGroup] spawn A3A_fnc_enemyReturnToBase;
     _coolerPetros spawn _fnc_despawner;


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Since the gun shop update, convoys can spawn escort helis. The code to handle this doesn't work on headless clients since 3.10 due to lacking sufficient garrison data, and mission code in general has been moved to server-only, so I've changed the remaining convoy uses to run strictly on the server.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
