### PR TITLE
Fix lack of UAV backpacks in loot when there are no radio backpacks

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_loot.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_loot.sqf
@@ -68,7 +68,7 @@ lootVest append allArmoredVests + allCivilianVests;
 //   Device Bags  ///
 /////////////////////
 lootDevice = allBackpacksRadio;
-private _quantity = ceil (count allBackpacksRadio / (count rebelBackpackDevice max 1));
+private _quantity = 1 max ceil (count allBackpacksRadio / (count rebelBackpackDevice max 1));
 for "_i" from 1 to _quantity do {
      lootDevice append rebelBackpackDevice;
 };


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
In #3730, code was added to balance the quantities of radio and UAV backpacks in loot crates. This worked a little too well and caused the array to be empty if there were no radio backpacks in the modset (eg. vanilla). This PR fixes the issue.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Start campaign, check value of `lootDevice`.