### PR TITLE
Support for the Advanced Combat Medicine mod

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_ACEpvpReDress.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_ACEpvpReDress.sqf
@@ -7,6 +7,16 @@ for "_i" from 1 to (_x select 1) do
 	};
 } forEach [["ACE_HandFlare_White",3],["ACE_Flashlight_XL50",1],["ACE_CableTie",1],["ACE_MapTools",1]];
 player addItemToUniform "ACE_EarPlugs";
+
+private _aceFakItems = [["ACE_morphine",2],["ACE_epinephrine",2],["ACE_elasticBandage",10],["ACE_PackingBandage",15],["ACE_tourniquet",3],["ACE_splint",2]];
+private _aceMedkitItems = [["ACE_morphine",5],["ACE_epinephrine",5],["ACE_adenosine",5],["ACE_bloodIV",4],["ACE_elasticBandage",20],["ACE_packingBandage",10],["ACE_tourniquet",5],["ACE_salineIV_250",2],["ACE_surgicalKit",1],["ACE_splint", 5]];
+
+if (A3A_hasACM) then
+	{
+		_aceFakItems = [["ACE_morphine",2],["ACE_epinephrine",2],["ACM_ElasticWrap",10],["ACM_PressureBandage",15],["ACE_tourniquet",3],["ACM_SAMSplint",2]];
+		_aceMedkitItems = [["ACE_morphine",5],["ACE_epinephrine",5],["ACE_adenosine",5],["ACM_BloodBag_ON_1000",4],["ACM_ElasticWrap",20],["ACM_PressureBandage",10],["ACE_tourniquet",5],["ACE_salineIV_250",2],["ACE_surgicalKit",1],["ACM_SAMSplint", 5],["ACM_IV_16g",1]];
+	};
+
 if (A3A_hasACEMedical) then
 	{
 	player removeItems "FirstAidKit";
@@ -19,7 +29,7 @@ if (A3A_hasACEMedical) then
 			{
 			player addItemToUniform _item
 			};
-		} forEach [["ACE_morphine",2],["ACE_epinephrine",2],["ACE_elasticBandage",10],["ACE_PackingBandage",15],["ACE_tourniquet",3],["ACE_splint",2]];
+		} forEach _aceFakItems;
 		}
 	else
 		{
@@ -29,6 +39,6 @@ if (A3A_hasACEMedical) then
 			{
 			player addItemToBackpack _item
 			};
-		} forEach [["ACE_morphine",5],["ACE_epinephrine",5],["ACE_adenosine",5],["ACE_bloodIV",4],["ACE_elasticBandage",20],["ACE_packingBandage",10],["ACE_tourniquet",5],["ACE_salineIV_250",2],["ACE_surgicalKit",1],["ACE_splint", 5]];
+		} forEach _aceMedkitItems;
 		};
 	};

