### PR TITLE
Fix setVariable 2 cases not working in SP

### DIFF
--- a/A3A/addons/core/functions/AI/fn_napalmDamage.sqf
+++ b/A3A/addons/core/functions/AI/fn_napalmDamage.sqf
@@ -53,8 +53,8 @@ private _invalidVictim = false;
 switch (true) do {
     case (_victim isKindOf "CAManBase"): {  // Man includes everything biological, even animals such as goats ect...
         if (_victim == petros and _side in [Occupants, Invaders]) then {
-            _victim setVariable ["A3A_napalmHit", true, 2];         // Need to set in advance so it's there when the unit dies
-            _fnc_final = _fnc_final + 'if (alive _victim and !(_victim getVariable ["incapacitated", false])) then { _victim setVariable ["A3A_napalmHit", nil, 2] };';
+            _victim setVariable ["A3A_napalmHit", true, [2, clientOwner]];         // Need to set in advance so it's there when the unit dies
+            _fnc_final = _fnc_final + 'if (alive _victim and !(_victim getVariable ["incapacitated", false])) then { _victim setVariable ["A3A_napalmHit", nil, [2, clientOwner]] };';
         };
         if (A3A_hasACEMedical) then {
             _fnc_onTick = _fnc_onTick +

--- a/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_spawnCiv.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_spawnCiv.sqf
@@ -57,7 +57,7 @@ private _vehicles = [];
 
     _vehicles pushBack _vehicle;
     _vehicle setVariable ["markerX", _spawnKey, true];
-    _vehicle setVariable ["A3A_vehID", _vehID, 2];
+    _vehicle setVariable ["A3A_vehID", _vehID, [2, clientOwner]];
     [_vehicle, civilian] call A3A_fnc_AIVEHinit;
 
 } forEach (_newGarrison get "vehicles");

--- a/A3A/addons/core/functions/GarrisonLocal/fn_spawnPoliceStation.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_spawnPoliceStation.sqf
@@ -83,7 +83,7 @@ if (_intelPos isNotEqualTo [] and _garrisonData getOrDefault ["intelCD", 0] <= 0
     _furniture pushBack _intel;
 };
 
-_station setVariable ["A3A_furniture", _furniture, 2];          // broadcast to server so it can be deleted on destruction
+_station setVariable ["A3A_furniture", _furniture, [2, clientOwner]];          // broadcast to server (inc SP, fuck Arma) so it can be deleted on destruction
 _activeGarrison get "buildings" append _furniture;
 
 


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement
4. [X] Fuck Arma

### What have you changed and why?
Apparently setVariable with a target of 2 does nothing in singleplayer, as of Arma version 2.20. As a workaround I've switched all cases to [2, clientOwner]. clientOwner resolves to 0 on SP clients for some reason and setVariable target 0 does work in SP. [2, clientOwner] is slightly slower when we actually wanted 2, but doesn't have any additional networking overhead in MP.

Should really go through all the clientOwner cases, because resolving to 0 is fucking weird and likely works by accident because we mostly pass it straight to remoteExec as a feedback target.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [?] No
2. [ ] Yes (Please provide further detail below.)
