### PR TITLE
Disable ACE Pylons

### DIFF
--- a/A3A/addons/core/Includes/cba_settings.sqf
+++ b/A3A/addons/core/Includes/cba_settings.sqf
@@ -33,3 +33,4 @@ force acex_headless_enabled = false;
 
 // ACE Rearm
 force ace_rearm_enabled = false;
+force ace_pylons_enabledFromAmmoTrucks = false;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?

ACE pylons were still enabled under the new ammo management system. This PR disables them. 

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
