### PR TITLE
Fix statics exploding when placed in cargo towers

### DIFF
--- a/A3A/addons/core/functions/UtilityItems/fn_dropItem.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_dropItem.sqf
@@ -53,10 +53,9 @@ isNil {
     [_item, surfaceNormal position _item] remoteExecCall ["setVectorUp", _item];
 
     // Place on closest surface
-    private _pos = getPosASL _item;
-    private _intersects = lineIntersectsSurfaces [_pos, _pos vectorAdd [0,0,-100], _item];
+    private _intersects = lineIntersectsSurfaces [getPosWorld _item, getPosASL _item vectorAdd [0,0,-0.3], _item];
     if (count _intersects > 0) then {
-        _item setPosASL (_intersects select 0 select 0);
+        _item setPosASL (_intersects#0#0 vectorAdd [0,0,0.3]);
     };
 
     [_item, true] remoteExecCall ["enableSimulationGlobal", 2];


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
The place-on-surface logic in dropItem tended to explode vanilla statics in cargo towers. I think there are a couple of things going on:
1. The collision check wasn't correct because it traces from the ASL position of the static, which is often below the surface already due to the floor position of these towers. Fixed to trace from getPosWorld (model center).
2. The ground position on the statics seems to be ~10cm off, and so setPosASL on a correct ray intersect places them slightly under the surface anyway. Not sure if this is a building or static geometry issue, but either way placing it 30cm above the surface works around it.

Should be 3.11.1 safe. Tested with various carried objects and situations.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Place a vanilla static (others might also be problematic) into the firing position of a small cargo tower, while standing on the slightly lower ground at the top of the stairs.
