### PR TITLE
SOG Faction tune up

### DIFF
--- a/A3A/addons/core/Templates/AircraftLoadouts/VN/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/VN/config.cpp
@@ -22,15 +22,20 @@ class A3A {
         {
             class baseCAS;
             class vn_b_air_f4c_at : baseCAS {
-                loadout[] = {"vn_missile_f4_out_agm12c_mag_x1","vn_missile_f4_out_agm12c_mag_x1","vn_rocket_ffar_f4_lau3_m229_he_x57","vn_rocket_ffar_f4_lau3_m229_he_x57","vn_bomb_f4_out_750_blu1b_fb_mag_x3","vn_missile_f4_lau7_aim9e_mag_x2","vn_missile_f4_lau7_aim9e_mag_x2","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1"};
+                loadout[] = {"vn_missile_f4_out_agm12c_mag_x1","vn_missile_f4_out_agm12c_mag_x1","vn_rocket_ffar_f4_lau3_m229_he_x57","vn_rocket_ffar_f4_lau3_m229_he_x57","vn_gunpod_suu23_v_1200_mag","","","","","",""};
+                mainGun[] = {"vn_gunpod_suu23"};
                 rocketLauncher[] = {"vn_rocket_ffar_275in_launcher_m229"};
                 missileLauncher[] = {"vn_missile_agm12c_launcher"};
             };
+            class vn_b_air_f4b_navy_cas : vn_b_air_f4c_at {
+                loadout[] = {"vn_missile_f4_out_agm12c_mag_x1","vn_missile_f4_out_agm12c_mag_x1","vn_rocket_ffar_f4_lau3_m229_he_x57","vn_rocket_ffar_f4_lau3_m229_he_x57","vn_gunpod_suu23_v_1200_mag","","","","","",""};
+                mainGun[] = {"vnx_gunpod_mk4_twin"};
+            };
             
             class vn_b_air_f100d_at : baseCAS {
-                loadout[] = {"vn_rocket_ffar_f4_lau59_m229_he_x21","vn_rocket_ffar_f4_lau59_m229_he_x21","vn_fuel_f100_335_camo_01_mag","vn_fuel_f100_335_camo_01_mag","vn_missile_agm12c_mag_01_x1","vn_missile_agm12c_mag_01_x1"};
+                loadout[] = {"vn_rocket_ffar_f4_lau3_mk32_atap_x12","vn_rocket_ffar_f4_lau3_mk32_atap_x12","vn_rocket_ffar_f4_lau3_mk32_atap_x12","vn_rocket_ffar_f4_lau3_mk32_atap_x12","vn_missile_agm12c_mag_01_x1","vn_missile_agm12c_mag_01_x1"};
                 mainGun[] = {"vn_m39a1_v_quad"};
-                rocketLauncher[] = {"vn_rocket_ffar_275in_launcher_m229"};
+                rocketLauncher[] = {"vn_rocket_ffar_5in_launcher"};
                 missileLauncher[] = {"vn_missile_agm12c_launcher"};
             };
             
@@ -51,10 +56,16 @@ class A3A {
         {
             class baseCAP;
             class vn_b_air_f4c_cap : baseCAP {
-                loadout[] = {"vn_fuel_f4_370_mag","vn_fuel_f4_370_mag","","","vn_fuel_f4_600_mag","vn_missile_f4_lau7_aim9e_mag_x2","vn_missile_f4_lau7_aim9e_mag_x2","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1"};
+                loadout[] = {"","","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1","vn_gunpod_suu23_v_1200_mag","vn_missile_f4_lau7_aim9e_mag_x2","vn_missile_f4_lau7_aim9e_mag_x2","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1"};
+            };
+            class vn_b_air_f4b_navy_cap : vn_b_air_f4c_cap {
+                loadout[] = {"","","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1","vnx_gunpod_mk4_twin_01_v_750_mag","vn_missile_f4_lau7_aim9e_mag_x2","vn_missile_f4_lau7_aim9e_mag_x2","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1"};
+            };
+            class vn_b_air_f4b_usmc_cap : vn_b_air_f4b_navy_cap {
+                loadout[] = {"vnx_gunpod_mk4_twin_02_v_750_mag","vnx_gunpod_mk4_twin_02_v_750_mag","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1","vnx_gunpod_mk4_twin_02_v_750_mag","vnx_missile_f4_lau7_aim9b_mag_x2","vnx_missile_f4_lau7_aim9b_mag_x2","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1","vn_missile_aim7e2_mag_x1"};
             };
             class vn_b_air_f100d_cap : baseCAP {
-                loadout[] = {"vn_rocket_ffar_f4_lau59_m229_he_x21","vn_rocket_ffar_f4_lau59_m229_he_x21","vn_fuel_f100_335_mag","vn_fuel_f100_335_mag","vn_missile_aim9e_mag_x1","vn_missile_aim9e_mag_x1"};
+                loadout[] = {"","","","","vn_missile_f100_lau7_aim9e_mag_x2","vn_missile_f100_lau7_aim9e_mag_x2"};
             };
             class vn_o_air_mig19_cap : baseCAP {
                 loadout[] = {"vn_missile_mig19_01_aa2_mag_x1","vn_missile_mig19_01_aa2_mag_x1","vn_missile_mig19_01_aa2_mag_x1","vn_missile_mig19_01_aa2_mag_x1"};

--- a/A3A/addons/core/Templates/AircraftLoadouts/VNX/config.cpp
+++ b/A3A/addons/core/Templates/AircraftLoadouts/VNX/config.cpp
@@ -29,9 +29,9 @@ class A3A {
             class vnx_b_air_ov10a_usmc_mr : vnx_b_air_ov10a_mr {};
             class vnx_b_air_ov10a_aus_covey : vnx_b_air_ov10a_mr {};
             class vnx_b_air_a4e_usmc_cas : baseCAS {
-                loadout[] = {"vnx_gunpod_mk12_100_mag","vnx_gunpod_mk12_100_mag","vnx_rocket_ffar_lau3_m151_he_x19_02","vnx_rocket_ffar_lau3_m151_he_x19_02","vnx_missile_agm12c_mag_01_x1","vnx_missile_agm12c_mag_01_x1","vnx_rocket_ffar_a4_lau3_m151_he_x57_02"};
+                loadout[] = {"vnx_gunpod_mk12_100_mag","vnx_gunpod_mk12_100_mag","vnx_rocket_ffar_lau10_mk32_atap_x4","vnx_rocket_ffar_lau10_mk32_atap_x4","vnx_missile_agm12c_mag_01_x1","vnx_missile_agm12c_mag_01_x1","vnx_rocket_ffar_a4_right_lau10_mk32_atap_x12"};
                 mainGun[] = {"vnx_gunpod_mk12"};
-                rocketLauncher[] = {"vnx_rocket_ffar_275in_launcher_m151"};
+                rocketLauncher[] = {"vnx_rocket_ffar_5in_atap_launcher"};
                 missileLauncher[] = {"vnx_missile_agm12c_launcher"};
             };
             class vnx_b_air_a4e_ran_cas : vnx_b_air_a4e_usmc_cas {};
@@ -41,7 +41,7 @@ class A3A {
         {
             class baseCAP;
             class vnx_b_air_a4e_ran_cap : baseCAP {
-                loadout[] = {"vnx_gunpod_mk12_100_mag","vnx_gunpod_mk12_100_mag","vnx_missile_lau7_aim9b_03_mag_x1","vnx_missile_lau7_aim9b_03_mag_x1","vnx_missile_lau7_aim9b_03_mag_x1","vnx_missile_lau7_aim9b_03_mag_x1","vnx_fuel_a4_300_02_mag"};
+                loadout[] = {"vnx_gunpod_mk12_100_mag","vnx_gunpod_mk12_100_mag","vnx_missile_lau7_aim9d_03_mag_x1","vnx_missile_lau7_aim9d_03_mag_x1","vnx_missile_lau7_aim9d_03_mag_x1","vnx_missile_lau7_aim9d_03_mag_x1","vnx_fuel_a4_300_02_mag"};
             };
             class vnx_b_air_a4e_rnzaf_cap : vnx_b_air_a4e_ran_cap {};
         };

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_ANZAC.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_ANZAC.sqf
@@ -31,7 +31,7 @@
 
 ["vehiclesBasic", ["vn_b_wheeled_m151_01_aus_army"]] call _fnc_saveToTemplate;
 ["vehiclesLightUnarmed", ["vn_b_wheeled_m151_01_aus_army", "vn_b_wheeled_m151_02_aus_army"]] call _fnc_saveToTemplate;
-["vehiclesLightArmed" , ["vn_b_wheeled_m151_mg_02_aus_army", "vn_b_wheeled_m151_mg_03_aus_army", "vn_b_wheeled_m151_mg_06_aus_army", "vn_b_wheeled_lr2a_mg_01_aus_army", "vn_b_wheeled_lr2a_mg_02_aus_army", "vn_b_wheeled_lr2a_mg_03_aus_army"]] call _fnc_saveToTemplate;
+["vehiclesLightArmed" , ["vn_b_wheeled_m151_mg_02_aus_army", "vn_b_wheeled_m151_mg_03_aus_army", "vn_b_wheeled_m151_mg_06_aus_army", "vn_b_wheeled_lr2a_mg_01_aus_army", "vn_b_wheeled_lr2a_mg_02_aus_army", "vn_b_wheeled_lr2a_mg_03_aus_army", "vn_b_armor_m125_01_aus_army"]] call _fnc_saveToTemplate;
 ["vehiclesTrucks", ["vn_b_wheeled_m54_01_aus_army", "vn_b_wheeled_m54_02_aus_army", "vn_b_wheeled_lr2a_01_aus_army", "vn_b_wheeled_lr2a_02_aus_army"]] call _fnc_saveToTemplate;
 ["vehiclesCargoTrucks", []] call _fnc_saveToTemplate;
 ["vehiclesAmmoTrucks", ["vn_b_wheeled_m54_ammo_aus_army"]] call _fnc_saveToTemplate;
@@ -40,7 +40,8 @@
 ["vehiclesMedical", ["vn_b_wheeled_lr2a_03_aus_army"]] call _fnc_saveToTemplate;
 ["vehiclesLightAPCs", []] call _fnc_saveToTemplate;
 ["vehiclesAPCs", ["vn_b_armor_m113_01_aus_army"]] call _fnc_saveToTemplate;
-["vehiclesIFVs", ["vn_b_armor_m67_01_01"]] call _fnc_saveToTemplate;
+["vehiclesIFVs", []] call _fnc_saveToTemplate;
+["vehiclesLightTanks", ["vn_b_armor_m41_01_01"]] call _fnc_saveToTemplate;
 ["vehiclesTanks", ["vn_b_armor_m48_01_01"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["a3a_vn_b_wheeled_m54_mg_02"]] call _fnc_saveToTemplate;
 
@@ -250,7 +251,10 @@ _sfLoadoutData set ["sniperRifles", [
 ["vn_m40a1_camo", "vn_s_m14", "", "vn_o_9x_m40a1", ["vn_m40a1_mag", "vn_m40a1_mag", "vn_m40a1_t_mag"], [], ""]
 ]];
 _sfLoadoutData set ["sidearms", [
-["vn_mx991_m1911", "vn_s_m1911", "", "", [], [], ""]
+["vn_mx991_m1911", "vn_s_m1911", "", "", [], [], ""],
+["vn_hp", "vn_s_hp", "", "", [], [], ""],
+["vn_m10", "vn_s_mk22", "", "", [], [], ""],
+["vn_ppk", "vn_s_ppk", "", "", [], [], ""]
 ]];
 
 /////////////////////////////////
@@ -320,20 +324,22 @@ _militaryLoadoutData set ["sidearms", [
 
 private _policeLoadoutData = _loadoutData call _fnc_copyLoadoutData;
 
-_policeLoadoutData set ["uniforms", ["vn_b_uniform_macv_01_03"]];
-_policeLoadoutData set ["vests", ["vn_b_vest_usarmy_13"]];
+_policeLoadoutData set ["uniforms", ["vn_b_uniform_nz_01_01", "vn_b_uniform_nz_02_01", "vn_b_uniform_nz_03_01"]];
+_policeLoadoutData set ["vests", ["vn_b_vest_anzac_10"]];
 _policeLoadoutData set ["helmets", ["vn_b_helmet_m1_01_02"]];
 
 _policeLoadoutData set ["carbines", [
-["vn_m1carbine", "", "", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""],
-["vn_m1carbine", "", "", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""],
-["vn_m2carbine", "", "", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""]
-]];
-_policeLoadoutData set ["shotGuns", [
-["vn_m1897", "", "", "", ["vn_m1897_buck_mag", "vn_m1897_fl_mag"], [], ""]
+["vn_mc10", "", "", "", ["vn_mc10_t_mag", "vn_mc10_t_mag", "vn_mc10_mag", "vn_mc10_mag"], [], ""],
+["vn_m45", "", "", "", ["vn_m45_t_mag", "vn_m45_mag", "vn_m45_mag"], [], ""],
+["vn_mpu", "", "", "", ["vn_mpu_t_mag", "vn_mpu_mag", "vn_mpu_mag"], [], ""],
+["vn_m1897", "", "vn_b_m1897", "", ["vn_m1897_buck_mag", "vn_m1897_buck_mag", "vn_m1897_fl_mag"], [], ""],
+["vn_m1897", "", "vn_b_m1897", "", ["vn_m1897_buck_mag", "vn_m1897_buck_mag", "vn_m1897_fl_mag"], [], ""],
+["vn_m1carbine", "", "vn_b_carbine", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""],
+["vn_m2carbine", "", "vn_b_carbine", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""]
 ]];
 _policeLoadoutData set ["sidearms", [
-"vn_m1911",
+"vn_p38s",
+"vn_m10",
 "vn_mx991_m1911"
 ]];
 
@@ -354,16 +360,12 @@ _militiaLoadoutData set ["helmets", ["vn_b_boonie_06_01","vn_b_headband_01","vn_
 _militiaLoadoutData set ["binoculars", ["vn_mk21_binocs"]];
 
 _militiaLoadoutData set ["rifles", [
-["vn_m16", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
 ["vn_l1a1_01", "", "vn_b_l1a1", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], [], ""],
 ["vn_l1a1_01", "", "", "", ["vn_l1a1_20_mag", "vn_l1a1_20_mag", "vn_l1a1_20_t_mag"], [], ""],
 ["vn_f1_smg", "", "", "", ["vn_f1_smg_mag", "vn_f1_smg_mag", "vn_f1_smg_t_mag"], [], ""]
 ]];
 _militiaLoadoutData set ["slRifles", [
-["vn_m16", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
-["vn_m16", "", "vn_b_m16", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
-["vn_m16_camo", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
-["vn_m16_camo", "", "vn_b_m16", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""]
+["vn_f1_smg", "", "", "", ["vn_f1_smg_mag", "vn_f1_smg_mag", "vn_f1_smg_t_mag"], [], ""]
 ]];
 _militiaLoadoutData set ["SMGs", [
 ["vn_f1_smg", "", "", "", ["vn_f1_smg_mag", "vn_f1_smg_mag", "vn_f1_smg_t_mag"], [], ""]
@@ -407,9 +409,9 @@ _pilotLoadoutData set ["vests", ["vn_b_vest_anzac_08"]];
 _pilotLoadoutData set ["helmets", ["vn_b_helmet_svh4_01_04","vn_b_helmet_svh4_02_04"]];
 
 if (isClass (configFile >> "vnx_credits")) then {
-	(_policeLoadoutData get "shotGuns") append [
-	["vnx_m77e", "", "", "", ["vnx_m77e_fl_mag","vnx_m77e_buck_mag"], [], ""],
-	["vnx_m77e_shorty", "", "", "", ["vnx_m77e_fl_mag","vnx_m77e_buck_mag"], [], ""]
+	(_policeLoadoutData get "carbines") append [
+	["vnx_m77e", "", "", "", ["vnx_m77e_buck_mag","vnx_m77e_fl_mag","vnx_m77e_buck_mag"], [], ""],
+	["vnx_m77e_shorty", "", "", "", ["vnx_m77e_buck_mag","vnx_m77e_fl_mag","vnx_m77e_buck_mag"], [], ""]
 	];
 	(_militiaLoadoutData get "SMGs") append [
 	["vn_f1_smg", "", "", "", ["vn_f1_smg_mag", "vn_f1_smg_mag", "vn_f1_smg_t_mag"], [], ""],
@@ -762,7 +764,7 @@ private _policeTemplate = {
 	["vests"] call _fnc_setVest;
 	["uniforms"] call _fnc_setUniform;
 
-	[selectRandom ["carbines", "shotGuns"]] call _fnc_setPrimary;
+	["carbines"] call _fnc_setPrimary;
 	["primary", 3] call _fnc_addMagazines;
 
 	["sidearms"] call _fnc_setHandgun;
@@ -882,7 +884,7 @@ private _unitTypes = [
 private _prefix = "police";
 private _unitTypes = [
 	["SquadLeader", _policeTemplate],
-	["Standard", _policeTemplate]
+	["Standard", _policeTemplate, nil, 10]
 ];
 
 [_prefix, _unitTypes, _policeLoadoutData] call _fnc_generateAndSaveUnitsToTemplate;

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_ANZAC.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_ANZAC.sqf
@@ -130,7 +130,7 @@ _loadoutData set ["sniperRifles", []];
 
 _loadoutData set ["lightATLaunchers", ["vn_m72"]];
 _loadoutData set ["ATLaunchers", [
-"vn_m20a1b1_01"
+"vn_m20a1b1_01",
 ["vn_m20a1b1_01", "", "", "", ["vn_m20a1b1_heat_mag", "vn_m20a1b1_heat_mag", "vn_m20a1b1_wp_mag"], [], ""]
 ]];
 _loadoutData set ["sidearms", []];

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_ANZAC.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_ANZAC.sqf
@@ -129,6 +129,10 @@ _loadoutData set ["marksmanRifles", []];
 _loadoutData set ["sniperRifles", []];
 
 _loadoutData set ["lightATLaunchers", ["vn_m72"]];
+_loadoutData set ["ATLaunchers", [
+"vn_m20a1b1_01"
+["vn_m20a1b1_01", "", "", "", ["vn_m20a1b1_heat_mag", "vn_m20a1b1_heat_mag", "vn_m20a1b1_wp_mag"], [], ""]
+]];
 _loadoutData set ["sidearms", []];
 
 _loadoutData set ["ATMines", ["vn_mine_m15_mag"]];
@@ -645,7 +649,8 @@ private _atTemplate = {
 	[selectRandom ["rifles", "SMGs"]] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 
-	["lightATLaunchers"] call _fnc_setLauncher;
+	["ATLaunchers"] call _fnc_setLauncher;
+    ["launcher", 4] call _fnc_addMagazines;
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 2] call _fnc_addMagazines;

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_ANZAC.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_ANZAC.sqf
@@ -90,7 +90,7 @@ if (isClass (configFile >> "vnx_credits")) then {
 
 ["staticMGs", ["vn_b_aus_army_static_m60_high", "vn_b_aus_army_static_m2_high"]] call _fnc_saveToTemplate;
 ["staticAT", ["vn_b_aus_army_static_m40a1rr"]] call _fnc_saveToTemplate;
-["staticAA", ["a3a_vn_b_army_static_m45"]] call _fnc_saveToTemplate;
+["staticAA", ["a3a_vn_b_army_static_m45", "a3a_vn_b_army_static_m45", "a3a_vn_b_army_static_m45", "vn_b_navy_static_l70mk2", "vn_b_navy_static_l60mk3"]] call _fnc_saveToTemplate;
 ["staticMortars", ["a3a_vn_b_static_mortar_m2"]] call _fnc_saveToTemplate;
 
 ["mortarMagazineHE", "vn_mortar_m2_mag_he_x8"] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_ANZAC.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_ANZAC.sqf
@@ -45,7 +45,7 @@
 ["vehiclesTanks", ["vn_b_armor_m48_01_01"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["a3a_vn_b_wheeled_m54_mg_02"]] call _fnc_saveToTemplate;
 
-["vehiclesTransportBoats", ["vn_o_boat_02_01", "vn_b_boat_10_01", "vn_b_boat_09_01"]] call _fnc_saveToTemplate;
+["vehiclesTransportBoats", ["vn_b_boat_09_01"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["vn_b_boat_13_02", "vn_b_boat_06_02", "vn_b_boat_05_02", "vn_b_boat_12_02"]] call _fnc_saveToTemplate;
 ["vehiclesAmphibious", ["vn_b_armor_m113_01_aus_army"]] call _fnc_saveToTemplate;
 

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_ANZAC.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_ANZAC.sqf
@@ -114,7 +114,7 @@ if (isClass (configFile >> "vnx_credits")) then {
 "WhiteHead_08", "WhiteHead_09", "WhiteHead_10", "WhiteHead_11", "WhiteHead_12",
 "WhiteHead_13", "WhiteHead_15", "WhiteHead_16", "WhiteHead_17", "WhiteHead_18",
 "WhiteHead_20", "WhiteHead_21"]] call _fnc_saveToTemplate;
-["voices", ["Male01ENG", "Male02ENG", "Male03ENG", "Male04ENG", "Male05ENG", "Male06ENG", "Male07ENG", "Male08ENG", "Male09ENG", "Male10ENG", "Male11ENG", "Male12ENG"]] call _fnc_saveToTemplate;
+["voices", ["Male01ENGB", "Male02ENGB", "Male03ENGB", "Male04ENGB", "Male05ENGB"]] call _fnc_saveToTemplate;
 "EnglishMen" call _fnc_saveNames;
 
 //////////////////////////

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_MACV.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_MACV.sqf
@@ -263,6 +263,13 @@ _sfLoadoutData set ["carbines", [
 ["vn_gau5a", "", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], [], ""],
 ["vn_gau5a", "", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], [], ""]
 ]];
+_sfLoadoutData set ["SMGs", [
+["vn_m3a1", "vn_s_m3a1", "", "", ["vn_m3a1_mag", "vn_m3a1_mag", "vn_m3a1_t_mag"], [], ""],
+["vn_m3a1", "vn_s_m3a1", "", "", ["vn_m3a1_mag", "vn_m3a1_mag", "vn_m3a1_t_mag"], [], ""],
+["vn_mc10", "vn_s_mc10", "", "", ["vn_mc10_t_mag", "vn_mc10_t_mag", "vn_mc10_mag", "vn_mc10_mag"], [], ""],
+["vn_m45_camo", "vn_s_m45_camo", "", "", ["vn_m45_t_mag", "vn_m45_mag", "vn_m45_mag"], [], ""],
+["vn_mpu", "vn_s_mpu", "", "", ["vn_mpu_t_mag", "vn_mpu_mag", "vn_mpu_mag"], [], ""]
+]];
 _sfLoadoutData set ["grenadeLaunchers", [
 ["vn_m16_xm148", "", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ""],
 ["vn_m16_xm148", "", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""],
@@ -274,7 +281,7 @@ _sfLoadoutData set ["grenadeLaunchers", [
 _sfLoadoutData set ["machineGuns", [
 ["vn_m60", "", "", "", [], [], ""],
 ["vn_m60_shorty_camo", "", "", "", [], [], ""],
-["vn_rpd", "", "", "", [], [], ""],
+["vn_rpd_shorty_01", "", "", "", [], [], ""],
 ["vn_m63a_cdo", "", "", "", ["vn_m63a_150_mag", "vn_m63a_150_mag", "vn_m63a_150_t_mag"], [], ""],
 ["vn_m63a_lmg", "", "", "", ["vn_m63a_100_mag", "vn_m63a_100_mag", "vn_m63a_100_t_mag"], [], ""]
 ]];
@@ -292,7 +299,12 @@ _sfLoadoutData set ["sniperRifles", [
 ]];
 _sfLoadoutData set ["sidearms", [
 ["vn_mx991_m1911", "vn_s_m1911", "", "", [], [], ""],
-["vn_mk22", "vn_s_mk22", "", "", [], [], ""]
+["vn_m1911", "vn_s_m1911", "", "", [], [], ""],
+["vn_mk22", "vn_s_mk22", "", "", [], [], ""],
+["vn_mk22", "vn_s_mk22", "", "", [], [], ""],
+["vn_hd", "", "", "", [], [], ""],
+["vn_m10", "vn_s_mk22", "", "", [], [], ""],
+["vn_ppk", "vn_s_ppk", "", "", [], [], ""]
 ]];
 /////////////////////////////////
 //    Military Loadout Data    //
@@ -318,18 +330,20 @@ _militaryLoadoutData set ["MGhelmets", ["vn_b_helmet_m1_08_01"]];
 _militaryLoadoutData set ["binoculars", ["vn_anpvs2_binoc"]];
 
 _militaryLoadoutData set ["rifles", [
+["vn_m14", "", "vn_b_m14", "", ["vn_m14_10_mag", "vn_m14_10_mag", "vn_m14_10_t_mag"], [], ""],
 ["vn_m16", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
+["vn_m16", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
+["vn_m16", "", "vn_b_m16", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""],
 ["vn_m16", "", "vn_b_m16", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""]
 ]];
 _militaryLoadoutData set ["slRifles", [
 ["vn_m16", "", "", "vn_o_4x_m16", ["vn_m16_30_mag", "vn_m16_30_mag", "vn_m16_30_t_mag"], [], ""],
 ["vn_xm177", "", "", "vn_o_4x_m16", ["vn_m16_30_mag", "vn_m16_30_mag", "vn_m16_30_t_mag"], [], ""],
 ["vn_m16", "", "", "", ["vn_m16_30_mag", "vn_m16_30_mag", "vn_m16_30_t_mag"], [], ""],
-["vn_xm177", "", "", "", ["vn_m16_30_mag", "vn_m16_30_mag", "vn_m16_30_t_mag"], [], ""],
-["vn_m63a", "", "", "", ["vn_m63a_30_mag", "vn_m63a_30_mag", "vn_m63a_30_t_mag"], [], ""]
+["vn_xm177", "", "", "", ["vn_m16_30_mag", "vn_m16_30_mag", "vn_m16_30_t_mag"], [], ""]
 ]];
 _militaryLoadoutData set ["slSidearms", [
-"vn_mx991_m1911",
+"vn_mx991_m1911","vn_m1911",
 ["vn_m79_p", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ["vn_40mm_m576_buck_mag"], ""],
 ["vn_m79_p", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ["vn_40mm_m576_buck_mag"], ""]
 ]];
@@ -367,6 +381,9 @@ _militaryLoadoutData set ["sniperRifles", [
 ]];
 _militaryLoadoutData set ["sidearms", [
 "vn_m1911",
+"vn_p38s",
+"vn_m10",
+"vn_m1911",
 "vn_mx991_m1911"
 ]];
 
@@ -377,17 +394,19 @@ _militaryLoadoutData set ["sidearms", [
 private _policeLoadoutData = _loadoutData call _fnc_copyLoadoutData;
 
 _policeLoadoutData set ["uniforms", ["vn_b_uniform_macv_01_03"]];
-_policeLoadoutData set ["vests", ["vn_b_vest_usarmy_13"]];
+_policeLoadoutData set ["vests", ["vn_b_vest_usarmy_02", "vn_b_vest_usarmy_03"]];
 _policeLoadoutData set ["helmets", ["vn_b_helmet_m1_01_02"]];
 
 _policeLoadoutData set ["rifles", [
-["vn_m16", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], [], ""]
+["vn_m1_garand", "", "vn_b_m1_garand", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], [], ""],
+["vn_mpu", "vn_s_mpu", "", "", ["vn_mpu_t_mag", "vn_mpu_mag", "vn_mpu_mag"], [], ""]
 ]];
 _policeLoadoutData set ["shotGuns", [
-["vn_m1897", "", "", "", ["vn_m1897_buck_mag", "vn_m1897_fl_mag"], [], ""]
+["vn_m1897", "", "", "", ["vn_m1897_buck_mag", "vn_m1897_fl_mag"], [], ""],
+["vn_m45", "", "", "", ["vn_m45_t_mag", "vn_m45_mag", "vn_m45_mag"], [], ""]
 ]];
 _policeLoadoutData set ["sidearms", [
-"vn_m1911",
+"vn_p38s",
 "vn_mx991_m1911"
 ]];
 
@@ -418,6 +437,7 @@ _militiaLoadoutData set ["rifles", [
 ["vn_m1_garand", "", "vn_b_m1_garand", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], [], ""]
 ]];
 _militiaLoadoutData set ["slRifles", [
+["vn_m1_garand", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], [], ""],
 ["vn_m14", "", "", "", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], ""],
 ["vn_m14", "", "vn_b_m14", "", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], ""]
 ]];
@@ -427,28 +447,34 @@ _militiaLoadoutData set ["carbines", [
 ["vn_m2carbine", "", "vn_b_carbine", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""],
 ["vn_m2carbine", "", "", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""]
 ]];
+_militiaLoadoutData set ["SMGs", [
+["vn_m3a1", "", "", "", ["vn_m3a1_mag", "vn_m3a1_mag", "vn_m3a1_t_mag"], [], ""]
+]];
 _militiaLoadoutData set ["grenadeLaunchers", [
-["vn_m16_xm148", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ""],
-["vn_m16_xm148", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""],
-["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ["vn_40mm_m576_buck_mag"], ""],
-["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ["vn_40mm_m576_buck_mag"], ""],
-["vn_m1_garand_gl", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m1a2_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_m19_wp_mag"], ""],
-["vn_m1_garand_gl", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m1a2_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_lume_mag"], ""]
+["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m576_buck_mag", "vn_40mm_m576_buck_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m680_smoke_w_mag"], ""],
+["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m576_buck_mag", "vn_40mm_m576_buck_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""],
+["vn_m1_garand_gl", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m9_heat_mag", "vn_22mm_m1a2_frag_mag","vn_22mm_m17_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_m19_wp_mag"], ""],
+["vn_m1_garand_gl", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m1a2_frag_mag", "vn_22mm_m9_heat_mag","vn_22mm_m17_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_lume_mag"], ""],
+["vn_m1carbine_gl", "", "", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], ["vn_22mm_m9_heat_mag", "vn_22mm_m1a2_frag_mag","vn_22mm_m17_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_m19_wp_mag"], ""],
+["vn_m2carbine_gl", "", "", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], ["vn_22mm_m17_frag_mag", "vn_22mm_m1a2_frag_mag","vn_22mm_m9_heat_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_lume_mag"], ""]
 ]];
 _militiaLoadoutData set ["machineGuns", [
 ["vn_m60", "", "", "", [], [], ""]
 ]];
 _militiaLoadoutData set ["marksmanRifles", [
+["vn_m1903", "", "", "vn_o_8x_m1903", ["vn_m1903_mag", "vn_m1903_mag", "vn_m1903_t_mag"], [], "vn_b_camo_m1903"],
+["vn_m1carbine", "", "", "vn_o_3x_m84", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""],
+["vn_m1_garand", "", "", "vn_o_3x_m84", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], [], "vn_b_camo_m1_garand"],
 ["vn_m14", "", "", "vn_o_9x_m14", ["vn_m14_10_mag", "vn_m14_10_mag", "vn_m14_10_t_mag"], [], "vn_b_camo_m14"],
 ["vn_m14", "", "vn_b_m14", "vn_o_9x_m14", ["vn_m14_10_mag", "vn_m14_10_mag", "vn_m14_10_t_mag"], [], "vn_b_camo_m14"]
 ]];
 _militiaLoadoutData set ["sniperRifles", [
-["vn_m40a1_camo", "", "", "vn_o_9x_m40a1", ["vn_m40a1_mag", "vn_m40a1_mag", "vn_m40a1_t_mag"], [], "vn_b_camo_m40a1"],
-["vn_m40a1_camo", "", "", "vn_o_9x_m40a1", ["vn_m40a1_mag", "vn_m40a1_mag", "vn_m40a1_t_mag"], [], ""]
+["vn_m1903", "", "", "vn_o_8x_m1903", ["vn_m1903_mag", "vn_m1903_mag", "vn_m1903_t_mag"], [], "vn_b_camo_m1903"]
 ]];
 _militiaLoadoutData set ["sidearms", [
 "vn_m1911",
-"vn_p38s"
+"vn_p38s",
+"vn_m10"
 ]];
 
 //////////////////////////
@@ -552,7 +578,7 @@ private _medicTemplate = {
 	[["medVests", "vests"] call _fnc_fallback] call _fnc_setVest;
 	["uniforms"] call _fnc_setUniform;
 	[["medBackpacks", "backpacks"] call _fnc_fallback] call _fnc_setBackpack;
-  	["carbines"] call _fnc_setPrimary;
+	[selectRandom ["SMGs", "carbines"]] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 
 	["sidearms"] call _fnc_setHandgun;
@@ -602,7 +628,7 @@ private _explosivesExpertTemplate = {
 	["uniforms"] call _fnc_setUniform;
 	[["engBackpacks", "backpacks"] call _fnc_fallback] call _fnc_setBackpack;
 
-	[selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+	[selectRandom ["SMGs", "carbines"]] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 
 
@@ -633,7 +659,7 @@ private _engineerTemplate = {
 	["uniforms"] call _fnc_setUniform;
 	[["engBackpacks", "backpacks"] call _fnc_fallback] call _fnc_setBackpack;
 
-	["carbines"] call _fnc_setPrimary;
+	[selectRandom ["SMGs", "carbines"]] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 
 	["sidearms"] call _fnc_setHandgun;
@@ -684,11 +710,11 @@ private _atTemplate = {
 	["vests"] call _fnc_setVest;
 	["uniforms"] call _fnc_setUniform;
 
-	[selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+	[selectRandom ["SMGs", "carbines"]] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 
-	[selectRandom ["ATLaunchers", "lightATLaunchers"]] call _fnc_setLauncher;
-    ["launcher", 2] call _fnc_addMagazines;
+	["ATLaunchers"] call _fnc_setLauncher;
+    ["launcher", 4] call _fnc_addMagazines;
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 2] call _fnc_addMagazines;
@@ -710,11 +736,11 @@ private _aaTemplate = {
 	["vests"] call _fnc_setVest;
 	["uniforms"] call _fnc_setUniform;
 
-	[selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
+	[selectRandom ["SMGs", "rifles", "carbines"]] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 
-	["ATLaunchers"] call _fnc_setLauncher;
-    ["launcher", 4] call _fnc_addMagazines;
+	[selectRandom ["ATLaunchers", "lightATLaunchers"]] call _fnc_setLauncher;
+    ["launcher", 2] call _fnc_addMagazines;
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 2] call _fnc_addMagazines;

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_MACV.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_MACV.sqf
@@ -145,7 +145,7 @@ _loadoutData set ["sniperRifles", []];
 
 _loadoutData set ["lightATLaunchers", ["vn_m72"]];
 _loadoutData set ["ATLaunchers", [
-"vn_m20a1b1_01"
+"vn_m20a1b1_01",
 ["vn_m20a1b1_01", "", "", "", ["vn_m20a1b1_heat_mag", "vn_m20a1b1_heat_mag", "vn_m20a1b1_wp_mag"], [], ""]
 ]];
 _loadoutData set ["sidearms", []];

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_MACV.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_MACV.sqf
@@ -39,7 +39,7 @@ private _vehiclesLightArmed = ["vn_b_wheeled_m151_mg_02", "vn_b_wheeled_m151_mg_
 ["vehiclesRepairTrucks", ["vn_b_wheeled_m54_repair"]] call _fnc_saveToTemplate;
 ["vehiclesFuelTrucks", ["vn_b_wheeled_m54_fuel"]] call _fnc_saveToTemplate;
 ["vehiclesMedical", ["vn_b_armor_m577_02"]] call _fnc_saveToTemplate;
-["vehiclesLightAPCs", ["vn_b_wheeled_m54_mg_03", "vn_b_wheeled_m54_mg_01", "vn_b_armor_m113_01"]] call _fnc_saveToTemplate;
+["vehiclesLightAPCs", ["vn_b_wheeled_m54_mg_03", "vn_b_wheeled_m54_mg_01", "vn_b_armor_m113_01", "vn_b_armor_m113_01"]] call _fnc_saveToTemplate;
 ["vehiclesAPCs", ["vn_b_armor_m113_acav_04", "vn_b_armor_m113_acav_02", "vn_b_armor_m113_acav_01", "vn_b_armor_m113_acav_06", "vn_b_armor_m113_acav_03", "vn_b_armor_m113_acav_05"]] call _fnc_saveToTemplate;
 ["vehiclesIFVs", ["vn_b_armor_m67_01_01"]] call _fnc_saveToTemplate;
 ["vehiclesLightTanks", ["vn_b_armor_m41_01_01"]] call _fnc_saveToTemplate;
@@ -77,7 +77,7 @@ private _uavsAttack = ["vn_b_air_oh6a_01"]; // scout helis are fine for this
 
 ["staticMGs", ["vn_b_army_static_m60_high", "vn_b_army_static_m1919a4_high", "vn_b_army_static_m2_high"]] call _fnc_saveToTemplate;
 ["staticAT", ["vn_b_army_static_m40a1rr", "vn_b_army_static_tow"]] call _fnc_saveToTemplate;
-["staticAA", ["a3a_vn_b_army_static_m45"]] call _fnc_saveToTemplate;
+["staticAA", ["a3a_vn_b_army_static_m45", "a3a_vn_b_army_static_m45", "a3a_vn_b_army_static_m45", "vn_b_navy_static_l70mk2", "vn_b_navy_static_l60mk3"]] call _fnc_saveToTemplate;
 ["staticMortars", ["a3a_vn_b_static_mortar_m2"]] call _fnc_saveToTemplate;
 
 ["mortarMagazineHE", "vn_mortar_m2_mag_he_x8"] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_MACV.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_MACV.sqf
@@ -46,7 +46,7 @@ private _vehiclesLightArmed = ["vn_b_wheeled_m151_mg_02", "vn_b_wheeled_m151_mg_
 ["vehiclesTanks", ["vn_b_armor_m48_01_01"]] call _fnc_saveToTemplate;
 private _vehiclesAA = ["a3a_vn_b_wheeled_m54_mg_02"];
 
-["vehiclesTransportBoats", ["vn_o_boat_02_01", "vn_b_boat_10_01", "vn_b_boat_09_01"]] call _fnc_saveToTemplate;
+["vehiclesTransportBoats", ["vn_b_boat_09_01"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["vn_b_boat_13_02", "vn_b_boat_06_02", "vn_b_boat_05_02", "vn_b_boat_12_02"]] call _fnc_saveToTemplate;
 ["vehiclesAmphibious", ["vn_b_armor_m113_01", "vn_b_armor_m113_acav_04", "vn_b_armor_m113_acav_02", "vn_b_armor_m113_acav_01", "vn_b_armor_m113_acav_06", "vn_b_armor_m113_acav_03", "vn_b_armor_m113_acav_05"]] call _fnc_saveToTemplate;
 

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_MACV.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_MACV.sqf
@@ -144,6 +144,10 @@ _loadoutData set ["marksmanRifles", []];
 _loadoutData set ["sniperRifles", []];
 
 _loadoutData set ["lightATLaunchers", ["vn_m72"]];
+_loadoutData set ["ATLaunchers", [
+"vn_m20a1b1_01"
+["vn_m20a1b1_01", "", "", "", ["vn_m20a1b1_heat_mag", "vn_m20a1b1_heat_mag", "vn_m20a1b1_wp_mag"], [], ""]
+]];
 _loadoutData set ["sidearms", []];
 
 _loadoutData set ["ATMines", ["vn_mine_m15_mag"]];
@@ -683,7 +687,8 @@ private _atTemplate = {
 	[selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 
-	["lightATLaunchers"] call _fnc_setLauncher;
+	[selectRandom ["ATLaunchers", "lightATLaunchers"]] call _fnc_setLauncher;
+    ["launcher", 2] call _fnc_addMagazines;
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 2] call _fnc_addMagazines;
@@ -708,7 +713,8 @@ private _aaTemplate = {
 	[selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 
-	["lightATLaunchers"] call _fnc_setLauncher;
+	["ATLaunchers"] call _fnc_setLauncher;
+    ["launcher", 4] call _fnc_addMagazines;
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 2] call _fnc_addMagazines;

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_PAVN.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_PAVN.sqf
@@ -208,40 +208,46 @@ _sfLoadoutData set ["helmets", ["vn_o_helmet_nva_01", "vn_o_helmet_nva_04", "vn_
 //["Weapon", "Muzzle", "Rail", "Sight", [], [], "Bipod"];
 
 _sfLoadoutData set ["rifles", [
-["vn_sks", "", "vn_b_sks", "", ["vn_sks_mag", "vn_sks_mag", "vn_sks_t_mag"], [], ""],
+"vn_type64_smg",
+["vn_kbkg", "", "", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], [], ""],
+["vn_ak_01", "", "", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], [], ""],
 ["vn_type56", "", "vn_b_type56", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], [], ""]
 ]];
 _sfLoadoutData set ["slRifles", [
-["vn_sks", "", "", "vn_o_3x_sks", ["vn_sks_mag", "vn_sks_mag", "vn_sks_t_mag"], [], ""],
+"vn_type64_smg",
+["vn_kbkg_gl", "", "", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], ["vn_20mm_f1n60_frag_mag", "vn_20mm_pgn60_heat_mag", "vn_20mm_dgn_wp_mag"], ""],
+["vn_ak_01", "", "", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], [], ""],
 ["vn_type56", "", "vn_b_type56", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], [], ""]
 ]];
 _sfLoadoutData set ["SMGs", [
-["vn_ppsh41", "", "", "", ["vn_ppsh41_35_mag", "vn_ppsh41_35_mag", "vn_ppsh41_35_t_mag"], [], ""],
-["vn_ppsh41", "", "", "", ["vn_ppsh41_35_mag", "vn_ppsh41_35_mag", "vn_ppsh41_35_t_mag"], [], ""],
-["vn_pps43", "", "", "", ["vn_pps_mag", "vn_pps_mag", "vn_pps_t_mag"], [], ""],
-["vn_mp40", "", "", "", ["vn_mp40_mag", "vn_mp40_mag", "vn_mp40_t_mag"], [], ""],
-["vn_ppsh41", "", "", "", ["vn_ppsh41_71_mag", "vn_ppsh41_71_mag", "vn_ppsh41_71_t_mag"], [], ""]
+["vn_mat49", "vn_s_mat49", "", "", [], [], ""],
+"vn_type64_smg"
 ]];
 _sfLoadoutData set ["grenadeLaunchers", [
-["vn_sks_gl", "", "", "", ["vn_sks_mag", "vn_sks_mag", "vn_sks_t_mag"], ["vn_22mm_m60_frag_mag", "vn_22mm_m19_wp_mag", "vn_22mm_m60_heat_mag", "vn_22mm_m22_smoke_mag"], ""],
-["vn_sks_gl", "", "", "", ["vn_sks_mag", "vn_sks_mag", "vn_sks_t_mag"], ["vn_22mm_m60_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_lume_mag"], ""],
+["vn_kbkg_gl", "", "", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], ["vn_20mm_f1n60_frag_mag", "vn_20mm_pgn60_heat_mag", "vn_20mm_dgn_wp_mag"], ""],
+["vn_kbkg_gl", "", "", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], ["vn_20mm_kgn_frag_mag", "vn_20mm_pgn60_heat_mag", "vn_20mm_dgn_wp_mag"], ""],
 ["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ["vn_40mm_m576_buck_mag"], ""],
 ["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ["vn_40mm_m576_buck_mag"], ""]
 ]];
 _sfLoadoutData set ["machineGuns", [
 ["vn_rpd", "", "", "", ["vn_rpd_100_mag"], [], ""],
-"vn_dp28", "vn_pk"
+["vn_rpd_shorty_01", "", "", "", ["vn_rpd_100_mag"], [], ""],
+"vn_pk", "vn_pk"
 ]];
 _sfLoadoutData set ["marksmanRifles", [
-["vn_sks", "", "", "vn_o_3x_sks", ["vn_sks_mag", "vn_sks_mag", "vn_sks_t_mag"], [], ""]
+["vn_svd", "", "", "vn_o_4x_svd", ["vn_svd_mag", "vn_svd_mag", "vn_svd_t_mag"], [], "vn_b_camo_svd"],
+["vn_m4956", "", "vn_b_m4956", "vn_o_4x_m4956", ["vn_m4956_10_t_mag", "vn_m4956_10_mag", "vn_m4956_10_mag"], [], ""]
 ]];
 _sfLoadoutData set ["sniperRifles", [
-["vn_m9130", "", "", "vn_o_3x_m9130", ["vn_m38_mag", "vn_m38_mag", "vn_m38_t_mag"], [], "vn_b_camo_m9130"],
-["vn_m9130", "", "vn_b_m38", "vn_o_3x_m9130", ["vn_m38_mag", "vn_m38_mag", "vn_m38_t_mag"], [], ""]
+["vn_svd", "", "", "vn_o_4x_svd", ["vn_svd_mag", "vn_svd_mag", "vn_svd_t_mag"], [], "vn_b_camo_svd"],
+["vn_m4956", "", "vn_b_m4956", "vn_o_4x_m4956", ["vn_m4956_10_t_mag", "vn_m4956_10_mag", "vn_m4956_10_mag"], [], ""]
 ]];
 _sfLoadoutData set ["sidearms", [
-"vn_fkb1_pm", "vn_pm", "vn_tt33",
-["vn_izh54_p", "", "", "", ["vn_izh54_mag", "vn_izh54_so_mag"], [], ""]
+"vn_type64",
+["vn_m1895", "vn_s_m1895", "", "", [], [], ""],
+["vn_p38", "vn_s_ppk", "", "", [], [], ""],
+["vn_pm", "vn_s_pm", "", "", [], [], ""],
+["vn_fkb1_pm", "vn_s_pm", "", "", [], [], ""]
 ]];
 /////////////////////////////////
 //    Military Loadout Data    //
@@ -262,38 +268,52 @@ _militaryLoadoutData set ["helmets", ["vn_o_helmet_nva_01", "vn_o_helmet_nva_04"
 
 _militaryLoadoutData set ["rifles", [
 ["vn_sks", "", "vn_b_sks", "", ["vn_sks_mag", "vn_sks_mag", "vn_sks_t_mag"], [], ""],
-["vn_type56", "", "vn_b_type56", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], [], ""]
+["vn_sks", "", "vn_b_sks", "", ["vn_sks_mag", "vn_sks_mag", "vn_sks_t_mag"], [], ""],
+["vn_type56", "", "vn_b_type56", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], [], ""],
+["vn_ak_01", "", "", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], [], ""],
+["vn_kbkg", "", "", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], [], ""]
 ]];
 _militaryLoadoutData set ["slRifles", [
+["vn_mat49_vc", "", "", "", ["vn_mat49_vc_t_mag", "vn_mat49_vc_mag", "vn_mat49_vc_mag"], [], ""],
+["vn_k50m", "", "", "", ["vn_ppsh41_35_t_mag", "vn_ppsh41_35_mag", "vn_ppsh41_35_mag"], [], ""],
 ["vn_sks", "", "", "vn_o_3x_sks", ["vn_sks_mag", "vn_sks_mag", "vn_sks_t_mag"], [], ""],
 ["vn_type56", "", "vn_b_type56", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], [], ""]
 ]];
 _militaryLoadoutData set ["SMGs", [
-["vn_ppsh41", "", "", "", ["vn_ppsh41_35_mag", "vn_ppsh41_35_mag", "vn_ppsh41_35_t_mag"], [], ""],
-["vn_ppsh41", "", "", "", ["vn_ppsh41_35_mag", "vn_ppsh41_35_mag", "vn_ppsh41_35_t_mag"], [], ""],
+["vn_mat49_vc", "", "", "", ["vn_mat49_vc_t_mag", "vn_mat49_vc_mag", "vn_mat49_vc_mag"], [], ""],
+["vn_k50m", "", "", "", ["vn_ppsh41_35_t_mag", "vn_ppsh41_35_mag", "vn_ppsh41_35_mag"], [], ""],
 ["vn_pps43", "", "", "", ["vn_pps_mag", "vn_pps_mag", "vn_pps_t_mag"], [], ""],
-["vn_mp40", "", "", "", ["vn_mp40_mag", "vn_mp40_mag", "vn_mp40_t_mag"], [], ""],
-["vn_ppsh41", "", "", "", ["vn_ppsh41_71_mag", "vn_ppsh41_71_mag", "vn_ppsh41_71_t_mag"], [], ""]
+["vn_pps52", "", "", "", ["vn_pps_t_mag", "vn_pps_mag", "vn_pps_mag"], [], ""],
+["vn_ppsh41", "", "", "", ["vn_ppsh41_71_t_mag", "vn_ppsh41_71_mag", "vn_ppsh41_71_mag"], [], ""]
 ]];
 _militaryLoadoutData set ["grenadeLaunchers", [
-["vn_sks_gl", "", "", "", ["vn_sks_mag", "vn_sks_mag", "vn_sks_t_mag"], ["vn_22mm_m60_frag_mag", "vn_22mm_m19_wp_mag", "vn_22mm_m60_heat_mag", "vn_22mm_m22_smoke_mag"], ""],
-["vn_sks_gl", "", "", "", ["vn_sks_mag", "vn_sks_mag", "vn_sks_t_mag"], ["vn_22mm_m60_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_lume_mag"], ""],
-["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ["vn_40mm_m576_buck_mag"], ""],
-["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ["vn_40mm_m576_buck_mag"], ""]
+["vn_kbkg_gl", "", "", "", ["vn_kbkg_t_mag", "vn_kbkg_mag", "vn_kbkg_mag"], ["vn_20mm_f1n60_frag_mag", "vn_20mm_kgn_frag_mag", "vn_20mm_pgn60_heat_mag", "vn_20mm_dgn_wp_mag"], ""],
+["vn_sks_gl", "", "", "", ["vn_sks_t_mag", "vn_sks_mag", "vn_sks_mag"], ["vn_22mm_m60_frag_mag", "vn_22mm_m19_wp_mag", "vn_22mm_m60_heat_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_lume_mag"], ""],
+["vn_m4956_gl", "", "", "", ["vn_m4956_10_t_mag", "vn_m4956_10_mag", "vn_m4956_10_mag"], ["vn_22mm_he_mag", "vn_22mm_m9_heat_mag", "vn_22mm_lume_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_m19_wp_mag"], ""],
+["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m576_buck_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""],
+["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m576_buck_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""]
 ]];
 _militaryLoadoutData set ["machineGuns", [
+["vn_mg42", "", "", "", ["vn_mg42_50_t_mag", "vn_mg42_50_mag", "vn_mg42_50_mag"], [], ""],
+["vn_rpd", "", "", "", ["vn_rpd_100_mag"], [], ""],
 ["vn_rpd", "", "", "", ["vn_rpd_100_mag"], [], ""],
 "vn_dp28", "vn_pk"
 ]];
 _militaryLoadoutData set ["marksmanRifles", [
-["vn_sks", "", "", "vn_o_3x_sks", ["vn_sks_mag", "vn_sks_mag", "vn_sks_t_mag"], [], ""]
+["vn_m9130", "", "vn_b_m38", "vn_o_3x_m9130", ["vn_m38_mag", "vn_m38_mag", "vn_m38_t_mag"], [], ""],
+["vn_sks", "", "", "vn_o_3x_sks", ["vn_sks_mag", "vn_sks_mag", "vn_sks_t_mag"], [], ""],
+["vn_vz54", "", "", "vn_o_3x_vz54", ["vn_m38_t_mag", "vn_m38_mag", "vn_m38_mag"], [], "vn_b_camo_vz54"],
+["vn_m4956", "", "vn_b_m4956", "vn_o_4x_m4956", ["vn_m4956_10_t_mag", "vn_m4956_10_mag", "vn_m4956_10_mag"], [], ""]
 ]];
 _militaryLoadoutData set ["sniperRifles", [
+["vn_svd", "", "", "vn_o_4x_svd", ["vn_svd_mag", "vn_svd_mag", "vn_svd_t_mag"], [], ""],
 ["vn_m9130", "", "", "vn_o_3x_m9130", ["vn_m38_mag", "vn_m38_mag", "vn_m38_t_mag"], [], "vn_b_camo_m9130"],
-["vn_m9130", "", "vn_b_m38", "vn_o_3x_m9130", ["vn_m38_mag", "vn_m38_mag", "vn_m38_t_mag"], [], ""]
+["vn_m9130", "", "vn_b_m38", "vn_o_3x_m9130", ["vn_m38_mag", "vn_m38_mag", "vn_m38_t_mag"], [], ""],
+["vn_vz54", "", "", "vn_o_3x_vz54", ["vn_m38_t_mag", "vn_m38_mag", "vn_m38_mag"], [], ""],
+["vn_vz54", "", "", "vn_o_3x_vz54", ["vn_m38_t_mag", "vn_m38_mag", "vn_m38_mag"], [], "vn_b_camo_vz54"]
 ]];
 _militaryLoadoutData set ["sidearms", [
-"vn_fkb1_pm", "vn_pm", "vn_tt33",
+"vn_fkb1_pm", "vn_pm", "vn_tt33", "vn_m1895", "vn_vz61_p", "vn_m712",
 ["vn_izh54_p", "", "", "", ["vn_izh54_mag", "vn_izh54_so_mag"], [], ""]
 ]];
 
@@ -308,12 +328,19 @@ _policeLoadoutData set ["vests", ["vn_o_vest_07"]];
 _policeLoadoutData set ["helmets", []];
 
 _policeLoadoutData set ["rifles", [
-["vn_sks", "", "", "", ["vn_sks_mag", "vn_sks_mag", "vn_sks_t_mag"], [], ""]
+["vn_m9130", "", "vn_b_m38", "", ["vn_m38_t_mag", "vn_m38_mag", "vn_m38_mag"], [], "vn_b_camo_m9130"],
+["vn_m36", "", "vn_b_m36", "", ["vn_m36_t_mag", "vn_m36_mag", "vn_m36_mag"], [], "vn_b_camo_m36"],
+["vn_k98k", "", "vn_b_k98k", "", ["vn_k98k_t_mag", "vn_k98k_mag", "vn_k98k_mag"], [], "vn_b_camo_k98k"],
+["vn_m1891", "", "vn_b_m38", "", ["vn_m38_t_mag", "vn_m38_mag", "vn_m38_mag"], [], ""],
+["vn_m38", "", "vn_b_m38", "", ["vn_m38_t_mag", "vn_m38_mag", "vn_m38_mag"], [], ""]
 ]];
 _policeLoadoutData set ["shotGuns", [
+["vn_mat49", "", "", "", ["vn_mat49_t_mag", "vn_mat49_mag", "vn_mat49_mag"], [], ""],
+["vn_izh54", "", "", "", ["vn_izh54_mag"], [], ""],
 ["vn_izh54", "", "", "", ["vn_izh54_mag"], [], ""]
 ]];
 _policeLoadoutData set ["sidearms", [
+"vn_m1895",
 "vn_tt33",
 "vn_fkb1_pm"
 ]];
@@ -337,35 +364,43 @@ _militiaLoadoutData set ["engBackpacks", ["vn_o_pack_05"]];
 _militiaLoadoutData set ["helmets", ["vn_o_helmet_nva_01", "vn_o_helmet_nva_04", "vn_o_helmet_nva_03", "vn_o_helmet_nva_02"]];
 
 _militiaLoadoutData set ["rifles", [
-["vn_sks", "", "", "", ["vn_sks_mag", "vn_sks_mag", "vn_sks_t_mag"], [], ""],
-["vn_sks", "", "vn_b_sks", "", ["vn_sks_mag", "vn_sks_mag", "vn_sks_t_mag"], [], ""],
-["vn_type56", "", "vn_b_type56", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], [], ""]
+["vn_m9130", "", "vn_b_m38", "", ["vn_m38_t_mag", "vn_m38_mag", "vn_m38_mag"], [], "vn_b_camo_m9130"],
+["vn_m36", "", "vn_b_m36", "", ["vn_m36_t_mag", "vn_m36_mag", "vn_m36_mag"], [], "vn_b_camo_m36"],
+["vn_k98k", "", "vn_b_k98k", "", ["vn_k98k_t_mag", "vn_k98k_mag", "vn_k98k_mag"], [], "vn_b_camo_k98k"],
+["vn_m1891", "", "vn_b_m38", "", ["vn_m38_t_mag", "vn_m38_mag", "vn_m38_mag"], [], ""],
+["vn_m38", "", "vn_b_m38", "", ["vn_m38_t_mag", "vn_m38_mag", "vn_m38_mag"], [], ""]
 ]];
 _militiaLoadoutData set ["slRifles", [
-["vn_sks", "", "", "vn_o_3x_sks", ["vn_sks_mag", "vn_sks_mag", "vn_sks_t_mag"], [], ""],
-["vn_type56", "", "vn_b_type56", "", ["vn_type56_mag", "vn_type56_mag", "vn_type56_t_mag"], [], ""]
+["vn_m38", "", "vn_b_m38", "", ["vn_m38_t_mag", "vn_m38_mag", "vn_m38_mag"], [], ""],
+["vn_mat49_vc", "", "", "", ["vn_mat49_vc_t_mag", "vn_mat49_vc_mag", "vn_mat49_vc_mag"], [], ""],
+["vn_pps52", "", "", "", ["vn_pps_t_mag", "vn_pps_mag", "vn_pps_mag"], [], ""],
+["vn_sks", "", "", "", ["vn_sks_t_mag", "vn_sks_mag", "vn_sks_mag"], [], ""],
+["vn_m4956", "", "vn_b_m4956", "", ["vn_m4956_10_t_mag", "vn_m4956_10_mag", "vn_m4956_10_mag"], [], ""]
 ]];
 _militiaLoadoutData set ["SMGs", [
-["vn_ppsh41", "", "", "", ["vn_ppsh41_35_mag", "vn_ppsh41_35_mag", "vn_ppsh41_35_t_mag"], [], ""],
-["vn_ppsh41", "", "", "", ["vn_ppsh41_35_mag", "vn_ppsh41_35_mag", "vn_ppsh41_35_t_mag"], [], ""],
-["vn_pps43", "", "", "", ["vn_pps_mag", "vn_pps_mag", "vn_pps_t_mag"], [], ""],
-["vn_mp40", "", "", "", ["vn_mp40_mag", "vn_mp40_mag", "vn_mp40_t_mag"], [], ""],
-["vn_ppsh41", "", "", "", ["vn_ppsh41_71_mag", "vn_ppsh41_71_mag", "vn_ppsh41_71_t_mag"], [], ""]
+["vn_pps52", "", "", "", ["vn_pps_t_mag", "vn_pps_mag", "vn_pps_mag"], [], ""],
+["vn_pps43", "", "", "", ["vn_pps_t_mag", "vn_pps_mag", "vn_pps_mag"], [], ""],
+["vn_vz61", "", "", "", ["vn_vz61_t_mag", "vn_vz61_mag", "vn_vz61_mag"], [], ""],
+["vn_mat49", "", "", "", ["vn_mat49_t_mag", "vn_mat49_mag", "vn_mat49_mag"], [], ""],
+["vn_mp40", "", "", "", ["vn_mp40_t_mag", "vn_mp40_mag", "vn_mp40_mag"], [], ""]
 ]];
 _militiaLoadoutData set ["grenadeLaunchers", [
-["vn_sks_gl", "", "", "", ["vn_sks_mag", "vn_sks_mag", "vn_sks_t_mag"], ["vn_22mm_m60_frag_mag", "vn_22mm_m19_wp_mag", "vn_22mm_m60_heat_mag", "vn_22mm_m22_smoke_mag"], ""],
-["vn_sks_gl", "", "", "", ["vn_sks_mag", "vn_sks_mag", "vn_sks_t_mag"], ["vn_22mm_m60_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_lume_mag"], ""]
+["vn_sks_gl", "", "", "", ["vn_sks_t_mag", "vn_sks_mag", "vn_sks_mag"], ["vn_22mm_m60_frag_mag", "vn_22mm_m19_wp_mag", "vn_22mm_m60_heat_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_lume_mag"], ""],
+["vn_m4956_gl", "", "", "", ["vn_m4956_10_t_mag", "vn_m4956_10_mag", "vn_m4956_10_mag"], ["vn_22mm_he_mag", "vn_22mm_m9_heat_mag", "vn_22mm_lume_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_m19_wp_mag"], ""]
 ]];
 _militiaLoadoutData set ["machineGuns", [
-["vn_rpd", "", "", "", ["vn_rpd_100_mag"], [], ""],
-"vn_dp28"
+["vn_mg42", "", "", "", ["vn_mg42_50_t_mag", "vn_mg42_50_mag", "vn_mg42_50_mag"], [], ""],
+"vn_dp28","vn_dp28","vn_dp28","vn_dp28"
 ]];
 _militiaLoadoutData set ["marksmanRifles", [
-["vn_sks", "", "", "vn_o_3x_sks", ["vn_sks_mag", "vn_sks_mag", "vn_sks_t_mag"], [], ""]
+["vn_k98k", "", "", "vn_o_1_5x_k98k", ["vn_k98k_t_mag", "vn_k98k_mag", "vn_k98k_mag"], [], "vn_b_camo_k98k"],
+["vn_m9130", "", "", "vn_o_3x_m9130", ["vn_m38_t_mag", "vn_m38_mag", "vn_m38_mag"], [], "vn_b_camo_m9130"],
+["vn_vz54", "", "", "vn_o_3x_vz54", ["vn_m38_t_mag", "vn_m38_mag", "vn_m38_mag"], [], "vn_b_camo_vz54"]
 ]];
 _militiaLoadoutData set ["sniperRifles", [
-["vn_m9130", "", "", "vn_o_3x_m9130", ["vn_m38_mag", "vn_m38_mag", "vn_m38_t_mag"], [], "vn_b_camo_m9130"],
-["vn_m9130", "", "vn_b_m38", "vn_o_3x_m9130", ["vn_m38_mag", "vn_m38_mag", "vn_m38_t_mag"], [], ""]
+["vn_m9130", "", "", "vn_o_3x_m9130", ["vn_m38_t_mag", "vn_m38_mag", "vn_m38_mag"], [], "vn_b_camo_m9130"],
+["vn_m9130", "", "", "vn_o_3x_m9130", ["vn_m38_t_mag", "vn_m38_mag", "vn_m38_mag"], [], ""],
+["vn_vz54", "", "", "vn_o_3x_vz54", ["vn_m38_t_mag", "vn_m38_mag", "vn_m38_mag"], [], "vn_b_camo_vz54"]
 ]];
 _militiaLoadoutData set ["sidearms", []];
 
@@ -386,6 +421,8 @@ _pilotLoadoutData set ["helmets", ["vn_o_helmet_zsh3_02", "vn_o_helmet_zsh3_01"]
 
 if (isClass (configFile >> "vnx_credits")) then {
     (_policeLoadoutData get "shotGuns") append [
+    ["vnx_m38_smg", "", "", "", ["vnx_m38_smg_32_t_mag","vnx_m38_smg_32_mag","vnx_m38_smg_32_mag"], [], ""],
+    ["vnx_m38_smg", "", "", "", ["vnx_m38_smg_32_t_mag","vnx_m38_smg_32_mag","vnx_m38_smg_32_mag"], [], ""],
     ["vnx_m77e", "", "", "", ["vnx_m77e_fl_mag","vnx_m77e_buck_mag"], [], ""],
     ["vnx_m77e_shorty", "", "", "", ["vnx_m77e_so_mag"], [], ""]
     ];
@@ -409,7 +446,15 @@ if (isClass (configFile >> "vnx_credits")) then {
     (_sfLoadoutData get "slRifles") append [
     ["vnx_stg44", "", "", "", ["vnx_stg44_t_mag", "vnx_stg44_t_mag", "vnx_stg44_mag"], [], ""]
     ];
+
+    (_militaryLoadoutData get "grenadeLaunchers") append [
+    ["vnx_type56_xm148", "", "", "", ["vn_kbkg_t_mag","vn_kbkg_mag","vn_kbkg_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""]
+    ];
+    (_sfLoadoutData get "grenadeLaunchers") append [
+    ["vnx_type56_xm148", "", "", "", ["vn_type56_t_mag","vn_type56_mag","vn_type56_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""]
+    ];
     (_militiaLoadoutData get "SMGs") append [
+    ["vnx_m38_smg", "", "", "", ["vnx_m38_smg_32_t_mag","vnx_m38_smg_32_mag","vnx_m38_smg_32_mag"], [], ""],
     ["vnx_m50_smg", "", "", "", ["vnx_m50_smg_t_mag", "vnx_m50_smg_mag"], [], ""]
     ];
     (_militaryLoadoutData get "SMGs") append [
@@ -434,9 +479,11 @@ if (isClass (configFile >> "vnx_credits")) then {
     "vnx_no4_sniper"
     ];
     _militiaLoadoutData set ["machineGuns",[
-    ["vnx_tul1", "", "", "", [], ["vn_type56_t_mag", "vn_type56_mag", "vn_type56_mag"], ""]
+    ["vnx_tul1", "", "", "", [], ["vn_type56_t_mag", "vn_type56_mag", "vn_type56_mag"], ""],
+    ["vnx_fm2429", "", "", "vnx_o_aa_fm2429", [], ["vnx_fm2429_t_mag", "vnx_fm2429_mag", "vnx_fm2429_mag"], ""]
     ]];
     (_militaryLoadoutData get "machineGuns") append [
+    ["vnx_tul1", "", "", "", [], ["vnx_rpk_40_t_mag", "vnx_rpk_40_mag", "vnx_rpk_40_mag"], ""],
     ["vnx_tul1", "", "", "", [], ["vnx_rpk_40_t_mag", "vn_type56_t_mag", "vn_type56_mag"], ""],
     ["vnx_tul1", "", "", "", [], ["vnx_rpk_75_mag", "vn_type56_vnx_rpk_40_mag", "vn_type56_mag"], ""]
     ];

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_PAVN.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_PAVN.sqf
@@ -117,8 +117,9 @@ _loadoutData set ["machineGuns", []];
 _loadoutData set ["marksmanRifles", []];
 _loadoutData set ["sniperRifles", []];
 
-_loadoutData set ["ATLaunchers", ["vn_rpg2", "vn_rpg7"]];
-_loadoutData set ["AALaunchers", ["vn_sa7", "vn_sa7b"]];
+_loadoutData set ["lightATLaunchers", ["vn_rpg2", "vn_rpg2", "vn_rpg7"]];
+_loadoutData set ["ATLaunchers", ["vn_rpg2", "vn_rpg7", "vn_rpg7"]];
+_loadoutData set ["AALaunchers", ["vn_sa7", "vn_sa7", "vn_sa7b"]];
 _loadoutData set ["sidearms", []];
 
 _loadoutData set ["ATMines", ["vn_mine_tripwire_f1_04_mag"]];
@@ -620,7 +621,7 @@ private _latTemplate = {
     [selectRandom ["rifles", "SMGs"]] call _fnc_setPrimary;
     ["primary", 6] call _fnc_addMagazines;
 
-    ["ATLaunchers"] call _fnc_setLauncher;
+    ["lightATLaunchers"] call _fnc_setLauncher;
     ["launcher", 2] call _fnc_addMagazines;
 
     ["sidearms"] call _fnc_setHandgun;
@@ -648,7 +649,7 @@ private _atTemplate = {
     ["primary", 6] call _fnc_addMagazines;
 
     ["ATLaunchers"] call _fnc_setLauncher;
-    ["launcher", 2] call _fnc_addMagazines;
+    ["launcher", 4] call _fnc_addMagazines;
 
     ["sidearms"] call _fnc_setHandgun;
     ["handgun", 2] call _fnc_addMagazines;

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_PAVN.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_PAVN.sqf
@@ -51,7 +51,7 @@
 ["vehiclesGunBoats", ["vn_o_boat_04_02"]] call _fnc_saveToTemplate;
 ["vehiclesAmphibious", []] call _fnc_saveToTemplate;
 
-["vehiclesPlanesCAS", ["vn_o_air_mig19_at", "vn_o_air_mig21_cas"]] call _fnc_saveToTemplate;
+["vehiclesPlanesCAS", ["vn_o_air_mig19_at", "vn_o_air_mig19_at", "vn_o_air_mig21_cas"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesAA", ["vn_o_air_mig19_cap", "vn_o_air_mig21_cap"]] call _fnc_saveToTemplate;
 ["vehiclesPlanesTransport", []] call _fnc_saveToTemplate;
 

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_PAVN.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_PAVN.sqf
@@ -47,7 +47,7 @@
 ["vehiclesTanks", ["vn_o_armor_type63_01","vn_o_armor_t54b_01","vn_o_armor_ot54_01"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["vn_o_wheeled_btr40_mg_03", "vn_o_wheeled_z157_mg_02"]] call _fnc_saveToTemplate;
 
-["vehiclesTransportBoats", ["vn_o_boat_01_mg_03"]] call _fnc_saveToTemplate;
+["vehiclesTransportBoats", ["vn_b_boat_09_01"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["vn_o_boat_04_02"]] call _fnc_saveToTemplate;
 ["vehiclesAmphibious", []] call _fnc_saveToTemplate;
 

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_PAVN.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_PAVN.sqf
@@ -30,18 +30,19 @@
 //////////////////////////
 
 ["attributeLowAir", true] call _fnc_saveToTemplate;             // Use fewer air units in general
+["attributeMoreTrucks", true] call _fnc_saveToTemplate;         // Use more truck for transports
 
 ["vehiclesBasic", ["vn_o_bicycle_01"]] call _fnc_saveToTemplate;
 ["vehiclesLightUnarmed", ["vn_o_wheeled_btr40_01"]] call _fnc_saveToTemplate;
-["vehiclesLightArmed",["vn_o_wheeled_btr40_mg_02", "vn_o_wheeled_btr40_mg_01", "vn_o_wheeled_btr40_mg_03", "vn_o_wheeled_z157_mg_02", "vn_o_wheeled_z157_mg_01"]] call _fnc_saveToTemplate;
+["vehiclesLightArmed",["vn_o_wheeled_btr40_mg_02", "vn_o_wheeled_btr40_mg_01", "vn_o_wheeled_btr40_mg_03", "vn_o_wheeled_z157_mg_02", "vn_o_wheeled_z157_mg_01", "vn_o_wheeled_btr40_mg_06", "vn_o_wheeled_btr40_mg_05"]] call _fnc_saveToTemplate;
 ["vehiclesTrucks", ["vn_o_wheeled_z157_01", "vn_o_wheeled_z157_02"]] call _fnc_saveToTemplate;
 ["vehiclesCargoTrucks", []] call _fnc_saveToTemplate;
 ["vehiclesAmmoTrucks", ["vn_o_wheeled_z157_ammo"]] call _fnc_saveToTemplate;
 ["vehiclesRepairTrucks", ["vn_o_wheeled_z157_repair"]] call _fnc_saveToTemplate;
 ["vehiclesFuelTrucks", ["vn_o_wheeled_z157_fuel"]] call _fnc_saveToTemplate;
 ["vehiclesMedical", ["vn_o_wheeled_btr40_02", "vn_o_armor_btr50pk_03"]] call _fnc_saveToTemplate;
-["vehiclesLightAPCs", ["vn_o_wheeled_z157_01", "vn_o_wheeled_z157_02", "vn_o_armor_m113_01", "vn_o_armor_btr50pk_02", "vn_o_armor_btr50pk_01"]] call _fnc_saveToTemplate;             // Fill out with trucks to make the tier scaling look more plausible
-["vehiclesAPCs", ["vn_o_wheeled_z157_01", "vn_o_wheeled_z157_02", "vn_o_armor_m113_acav_01","vn_o_armor_m113_acav_03"]] call _fnc_saveToTemplate;
+["vehiclesLightAPCs", ["vn_o_armor_m113_01", "vn_o_armor_btr50pk_02"]] call _fnc_saveToTemplate;             // Fill out with trucks to make the tier scaling look more plausible
+["vehiclesAPCs", ["vn_o_armor_m113_acav_01","vn_o_armor_m113_acav_03"]] call _fnc_saveToTemplate;
 ["vehiclesIFVs", ["vn_o_armor_pt76a_01","vn_o_armor_pt76b_01","vn_o_armor_type63_01"]] call _fnc_saveToTemplate;
 ["vehiclesLightTanks", ["vn_o_armor_m41_01","vn_o_armor_pt76a_01","vn_o_armor_pt76b_01"]] call _fnc_saveToTemplate;
 ["vehiclesTanks", ["vn_o_armor_type63_01","vn_o_armor_t54b_01","vn_o_armor_ot54_01"]] call _fnc_saveToTemplate;
@@ -74,10 +75,11 @@
 
 ["vehiclesPolice", ["vn_i_wheeled_m151_02_mp"]] call _fnc_saveToTemplate;
 
-["staticMGs", ["vn_o_nva_static_dshkm_high_01", "vn_o_nva_static_rpd_high", "vn_o_nva_static_pk_high"]] call _fnc_saveToTemplate;
+["staticMGs", ["vn_o_nva_static_dshkm_high_02", "vn_o_nva_static_dshkm_high_01", "vn_o_nva_static_rpd_high", "vn_o_nva_static_pk_high"]] call _fnc_saveToTemplate;
 ["staticAT", ["vn_o_vc_static_type56rr"]] call _fnc_saveToTemplate;
-["staticAA", ["vn_o_nva_static_zpu4", "a3a_vn_o_nva_static_zgu1_01"]] call _fnc_saveToTemplate;
+["staticAA", ["vn_o_nva_static_zpu4", "a3a_vn_o_nva_static_zgu1_01", "vn_o_nva_navy_static_v11m", "vn_o_nva_static_dshkm_high_02"]] call _fnc_saveToTemplate;
 ["staticMortars", ["vn_o_nva_65_static_mortar_type63"]] call _fnc_saveToTemplate;
+
 
 ["vehiclesSAM", ["vn_sa2"]] call _fnc_saveToTemplate;
 ["vehiclesRadar", ["vn_o_static_rsna75"]] call _fnc_saveToTemplate;
@@ -672,7 +674,7 @@ private _aaTemplate = {
     ["uniforms"] call _fnc_setUniform;
     ["backpacks"] call _fnc_setBackpack;
 
-    [selectRandom ["rifles", "SMGs"]] call _fnc_setPrimary;
+    ["SMGs"] call _fnc_setPrimary;
     ["primary", 6] call _fnc_addMagazines;
 
     ["AALaunchers"] call _fnc_setLauncher;

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_USMC.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_USMC.sqf
@@ -153,7 +153,7 @@ _loadoutData set ["sniperRifles", []];
 
 _loadoutData set ["lightATLaunchers", ["vn_m72"]];
 _loadoutData set ["ATLaunchers", [
-"vn_m20a1b1_01"
+"vn_m20a1b1_01",
 ["vn_m20a1b1_01", "", "", "", ["vn_m20a1b1_heat_mag", "vn_m20a1b1_heat_mag", "vn_m20a1b1_wp_mag"], [], ""]
 ]];
 _loadoutData set ["sidearms", []];
@@ -465,7 +465,7 @@ _militiaLoadoutData set ["marksmanRifles", [
 ["vn_m14", "", "vn_b_m14", "vn_o_9x_m14", ["vn_m14_10_mag", "vn_m14_10_mag", "vn_m14_10_t_mag"], [], "vn_b_camo_m14"]
 ]];
 _militiaLoadoutData set ["sniperRifles", [
-["vn_m1903", "", "", "vn_o_8x_m1903", ["vn_m1903_mag", "vn_m1903_mag", "vn_m1903_t_mag"], [], "vn_b_camo_m1903"]
+["vn_m1903", "", "", "vn_o_8x_m1903", ["vn_m1903_mag", "vn_m1903_mag", "vn_m1903_t_mag"], [], "vn_b_camo_m1903"],
 ["vn_m40a1_camo", "", "", "vn_o_9x_m40a1", ["vn_m40a1_mag", "vn_m40a1_mag", "vn_m40a1_t_mag"], [], "vn_b_camo_m40a1"],
 ["vn_m40a1_camo", "", "", "vn_o_9x_m40a1", ["vn_m40a1_mag", "vn_m40a1_mag", "vn_m40a1_t_mag"], [], ""]
 ]];

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_USMC.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_USMC.sqf
@@ -46,7 +46,7 @@ private _vehiclesAPCs = ["vn_b_armor_m113_acav_01", "vn_b_armor_m113_acav_03", "
 ["vehiclesTanks", ["vn_b_armor_m48_01_02"]] call _fnc_saveToTemplate;
 private _vehiclesAA = ["a3a_vn_b_wheeled_m54_mg_02"];
 
-["vehiclesTransportBoats", ["vn_o_boat_02_01", "vn_b_boat_10_01", "vn_b_boat_09_01"]] call _fnc_saveToTemplate;
+["vehiclesTransportBoats", ["vn_b_boat_09_01"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["vn_b_boat_13_02", "vn_b_boat_06_02", "vn_b_boat_05_02", "vn_b_boat_12_02"]] call _fnc_saveToTemplate;
 private _vehiclesAmphibious = ["vn_b_armor_m113_acav_01", "vn_b_armor_m113_acav_03", "vn_b_armor_m113_acav_06"];
 

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_USMC.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_USMC.sqf
@@ -152,6 +152,10 @@ _loadoutData set ["marksmanRifles", []];
 _loadoutData set ["sniperRifles", []];
 
 _loadoutData set ["lightATLaunchers", ["vn_m72"]];
+_loadoutData set ["ATLaunchers", [
+"vn_m20a1b1_01"
+["vn_m20a1b1_01", "", "", "", ["vn_m20a1b1_heat_mag", "vn_m20a1b1_heat_mag", "vn_m20a1b1_wp_mag"], [], ""]
+]];
 _loadoutData set ["sidearms", []];
 
 _loadoutData set ["ATMines", ["vn_mine_m15_mag"]];
@@ -685,7 +689,8 @@ private _atTemplate = {
 	[selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 
-	["lightATLaunchers"] call _fnc_setLauncher;
+	[selectRandom ["ATLaunchers", "lightATLaunchers"]] call _fnc_setLauncher;
+    ["launcher", 2] call _fnc_addMagazines;
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 2] call _fnc_addMagazines;
@@ -710,7 +715,8 @@ private _aaTemplate = {
 	[selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 
-	["lightATLaunchers"] call _fnc_setLauncher;
+	["ATLaunchers"] call _fnc_setLauncher;
+    ["launcher", 4] call _fnc_addMagazines;
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 2] call _fnc_addMagazines;

--- a/A3A/addons/core/Templates/Templates/VN/VN_AI_USMC.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_AI_USMC.sqf
@@ -43,15 +43,15 @@ private _vehiclesLightAPCs = ["vn_b_wheeled_m54_mg_03", "vn_b_wheeled_m54_mg_01"
 private _vehiclesAPCs = ["vn_b_armor_m113_acav_01", "vn_b_armor_m113_acav_03", "vn_b_armor_m113_acav_06"];
 ["vehiclesIFVs", ["vn_b_armor_m67_01_02"]] call _fnc_saveToTemplate;
 ["vehiclesLightTanks", ["vn_b_armor_m41_01_02"]] call _fnc_saveToTemplate;
-["vehiclesTanks", ["vn_b_armor_m48_01_02"]] call _fnc_saveToTemplate;
+["vehiclesTanks", ["vn_b_armor_m41_01_02", "vn_b_armor_m48_01_02"]] call _fnc_saveToTemplate;
 private _vehiclesAA = ["a3a_vn_b_wheeled_m54_mg_02"];
 
 ["vehiclesTransportBoats", ["vn_b_boat_09_01"]] call _fnc_saveToTemplate;
 ["vehiclesGunBoats", ["vn_b_boat_13_02", "vn_b_boat_06_02", "vn_b_boat_05_02", "vn_b_boat_12_02"]] call _fnc_saveToTemplate;
 private _vehiclesAmphibious = ["vn_b_armor_m113_acav_01", "vn_b_armor_m113_acav_03", "vn_b_armor_m113_acav_06"];
 
-private _vehiclesPlanesCAS = ["vn_b_air_f4c_at"];
-["vehiclesPlanesAA", ["vn_b_air_f4c_cap"]] call _fnc_saveToTemplate;
+private _vehiclesPlanesCAS = ["vn_b_air_f4b_navy_cas"];
+["vehiclesPlanesAA", ["vn_b_air_f4b_navy_cap", "vn_b_air_f4b_usmc_cap"]] call _fnc_saveToTemplate;
 private _vehiclesPlanesTransport = [];
 private _vehiclesAirPatrol = ["vn_b_air_uh1c_07_05", "vn_b_air_uh1b_01_04"];
 
@@ -77,7 +77,7 @@ private _uavsAttack = ["vn_b_air_oh6a_01"]; // scout helis are fine for this
 
 ["staticMGs", ["vn_b_army_static_m60_high", "vn_b_army_static_m2_high"]] call _fnc_saveToTemplate;
 ["staticAT", ["vn_b_army_static_m40a1rr"]] call _fnc_saveToTemplate;
-["staticAA", ["vn_b_navy_static_l70mk2", "vn_b_navy_static_l60mk3"]] call _fnc_saveToTemplate;
+["staticAA", ["vn_b_navy_static_l70mk2", "vn_b_navy_static_l60mk3", "a3a_vn_b_army_static_m45"]] call _fnc_saveToTemplate;
 ["staticMortars", ["a3a_vn_b_static_mortar_m2"]] call _fnc_saveToTemplate;
 
 ["mortarMagazineHE", "vn_mortar_m2_mag_he_x8"] call _fnc_saveToTemplate;
@@ -270,6 +270,13 @@ _sfLoadoutData set ["carbines", [
 ["vn_gau5a", "", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], [], ""],
 ["vn_gau5a", "", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], [], ""]
 ]];
+_sfLoadoutData set ["SMGs", [
+["vn_m3a1", "vn_s_m3a1", "", "", ["vn_m3a1_mag", "vn_m3a1_mag", "vn_m3a1_t_mag"], [], ""],
+["vn_m3a1", "vn_s_m3a1", "", "", ["vn_m3a1_mag", "vn_m3a1_mag", "vn_m3a1_t_mag"], [], ""],
+["vn_mc10", "vn_s_mc10", "", "", ["vn_mc10_t_mag", "vn_mc10_t_mag", "vn_mc10_mag", "vn_mc10_mag"], [], ""],
+["vn_m45_camo", "vn_s_m45_camo", "", "", ["vn_m45_t_mag", "vn_m45_mag", "vn_m45_mag"], [], ""],
+["vn_mpu", "vn_s_mpu", "", "", ["vn_mpu_t_mag", "vn_mpu_mag", "vn_mpu_mag"], [], ""]
+]];
 _sfLoadoutData set ["grenadeLaunchers", [
 ["vn_m16_xm148", "", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ""],
 ["vn_m16_xm148", "", "", "", ["vn_m16_40_mag", "vn_m16_40_mag", "vn_m16_40_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""],
@@ -300,7 +307,12 @@ _sfLoadoutData set ["sniperRifles", [
 ]];
 _sfLoadoutData set ["sidearms", [
 ["vn_mx991_m1911", "vn_s_m1911", "", "", [], [], ""],
-["vn_mk22", "vn_s_mk22", "", "", [], [], ""]
+["vn_m1911", "vn_s_m1911", "", "", [], [], ""],
+["vn_mk22", "vn_s_mk22", "", "", [], [], ""],
+["vn_mk22", "vn_s_mk22", "", "", [], [], ""],
+["vn_hd", "", "", "", [], [], ""],
+["vn_m10", "vn_s_mk22", "", "", [], [], ""],
+["vn_ppk", "vn_s_ppk", "", "", [], [], ""]
 ]];
 /////////////////////////////////
 //    Military Loadout Data    //
@@ -366,10 +378,14 @@ _militaryLoadoutData set ["marksmanRifles", [
 ["vn_m14", "", "", "vn_o_9x_m14", ["vn_m14_mag", "vn_m14_mag", "vn_m14_t_mag"], [], ""]
 ]];
 _militaryLoadoutData set ["sniperRifles", [
+["vn_m1903", "", "", "vn_o_8x_m1903", ["vn_m1903_mag", "vn_m1903_mag", "vn_m1903_t_mag"], [], "vn_b_camo_m1903"],
 ["vn_m40a1_camo", "", "", "vn_o_9x_m40a1", ["vn_m40a1_mag", "vn_m40a1_mag", "vn_m40a1_t_mag"], [], "vn_b_camo_m40a1"],
 ["vn_m40a1_camo", "", "", "vn_o_9x_m40a1", ["vn_m40a1_mag", "vn_m40a1_mag", "vn_m40a1_t_mag"], [], ""]
 ]];
 _militaryLoadoutData set ["sidearms", [
+"vn_m1911",
+"vn_p38s",
+"vn_m10",
 "vn_m1911",
 "vn_mx991_m1911"
 ]];
@@ -427,21 +443,29 @@ _militiaLoadoutData set ["carbines", [
 ["vn_m2carbine", "", "vn_b_carbine", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""],
 ["vn_m2carbine", "", "", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""]
 ]];
+_militiaLoadoutData set ["SMGs", [
+["vn_m3a1", "", "", "", ["vn_m3a1_mag", "vn_m3a1_mag", "vn_m3a1_t_mag"], [], ""]
+]];
 _militiaLoadoutData set ["grenadeLaunchers", [
-["vn_m16_xm148", "", "", "", ["vn_m16_20_mag", "vn_m16_20_mag", "vn_m16_20_t_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""],
-["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m397_ab_mag", "vn_40mm_m680_smoke_w_mag"], ["vn_40mm_m576_buck_mag"], ""],
-["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ["vn_40mm_m576_buck_mag"], ""],
-["vn_m1_garand_gl", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m1a2_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_m19_wp_mag"], ""],
-["vn_m1_garand_gl", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m1a2_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_lume_mag"], ""]
+["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m576_buck_mag", "vn_40mm_m576_buck_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m433_hedp_mag", "vn_40mm_m680_smoke_w_mag"], ""],
+["vn_m79", "", "", "", ["vn_40mm_m381_he_mag", "vn_40mm_m576_buck_mag", "vn_40mm_m576_buck_mag"], ["vn_40mm_m381_he_mag", "vn_40mm_m680_smoke_w_mag", "vn_40mm_m661_flare_g_mag"], ""],
+["vn_m1_garand_gl", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m9_heat_mag", "vn_22mm_m1a2_frag_mag","vn_22mm_m17_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_m19_wp_mag"], ""],
+["vn_m1_garand_gl", "", "", "", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], ["vn_22mm_m1a2_frag_mag", "vn_22mm_m9_heat_mag","vn_22mm_m17_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_lume_mag"], ""],
+["vn_m1carbine_gl", "", "", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], ["vn_22mm_m9_heat_mag", "vn_22mm_m1a2_frag_mag","vn_22mm_m17_frag_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_m19_wp_mag"], ""],
+["vn_m2carbine_gl", "", "", "", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], ["vn_22mm_m17_frag_mag", "vn_22mm_m1a2_frag_mag","vn_22mm_m9_heat_mag", "vn_22mm_m22_smoke_mag", "vn_22mm_lume_mag"], ""]
 ]];
 _militiaLoadoutData set ["machineGuns", [
 ["vn_m60", "", "", "", [], [], ""]
 ]];
 _militiaLoadoutData set ["marksmanRifles", [
+["vn_m1903", "", "", "vn_o_8x_m1903", ["vn_m1903_mag", "vn_m1903_mag", "vn_m1903_t_mag"], [], "vn_b_camo_m1903"],
+["vn_m1carbine", "", "", "vn_o_3x_m84", ["vn_carbine_15_mag", "vn_carbine_15_mag", "vn_carbine_15_t_mag"], [], ""],
+["vn_m1_garand", "", "", "vn_o_3x_m84", ["vn_m1_garand_mag", "vn_m1_garand_mag", "vn_m1_garand_t_mag"], [], "vn_b_camo_m1_garand"],
 ["vn_m14", "", "", "vn_o_9x_m14", ["vn_m14_10_mag", "vn_m14_10_mag", "vn_m14_10_t_mag"], [], "vn_b_camo_m14"],
 ["vn_m14", "", "vn_b_m14", "vn_o_9x_m14", ["vn_m14_10_mag", "vn_m14_10_mag", "vn_m14_10_t_mag"], [], "vn_b_camo_m14"]
 ]];
 _militiaLoadoutData set ["sniperRifles", [
+["vn_m1903", "", "", "vn_o_8x_m1903", ["vn_m1903_mag", "vn_m1903_mag", "vn_m1903_t_mag"], [], "vn_b_camo_m1903"]
 ["vn_m40a1_camo", "", "", "vn_o_9x_m40a1", ["vn_m40a1_mag", "vn_m40a1_mag", "vn_m40a1_t_mag"], [], "vn_b_camo_m40a1"],
 ["vn_m40a1_camo", "", "", "vn_o_9x_m40a1", ["vn_m40a1_mag", "vn_m40a1_mag", "vn_m40a1_t_mag"], [], ""]
 ]];
@@ -689,8 +713,8 @@ private _atTemplate = {
 	[selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 
-	[selectRandom ["ATLaunchers", "lightATLaunchers"]] call _fnc_setLauncher;
-    ["launcher", 2] call _fnc_addMagazines;
+	["ATLaunchers"] call _fnc_setLauncher;
+    ["launcher", 4] call _fnc_addMagazines;
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 2] call _fnc_addMagazines;
@@ -715,8 +739,8 @@ private _aaTemplate = {
 	[selectRandom ["rifles", "carbines"]] call _fnc_setPrimary;
 	["primary", 8] call _fnc_addMagazines;
 
-	["ATLaunchers"] call _fnc_setLauncher;
-    ["launcher", 4] call _fnc_addMagazines;
+	[selectRandom ["ATLaunchers", "lightATLaunchers"]] call _fnc_setLauncher;
+    ["launcher", 2] call _fnc_addMagazines;
 
 	["sidearms"] call _fnc_setHandgun;
 	["handgun", 2] call _fnc_addMagazines;

--- a/A3A/addons/core/Templates/Templates/VN/VN_CIV.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_CIV.sqf
@@ -92,10 +92,21 @@ private _pressUniforms = [
 ["uniforms", _civUniforms + _pressUniforms] call _fnc_saveToTemplate;
 
 private _civhats = [
+    "vn_o_pl_cap_02_02",
+    "vn_o_pl_cap_02_02",
+    "vn_c_headband_04",
     "vn_c_headband_04",
     "vn_c_headband_03",
+    "vn_c_headband_03",
     "vn_c_headband_02",
-    "vn_c_headband_01"
+    "vn_c_headband_02",
+    "vn_c_headband_01",
+    "vn_c_headband_01",
+    "H_Bandanna_gry",
+    "H_StrawHat_dark",
+    "H_HeadBandage_clean_F",
+    "H_HeadBandage_stained_F",
+    "H_HeadBandage_bloody_F"
 ];
 
 ["headgear", _civHats] call _fnc_saveToTemplate;
@@ -104,8 +115,10 @@ private _loadoutData = call _fnc_createLoadoutData;
 
 _loadoutData set ["uniforms", _civUniforms];
 _loadoutData set ["pressUniforms", _pressUniforms];
-_loadoutData set ["workerHelmets", ["vn_c_conehat_02"]];
+_loadoutData set ["workerHelmets", ["vn_c_conehat_01", "vn_c_conehat_02"]];
 _loadoutData set ["helmets", _civHats];
+_loadoutData set ["backpack1", ["vn_c_pack_01"]];
+_loadoutData set ["backpack2", ["vn_c_pack_02"]];
 
 _loadoutData set ["maps", ["ItemMap"]];
 _loadoutData set ["watches", ["ItemWatch"]];
@@ -115,6 +128,9 @@ _loadoutData set ["compasses", ["ItemCompass"]];
 private _manTemplate = {
     ["helmets"] call _fnc_setHelmet;
     ["uniforms"] call _fnc_setUniform;
+    if(random 10 > 8) then {
+        ["backpack2"] call _fnc_setBackpack;
+    };
 
     ["items_medical_standard"] call _fnc_addItemSet;
 
@@ -125,6 +141,9 @@ private _manTemplate = {
 private _workerTemplate = {
     ["workerHelmets"] call _fnc_setHelmet;
     ["uniforms"] call _fnc_setUniform;
+    if(random 10 > 8) then {
+        ["backpack1"] call _fnc_setBackpack;
+    };
 
     ["items_medical_standard"] call _fnc_addItemSet;
 
@@ -144,7 +163,7 @@ private _pressTemplate = {
 private _prefix = "militia";
 private _unitTypes = [
     ["Press", _pressTemplate],
-    ["Worker", _workerTemplate],
+    ["Worker", _workerTemplate, nil, 10],
     ["Man", _manTemplate, nil, 10]
 ];
 

--- a/A3A/addons/core/Templates/Templates/VN/VN_Reb_POF.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_Reb_POF.sqf
@@ -82,6 +82,7 @@ private _initialRebelEquipment = [
 "vn_izh54_shorty", "vn_izh54",
 "vn_m_mk2_knife_01", "vn_m_axe_01", "vn_b_type56", "vn_b_sks", "vn_b_m38", "vn_b_camo_m9130", "vn_b_camo_m40a1", "vn_b_camo_m14",
 "vn_m127", ["vn_m72", 5], ["vn_m72_mag", 5],
+["vn_mine_tripwire_m49_02_mag", 5], ["vn_mine_tripwire_arty_mag", 3], ["IEDLandSmall_Remote_Mag", 3],
 "vn_m10_mag", "vn_m1895_mag", "vn_welrod_mag", "vn_izh54_mag", "vn_izh54_so_mag", "vn_t67_grenade_mag", "vn_rdg2_mag", "vn_molotov_grenade_mag", "vn_m127_mag", "vn_mine_punji_03_mag",
 "vn_c_pack_01",
 "vn_o_vest_05", "vn_b_vest_usarmy_01",

--- a/A3A/addons/core/Templates/Templates/VN/VN_Reb_POF.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_Reb_POF.sqf
@@ -29,9 +29,9 @@
 
 ["vehiclesBasic", ["vn_c_bicycle_01", "vn_b_wheeled_m274_02_03"]] call _fnc_saveToTemplate;
 ["vehiclesLightUnarmed", ["vn_i_wheeled_m151_02", "vn_b_wheeled_m274_01_02"]] call _fnc_saveToTemplate;
-private _vehiclesLightArmed = ["vn_o_car_04_mg_01", "vn_b_wheeled_m274_mg_01_02"];
+private _vehiclesLightArmed = ["vn_o_wheeled_btr40_mg_01_pl", "vn_o_car_04_mg_01", "vn_b_wheeled_m274_mg_01_02", "vn_o_wheeled_z157_mg_01_pl"];
 ["vehiclesTruck", ["vn_i_wheeled_m54_01"]] call _fnc_saveToTemplate;
-["vehiclesAT", ["vn_b_wheeled_m151_mg_05", "vn_b_wheeled_m274_mg_02_02"]] call _fnc_saveToTemplate;
+["vehiclesAT", ["vn_o_wheeled_btr40_mg_05_pl", "vn_b_wheeled_m274_mg_02_02"]] call _fnc_saveToTemplate;
 ["vehiclesAA", ["a3a_vn_b_wheeled_m54_mg_02"]] call _fnc_saveToTemplate;
 
 ["vehiclesBoat", ["vn_o_boat_02_01","vn_b_boat_09_01"]] call _fnc_saveToTemplate;
@@ -53,7 +53,7 @@ if (isClass (configFile >> "vnx_credits")) then {
 ["vehiclesCivBoat", ["vn_c_boat_08_01"]] call _fnc_saveToTemplate;
 
 ["staticMGs", ["vn_i_static_m60_high","vn_i_static_m1919a4_high","vn_o_kr_static_m1910_high_01","vn_i_static_m2_high", "vn_b_army_static_m2_scoped_high"]] call _fnc_saveToTemplate;
-["staticAT", ["vn_o_vc_static_type56rr","vn_i_static_m101_01"]] call _fnc_saveToTemplate;
+["staticAT", ["vn_o_vc_static_type56rr", "vn_b_army_static_m40a1rr","vn_i_static_m101_01"]] call _fnc_saveToTemplate;
 ["staticAA", ["a3a_vn_o_nva_static_zgu1_01"]] call _fnc_saveToTemplate;
 ["staticMortars", ["a3a_vn_b_static_mortar_m2", "a3a_vn_b_static_mortar_m29"]] call _fnc_saveToTemplate;
 ["staticMortarMagHE", "vn_mortar_m2_mag_he_x8"] call _fnc_saveToTemplate;
@@ -78,15 +78,18 @@ if (isClass (configFile >> "vnx_credits")) then {
 ///////////////////////////
 
 private _initialRebelEquipment = [
-"vn_p38s", "vn_welrod",
-"vn_m38",
+"vn_m10", "vn_p38s", "vn_welrod", "vn_izh54_p", "vn_m1895", 
+"vn_izh54_shorty", "vn_izh54",
 "vn_m_mk2_knife_01", "vn_m_axe_01", "vn_b_type56", "vn_b_sks", "vn_b_m38", "vn_b_camo_m9130", "vn_b_camo_m40a1", "vn_b_camo_m14",
 "vn_m127",
-"vn_m10_mag", "vn_welrod_mag", "vn_m38_t_mag", "vn_m38_mag", "vn_t67_grenade_mag", "vn_rdg2_mag", "vn_molotov_grenade_mag", "vn_m127_mag", "vn_mine_punji_03_mag",
+"vn_m10_mag", "vn_m1895_mag", "vn_welrod_mag", "vn_izh54_mag", "vn_izh54_so_mag", "vn_t67_grenade_mag", "vn_rdg2_mag", "vn_molotov_grenade_mag", "vn_m127_mag", "vn_mine_punji_03_mag",
 "vn_c_pack_01",
 "vn_o_vest_05", "vn_b_vest_usarmy_01",
 "vn_m19_binocs_grey", "vn_mx991", "vn_mx991_red"
 ];
+if (isClass (configFile >> "vnx_credits")) then {
+    _initialRebelEquipment append ["vnx_hd_02","vnx_hd_02_mag"];
+};
 
 _initialRebelEquipment append ["Chemlight_blue","Chemlight_green","Chemlight_red","Chemlight_yellow"];
 ["initialRebelEquipment", _initialRebelEquipment] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/VN/VN_Reb_POF.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_Reb_POF.sqf
@@ -81,7 +81,7 @@ private _initialRebelEquipment = [
 "vn_m10", "vn_p38s", "vn_welrod", "vn_izh54_p", "vn_m1895", 
 "vn_izh54_shorty", "vn_izh54",
 "vn_m_mk2_knife_01", "vn_m_axe_01", "vn_b_type56", "vn_b_sks", "vn_b_m38", "vn_b_camo_m9130", "vn_b_camo_m40a1", "vn_b_camo_m14",
-"vn_m127",
+"vn_m127", ["vn_m72", 5], ["vn_m72_mag", 5],
 "vn_m10_mag", "vn_m1895_mag", "vn_welrod_mag", "vn_izh54_mag", "vn_izh54_so_mag", "vn_t67_grenade_mag", "vn_rdg2_mag", "vn_molotov_grenade_mag", "vn_m127_mag", "vn_mine_punji_03_mag",
 "vn_c_pack_01",
 "vn_o_vest_05", "vn_b_vest_usarmy_01",

--- a/A3A/addons/core/Templates/Templates/VN/VN_Reb_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_Reb_Vehicle_Attributes.sqf
@@ -10,8 +10,10 @@
 	["vn_c_wheeled_m151_02", ["rebCost", 200]],
 
     //statics
-    ["vn_b_army_static_m2_scoped_high", ["rebCost", 600]], //scoped hmg, 8x scope
-    ["vn_i_static_m101_01", ["rebCost", 1700]], //105mm Anti-tank gun, big
+    ["vn_i_static_m2_high", ["rebCost", 600]], //hmg
+    ["vn_b_army_static_m2_scoped_high", ["rebCost", 700]], //scoped hmg, 8x scope
+    ["vn_b_army_static_m40a1rr", ["rebCost", 1200], ["threat", 160]], //106mm RR
+    ["vn_i_static_m101_01", ["rebCost", 2000], ["threat", 320]], //105mm Anti-tank gun, big
     ["a3a_vn_b_static_mortar_m29", ["rebCost", 2000]], //81mm mortar
     ["vn_b_boat_09_01", ["rebCost", 700]], //assault boat with M60s
     ["a3a_vn_o_nva_static_zgu1_01", ["rebCost", 800]] // single barrel slow AA gun

--- a/A3A/addons/core/Templates/Templates/VN/VN_Vehicle_Attributes.sqf
+++ b/A3A/addons/core/Templates/Templates/VN/VN_Vehicle_Attributes.sqf
@@ -19,7 +19,8 @@
     ["vn_b_air_f100d_at", ["cost", 210]],
     ["vn_b_air_f100d_cap", ["cost", 200]],
     
-    // PT76 with slightly better armor and gunner
+    ["vn_b_armor_m41_01_02", ["cost", 150], ["threat", 200]],
+    // PT76 with slightly better armor and gunner //Is the armour actually better, is it not tinfoil?
     ["vn_o_armor_type63_01", ["cost", 180]]
 ]] call _fnc_saveToTemplate;
 


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement

### What have you changed and why?
Information:

- Updated aircraft loadouts & added guns to F-4 Phantoms.
- Pushed around vehicles for tiering purposes.
- removed unarmed trucks from APC categories in PAVN, applied more truck attribute to keep original intent.
- replaced slow boats and boats with insufficient capacity with a faster boat with better capacity.
- Touched up MACV, USMC, ANZAC loadouts to use a wider set of weapons.
- Redid PAVN militia, military, and SF loadouts to use more distinct sets of weapons. Previously there were no difference between tiers.
- Made PAVN light AT more likely to use B40, and regular AT more likely to use B41.
- Added the M20 Super bazooka to applicable factions as medium/heavy AT.
- Updated rebel POF faction starting equipment and vehicles.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
