### PR TITLE
Issue 3353 - Improved arsenal's default sort behaviour

### DIFF
--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal.sqf
@@ -138,6 +138,53 @@ private _minItemsMember = {
 	_min;
 };
 
+private _antistasiBerets = ["a3a_g_beret_01", "a3a_g_beret_02", "a3a_g_beret_03", "a3a_g_beret_04"];
+private _alphabeticalSort = {
+	params ["_ctrlList", "_prefixBerets"];
+
+	private _itemCount = lbSize _ctrlList;
+	private _type = (ctrltype _ctrlList == 102);
+
+	private _displayNameArray = [];
+	private _dataArray = [];
+
+	//Iterate in reverse order to avoid a lot of array resizes in _dataArray;
+	for "_i" from (_itemCount - 1) to 0 step -1 do {
+		private _dataStr = if _type then {_ctrlList lnbdata [_i,0]} else {_ctrlList lbdata _i};
+
+		if (_dataStr != "") then {
+			private _data = call compile _dataStr;
+			private _displayName = _data select 2;
+
+			_displayNameArray pushBack _displayName;
+			_dataArray set [_i, _data];
+		};
+	};
+
+	_displayNameArray sort true;
+
+	for "_i" from 0 to (_itemCount - 1) do {
+		private _data = _dataArray select _i;
+		if (!isNil "_data") then {
+			private _item = _data select 0;
+
+			if (_item == "") then {
+				_ctrlList lbSetValue [_i, -100];
+			} else {
+				private _beretIndex = _antistasiBerets find _item;
+				if (_prefixBerets && _beretIndex != -1) then {
+					_ctrlList lbSetValue [_i, -99 + _beretIndex];
+				} else {
+					private _displayName = _data select 2;
+					_ctrlList lbSetValue [_i, _displayNameArray find _displayName];
+				};
+			};
+		};
+	};
+
+	lbSortByValue _ctrlList;
+};
+
 _mode = [_this,0,"Open",[displaynull,""]] call bis_fnc_param;
 _this = [_this,1,[]] call bis_fnc_param;
 //if!(_mode in ["draw3D","ListCurSel"])then{diag_log ("jna call "+_mode);};
