### PR TITLE
Add uncontested-area Loot to Crate range option

### DIFF
--- a/A3A/addons/core/Params.hpp
+++ b/A3A/addons/core/Params.hpp
@@ -401,6 +401,24 @@ class Params
         texts[] = {$STR_A3A_Params_generic_disabled, $STR_A3A_Params_generic_10m, $STR_A3A_Params_generic_15m, $STR_A3A_Params_generic_20m};
         default = 10;
     };
+
+    class A3A_lootToCrateUncontestedRange
+    {
+        title = $STR_A3A_Params_lootToCrateUncontestedRange_title;
+        tooltip = $STR_A3A_Params_lootToCrateUncontestedRange_tooltip;
+        values[] = {0,60,100,150,200,300,400};
+        texts[] = {
+            $STR_A3A_Params_generic_disabled,
+            "60m",
+            "100m",
+            "150m",
+            "200m",
+            "300m",
+            "400m"
+        };
+        default = 0;
+    };
+
     class LTCLootUnlocked
     {
         title = $STR_A3A_Params_LTCLootUnlocked_title;

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -4725,6 +4725,12 @@
         <Polish>Skrzynia z łupami</Polish>
         <Czech>Bedna</Czech>
       </Key>
+      <Key ID="STR_A3A_Params_lootToCrateUncontestedRange_title">
+        <Original>Uncontested Area Loot to Crate Range</Original>
+      </Key>
+      <Key ID="STR_A3A_Params_lootToCrateUncontestedRange_tooltip">
+        <Original>Optionally extends the Loot to Crate collection range when the area around the crate is clear of living enemies. Enemies are checked within twice the selected range. Disabled preserves the normal Loot to Crate radius.</Original>
+      </Key>
     </Container>
     <Container name="A3A_fn_mission">
       <Key ID="STR_A3A_fn_mission_as_off_text">

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -4716,6 +4716,9 @@
         <Polish>Pobliski łup przeniesiony do skrzyni.</Polish>
         <Czech>Nejbližší loot přesunut do bedny.</Czech>
       </Key>
+      <Key ID="STR_A3A_fn_ltc_ltc_extendedRangeUsed">
+        <Original>Extended Loot to Crate range used.</Original>
+      </Key>
       <Key ID="STR_A3A_fn_ltc_title">
         <Original>Loot crate</Original>
         <Italian>Cassa delle spoglie</Italian>

--- a/A3A/addons/core/functions/LTC/fn_lootToCrate.sqf
+++ b/A3A/addons/core/functions/LTC/fn_lootToCrate.sqf
@@ -126,10 +126,8 @@ _lootBodies = {
 private _leftovers = [[],[],[],[]];
 
 private _lootToCrateRadius = LootToCrateRadius;
+private _lootToCrateRangeFeedback = "";
 
-// Extend loot collection only when the area around the crate is clear.
-// The check radius is twice the collection radius to avoid pulling loot
-// from areas that may still have nearby enemies.
 if (A3A_lootToCrateUncontestedRange > LootToCrateRadius) then {
     private _uncontestedRange = A3A_lootToCrateUncontestedRange;
     private _uncontestedCheckRange = _uncontestedRange * 2;
@@ -146,6 +144,7 @@ if (A3A_lootToCrateUncontestedRange > LootToCrateRadius) then {
 
     if (_nearEnemies isEqualTo []) then {
         _lootToCrateRadius = _uncontestedRange;
+        _lootToCrateRangeFeedback = localize "STR_A3A_fn_ltc_ltc_extendedRangeUsed";
     };
 };
 
@@ -215,10 +214,16 @@ if !(_leftovers isEqualTo [[],[],[],[]]) then {
     [_newContainer, _allUnlocked] remoteExec ["A3A_fnc_postmortem", 2];        // If all unlocked, priority clean up
 };
 
+private _message = localize "STR_A3A_fn_ltc_ltc_notrans";
 if (_allUnlocked) then {
-    [_titleStr, localize "STR_A3A_fn_ltc_ltc_transfered"] call A3A_fnc_customHint;
-} else {
-    [_titleStr, localize "STR_A3A_fn_ltc_ltc_notrans"] call A3A_fnc_customHint;
+    _message = localize "STR_A3A_fn_ltc_ltc_transfered";
 };
+
+if !(_lootToCrateRangeFeedback isEqualTo "") then {
+    _message = _message + " " + _lootToCrateRangeFeedback;
+};
+
+[_titleStr, _message] call A3A_fnc_customHint;
+
 
 [_container, clientOwner, true] remoteExecCall ["A3A_fnc_canLoot", 2];

--- a/A3A/addons/core/functions/LTC/fn_lootToCrate.sqf
+++ b/A3A/addons/core/functions/LTC/fn_lootToCrate.sqf
@@ -125,7 +125,31 @@ _lootBodies = {
 
 private _leftovers = [[],[],[],[]];
 
-private _units = nearestObjects [getposATL _container, ["Man"], LootToCrateRadius];
+private _lootToCrateRadius = LootToCrateRadius;
+
+// Extend loot collection only when the area around the crate is clear.
+// The check radius is twice the collection radius to avoid pulling loot
+// from areas that may still have nearby enemies.
+if (A3A_lootToCrateUncontestedRange > LootToCrateRadius) then {
+    private _uncontestedRange = A3A_lootToCrateUncontestedRange;
+    private _uncontestedCheckRange = _uncontestedRange * 2;
+
+    private _nearEnemies = (units Occupants + units Invaders) inAreaArray [
+        getPosATL _container,
+        _uncontestedCheckRange,
+        _uncontestedCheckRange
+    ];
+
+    _nearEnemies = _nearEnemies select {
+        alive _x && {_x call A3A_fnc_canFight}
+    };
+
+    if (_nearEnemies isEqualTo []) then {
+        _lootToCrateRadius = _uncontestedRange;
+    };
+};
+
+private _units = nearestObjects [getposATL _container, ["Man"], _lootToCrateRadius];
 _units = _units select {!alive _x};
 {[_x, _container, _leftovers] call _lootBodies} forEach _units;
 
@@ -134,7 +158,7 @@ _units = _units select {!alive _x};
 //pickup weapons on the ground
 //----------------------------//
 
-private _weaponHolders = nearestObjects [getposATL _container, ["WeaponHolder","WeaponHolderSimulated"], LootToCrateRadius];
+private _weaponHolders = nearestObjects [getposATL _container, ["WeaponHolder","WeaponHolderSimulated"], _lootToCrateRadius];
 
 {
     private _return = [_x, _container] call A3A_fnc_lootFromContainer;


### PR DESCRIPTION
## What type of PR is this?

Change / Enhancement

## What does this PR change and why?

Adds an optional uncontested-area range for the existing Loot to Crate functionality.

The current Loot to Crate behavior is preserved by default. When the new setting is disabled, the existing `LootToCrateRadius` is used as before.

When enabled, the existing loot collection logic can use an extended range only if there are no living fight-capable enemy units near the crate. Enemies are checked within twice the selected range, so a 400m collection range requires the surrounding 800m area to be clear.

A feedback message is shown when the extended Loot to Crate range is actually used, so players can tell when the new behavior was applied without exposing whether nearby enemies blocked it.

The intent is to reduce repetitive post-combat cleanup for solo and small-group players without changing behavior while an area is still contested.

## Testing

Local checks performed:

* `git diff --check`
* manual review of changed SQF/config/stringtable files

Functional validation:

* Confirmed working in singleplayer
* Confirmed working in hosted LAN
* Confirmed working on dedicated server
* Confirmed extended range feedback appears when the extended range is used

## Discussion

The enemy check radius is currently calculated as twice the selected uncontested loot range.

This keeps the setting simple for players and prevents unsafe combinations such as a very large collection range with a very small enemy check radius. For example, a 400m uncontested collection range requires the surrounding 800m area to be clear.

An alternative would be to expose the enemy check radius as a separate parameter. That would allow more flexibility for different server balance preferences, but would also add another mission parameter and could allow configurations that make the feature easier to exploit.

Feedback welcome on whether the fixed 2x check radius is preferred, or whether a separate configurable check range would be useful.
