### PR TITLE
Fix bank building radius calc including the Z values

### DIFF
--- a/A3A/addons/core/functions/Missions/fn_LOG_Bank.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Bank.sqf
@@ -83,7 +83,7 @@ for "_i" from 1 to 4 do
 	};
 
 private _bb = flatten boundingBoxReal _banco apply { abs _x };
-private _bankDistMax = selectMin _bb + 10;
+private _bankDistMax = selectMin [_bb#0, _bb#1, _bb#3, _bb#4] + 10;		// smallest x/y value + 10m
 
 waitUntil {sleep 1; (dateToNumber date > _dateLimitNum) or (!alive _truckX) or (_truckX distance2d _banco < _bankDistMax)};
 _bonus = if (_difficultX) then {2} else {1};


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
The bank building radius calc included the bounding box Z values incorrectly when looking for the minimum value, causing some buildings (notably the Hanoi bank) to require the bank robbery truck to be too close. Fixed.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