@@ -476,35 +523,7 @@ switch _mode do {
 
     switch (_sortType) do {
       case SORT_ALPHABETICAL: {
-        private _displayNameArray = [];
-        private _dataArray = [];
-
-        //Iterate in reverse order to avoid a lot of array resizes in _dataArray;
-        for "_i" from (_itemCount - 1) to 0 step -1 do {
-          private _dataStr = if _type then{_ctrlList lnbdata [_i,0]}else{_ctrlList lbdata _i};
-
-          if (_dataStr != "") then {
-            private _data = call compile _dataStr;
-            private _item = _data select 0;
-            private _amount = _data select 1;
-            private _displayName = _data select 2;
-
-            _displayNameArray pushBack _displayName;
-            _dataArray set [_i, _data];
-          };
-        };
-
-        _displayNameArray sort true;
-
-        for "_i" from 0 to (_itemCount - 1) do {
-          private _data = _dataArray select _i;
-          if (!isNil "_data") then {
-            private _displayName = _data select 2;
-            _ctrlList lbSetValue [_i, _displayNameArray find _displayName];
-          };
-        };
-
-        lbSortByValue _ctrlList;
+        [_ctrlList, false] call _alphabeticalSort;
       };
       case SORT_AMOUNT: {
         for "_i" from 0 to (_itemCount - 1) do {
@@ -528,7 +547,7 @@ switch _mode do {
         };
       };
       case SORT_DEFAULT: {
-        lbSort _ctrlList;
+		[_ctrlList, true] call _alphabeticalSort;
       };
   };
 
@@ -645,6 +664,8 @@ switch _mode do {
 
 			if (_active) then {
 				_ctrlList = _display displayctrl (IDC_RSCDISPLAYARSENAL_LIST + _idc);
+				[_ctrlList, true] call _alphabeticalSort;
+
 				_ctrlLineTabLeft = _display displayctrl IDC_RSCDISPLAYARSENAL_LINETABLEFT;
 				_ctrlLineTabLeft ctrlsetfade 0;
 				_ctrlTabPos = ctrlposition _ctrlTab;

--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal.sqf
@@ -139,29 +139,29 @@ private _minItemsMember = {
 };
 
 private _antistasiBerets = ["a3a_g_beret_01", "a3a_g_beret_02", "a3a_g_beret_03", "a3a_g_beret_04"];
-private _alphabeticalSort = {
-	params ["_ctrlList", "_prefixBerets"];
+private _defaultSort = {
+	params ["_ctrlList"];
 
 	private _itemCount = lbSize _ctrlList;
 	private _type = (ctrltype _ctrlList == 102);
 
-	private _displayNameArray = [];
-	private _dataArray = [];
+	private _lbTextArray = [];
+    private _dataArray = [];
 
 	//Iterate in reverse order to avoid a lot of array resizes in _dataArray;
 	for "_i" from (_itemCount - 1) to 0 step -1 do {
-		private _dataStr = if _type then {_ctrlList lnbdata [_i,0]} else {_ctrlList lbdata _i};
+		private _dataStr = if _type then{_ctrlList lnbdata [_i,0]}else{_ctrlList lbdata _i};
 
 		if (_dataStr != "") then {
 			private _data = call compile _dataStr;
-			private _displayName = _data select 2;
+			private _lbText = if _type then{_ctrlList lnbText [_i,0]}else{_ctrlList lbText _i};
 
-			_displayNameArray pushBack _displayName;
+			_lbTextArray pushBack _lbText;
 			_dataArray set [_i, _data];
 		};
 	};
 
-	_displayNameArray sort true;
+	_lbTextArray sort true;
 
 	for "_i" from 0 to (_itemCount - 1) do {
 		private _data = _dataArray select _i;
@@ -172,11 +172,11 @@ private _alphabeticalSort = {
 				_ctrlList lbSetValue [_i, -100];
 			} else {
 				private _beretIndex = _antistasiBerets find _item;
-				if (_prefixBerets && _beretIndex != -1) then {
+				if (_beretIndex != -1) then {
 					_ctrlList lbSetValue [_i, -99 + _beretIndex];
 				} else {
-					private _displayName = _data select 2;
-					_ctrlList lbSetValue [_i, _displayNameArray find _displayName];
+					private _lbText = if _type then{_ctrlList lnbText [_i,0]}else{_ctrlList lbText _i};
+					_ctrlList lbSetValue [_i, _lbTextArray find _lbText];
 				};
 			};
 		};
@@ -523,7 +523,35 @@ switch _mode do {
 
     switch (_sortType) do {
       case SORT_ALPHABETICAL: {
-        [_ctrlList, false] call _alphabeticalSort;
+        private _displayNameArray = [];
+        private _dataArray = [];
+
+        //Iterate in reverse order to avoid a lot of array resizes in _dataArray;
+        for "_i" from (_itemCount - 1) to 0 step -1 do {
+          private _dataStr = if _type then{_ctrlList lnbdata [_i,0]}else{_ctrlList lbdata _i};
+
+          if (_dataStr != "") then {
+            private _data = call compile _dataStr;
+            private _item = _data select 0;
+            private _amount = _data select 1;
+            private _displayName = _data select 2;
+
+            _displayNameArray pushBack _displayName;
+            _dataArray set [_i, _data];
+          };
+        };
+
+        _displayNameArray sort true;
+
+        for "_i" from 0 to (_itemCount - 1) do {
+          private _data = _dataArray select _i;
+          if (!isNil "_data") then {
+            private _displayName = _data select 2;
+            _ctrlList lbSetValue [_i, _displayNameArray find _displayName];
+          };
+        };
+
+        lbSortByValue _ctrlList;
       };
       case SORT_AMOUNT: {
         for "_i" from 0 to (_itemCount - 1) do {
@@ -542,12 +570,12 @@ switch _mode do {
 
             _ctrlList lbSetValue [_i, _amount];
           };
-
-          lbSortByValue _ctrlList;
         };
+
+		lbSortByValue _ctrlList;
       };
       case SORT_DEFAULT: {
-		[_ctrlList, true] call _alphabeticalSort;
+		_ctrlList call _defaultSort;
       };
   };
 
@@ -664,7 +692,7 @@ switch _mode do {
 
 			if (_active) then {
 				_ctrlList = _display displayctrl (IDC_RSCDISPLAYARSENAL_LIST + _idc);
-				[_ctrlList, true] call _alphabeticalSort;
+				_ctrlList call _defaultSort;
 
 				_ctrlLineTabLeft = _display displayctrl IDC_RSCDISPLAYARSENAL_LINETABLEFT;
 				_ctrlLineTabLeft ctrlsetfade 0;


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [X] Enhancement

### What have you changed and why?
**1. Default sort**
Currently when opening the arsenal, pre-unlocked rebel items may appear in an unsorted manner by default (e.g. as noted in issue #3353, headgear appears loaded initially in a random order), although looted items will appear in the order they were obtained. However if you select some different sorting options and then click again on the "default" sort option, the ``lbSort`` call will sort items by the text of the ``_ctrlList`` items. This sorting works fine actually, since it effectively sorts items first by amount and then alphabetically, though it is also inconsistent behaviour to what you see when you initially open the arsenal.

This PR makes the default sort acts as a slightly modified lbSort. As specified in #3353, the Antistasi berets will appear first in the list if you are viewing the headgear section with the "default" sort, while everything else will sort itself by its text (i.e. by amount) as occurs with regular lbSort. The modified lbSort will also be called when initially loading the arsenal as well for consistency.

A small caveat to this solution is that when opening the arsenal, items won't appear in the order they were obtained/looted, but I think sorting by amount + name is still a good default sorting behaviour. If the original behaviour is  important to maintain though, I'll make further changes.

**2. Fixed sort by amount**
In the case for sorting items by amount, ``lbSortByValue _ctrlList;`` was called inside the for loop, which occasionally caused items to be listed in the wrong order. I moved it outside the for loop, and everything seems fixed now.

### Please specify which Issue this PR Resolves.
closes #3353

### Please verify the following and ensure all checks are completed.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: Open the arsenal and verify the items are sorted properly. Check the headgear in the "default" sort, and the Antistasi berets should be the first items in that list.

********************************************************
Notes:
N/A.