### PR TITLE
Move static places definitions to config

### DIFF
--- a/A3A/addons/core/config.cpp
+++ b/A3A/addons/core/config.cpp
@@ -19,6 +19,7 @@ class A3A {
     #include "Templates.hpp"
     #include "Params.hpp"
     #include "clientOptions.hpp"
+    #include "staticPlaces.hpp"
 
 #if __A3_DEBUG__
     #include "CfgFunctions.hpp"

--- a/A3A/addons/core/functions/init/fn_initStaticPlaces.sqf
+++ b/A3A/addons/core/functions/init/fn_initStaticPlaces.sqf
@@ -9,15 +9,7 @@
 */
 
 /*
-// old spawning code example
-private _dir = (getDir _building) - 180;
-private _zpos = AGLToASL (_building buildingPos 1);
-private _pos = _zpos getPos [1.5, _dir];			// zeroes Z value because BIS
-_pos = ASLToATL ([_pos select 0, _pos select 1, _zpos select 2]);
-private _veh = createVehicle ["I_HMG_02_high_F", _pos, [], 0, "CAN_COLLIDE"];
-_veh setDir _dir;
-
-// new spawning code:
+// example spawning code:
 private _building = cursorObject;
 private _pos = _building modelToWorld [-2.34473,-0.65332,-0.560341];
 private _veh = createVehicle ["I_HMG_02_high_F", _pos, [], 0, "CAN_COLLIDE"];
@@ -34,121 +26,19 @@ _statics = [[typeof _building]];
 _statics;
 */
 
-// Should move all this to config? Could actually put stuff in config_fixes to take advantage of inheritance
-
-private _buildingData = [
-
-    // Short vanilla MG towers
-    [["Land_Cargo_Patrol_V1_F", "Land_Cargo_Patrol_V2_F", "Land_Cargo_Patrol_V3_F", "Land_Cargo_Patrol_V4_F"],
-        ["MG", [-2.345,-0.653,-0.560], 180]
-    ],
-
-    // Elevated MG tower (CUP & VN versions identical)
-    [["Land_Hlaska", "Land_vn_hlaska"],
-        ["MG", [0.285,0.616,3.783], 0]
-    ],
-
-    // Short vanilla HQ buildings
-    [["Land_Cargo_HQ_V1_F", "Land_Cargo_HQ_V2_F", "Land_Cargo_HQ_V3_F"],
-        ["AA", [0.004,0.004,-0.735], 0]
-    ],
-
-    // Giant vanilla towers
-    [["Land_Cargo_Tower_V1_F", "Land_Cargo_Tower_V1_No1_F", "Land_Cargo_Tower_V1_No2_F", "Land_Cargo_Tower_V1_No3_F", "Land_Cargo_Tower_V1_No4_F", "Land_Cargo_Tower_V1_No5_F", "Land_Cargo_Tower_V1_No6_F", "Land_Cargo_Tower_V1_No7_F", "Land_Cargo_Tower_V2_F", "Land_Cargo_Tower_V3_F", "Land_Cargo_Tower_V4_F"],
-        ["MG", [5.883,-0.759,4.973], -270],
-        ["MG", [-1.886,5.042,4.973], 0],
-        ["MG", [-4.435,-4.998,4.973], -180]
-    ],
-
-    // Livonia control/guard tower
-    [["Land_ControlTower_01_F"],
-        ["MG", [2.269,-1.918,1.769], 90],
-        ["MG",[-0.589,-2.299,1.769], 270],
-        ["MG",[0.627,-2.290,-1.331], 180]
-    ],
-
-    // Livonia control tower
-    [["Land_ControlTower_02_F"],
-        ["MG", [7.363,1.998,2.801], 45],
-        ["MG", [1.940,-2.295,2.799], -135]
-    ],
-
-    // Tall Livonia MG platform
-    [["Land_Sawmill_01_illuminati_tower_F"],
-        ["MG", [-0.213,-0.213,10.321], 180]
-    ],
-
-    // Livonia castle bastion
-    [["Land_CastleRuins_01_bastion_F"],
-        ["MG", [2.271,1.360,2.949], 90]
-    ],
-
-    // Ground-level vanilla sandbag bunkers. Offset for some reason?
-    [["Land_BagBunker_Small_F", "Land_BagBunker_01_small_green_F", "Land_vn_bagbunker_01_small_green_f", "Land_vn_bagbunker_small_f", "Land_vn_bunker_small_01"], 
-        ["MG", [-0.998,-0.249,-0.946], 180]
-    ],
-
-    // Large wooden VN bunker
-    [["Land_vn_o_shelter_05"],
-        ["MG", [-1.727,0.0708,-1.206], 270]
-    ],
-
-    // Ground-level CUP sandbag bunkers
-    [["Land_fortified_nest_small_EP1", "Land_fortified_nest_small", "Fort_Nest"],
-        ["MG", [-0.243,-0.100,-0.951], 180]
-    ],
-
-    // Some sort of military building with open roof. Common on Stubbhult. VN version not tested.
-    [["Land_Radar_01_HQ_F", "Land_vn_radar_01_hq_f"],
-        ["AA", [-0.016,-0.031,3.841], 0],
-        ["MG", [-9.538,3.258,3.841], -45],
-        ["MG", [4.977,-10.323,3.841], 135]
-    ],
-
-    // Camouflaged wooden tower
-    [["Land_vn_o_tower_02"],
-        ["MG", [-1.499,0.987,0.816], 270]
-    ],
-
-    [["Land_vn_hut_tower_01"],
-        ["MG", [-0.219,-0.165,3.172], 180]
-    ],
-
-    // Opening too low on one, other too open
-    //[["Land_vn_o_platform_05", "Land_vn_o_platform_06"],
-
-    // Two-level bunker
-    [["Land_vn_b_trench_bunker_04_01"],
-        ["AA", [3.965,0.490,0.721], 90]
-    ],
-
-    // Large factory buildings 
-    [["Land_vn_cementworks_01_brick_f", "Land_vn_cementworks_01_grey_f"],
-        ["AA", [0,0,5.70116], 0]
-    ],
-
-    // Building with tall center roof
-    [["Land_vn_a_office01"], 
-        ["AA", [-1.243,3.108,6.203], 0]
-    ]
-];
-
-// Compile building classes into hashmap for faster lookup
-// Would change if data is converted to config
+// Compile building classes from config to hashmap for faster lookup
 private _buildingHM = createHashMap;
 {
-    private _classes = _x#0;
-    private _statics = _x select [1, count _x];
-    {
-        if !(isClass (configFile >> "CfgVehicles" >> _x)) then { continue };
-        _buildingHM set [_x, _statics];
-    } forEach _classes;
-} forEach _buildingData;
+    private _class = configName _x;
+    if !(isClass (configFile >> "CfgVehicles" >> _class)) then { continue };        // may as well strip buildings that aren't in the modset
+    private _places = getArray (_x >> "places");
+    _buildingHM set [_class, _places];
+} forEach ("true" configClasses (configFile >> "A3A" >> "StaticPlaces"));
+
 
 params ["_markers"];
 
 private _usedBuildings = [];
