### PR TITLE
Fix logging & marker overlap errors

### DIFF
--- a/A3A/addons/core/functions/AI/fn_artySupportFire.sqf
+++ b/A3A/addons/core/functions/AI/fn_artySupportFire.sqf
@@ -58,7 +58,7 @@ private _ang = if (_strikeType == "barrage") then {_startPos getDir _detail} els
 			waitUntil { sleep 0.1; !(_piece isNil "A3A_artyFired") or time > _timeout };
 			if (_piece isNil "A3A_artyFired") exitWith {
 				private _weaponState = weaponState [_piece, [0]];
-				Error_2("Arty failed to fire round #%1; order %2; state %3", _r, _this, _weaponState);
+				Error_3("Arty failed to fire round #%1; order %2; state %3", _r, _this, _weaponState);
 			};
 			waitUntil {
 				sleep 0.1;

--- a/A3A/addons/core/functions/Base/fn_chooseAttack.sqf
+++ b/A3A/addons/core/functions/Base/fn_chooseAttack.sqf
@@ -109,7 +109,7 @@ if (_isCity and sidesX getVariable _targetMrk == teamPlayer) exitWith {
 };
 
 if (_targetMrk == "Synd_HQ") exitWith {
-    Info_2("Starting HQ attack from %1", _originMrk);
+    Info_1("Starting HQ attack from %1", _originMrk);
     [-400, _side, "attack"] call A3A_fnc_addEnemyResources;
     bigAttackInProgress = true; publicVariable "bigAttackInProgress";
     [_side, _originMrk] spawn A3A_fnc_attackHQ;

--- a/A3A/addons/core/functions/Base/fn_garbageCleanerTracker.sqf
+++ b/A3A/addons/core/functions/Base/fn_garbageCleanerTracker.sqf
@@ -94,7 +94,7 @@ private _fnc_onAutoGC = {
 
     private _timeSinceLastGC = [[serverTime-A3A_lastGarbageCleanTime] call A3A_fnc_secondsToTimeSpan,0,0,false,2] call A3A_fnc_timeSpan_format;
 
-    Debug_2("Garbage Cleaner Tracker has ran a gc as players reached threshold, time since last gc: %1", _timeSinceLastGC);
+    Debug_1("Garbage Cleaner Tracker has ran a gc as players reached threshold, time since last gc: %1", _timeSinceLastGC);
 };
 
 // Noop function just to be safe and to not break the Context Queue format.

--- a/A3A/addons/core/functions/EventHandler/fn_enemyUnitDeletedEH.sqf
+++ b/A3A/addons/core/functions/EventHandler/fn_enemyUnitDeletedEH.sqf
@@ -26,7 +26,7 @@ if (!alive _unit) exitWith {};
 private _pool = _unit getVariable ["A3A_resPool", "legacy"];
 private _side = _unit getVariable ["originalSide", sideUnknown];
 if (_side != Occupants and _side != Invaders) then {
-    Error_2("Wrong unit had delete handler, side %1, type %2, pool %3", _side, _unit getVariable "UnitType", _pool);
+    Error_3("Wrong unit had delete handler: side %1 type %2 pool %3", _side, _unit getVariable "UnitType", _pool);
 };
 
 //Debug_3("Enemy delete handler called with side %1, type %2, pool %3", _side, _unit getVariable "UnitType", _pool)

--- a/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_spawnCiv.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_spawnCiv.sqf
@@ -44,7 +44,7 @@ private _vehicles = [];
         continue;
     };
     if (_policeCarPos isEqualType [] and {_policeCarPos distance2d _pos < 10}) then {
-        Debug_1("Spawn of %1 in %2 blocked by police", _class, _spawnKey);
+        Debug_2("Spawn of %1 in %2 blocked by police", _class, _spawnKey);
         continue;
     };
 

--- a/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_vehActionEnd.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_garrisonLocal_vehActionEnd.sqf
@@ -25,7 +25,7 @@ private _vehActions = _garrison get "vehActions";
 private _index = _vehActions findIf { _x#0 == _vehID };
 if (_index == -1) then {
     // Normal error because support might be terminated locally and then externally
-    Trace_1("Vehicle ID %1 not found in active supports");
+    Trace_1("Vehicle ID %1 not found in active supports", _vehID);
 };
 _vehActions deleteAt _index params ["", "_vehicle", "_crewGroup", "_scriptHandle"];
 

--- a/A3A/addons/core/functions/GarrisonLocal/fn_garrisonOpLoop.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_garrisonOpLoop.sqf
@@ -26,7 +26,7 @@ while {true} do
     _nextOp params ["_opType", "_params"];
 
     if (_opType in _updateOps and {_nextOp in A3A_garrisonOps}) then {
-        Debug_1("Skipping %1 (%2) due to duplicates", _opType, _params);
+        Debug_2("Skipping %1 (%2) due to duplicates", _opType, _params);
         continue;
     };
 

--- a/A3A/addons/core/functions/GarrisonLocal/fn_spawnGarrisonPatrols.sqf
+++ b/A3A/addons/core/functions/GarrisonLocal/fn_spawnGarrisonPatrols.sqf
@@ -29,7 +29,7 @@ private _troops = _activeGarrison get "troops";
 // No patrols if there are enemy markers nearby (TODO: should be size-dependent?)
 private _indexes = markersX inAreaArrayIndexes [markerPos _marker, 300, 300] select { sidesX getVariable markersX#_x != _side };
 if (_type != "city" and _indexes isNotEqualTo []) exitWith {
-    Debug_2("Not spawning patrols for %1 due to enemy sites nearby");
+    Debug_1("Not spawning patrols for %1 due to enemy sites nearby", _marker);
 };
 
 private _numPatrols = call {

--- a/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_cleanup.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_cleanup.sqf
@@ -35,7 +35,7 @@ if ("_civ" in _marker) exitWith
 
         // Shouldn't trigger now that save is checked
         if (_slotNum isEqualType 0 and { _slotNum >= count _places }) then {
-            Error_1("Slot number above slot count for %1 in %2", _x, _marker);
+            Error_2("Slot number above slot count for %1 in %2", _x, _marker);
             _vehicles deleteAt _forEachIndex;
             continue;
         };

--- a/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_despawn.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_despawn.sqf
@@ -52,6 +52,6 @@ private _supportsBusy = false;
 
 // If all the support vehicles are inactive then we can clear the machine ID
 if (!_supportsBusy) then {
-    Trace_1("Clearing machine ID for %1");
+    Trace_1("Clearing machine ID for %1", _marker);
     A3A_garrisonMachine deleteAt _marker;       // clear machine ID
 };

--- a/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_vehActionSetState.sqf
+++ b/A3A/addons/core/functions/GarrisonServer/fn_garrisonServer_vehActionSetState.sqf
@@ -31,6 +31,6 @@ if !(_vehID in _supportVehicles) then {
 // If all support vehicles are ready, and garrison isn't spawned, then we can drop the machine ID
 if (spawner getVariable _marker != 2) exitWith {};
 if (values _supportVehicles findIf { _x#0 != "ready" } == -1) then {
-    Trace_1("Clearing machine ID for %1");
+    Trace_1("Clearing machine ID for %1", _marker);
     A3A_garrisonMachine deleteAt _marker;       // clear machine ID
 };

--- a/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
+++ b/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
@@ -7,7 +7,7 @@ private _costs = 0;
 
 if (isNil "_typeX") then
 {
-	Error_1("Vehicle does not exist.");
+	Error("Vehicle does not exist.");
 	_costs = 0;
 }
 else

--- a/A3A/addons/core/functions/Supports/fn_addSupportTarget.sqf
+++ b/A3A/addons/core/functions/Supports/fn_addSupportTarget.sqf
@@ -26,7 +26,7 @@ if (_activeSupport isEqualType "") exitWith { Error_1("Support name %1 not in ac
 
 _activeSupport params ["_suppName", "_suppSide", "_suppType", "_center", "_radius", "_suppTarget"];
 // Shouldn't really need these checks but whatever
-if (_radius == 0 or _suppTarget isNotEqualTo []) exitWith { Error_2("No remaining targets for support %1", _suppName) };
+if (_radius == 0 or _suppTarget isNotEqualTo []) exitWith { Error_1("No remaining targets for support %1", _suppName) };
 
 _suppTarget append [_target, _targPos];              // target list may need both
 Info_3("Added target %1 (position %2) to support %3", _target, _targPos, _suppName);

--- a/A3A/addons/core/functions/init/fn_initZones.sqf
+++ b/A3A/addons/core/functions/init/fn_initZones.sqf
@@ -248,17 +248,20 @@ private _fuelStationTypes = getArray (_mapInfo/"fuelStationTypes");
 if( _fuelStationTypes isEqualTo [] ) then {_fuelStationTypes = ["Land_FuelStation_Feed_F","Land_fs_feed_F","Land_FuelStation_01_pump_malevil_F","Land_FuelStation_01_pump_F","Land_FuelStation_02_pump_F","Land_FuelStation_03_pump_F","Land_A_FuelStation_Feed","Land_Ind_FuelStation_Feed_EP1","Land_FuelStation_Feed_PMC","Land_Fuelstation","Land_Fuelstation_army","Land_Benzina_schnell","Land_vn_b_prop_fueldrum_01","Land_vn_usaf_fueltank_75_01","Land_vn_fuelstation_feed_f","Land_vn_fuelstation_01_pump_f","Land_vn_fuelstation_02_pump_f"]};
 A3A_fuelStationTypes = _fuelStationTypes;
 A3A_fuelStations = nearestObjects [[worldSize/2, worldSize/2], _fuelStationTypes, worldSize];
-A3A_fuelStations apply {
-	_mrkFinalFuel = createMarkerLocal [format ["Fuel%1", mapGridPosition _x], position _x];
+{
+	if(A3A_hasACE) then {
+		[_x, 250] call ace_refuel_fnc_setFuel; // only call on fuels that are not blacklisted and first zone init.
+	};
+
+	private _mrkFinalFuel = format ["Fuel%1", mapGridPosition _x];
+	if (markerShape _mrkFinalFuel != "") then {continue};				// Might have multiple pumps on same map grid 
+	createMarkerLocal [_mrkFinalFuel, getPosATL _x];
 	_mrkFinalFuel setMarkerShapeLocal "ICON";
 	_mrkFinalFuel setMarkerTypeLocal "loc_Fuelstation";
 	_mrkFinalFuel setMarkerColorLocal "ColorWhite";
 	_mrkFinalFuel setMarkerTextLocal "Fuel station";
 	_mrkFinalFuel setMarkerAlpha 0.75;
-	if(A3A_hasACE) then {
-		[_x, 250] call ace_refuel_fnc_setFuel; // only call on fuels that are not blacklisted and first zone init.
-	};
-};
+} forEach A3A_fuelStations;
 
 // Generate rebel resource multipliers based on the map
 private _reqGarrison = 0;

--- a/A3A/addons/garage/Core/fn_sellVehGRG.sqf
+++ b/A3A/addons/garage/Core/fn_sellVehGRG.sqf
@@ -29,7 +29,7 @@ if (!isServer) exitWith {Error("Not server executed")};
 if !(_player call HR_GRG_canSell) exitWith {["STR_HR_GRG_Feedback_sellVehicle_comOnly"] remoteExecCall ["HR_GRG_fnc_hint", _player];};
 _selectedVehicle params [["_catIndex", -1], ["_vehUID", -1], ["_class", ""]];
 if ( (_catIndex isEqualTo -1) || (_vehUID isEqualTo -1) ) exitWith {};
-Trace_2("Attempting to sell vehicle at cat: %1 | Vehicle ID: %2 | Classname: %3", _catIndex, _vehUID, _class);
+Trace_3("Attempting to sell vehicle at cat: %1 | Vehicle ID: %2 | Classname: %3", _catIndex, _vehUID, _class);
 
 private _refund = [_class] call HR_GRG_getVehicleSellPrice;
 if (_refund == 0) exitWith {["STR_HR_GRG_Feedback_sellVehicle_noPrice"] remoteExecCall ["HR_GRG_fnc_hint", _player];};

--- a/A3A/addons/gui/functions/GUI/fn_buyVehicleDialog.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_buyVehicleDialog.sqf
@@ -54,7 +54,7 @@ switch (_mode) do
         };
 
         if (_selectedTabIDC == -1) exitWith {
-            Error("Attempted to access tab without permission : %1", _selectedTab);
+            Error_1("Attempted to access tab without permission : %1", _selectedTab);
         };
 
         private _allTabs = [

--- a/A3A/addons/gui/functions/GUI/fn_hqDialog.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_hqDialog.sqf
@@ -140,7 +140,7 @@ switch (_mode) do
 
         // Log attempt at accessing tab without permission
         if (_selectedTabIDC == -1) exitWith {
-            Error("Attempted to access non-existant tab: %1", _selectedTab);
+            Error_1("Attempted to access non-existant tab: %1", _selectedTab);
         };
 
         // Array of IDCs for all the tabs, including subtabs (like AI & player management)

--- a/A3A/addons/gui/functions/GUI/fn_mainDialog.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_mainDialog.sqf
@@ -242,7 +242,7 @@ switch (_mode) do
 
         // Log attempt at accessing tab without permission
         if (_selectedTabIDC == -1) exitWith {
-            Error("Attempted to access tab without permission : %1", _selectedTab);
+            Error_1("Attempted to access tab without permission : %1", _selectedTab);
         };
 
         // Array of IDCs for all the tabs, including subtabs (like AI & player management)

--- a/A3A/addons/gui/functions/GUI/fn_requestMissionDialog.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_requestMissionDialog.sqf
@@ -42,7 +42,7 @@ switch (_mode) do
         };
 
         // Check param count
-        if (count _params != 1) exitWith {Error("Invalid parameter count for missionButtonClicked. Got %1, expected 1", count _params)};
+        if (count _params != 1) exitWith {Error_1("Invalid parameter count for missionButtonClicked. Got %1; expected 1", count _params)};
         private _missionType = _params select 0;
 
         // Check if mission type exists

--- a/A3A/addons/gui/functions/SetupGUI/fn_setupParamsTab.sqf
+++ b/A3A/addons/gui/functions/SetupGUI/fn_setupParamsTab.sqf
@@ -10,7 +10,7 @@ FIX_LINE_NUMBERS()
 
 params["_mode", "_params"];
 
-Debug("Params dialog called with mode %1", _mode);
+Debug_1("Params dialog called with mode %1", _mode);
 
 // Get display
 private _display = findDisplay A3A_IDD_SETUPDIALOG;

--- a/A3A/addons/gui/functions/gunShop/fn_createGunShopTab.sqf
+++ b/A3A/addons/gui/functions/gunShop/fn_createGunShopTab.sqf
@@ -101,10 +101,10 @@ switch(_selectedTab) do
 
 
 if (_selectedTabIDC == -1) ExitWith {
-    Error("Tried to access a tab, might not exist: %1",_selectedTab);
+    Error_1("Tried to access a tab that might not exist: %1",_selectedTab);
 };
 if (_selectedTabCtrl == -1) ExitWith {
-    Error("Tried to assign a ctrl group, might not exist: %1",_selectedTab);
+    Error_1("Tried to assign a ctrl group that might not exist: %1",_selectedTab);
 };
 
 private _controlsGroup = _display displayCtrl _selectedTabCtrl;

--- a/A3A/addons/gui/functions/gunShop/fn_gunShop.sqf
+++ b/A3A/addons/gui/functions/gunShop/fn_gunShop.sqf
@@ -70,7 +70,7 @@ switch (_mode) do
         };
 
         if (_selectedTabIDC == -1) ExitWith {
-            Error("Tried to access a tab, might not exist: %1", _selectedTab);
+            Error_1("Tried to access a tab that might not exist: %1", _selectedTab);
         };
 
         private _allTabs = [
@@ -127,7 +127,7 @@ switch (_mode) do
         };
 
         if (_selectedTabIDC == -1) ExitWith {
-            Error("Tried to access a tab, might not exist: %1", _selectedTab);
+            Error_1("Tried to access a tab that might not exist: %1", _selectedTab);
         };
 
         private _allTabs = [

--- a/A3A/addons/tasks/Tasks/fn_city_hostage.sqf
+++ b/A3A/addons/tasks/Tasks/fn_city_hostage.sqf
@@ -68,7 +68,7 @@ _task set ["_fnc_getOut", {
 _task set ["state", "s_waitForPickup"];
 _task set ["interval", 1];
 
-Trace_1("Initial data: %1" _task);
+Trace_1("Initial data: %1", _task);
 
 _task set ["s_waitForPickup", {
     private _hostage = _this get "_hostage";

--- a/A3A/addons/tasks/Tasks/fn_city_killcop.sqf
+++ b/A3A/addons/tasks/Tasks/fn_city_killcop.sqf
@@ -25,7 +25,7 @@ _task set ["_taskId", _taskId];
 _task set ["state", "s_waitForKill"];
 _task set ["interval", 1];
 
-Trace_1("Initial data: %1" _task);
+Trace_1("Initial data: %1", _task);
 
 _task set ["s_waitForKill", {
     private _target = _this get "_target";

--- a/A3A/addons/tasks/Tasks/fn_city_taxi.sqf
+++ b/A3A/addons/tasks/Tasks/fn_city_taxi.sqf
@@ -65,7 +65,7 @@ _task set ["_fnc_getOut", {
 _task set ["state", "s_waitForPickup"];
 _task set ["interval", 1];
 
-Trace_1("Initial data: %1" _task);
+Trace_1("Initial data: %1", _task);
 
 /////////////////////
 // State functions //


### PR DESCRIPTION
### What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Perf branch recently added logging for a couple of previously silent errors:
1. Macros now throw an RPT warning when they have the wrong parameter count.
2. createMarker now throws a script error when the marker already exists.

Our logging macros were extremely prone to having the wrong parameter count, and the fuel station marker logic attempted to generate multiple markers with the same name if there were multiple fuel pumps on the same grid ref. Fixed all of these.

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [X] No
2. [ ] Yes (Please provide further detail below.)