--- a/A3A/addons/core/functions/Templates/Itemsets/fn_itemset_medicalSupplies.sqf
+++ b/A3A/addons/core/functions/Templates/Itemsets/fn_itemset_medicalSupplies.sqf
@@ -23,7 +23,27 @@ private _factionData = if (_side in [west, east, independent, civilian]) then {	
 
 if (_level == "MEDIC") exitWith {
 	switch (true) do {
-		case (A3A_hasACEMedical): {
+		case (A3A_hasACEMedical && A3A_hasACM): {
+			[
+				["ACE_surgicalKit",1],
+
+				["ACM_PressureBandage",25],
+				["ACM_ElasticWrap",10],
+
+				["ACE_morphine",5],
+				["ACE_epinephrine",5],
+				["ACE_adenosine",5],
+
+				["ACE_plasmaIV_250",5],
+				["ACE_salineIV_500",3],
+				["ACM_BloodBag_ON_1000",1],
+				["ACM_IV_16g",1],
+
+				["ACE_tourniquet",3],
+				["ACM_SAMSplint",4]
+			]
+		};
+		case (A3A_hasACEMedical && !A3A_hasACM): {
 			[
 				["ACE_surgicalKit",1],
 
@@ -56,7 +76,20 @@ if (_level == "MEDIC") exitWith {
 
 	if (_level == "STANDARD") exitWith {
 	switch (true) do {
-		case (A3A_hasACEMedical): {
+		case (A3A_hasACEMedical && A3A_hasACM): {
+			[
+				["ACE_tourniquet",1],
+				["ACE_salineIV_500",1],
+				["ACM_IV_16g",1],
+				["ACE_morphine",2],
+				["ACE_epinephrine",2],
+				["ACE_adenosine",2],
+				["ACM_PressureBandage",8],
+				["ACM_ElasticWrap",3],
+				["ACM_SAMSplint", 2]
+			]
+		};
+		case (A3A_hasACEMedical && !A3A_hasACM): {
 			[
 				["ACE_tourniquet",1],
 				["ACE_salineIV_500",1],
@@ -79,7 +112,14 @@ if (_level == "MEDIC") exitWith {
 };
 //If neither of them, return minimal medical supplies
 switch (true) do {
-	case (A3A_hasACEMedical): {
+	case (A3A_hasACEMedical && A3A_hasACM): {
+		[
+			["ACE_morphine",1],
+			["ACE_epinephrine",1],
+			["ACM_PressureBandage",3]
+		]
+	};
+	case (A3A_hasACEMedical && !A3A_hasACM): {
 		[
 			["ACE_morphine",1],
 			["ACE_epinephrine",1],

--- a/A3A/addons/core/functions/Templates/fn_aceModCompat.sqf
+++ b/A3A/addons/core/functions/Templates/fn_aceModCompat.sqf
@@ -42,10 +42,6 @@ aceItems = [
 ];
 
 aceMedItems = [
-	"ACE_fieldDressing",
-	"ACE_elasticBandage",
-	"ACE_packingBandage",
-	"ACE_quikclot",
 	"ACE_plasmaIV",
 	"ACE_plasmaIV_500",
 	"ACE_plasmaIV_250",
@@ -66,11 +62,18 @@ aceMedItems = [
 	"a3a_coffeeIV_250"
 ];
 
-aceMedItemsNonKat = [
+aceDefaultBloodItems = [
 	"ACE_bloodIV",
 	"ACE_bloodIV_250",
 	"ACE_bloodIV_500",
 	"ACE_painkillers"
+];
+
+aceDefaultBandages = [ //ACM is intended to be used with its own bandage items.
+	"ACE_fieldDressing",
+	"ACE_elasticBandage",
+	"ACE_packingBandage",
+	"ACE_quikclot"
 ];
 
 advItems = [
@@ -189,6 +192,106 @@ katMedItems = [ //Support and tested with KAM 2.13.3 Stable
 	"kat_stretcherBag"	//KAT Misc - Vehicle (Backpack)
 ];
 
+acmMedItems = [ //Support and tested with ACM 1.4.7 Stable
+	"ACM_PressureBandage", //ACM Catastrophic Bleeding - Item
+	"ACM_EmergencyTraumaDressing", //ACM Catastrophic Bleeding - Item
+	"ACM_ElasticWrap", //ACM Catastrophic Bleeding - Item
+
+	"ACM_ACCUVAC", //ACM Airway Management - Item
+	"ACM_CricKit", //ACM Airway Management - Item
+	"ACM_IGel", //ACM Airway Management - Item
+	"ACM_NPA", //ACM Airway Management - Item
+	"ACM_OPA", //ACM Airway Management - Item
+	"ACM_SuctionBag", //ACM Airway Management - Item
+
+	"ACM_BVM", //ACM Breathing - Item
+	"ACM_ChestSeal", //ACM Breathing - Item
+	"ACM_ChestTubeKit", //ACM Breathing - Item
+	"ACM_NCDKit", //ACM Breathing - Item
+	"ACM_OxygenTank_425", //ACM Breathing - Magazine
+	"ACM_OxygenTank_425_Empty", //ACM Breathing - Item
+	"ACM_PocketBVM", //ACM Breathing - Item
+	"ACM_PulseOximeter", //ACM Breathing - Item
+	"ACM_Stethoscope", //ACM Breathing - Item
+	"ACM_ThoracostomyKit", //ACM Breathing - Item
+
+	"ACM_IV_14g", //ACM Circulation - Item
+	"ACM_IV_16g", //ACM Circulation - Item
+	"ACM_AED", //ACM Circulation - Item
+	"ACM_IO_EZ", //ACM Circulation - Item
+	"ACM_IO_FAST", //ACM Circulation - Item
+	"ACM_PressureCuff", //ACM Circulation - Item
+	"ACM_Syringe_1", //ACM Circulation - Item
+	"ACM_Syringe_3", //ACM Circulation - Item
+	"ACM_Syringe_5", //ACM Circulation - Item
+	"ACM_Syringe_10", //ACM Circulation - Item
+	"ACM_Syringe_10_Epinephrine", //ACM Circulation - Magazine. This class is also used for other medications
+
+	"ACM_BloodBag_A_250", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_A_500", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_A_1000", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_AN_250", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_AN_500", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_AN_1000", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_AB_250", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_AB_500", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_AB_1000", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_ABN_250", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_ABN_500", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_ABN_1000", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_B_250", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_B_500", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_B_1000", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_BN_250", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_BN_500", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_BN_1000", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_O_250", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_O_500", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_O_1000", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_ON_250", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_ON_500", //ACM Fluid Transfusion - Item
+	"ACM_BloodBag_ON_1000", //ACM Fluid Transfusion - Item
+	
+	"ACM_FieldBloodTransfusionKit_250", //ACM Fluid Transfusion - Item
+	"ACM_FieldBloodTransfusionKit_500", //ACM Fluid Transfusion - Item
+	"ACM_FreshBloodBag_250", //ACM Fluid Transfusion - Item
+	"ACM_FreshBloodBag_500", //ACM Fluid Transfusion - Item
+
+	"ACM_Vial_Adenosine", //ACM Medication - Item
+	"ACM_Vial_Amiodarone", //ACM Medication - Item
+	"ACM_Vial_Atropine", //ACM Medication - Item
+	"ACM_Vial_CalciumChloride", //ACM Medication - Item
+	"ACM_Vial_Epinephrine", //ACM Medication - Item
+	"ACM_Vial_Etrapenem", //ACM Medication - Item
+	"ACM_Vial_Esmolol", //ACM Medication - Item
+	"ACM_Vial_Fentanyl", //ACM Medication - Item
+	"ACM_Vial_Ketamine", //ACM Medication - Item
+	"ACM_Vial_Lidocaine", //ACM Medication - Item
+	"ACM_Vial_Morphine", //ACM Medication - Item
+	"ACM_Vial_Ondansetron", //ACM Medication - Item
+	"ACM_Vial_TXA", //ACM Medication - Item
+
+	"ACM_AmmoniaInhalant", //ACM Medication - Magazine
+	"ACM_Autoinjector_ATNA", //ACM Medication - Item
+	"ACM_Lozenge_Fentanyl", //ACM Medication - Item
+	"ACM_Autoinjector_Midazolam", //ACM Medication - Item
+	"ACM_Spray_Naloxone", //ACM Medication - Item
+	"ACM_Paracetamol", //ACM Medication - Magazine
+	"ACM_Paracetamol_SinglePack", //ACM Medication - Item
+	"ACM_Paracetamol_DoublePack", //ACM Medication - Magazine
+	"ACM_Inhaler_Penthrox", //ACM Medication - Magazine
+
+	"ACM_SAMSplint", //ACM Disability
+
+	//"ACM_Grenade_CS", //ACM CBRN - Magazine
+	//"ACM_Grenade_Shell_CS", //ACM CBRN - Magazine
+	//"ACM_Mortar_Shell_8Rnd_CS", //ACM CBRN - Magazine
+	//"ACM_Mortar_Shell_8Rnd_Chlorine", //ACM CBRN - Magazine
+	//"ACM_Mortar_Shell_8Rnd_Sarin", //ACM CBRN - Magazine
+	//"ACM_Mortar_Shell_8Rnd_Lewisite", //ACM CBRN - Magazine
+	"ACM_GasMaskFilter" //ACM CBRN - Item
+];
+
 aceCoolingItems = [
 	"ACE_Canteen",
 	"ACE_Canteen_Half",
@@ -232,18 +335,25 @@ FactionGet(reb,"initialRebelEquipment") append aceItems;
 
 
 //ACE medical starting items
-if (A3A_hasACEMedical && !A3A_hasKAT) then {
+if (A3A_hasACEMedical && !A3A_hasKAT && !A3A_hasACM) then {
 	FactionGet(reb,"initialRebelEquipment") append aceMedItems;
-	FactionGet(reb,"initialRebelEquipment") append aceMedItemsNonKat;
+	FactionGet(reb,"initialRebelEquipment") append aceDefaultBloodItems;
+	FactionGet(reb,"initialRebelEquipment") append aceDefaultBandages;
 };
 
 if (A3A_hasADV) then {
 	FactionGet(reb,"initialRebelEquipment") append advItems;
 };
 
-if (A3A_hasKAT && A3A_hasACEMedical) then {
+if (A3A_hasKAT && A3A_hasACEMedical && !A3A_hasACM) then {
 	FactionGet(reb,"initialRebelEquipment") append aceMedItems;
 	FactionGet(reb,"initialRebelEquipment") append katMedItems;
+	FactionGet(reb,"initialRebelEquipment") append aceDefaultBandages;
+};
+
+if (A3A_hasACM && A3A_hasACEMedical && !A3A_hasKAT) then {
+	FactionGet(reb,"initialRebelEquipment") append aceMedItems;
+	FactionGet(reb,"initialRebelEquipment") append acmMedItems;
 };
 
 FactionGet(reb,"initialRebelEquipment") append aceCoolingItems;

--- a/A3A/addons/core/functions/init/fn_initVarCommon.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarCommon.sqf
@@ -128,6 +128,10 @@ if (A3A_hasACEMedical && isClass (configFile >> "CfgPatches" >> "adv_aceCPR")) t
 A3A_hasKAT = false;
 if(A3A_hasACEMedical && isClass (configFile >> "CfgWeapons" >> "kat_scalpel")) then {A3A_hasKAT = true; Info("KAT MED Detected.") };
 
+//ACM medical detection. KAT and ACM are incompatible systems so A3A_hasKAT is set to false here, albiet ACM itself already throws an error if it detects that KAT is loaded.
+A3A_hasACM = false;
+if(A3A_hasACEMedical && isClass (configFile >> "CfgWeapons" >> "ACM_OPA")) then {A3A_hasACM = true; A3A_hasKAT = false; Info("ACM Detected.") };
+
 A3A_hasIFA = false;			// this one is everywhere, just mark it false and remove later
 
 // Zeus enhanced

--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal.sqf
@@ -2654,13 +2654,19 @@ switch _mode do {
 		// unifrom
 		_itemsUnifrom = [];
 		if(A3A_hasACEMedical)then{
-			_itemsUnifrom pushBack ["ACE_elasticBandage",2];
-			_itemsUnifrom pushBack ["ACE_packingBandage",2];
+			if(A3A_hasACM)then{
+				_itemsUnifrom pushBack ["ACM_ElasticWrap",2];
+				_itemsUnifrom pushBack ["ACM_PressureBandage",2];
+				_itemsUnifrom pushBack ["ACM_SAMSplint", 1];
+			}else{
+				_itemsUnifrom pushBack ["ACE_elasticBandage",2];
+				_itemsUnifrom pushBack ["ACE_packingBandage",2];
+				_itemsUnifrom pushBack ["ACE_splint", 1];
+			};
 			_itemsUnifrom pushBack ["ACE_morphine",1];
 			_itemsUnifrom pushBack ["ACE_epinephrine",1];
 			_itemsUnifrom pushBack ["ACE_adenosine", 1];
 			_itemsUnifrom pushBack ["ACE_tourniquet",1];
-			_itemsUnifrom pushBack ["ACE_splint", 1];
 		}else{
 			_itemsUnifrom pushBack ["FirstAidKit",2];
 			if(A3A_hasACE) then {
@@ -2703,8 +2709,13 @@ switch _mode do {
 		if([player] call A3A_fnc_isMedic)then{
 
 			if(A3A_hasACEMedical) then { //Medic equipment
-				_itemsBackpack pushBack ["ACE_elasticBandage",15];
-				_itemsBackpack pushBack ["ACE_packingBandage",15];
+				if(A3A_hasACM)then{
+					_itemsBackpack pushBack ["ACM_ElasticWrap",15];
+					_itemsBackpack pushBack ["ACM_PressureBandage",15];
+				}else{
+					_itemsBackpack pushBack ["ACE_elasticBandage",15];
+					_itemsBackpack pushBack ["ACE_packingBandage",15];
+				};
 				_itemsBackpack pushBack ["ACE_tourniquet",5];
 				_itemsBackpack pushBack ["ACE_personalAidKit",1];
 				_itemsBackpack pushBack ["ACE_adenosine", 10];
@@ -2716,14 +2727,20 @@ switch _mode do {
 			};
 		} else {
 		 		if(A3A_hasACEMedical) then {
-					_itemsBackpack pushBack ["ACE_fieldDressing",5];
-					_itemsBackpack pushBack ["ACE_packingBandage",5];
-					_itemsBackpack pushBack ["ACE_elasticBandage",5];
+					if(A3A_hasACM)then{
+						_itemsBackpack pushBack ["ACM_PressureBandage",10];
+						_itemsBackpack pushBack ["ACM_ElasticWrap",5];
+						_itemsBackpack pushBack ["ACM_SAMSplint", 2];
+					}else{
+						_itemsBackpack pushBack ["ACE_fieldDressing",5];
+						_itemsBackpack pushBack ["ACE_packingBandage",5];
+						_itemsBackpack pushBack ["ACE_elasticBandage",5];
+						_itemsBackpack pushBack ["ACE_splint", 2];
+					};
 					_itemsBackpack pushBack ["ACE_morphine",3];
 					_itemsBackpack pushBack ["ACE_epinephrine",2];
 					_itemsBackpack pushBack ["ACE_adenosine", 2];
 					_itemsBackpack pushBack ["ACE_tourniquet",2];
-					_itemsBackpack pushBack ["ACE_splint", 2];
 			} else { //Vanilla FAK for soldiers
 				_itemsBackpack pushBack ["FirstAidKit",5];
 			};


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
[Advanced Combat Medicine](https://steamcommunity.com/sharedfiles/filedetails/?id=3235483358) is a mod that extends the ACE medical system, in a somewhat similar manner to KAT.

Like KAT, the most important change for compatibility was modifying ``fn_arsenal.sqf`` and ``fn_initVarCommon.sqf`` so that ACM medical items are unlocked in the arsenal, and hiding the default ACE blood bags + painkiller as is done when KAT is loaded. ACM also comes with new bandage items that are intended to be used instead of the default ACE bandages (see note 1.), so I decided to also hide ACE bandages from the arsenal when ACM is loaded.

The only other change made is modifications to ``fn_ACEpvpReDress.sqf``, ``fn_itemset_medicalSupplies.sqf``, and ``fn_aceModCompat.sqf`` for AI units to have the correct medical items for ACM. In particular:
- ``ACM_ElasticWrap`` replaces ``ACE_elasticBandage``, and ``ACM_PressureBandage`` replaces the rest of the ACE bandages (basic bandage, packing bandage, and quikclot).
- ACM comes with its own splint that replaces the ACE splint, and ACM O- blood replaces ACE's generic blood (albiet when you equip an ACE splint/blood item in your inventory, ACM will auto-convert it anyways).
- ACM requires an IV/IO to be inserted before using blood or saline, so ``ACM_IV_16g`` has been added to any medical loadouts that contain blood or saline.

If these first-aid loadout changes are a bit too much however, a simpler alternative patch for compatibility would be to just unlock ACM items in the arsenal (i.e. keeping the changes made to ``fn_arsenal.sqf`` and ``fn_initVarCommon.sqf``, maybe without hiding ACE bandages so that looting doesn't become messy).

### Please specify which Issue this PR Resolves.
No existing issue references this.

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Install and load both ACE and Advanced Combat Medicine. If you go to the arsenal, you should see that ACM items are unlocked and that the default ACE blood & bandages are hidden. If you purchase a militiaman and a medic and view their inventory, they should have ACM items as I described earlier. If you manage to kill an enemy rifleman and combat-life-saver, they should also have the appropriate medical items. For my personal testing, I also verified that non-ACE, ACE, and ACE + KAT still gave the correct items.

Other than the above, you could also just test general gameplay and combat. I ran multiple trials using ACM where I bought some friendly AI and attacked a roadblock, and I did not run into any bugs even after healing units (naturally via the medical system to be clear, not with commands or anything).

********************************************************
Notes:
1. I figure that compatibility for ACM is as simple as just providing the correct items as is done for KAT, but if you'd like to investigate ACM itself further for potential issues, you can view the [ACM Github](https://github.com/BlueTheKing/ACM) here. The [ACM Wiki](https://bluetheking.github.io/ACM-wiki/en/Overview) and [ACM Guide](https://docs.google.com/presentation/d/1p95ChrNZ5Y-aYGjn7Z5Un5yFIMnrpVQp78qHV8Y4LFg/edit?slide=id.g328c08db6ea_1_225#slide=id.g328c08db6ea_1_225) may also be helpful resources. Note that Slide 6 in the ACM Guide (from their official Discord) strongly discourages using ACE bandages with ACM.

2. If it wasn't already clear, KAT and ACM are incompatible with each other. ACM already throws an error if you attempt to start a mission with both ACM and KAT enabled so I don't think Antistasi itself needs to add its own warning for this, but let me know if I need to make further changes to address this.
<img width="733" height="259" alt="Screenshot 2026-06-10 223636" src="https://github.com/user-attachments/assets/97c959c3-35c9-4188-9662-f9fbe4b9859d" />

3. This is outside of the scope of PR, but something relevant for both KAT and ACM is that they add a chance for lung injuries if you get hit in the torso. One important item they add to treat this that is generally expected to be present in your FAK are chest seals. I think it'd be convenient if AI units were modified to carry a chest seal item as part of their medical supplies if KAT is loaded (and ACM, if this compatibility PR ends up accepted) so that players who use AI in their squads can heal them easier. If it's desired, I can make a separate PR for this.
