### PR TITLE
Workaround knowsAbout sometimes returning max-float

### DIFF
--- a/A3A/addons/core/functions/EventHandler/fn_combatModeChangedEH.sqf
+++ b/A3A/addons/core/functions/EventHandler/fn_combatModeChangedEH.sqf
@@ -19,7 +19,7 @@ if (isNil "_marker") exitWith {};       // might be ex-garrison? Unlikely
     // Find target that this group knows most about
     private _targets = _group targets [true];
     if (_targets isEqualTo []) exitWith { Debug_1("Group %1 changed combat mode without targets", _group) };
-    private _knowledge = _targets apply { _group knowsAbout _x };
+    private _knowledge = _targets apply { (_group knowsAbout _x) min 4 };           // sometimes returns max-float
     private _index = _knowledge find selectMax _knowledge;
 
     A3A_garrisonOps pushBack ["enemyInfo", [_marker, "detect", _targets#_index, _knowledge#_index]];


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement
4. [X] Fuck Arma

### What have you changed and why?
Apparently knowsAbout sometimes return max-float (~4e38) instead of 4 when used on ArtilleryTargetE, which can show up in `_group targets [true]`. This breaks the precision radius arithmetic in enemyInfo causing potential follow-on errors in patcom. Capping it for now.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
