### PR TITLE
Add rebel HQ to localizar

### DIFF
--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -1666,6 +1666,9 @@
         <Korean>%1 인근 숲</Korean>
         <Russian>Лес рядом с %1</Russian>
       </Key>
+      <Key ID="STR_A3A_fn_base_localizar_HQ">
+        <Original>Our rebel HQ</Original>
+      </Key>
       <Key ID="STR_A3A_fn_base_localizar_outpost">
         <Original>Outpost near %1</Original>
         <French>Avant-poste près de %1</French>

--- a/A3A/addons/core/functions/Base/fn_localizar.sqf
+++ b/A3A/addons/core/functions/Base/fn_localizar.sqf
@@ -32,5 +32,6 @@ else
 			_textX = format [localize "STR_A3A_fn_base_localizar_forest",_city]
 			};
 		};
+	if (_siteX == "Synd_HQ") then {_textX = localize "STR_A3A_fn_base_localizar_HQ"};
 	};
 _textX


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
When a contact report was made, if it was made for HQ it wouldn't hit any of the localizar filters and display a blank space. This adds HQ as an option. The syntax on this function is bad and should be rewritten but not for a .1

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: Garrison rebels at HQ, Zeus in enemy AI, wait for contact report once they start fighting