### PR TITLE
Fix copypaste error in REP_Antenna player rewards

### DIFF
--- a/A3A/addons/core/functions/Missions/fn_REP_Antenna.sqf
+++ b/A3A/addons/core/functions/Missions/fn_REP_Antenna.sqf
@@ -64,7 +64,7 @@ if (spawner getVariable _markerX != 2) then
 		[Occupants, 15, 90] remoteExec ["A3A_fnc_addAggression", 2];
 		[Invaders, 5, 60] remoteExec ["A3A_fnc_addAggression", 2];
 		[500, Occupants] remoteExec ["A3A_fnc_timingCA",2];
-		[20*_bonus, false, _veh, 500] call A3A_tasks_fnc_rewardPlayers;     // any players within 500m
+		[20, false, _veh, 500] call A3A_tasks_fnc_rewardPlayers;     // any players within 500m
 		};
 	};
 if (dateToNumber date > _dateLimitNum) then


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
REP_Antenna acquired a copypaste error when converting the player rewards code. Most of the missions have a _bonus parameter but this one never did.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