-
 {
     private _radius = vectorMagnitude markerSize _x;
     private _buildings = nearestObjects [markerPos _x, keys _buildingHM, _radius, true];

--- a/A3A/addons/core/staticPlaces.hpp
+++ b/A3A/addons/core/staticPlaces.hpp
@@ -1,0 +1,153 @@
+// Static place definition (A3A >> StaticPlaces) for vanilla buildings
+
+class StaticPlaces {
+    // Short vanilla MG towers
+    class Land_Cargo_Patrol_V1_F {
+        places[] = {
+            {"MG", {-2.345,-0.653,-0.560}, 180}
+        };
+    };
+    class Land_Cargo_Patrol_V2_F : Land_Cargo_Patrol_V1_F {};
+    class Land_Cargo_Patrol_V3_F : Land_Cargo_Patrol_V1_F {};
+    class Land_Cargo_Patrol_V4_F : Land_Cargo_Patrol_V1_F {};
+
+    // Short vanilla HQ buildings
+    class Land_Cargo_HQ_V1_F {
+        places[] = {
+            {"AA", {0.004,0.004,-0.735}, 0}
+        };
+    };
+    class Land_Cargo_HQ_V2_F : Land_Cargo_HQ_V1_F {};
+    class Land_Cargo_HQ_V3_F : Land_Cargo_HQ_V1_F {};
+
+    // Giant vanilla towers
+    class Land_Cargo_Tower_V1_F {
+        places[] = {
+            {"MG", {5.883,-0.759,4.973}, -270},
+            {"MG", {-1.886,5.042,4.973}, 0},
+            {"MG", {-4.435,-4.998,4.973}, -180}
+        };
+    };
+    class Land_Cargo_Tower_V2_F : Land_Cargo_Tower_V1_F {};
+    class Land_Cargo_Tower_V3_F : Land_Cargo_Tower_V1_F {};
+    class Land_Cargo_Tower_V4_F : Land_Cargo_Tower_V1_F {};
+    class Land_Cargo_Tower_V1_No1_F : Land_Cargo_Tower_V1_F {};
+    class Land_Cargo_Tower_V1_No2_F : Land_Cargo_Tower_V1_F {};
+    class Land_Cargo_Tower_V1_No3_F : Land_Cargo_Tower_V1_F {};
+    class Land_Cargo_Tower_V1_No4_F : Land_Cargo_Tower_V1_F {};
+    class Land_Cargo_Tower_V1_No5_F : Land_Cargo_Tower_V1_F {};
+    class Land_Cargo_Tower_V1_No6_F : Land_Cargo_Tower_V1_F {};
+    class Land_Cargo_Tower_V1_No7_F : Land_Cargo_Tower_V1_F {};
+
+    // Livonia control/guard tower
+    class Land_ControlTower_01_F {
+        places[] = {
+            {"MG", {2.269,-1.918,1.769}, 90},
+            {"MG", {-0.589,-2.299,1.769}, 270},
+            {"MG", {0.627,-2.290,-1.331}, 180}
+        };
+    };
+
+    // Livonia control tower
+    class Land_ControlTower_02_F {
+        places[] = {
+            {"MG", {7.363,1.998,2.801}, 45},
+            {"MG", {1.940,-2.295,2.799}, -135}
+        };
+    };
+
+    // Tall Livonia MG platform
+    class Land_Sawmill_01_illuminati_tower_F {
+        places[] = {
+            {"MG", {-0.213,-0.213,10.321}, 180}
+        };
+    };
+
+    // Livonia castle bastion
+    class Land_CastleRuins_01_bastion_F {
+        places[] = {
+            {"MG", {2.271,1.360,2.949}, 90}
+        };
+    };
+
+    // Ground-level vanilla sandbag bunkers. Offset for some reason?
+    class Land_BagBunker_Small_F {
+        places[] = {
+            {"MG", {-0.998,-0.249,-0.946}, 180}
+        };
+    };
+    class Land_BagBunker_01_small_green_F : Land_BagBunker_Small_F {};
+    // VN versions
+    class Land_vn_bagbunker_01_small_green_f : Land_BagBunker_Small_F {};
+    class Land_vn_bagbunker_small_f : Land_BagBunker_Small_F {};
+    class Land_vn_bunker_small_01 : Land_BagBunker_Small_F {};
+
+    // Some sort of military building with open roof. Common on Stubbhult. VN version not tested.
+    class Land_Radar_01_HQ_F {
+        places[] = {
+            {"AA", {-0.016,-0.031,3.841}, 0},
+            {"MG", {-9.538,3.258,3.841}, -45},
+            {"MG", {4.977,-10.323,3.841}, 135}
+        };
+    };
+    class Land_vn_radar_01_hq_f : Land_Radar_01_HQ_F {};
+
+    // Ground-level CUP sandbag bunkers
+    class Fort_Nest {
+        places[] = {
+            {"MG", {-0.243,-0.100,-0.951}, 180}
+        };
+    };
+    class Land_fortified_nest_small_EP1 : Fort_Nest {};
+    class Land_fortified_nest_small : Fort_Nest {};
+
+    // Elevated MG tower (CUP & VN versions identical)
+    class Land_Hlaska {
+        places[] = {
+            {"MG", {0.285,0.616,3.783}, 0}
+        };
+    };
+    class Land_vn_hlaska : Land_Hlaska {};
+
+    // Large wooden VN bunker
+    class Land_vn_o_shelter_05 {
+        places[] = {
+            {"MG", {-1.727,0.0708,-1.206}, 270}
+        };
+    };
+
+    // Camouflaged wooden tower
+    class Land_vn_o_tower_02 {
+        places[] = {
+            {"MG", {-1.499,0.987,0.816}, 270}
+        };
+    };
+
+    class Land_vn_hut_tower_01 {
+        places[] = {
+            {"MG", {-0.219,-0.165,3.172}, 180}
+        };
+    };
+
+    // Two-level bunker
+    class Land_vn_b_trench_bunker_04_01 {
+        places[] = {
+            {"AA", {3.965,0.490,0.721}, 90}
+        };
+    };
+
+    // Large factory buildings 
+    class Land_vn_cementworks_01_brick_f {
+        places[] = {
+            {"AA", {0,0,5.70116}, 0}
+        };
+    };
+    class Land_vn_cementworks_01_grey_f : Land_vn_cementworks_01_brick_f {};
+
+    // Building with tall center roof
+    class Land_vn_a_office01 {
+        places[] = {
+            {"AA", {-1.243,3.108,6.203}, 0}
+        };
+    };
+};


### PR DESCRIPTION
### What type of PR is this.
1. [ ] Bug
2. [X] Change
3. [ ] Enhancement

### What have you changed and why?
Moved the building static places definitions to config so that they can be added to by extender mods.

Dumped the file into root core, which oddly enough seems consistent with other similar config. Should probably chuck various files into a "config" folder instead, but whatever.

### Please specify which Issue this PR Resolves.
closes #3687

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
