### PR TITLE
Fix traitor mission airbase bug

### DIFF
--- a/A3A/addons/core/functions/Missions/fn_AS_Traitor.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_Traitor.sqf
@@ -2,7 +2,7 @@
 if (!isServer and hasInterface) exitWith{};
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
-_markerX = _this select 0;
+params ["_markerX", "_base"];
 
 _difficultX = if (random 10 < tierWar) then {true} else {false};
 
@@ -40,8 +40,6 @@ private _faction = Faction(_enemySide);
 
 _groupTraitor = createGroup _enemySide;
 
-_arrayAirports = airportsX select {sidesX getVariable [_x,sideUnknown] == _enemySide};
-_base = [_arrayAirports, _positionX] call BIS_Fnc_nearestPosition;
 _posBase = getMarkerPos _base;
 
 private _traitorIdentity = [A3A_faction_reb, _faction get "unitTraitor"] call A3A_fnc_createRandomIdentity;

--- a/A3A/addons/tasks/Params/fn_AS_Traitor_p.sqf
+++ b/A3A/addons/tasks/Params/fn_AS_Traitor_p.sqf
@@ -4,5 +4,13 @@ FIX_LINE_NUMBERS()
 private _cities = citiesX inAreaArrayIndexes ["Synd_HQ", distanceMission, distanceMission] apply { citiesX#_x }
     select { sidesX getVariable _x != teamPlayer } select { spawner getVariable _x != 0 };
 
-if (_cities isEqualTo []) exitWith {false};
-[1, [selectRandom _cities]];
+private _selPair = [];
+while {_cities isNotEqualTo []} do {
+    private _city = _cities deleteAt random count _cities;
+    private _citySide = sidesX getVariable _city;
+    private _airports = ([_city, false] call A3A_fnc_findLandSupportMarkers) select {_x#0 in airportsX} select {_citySide isEqualTo (sidesX getVariable (_x#0))};
+    if (_airports isNotEqualTo []) exitWith {_selPair = [_city, (selectRandom _airports)#0]};
+};  
+if (_selPair isEqualTo []) exitWith {false};
+
+[1, _selPair];

--- a/A3A/addons/tasks/Params/fn_AS_Traitor_p.sqf
+++ b/A3A/addons/tasks/Params/fn_AS_Traitor_p.sqf
@@ -6,10 +6,11 @@ private _cities = citiesX inAreaArrayIndexes ["Synd_HQ", distanceMission, distan
 
 private _selPair = [];
 while {_cities isNotEqualTo []} do {
-    private _city = _cities deleteAt random count _cities;
+    private _city = _cities deleteAt floor random count _cities;
     private _citySide = sidesX getVariable _city;
-    private _airports = ([_city, false] call A3A_fnc_findLandSupportMarkers) select {_x#0 in airportsX} select {_citySide isEqualTo (sidesX getVariable (_x#0))};
-    if (_airports isNotEqualTo []) exitWith {_selPair = [_city, (selectRandom _airports)#0]};
+    private _supportMarkers = ([_city, false] call A3A_fnc_findLandSupportMarkers) apply {_x#0}; 
+    private _airports = _supportMarkers select {_x in airportsX} select {_citySide isEqualTo (sidesX getVariable _x)};
+    if (_airports isNotEqualTo []) exitWith {_selPair = [_city, selectRandom _airports]};
 };  
 if (_selPair isEqualTo []) exitWith {false};
 


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Fixed a bug where having no airbases for the traitor to retreat to would break the mission.
Gameplay minorly affected; now only nearby airbases can be selected
 

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
